### PR TITLE
Add unique_id property to enable configuration via UI

### DIFF
--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -115,6 +115,10 @@ class ScheduleSensor(Entity):
         return self._name
 
     @property
+    def unique_id(self):
+        return self._name
+
+    @property
     def should_poll(self):
         return False
 


### PR DESCRIPTION
The unique_id property allows users to configure and manage entities in the Home Assistant UI. So, this PR accomplishes that, and thus fixes the warning: "This entity does not have a unique ID, therefore its settings cannot be managed from the UI."