### PR TITLE
Add Awista Starnberg

### DIFF
--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -7,6 +7,7 @@ This source has been successfully tested with the following service providers:
 - [Abfall Landkreis Stade](https://abfall.landkreis-stade.de/)
 - [AVL Ludwigsburg](https://www.avl-ludwigsburg.de/)
 - [AWB Esslingen](https://www.awb-es.de/)
+- [Awista Starnberg](https://www.awista-starnberg.de/)
 - [AWM München](https://www.awm-muenchen.de)
 - [EDG Entsorgung Dortmund](https://www.edg.de/)
 - [Stadtreinigung Leipzig](https://www.stadtreinigung-leipzig.de/)


### PR DESCRIPTION
Add Awista Starnberg (Abfallwirtschaft Starnberg KU).

Running the ICS download with Awista Starnberg for over a year now, checked explicitly for the new year, all worked without any problem!