### PR TITLE
Using MyMuell with jumomind sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Currently the following service providers are supported:
 - [Muellmax.de](./doc/source/muellmax_de.md)
 - [Stadtreinigung.Hamburg](./doc/source/stadtreinigung_hamburg.md)
 - [Abfallwirtschaft Zollernalbkreis](./doc/source/abfall_zollernalbkreis_de.md)
+- [Cities using MyMuell App from Junker.Digital](./doc/source/jumomind_de.md)
 
 ### United States of America
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/jumomind_de.py
@@ -18,6 +18,7 @@ def main():
         # ('Ingolstadt', 'inkb'),
         ("Lübbecke", "lue"),
         ("Minden", "sbm"),
+        ("MyMüll App", "mymuell"),
         ("Recklinghausen", "ksr"),
         ("Rhein-Hunsrück", "rhe"),
         ("Uckermark", "udg"),
@@ -58,6 +59,12 @@ def main():
     )
     areas = json.loads(r.text)
 
+    # Quit if areas empty. Possible reason: the disposal company saved no data for this city
+    if answers['service_id'] == "mymuell" and len(areas) == 0:
+        print("Your waste disposal company / city-administration has not saved any furter data for in the MyMuell app!\n")        
+        print("You can't use the jumomind source to display your waste collection schedule \n")        
+        quit()
+    
     area_choices = []
     house_numbers = {}
     for area in areas:

--- a/doc/source/jumomind_de.md
+++ b/doc/source/jumomind_de.md
@@ -1,6 +1,6 @@
 # Jumomind.de
 
-Support for schedules provided by [jumomind.de](https://jumomind.de/). Jumomind is a service from [junker.digital](https://junker.digital/).
+Support for schedules provided by [jumomind.de](https://jumomind.de/) and [MyMüll App](https://www.mymuell.de). Jumomind and MyMüll is a service from [junker.digital](https://junker.digital/).
 
 ## Configuration via configuration.yaml
 
@@ -27,6 +27,7 @@ waste_collection_schedule:
 
 ## Example
 
+### Generic example
 ```yaml
 waste_collection_schedule:
   sources:
@@ -37,10 +38,23 @@ waste_collection_schedule:
         area_id: 94
 ```
 
+### MyMüll Example
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: jumomind_de
+      args:
+        service_id: mymuell
+        city_id: 106
+        area_id: 94
+```
+
 ## How to get the source arguments
 
 There is a script with an interactive command line interface which generates the required source configuration:
 
-[https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/package/wizard/jumomind_de.py](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/package/wizard/jumomind_de.py).
+[https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/jumomind_de.py](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/jumomind_de.py).
 
 Just run this script from a shell and answer the questions.
+
+


### PR DESCRIPTION
I found out that you can also use the data of the mymuell.de App with the junomind source.

to get the needed city and area id i have modified the jumomind_de.py script to use it with mymuell
during my testing i got some cities which does not deliver street-data. The script will now quit with a message if you are using mymuell and answer of the "street-data" request is empty.

