### PR TITLE
Add attribute to choose GET or POST for ICS parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.swo
 .vscode/
 .mypy_cache/
+venv/

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -3,6 +3,9 @@ import re
 
 import icalendar
 import recurring_ical_events
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ICS:
@@ -14,7 +17,12 @@ class ICS:
 
     def convert(self, ics_data):
         # parse ics file
-        calendar = icalendar.Calendar.from_ical(ics_data)
+        try:
+            calendar = icalendar.Calendar.from_ical(ics_data)
+        except:
+            # there s an error, simply show the data string
+            _LOGGER.debug(ics_data)
+            return []
 
         # calculate start- and end-date for recurring events
         start_date = datetime.datetime.now().replace(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -43,6 +43,31 @@ TEST_CASES = {
     "Buxtehude, Am Berg": {
         "url": "https://abfall.landkreis-stade.de/api_v2/collection_dates/1/ort/10/strasse/90/hausnummern/1/abfallarten/R02-R04-B02-D04-D12-P04-R12-R14-W0-R22-R24-R31/kalender.ics"
     },
+    "Hausmüllinfo: ASR Chemnitz": {
+        "url": "https://asc.hausmuell.info/ics/ics.php",
+        "method": "POST",
+        "params": {
+            "hidden_id_egebiet": 439087,
+            "input_ort": "Chemnitz",
+            "input_str": "Straße der Nationen",
+            "input_hnr": 2,
+            "hidden_send_btn": "ics",
+            "hiddenYear": 2021,
+            "hidden_id_ort": 10,
+            "hidden_id_ortsteil": 0,
+            "hidden_id_str": 17814,
+            "hidden_id_hnr": 5538100,
+            "hidden_kalenderart": "privat",
+            "showBinsBio": "on",
+            "showBinsRest": "on",
+            "showBinsRest_rc": "on",
+            "showBinsPapier": "on",
+            "showBinsOrganic": "on",
+            "showBinsXmas": "on",
+            "showBinsDsd": "on",
+            "showBinsProb": "on",
+        }
+    },
     "Abfall Zollernalbkreis, Ebingen": {
         "url": "https://www.abfallkalender-zak.de",
         "params": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -150,6 +150,11 @@ class Source:
             return "error"
         r.encoding = "utf-8"  # requests doesn't guess the encoding correctly
 
+        # check the return code
+        if not r.ok:
+            _LOGGER.error("Error: the response is not ok; need code 200, but got code %s" % r.status_code)
+            return "error"
+
         return self._convert(r.text)
 
     def fetch_file(self, file):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -71,7 +71,7 @@ HEADERS = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
 
 
 class Source:
-    def __init__(self, url=None, file=None, offset=None, params=None, year_field=None):
+    def __init__(self, url=None, file=None, offset=None, params=None, year_field=None, method='GET'):
         self._url = url
         self._file = file
         if bool(self._url is not None) == bool(self._file is not None):
@@ -79,6 +79,7 @@ class Source:
         self._ics = ICS(offset)
         self._params = params
         self._year_field = year_field  # replace this field in params with current year
+        self._method = method # The method to send the params
 
     def fetch(self):
         if self._url is not None:
@@ -115,7 +116,13 @@ class Source:
 
     def fetch_url(self, url, params=None):
         # get ics file
-        r = requests.get(url, params=params, headers=HEADERS)
+        if self._method == 'GET':
+            r = requests.get(url, params=params, headers=HEADERS)
+        elif self._method == 'POST':
+            r = requests.post(url, data=params, headers=HEADERS)
+        else:
+            _LOGGER.error("Error: unknown method to fetch URL, use GET or POST; got %s" % self._method)
+            return "error"
         r.encoding = "utf-8"  # requests doesn't guess the encoding correctly
 
         return self._convert(r.text)

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -13,6 +13,7 @@ This source has been successfully tested with the following service providers:
 - [Stadtreinigung Leipzig](https://www.stadtreinigung-leipzig.de/)
 - [Entsorgungsgesellschaft Görlitz-Löbau-Zittau](https://www.abfall-eglz.de/abfallkalender.0.html) (Remove the year from the generated URL to always get the current year.)
 - [Abfallwirtschaft Kreis Böblingen](https://www.lrabb.de/start/Service+_+Verwaltung/Abfuhrtermine.html) (API from AbfallPlus / Abfall.IO)
+- [ASR Chemnitz](https://www.asr-chemnitz.de/kundenportal/entsorgungskalender/) (Service von https://asc.hausmuell.info/ics/ics.php)
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -24,6 +24,7 @@ waste_collection_schedule:
         url: URL
         file: FILE
         offset: OFFSET
+        method: METHOD
         params: PARAMS
         year_field: YEAR_FIELD
 ```
@@ -50,6 +51,13 @@ You have to specify either `url` or `file`!
 *(int) (optional, default: `0`)*
 
 Offset in days which will be added to every start time. Can be used if the start time of the events in the ICS file are ahead of the actual date.
+
+**method**<br>
+*(string) (optional, default: `GET`)*
+
+Method to send the URL `params`.
+
+Need to be `GET` or `POST`
 
 **params**<br>
 *(dict) (optional, default: None)*


### PR DESCRIPTION
I want to use a garbage service that is only accessible with POST parameters.  
So I added a new attribute in yaml to choose whether to use GET or POST.  GET is the default so there are no adaptions needed for other services.  

Additionally there is bit more debug logging when using in hass.