### PR TITLE
Add HVCGroep waste management

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Currently the following service providers are supported:
 ### Netherlands
 
 - [Ximmio](./doc/source/ximmio_nl.md)
+- [HVCGroep](./doc/source/hvcgroep_nl.md)
 
 ### New Zealand
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+import requests
+import json
+
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+TITLE = "HVCGroep"
+DESCRIPTION = "Source for the Dutch HVCGroep waste management."
+URL = "https://www.hvcgroep.nl/zelf-regelen/afvalkalender"
+TEST_CASES = {
+    "Obdam": {
+        "postal_code": "1713VM",
+        "house_number": "1",
+    },
+    "Tollebeek": {
+        "postal_code": "8309AV",
+        "house_number": "1",
+    }
+}
+
+
+class Source:
+    def __init__(self, postal_code, house_number):
+        self.postal_code = postal_code
+        self.house_number = house_number
+        self.icons = {"plastic-blik-drinkpak": "mdi:recycle", "gft": "mdi:leaf", "papier-en-karton": "mdi:archive", "restafval": "mdi:trash-can"}
+
+    def fetch(self):
+        bag_id = 0
+
+        # Retrieve bagid (unique waste management identifier)
+        r = requests.get(
+            f"https://inzamelkalender.hvcgroep.nl/adressen/{self.postal_code}:{self.house_number}"
+        )
+        data = json.loads(r.text)
+
+        bag_id = data[0]["bagid"]
+
+        # Something must be wrong, maybe the address isn't valid? No need to do the extra requests so just return here.
+        if bag_id == 0:
+            return []
+
+        # Retrieve the details about different waste management flows (for example, paper, plastic etc.)
+        r = requests.get(
+            f"https://inzamelkalender.hvcgroep.nl/rest/adressen/{bag_id}/afvalstromen"
+        )
+        waste_flows = json.loads(r.text)
+
+        # Retrieve the coming pickup dates for waste.
+        r = requests.get(
+            f"https://inzamelkalender.hvcgroep.nl/rest/adressen/{bag_id}/ophaaldata"
+        )
+        data = json.loads(r.text)
+
+        entries = []
+
+        for item in data:
+            waste_details = [x for x in waste_flows if x["id"] == item["afvalstroom_id"]]
+            entries.append(
+                Collection(
+                    date=datetime.strptime(item["ophaaldatum"], "%Y-%m-%d").date(),
+                    t=waste_details[0]["title"],
+                    icon=self.icons.get(waste_details[0]["icon"], 'mdi:trash-can')
+                )
+            )
+
+        return entries

--- a/doc/source/hvcgroep_nl.md
+++ b/doc/source/hvcgroep_nl.md
@@ -1,0 +1,33 @@
+# HVCGroep
+
+Support for schedules provided by [hvcgroep.nl](https://www.hvcgroep.nl/).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: hvcgroep_nl
+      args:
+        postal_code: POSTAL_CODE
+        house_number: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**postal_code**<br>
+*(string) (required)*
+
+**house_number**<br>
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: hvcgroep_nl
+      args:
+        postal_code: 1713VM
+        house_number: 1
+```

--- a/info.md
+++ b/info.md
@@ -60,6 +60,7 @@ Currently the following service providers are supported:
 ### Netherlands
 
 - [Ximmio](./doc/source/ximmio_nl.md)
+- [HVCGroep](./doc/source/hvcgroep_nl.md)
 
 ### New Zealand
 


### PR DESCRIPTION
This will add waste management from the Dutch HVCGroep ([hvcgroep.nl](https://www.hvcgroep.nl/).) 
In case you want to validate the results, they can be manually seen at https://www.hvcgroep.nl/zelf-regelen/afvalkalender