### PR TITLE
Write error log.

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -21,7 +21,7 @@ class ICS:
             calendar = icalendar.Calendar.from_ical(ics_data)
         except:
             # there s an error, simply show the data string
-            _LOGGER.debug(ics_data)
+            _LOGGER.error(f'Parsing ics data failed:{str(err)} :{ics_data}')
             return []
 
         # calculate start- and end-date for recurring events


### PR DESCRIPTION
Errors when parsing an ICS file are not reported to log. 
This patch adds a message to the error log.