### PR TITLE
Change shebang line to respect venvs

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/scraper.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/scraper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import datetime
 import importlib

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import importlib

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from html.parser import HTMLParser
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_kreis_tuebingen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_kreis_tuebingen_de.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from html.parser import HTMLParser
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfallnavi_de.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import site
 from pathlib import Path

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/awbkoeln_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/awbkoeln_de.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/bsr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/bsr_de.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/jumomind_de.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/muellmax_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/muellmax_de.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from html.parser import HTMLParser
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/stadtreinigung_hamburg.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/stadtreinigung_hamburg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from html.parser import HTMLParser
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/stuttgart_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/stuttgart_de.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 


### PR DESCRIPTION
To run this script in a virtual environment (venv), the shebang line needs to invoke /usr/bin/env instead of /usr/bin/python3 to make sure the python3 version from the venv (including its modules) is executed.