### PR TITLE
add source for oberhausen.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Currently the following service providers are supported:
 - [Jumomind.de](./doc/source/jumomind_de.md)
 - [Muellmax.de](./doc/source/muellmax_de.md)
 - [MyMuell App](./doc/source/jumomind_de.md)
+- [Oberhausen.de](./doc/source/oberhausen_de.md)
 - [Rhein-Hunsrück Entsorgung (RHE)](./doc/source/rh_entsorgung_de.md)
 - [Sector27.de](./doc/source/sector27_de.md)
 - [Stadtreinigung.Hamburg](./doc/source/stadtreinigung_hamburg.md)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberhausen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberhausen_de.py
@@ -1,0 +1,103 @@
+import datetime
+import requests
+from html.parser import HTMLParser
+from urllib.parse import urljoin
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Oberhausen.de"
+DESCRIPTION = "Source for Oberhausen waste collection."
+URL = "https://www.oberhausen.de/abfallkalender"
+
+TEST_CASES = {
+    "Max-Planck-Ring": {
+        "street": "Max-Planck-Ring",
+    },
+    "Mülheimer Straße 1": {
+        "street": "Mülheimer Straße 1",
+    },
+}
+
+# Parser for HTML input (hidden) text
+class ICSLinkParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._args = {}
+
+    @property
+    def args(self):
+        return self._args
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            d = dict(attrs)
+            if "href" in d and 'abfallkalender_ical.php' in str(d["href"]):
+                self._args["href"] = urljoin(URL, d["href"])
+
+class Source:
+    def __init__(self, street):
+        self._street = street
+        self._ics = ICS()
+
+    def fetch(self):
+        now = datetime.datetime.now()
+        entries = self.fetch_year(now.year)
+
+        if now.month == 12:
+            # also get data for next year if we are already in december
+            try:
+                entries.extend(self.fetch_year(now.year + 1))
+            except Exception:
+                # ignore if fetch for next year fails
+                pass
+        return entries
+
+    def fetch_year(self, year):
+        with requests.Session() as s:
+            # get session id
+            s.get("https://www.oberhausen.de/abfallkalender")
+
+            # update session with filters and get ICS link
+            r = s.post("https://www.oberhausen.de/abfallkalender", data={
+                "abfall_searchstring": self._street,
+                "abfall_jahr": year,
+                "actbio": "on",
+                "actdeckgruen": "on",
+                "actdeckrot": "on",
+                "actdeckblau": "on",
+                "actgelb": "on",
+                "actpapier": "on",
+                "submit_search": ""
+            })
+
+            # extract ICS link
+            parser = ICSLinkParser()
+            parser.feed(r.text)
+
+            if not "href" in parser.args or parser.args["href"] == "":
+                raise Exception(
+                   "Error: could not extract ICS download link for year / street: {}, '{}'".format(
+                       year,
+                       self._street
+                   )
+               )
+
+            # download ICS file
+            r = s.get(parser.args['href'])
+
+            # check the return code
+            if not r.ok:
+                raise Exception(
+                    "Error: the response is not ok; need code 200, but got code {}".format(
+                        r.status_code
+                    )
+                )
+
+        # parse ics file
+        r.encoding = "utf-8"
+        dates = self._ics.convert(r.text)
+
+        entries = []
+        for d in dates:
+            entries.append(Collection(d[0], d[1]))
+        return entries

--- a/doc/source/oberhausen_de.md
+++ b/doc/source/oberhausen_de.md
@@ -1,0 +1,68 @@
+# Oberhausen.de / Stadt Oberhausen
+
+Support for schedules provided by [Oberhausen.de](https://www.oberhausen.de) (Stadt Oberhausen / WBO / SBO) located in Northrhine-Westfalia, Germany.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: oberhausen_de
+      args:
+        street: street name
+```
+
+### Configuration Variables
+
+**street**<br>
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: oberhausen_de
+      args:
+        street: Max-Plank-Ring
+        
+        # on large streets please check the available sections by supplying
+        # just the street name on https://www.oberhausen.de/abfallkalender
+        # and add more characters to make the request unique.
+        #
+        # eg. "Mülheimer Straße" gives:
+        #  - Mülheimer Straße 1-299, 2-324
+        #  - Mülheimer Straße 321-439,326-438
+        #
+        # Either use the full string "Mülheimer Straße 1-299, 2-324" or at least
+        # as many characters to make a distinct choice, eg. the following would
+        # be sufficient: 
+        # street: Mülheimer Straße 1
+```
+
+Use `sources.customize` to filter or rename the waste types:
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: oberhausen_de
+      args:
+        street: Max-Planck-Ring
+      calendar_title: Abfallkalender
+      customize:
+        # rename types to shorter name
+        - type: Blaue Papiertonne
+          alias: Papiertonne
+        - type: Hausmüll, grüner Deckel
+          alias: Hausmüll
+        - type: Gelber Sack / Gelbe Tonne
+          alias: Gelbe Tonne
+        
+        # hide unwanted types
+        - type: Hausmüll, blauer Deckel
+          show: false
+        - type: Hausmüll, roter Deckel
+          show: false
+        - type: Biotonne
+          show: false
+```

--- a/info.md
+++ b/info.md
@@ -57,6 +57,7 @@ Currently the following service providers are supported:
 - [Jumomind.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/jumomind_de.md)
 - [Muellmax.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/muellmax_de.md)
 - [MyMuell App](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/jumomind_de.md)
+- [Oberhausen.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/oberhausen_de.md)
 - [Rhein-Hunsrück Entsorgung (RHE)](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rh_entsorgung_de.md)
 - [Sector27.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/sector27_de.md)
 - [Stadtreinigung.Hamburg](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/stadtreinigung_hamburg.md)


### PR DESCRIPTION
This PR adds support for schedules provided by [Oberhausen.de](https://www.oberhausen.de) (Stadt Oberhausen / WBO / SBO) located in Northrhine-Westfalia, Germany.