### PR TITLE
Add support for directly specifying prem_code for seattle_gov 

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
@@ -20,8 +20,9 @@ def get_service_icon(service_name):
 
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address, prem_code):
         self._street_address = street_address
+        self._prem_code = prem_code
 
     def fetch(self):
 
@@ -32,18 +33,19 @@ class Source:
         # 4. get account summary
         # 5. get calendar
 
-        # step 1
-        find_address_payload = {
-            "address": {"addressLine1": self._street_address, "city": "", "zip": ""}
-        }
+        # step 1 - Look up premCode if it wasn't explicitly provided
+        if prem_code is None:
+            find_address_payload = {
+                "address": {"addressLine1": self._street_address, "city": "", "zip": ""}
+            }
 
-        r = requests.post(
-            "https://myutilities.seattle.gov/rest/serviceorder/findaddress",
-            json=find_address_payload,
-        )
+            r = requests.post(
+                "https://myutilities.seattle.gov/rest/serviceorder/findaddress",
+                json=find_address_payload,
+            )
 
-        address_info = json.loads(r.text)
-        prem_code = address_info["address"][0]["premCode"]
+            address_info = json.loads(r.text)
+            prem_code = address_info["address"][0]["premCode"]
 
         # step 2
         find_account_payload = {"address": {"premCode": prem_code}}

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
@@ -20,7 +20,7 @@ def get_service_icon(service_name):
 
 
 class Source:
-    def __init__(self, street_address, prem_code):
+    def __init__(self, street_address, prem_code = None):
         self._street_address = street_address
         self._prem_code = prem_code
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
@@ -11,6 +11,7 @@ TEST_CASES = {
     "City Hall": {"street_address": "600 4th Ave"},
     "Ballard Builders": {"street_address": "7022 12th Ave NW"},
     "Carmona Court": {"street_address": "1127 17th Ave E"},
+    "2111 E John St": {"street_address":"2111 E John St","prem_code": "DRMGcnGxUEg+gu8pN8vesQ=="}
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/seattle_gov.py
@@ -34,7 +34,7 @@ class Source:
         # 5. get calendar
 
         # step 1 - Look up premCode if it wasn't explicitly provided
-        if prem_code is None:
+        if self._prem_code is None:
             find_address_payload = {
                 "address": {"addressLine1": self._street_address, "city": "", "zip": ""}
             }
@@ -46,6 +46,8 @@ class Source:
 
             address_info = json.loads(r.text)
             prem_code = address_info["address"][0]["premCode"]
+        else:
+            prem_code = self._prem_code
 
         # step 2
         find_account_payload = {"address": {"premCode": prem_code}}

--- a/doc/source/seattle_gov.md
+++ b/doc/source/seattle_gov.md
@@ -10,12 +10,16 @@ waste_collection_schedule:
     - name: seattle_gov
       args:
         street_address: STREET_ADDRESS
+        prem_code: PREM_CODE
 ```
 
 ### Configuration Variables
 
 **street_address**<br>
 *(string) (required)*
+
+**prem_code**<br>
+*(string) (optional)*
 
 ## Example
 
@@ -29,4 +33,6 @@ waste_collection_schedule:
 
 ## How to get the source argument
 
-The source argument is simply the house mailing address. Road type (eg. St, Ave) and cardinal direction if applicable (eg. N/S/NW) are required, so "501 23rd Ave" and "501 23rd Ave E" will give different results.
+The street_address argument is simply the house mailing address. Road type (eg. St, Ave) and cardinal direction if applicable (eg. N/S/NW) are required, so "501 23rd Ave" and "501 23rd Ave E" will give different results.
+
+If the service cannot be identified based on street address alone (in some multi-family houses, etc), a `prem_code` can be extracted by inspecting the "findAccount" call when looking up your service on the Collection Calendar.


### PR DESCRIPTION
Adds support for manually specifying a `prem_code` in the configuration for the seattle_gov source, as automatic lookup can struggle with multi-tenant addresses sometimes (as can the city collection calendar website).

Documentation was updated to mention how to look this up manually, a test case with a manually specified prem_code was added and test_sources passed.