### PR TITLE
fix problem in ics source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -159,10 +159,11 @@ class Source:
                 if now.month == 12:
                     # also get data for next year if we are already in december
                     url = self._url.replace("{%Y}", str(now.year + 1))
-                    self._params[self._year_field] = str(now.year + 1)
+                    if self._year_field is not None:
+                        self._params[self._year_field] = str(now.year + 1)
 
                     try:
-                        entries.extend(self.fetch_url(url), self._params)
+                        entries.extend(self.fetch_url(url, self._params))
                     except Exception:
                         # ignore if fetch for next year fails
                         pass


### PR DESCRIPTION
When trying to prefetch the next year the component crashed when no
year_field was provided.
Additionally there was a syntax error in the fetching of next years ics.