### PR TITLE
add Ludwigshafen am Rhein to abfall.io

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
@@ -37,6 +37,12 @@ TEST_CASES = {
         "f_id_bezirk": 22017,
         "f_id_strasse": 22155,
     },
+    "Ludwigshafen am Rhein": {
+        "key": "6efba91e69a5b454ac0ae3497978fe1d",
+        "f_id_kommune": "5916",
+        "f_id_strasse": "5916abteistrasse",
+        "f_id_strasse_hnr": 33,
+    },
 }
 
 MODUS_KEY = "d6c5855a62cf32a4dadbc2831f0f295f"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io.py
@@ -33,6 +33,7 @@ DISTRICT_CHOICES = [
     ("Kitzingen", "594f805eb33677ad5bc645aeeeaf2623"),
     ("Landsberg am Lech", "7df877d4f0e63decfb4d11686c54c5d6"),
     ("Landshut", "bd0c2d0177a0849a905cded5cb734a6f"),
+    ("Ludwigshafen am Rhein", "6efba91e69a5b454ac0ae3497978fe1d"),
     ("MüllALARM / Schönmackers", "e5543a3e190cb8d91c645660ad60965f"),
     ("Rhein-Neckar-Kreis", "914fb9d000a9a05af4fd54cfba478860"),
     ("Rotenburg (Wümme)", "645adb3c27370a61f7eabbb2039de4f1"),


### PR DESCRIPTION
Thanks for writing this integration! Here's a PR that adds my hometown (Ludwigshafen am Rhein).

Also added to wizard, one small detail I noticed is that the wizard terminates after querying `f_id_kommune` and `f_id_strasse`. Using only those parameters works, however it results in less events returned (164) compared to when `f_id_strasse_hnr` is added to the query as well (198). 

Bests,

Florian

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>