### PR TITLE
Add wuerzburg_de

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Currently the following service providers are supported:
 
 - [Abfall.IO / AbfallPlus.de](./doc/source/abfall_io.md)
 - [AbfallNavi.de (RegioIT.de)](./doc/source/abfallnavi_de.md)
+- [Abfallkalender Würzburg](./doc/source/wuerzburg_de.md)
 - [Abfallwirtschaft Rendsburg](./doc/source/awr_de.md)
 - [Abfallwirtschaft Stuttgart](./doc/source/stuttgart_de.md)
 - [Abfallwirtschaft Südholstein](./doc/source/awsh_de.md)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py
@@ -1,0 +1,94 @@
+import datetime
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+TITLE = "Abfallkalender Würzburg"
+DESCRIPTION = "Source for waste collection in the city of Würzburg, Germany."
+URL = "https://www.wuerzburg.de/themen/umwelt-verkehr/vorsorge-entsorgung/abfallkalender/32208.Abfallkalender.html"
+TEST_CASES = {
+    "District only": {"district": "Altstadt"},
+    "Street only": {"street": "Juliuspromenade"},
+    "District + Street": {"district": "Altstadt", "street": "Juliuspromenade"},
+    "District + Street diff": {"district": "Altstadt", "street": "Oberer Burgweg"},
+}
+
+
+class Source:
+    def __init__(self, district: str = None, street: str = None, days: int = 365):
+        self._district = district
+        self._street = street
+        self._days = days
+        self._district_id = None
+
+    @staticmethod
+    def map_district_id(district: str = None, street: str = None):
+        """Map `street` or `district` to `district_id`, giving priority to `street`.
+
+        Parameters must exactly be the same as visible in dropdowns on `URL`.
+        """
+        if not district and not street:
+            raise ValueError("One of ['district', 'street'] is required.")
+
+        r = requests.get(URL)
+        r.raise_for_status()
+        selects = BeautifulSoup(r.content, "html.parser").body.find_all("select")
+
+        if street:
+            strlist = next(iter([s for s in selects if s["id"] == "strlist"]))
+            strdict = {option.text: option["value"] for option in strlist}
+
+            try:
+                return strdict[street]
+            except KeyError:
+                raise KeyError(
+                    f"Unable to find street '{street}'. Please compare exact typing with {URL}"
+                )
+
+        if district:
+            reglist = next(iter([s for s in selects if s["id"] == "reglist"]))
+            regdict = {
+                option.text: option.attrs["value"] for option in reglist.contents
+            }
+
+            try:
+                return regdict[district]
+            except KeyError:
+                raise KeyError(
+                    f"Unable to find district '{district}'. Please compare exact typing with {URL}"
+                )
+
+    def fetch(self):
+        # Get & parse full HTML only on first call to fetch() to map district or street to district_id
+        if not self._district_id:
+            self._district_id = self.map_district_id(self._district, self._street)
+
+        if not self._district_id:
+            raise ValueError("'_district_id' is not set!")
+
+        now = datetime.datetime.now().date()
+
+        r = requests.get(
+            URL,
+            params={
+                "_func": "evList",
+                "_mod": "events",
+                "ev[start]": str(now),
+                "ev[end]": str(now + datetime.timedelta(days=self._days)),
+                "ev[addr]": self._district_id,
+            },
+        )
+        r.raise_for_status()
+
+        entries = []
+        for event in r.json()["contents"].values():
+            entries.append(
+                Collection(
+                    datetime.datetime.fromisoformat(event["start"]).date(),
+                    event["title"],
+                    picture=event.get("thumb", {}).get("url"),
+                )
+            )
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py
@@ -16,10 +16,9 @@ TEST_CASES = {
 
 
 class Source:
-    def __init__(self, district: str = None, street: str = None, days: int = 365):
+    def __init__(self, district: str = None, street: str = None):
         self._district = district
         self._street = street
-        self._days = days
         self._district_id = None
 
     @staticmethod
@@ -75,7 +74,7 @@ class Source:
                 "_func": "evList",
                 "_mod": "events",
                 "ev[start]": str(now),
-                "ev[end]": str(now + datetime.timedelta(days=self._days)),
+                "ev[end]": str(now + datetime.timedelta(days=365)),
                 "ev[addr]": self._district_id,
             },
         )

--- a/doc/source/wuerzburg_de.md
+++ b/doc/source/wuerzburg_de.md
@@ -11,7 +11,6 @@ waste_collection_schedule:
       args:
         district: ADDRESS
         street: STREET
-        days: DAYS
 ```
 
 ### Configuration Variables
@@ -24,9 +23,6 @@ waste_collection_schedule:
 
 **street**<br>
 *(string) (required)* - if *district* is empty
-
-**days**<br>
-*(int) (optional, default: 365)* - number of future days to fetch
 
 ## Example
 
@@ -50,4 +46,4 @@ waste_collection_schedule:
 
 ## How to get the source argument
 
-The source argument is either district or street as displayed in the web form. Exact match is required.
+The source argument is either district or street as displayed in the web form at [Abfallkalender Würzburg](https://www.wuerzburg.de/themen/umwelt-verkehr/vorsorge-entsorgung/abfallkalender/32208.Abfallkalender.html). Exact match is required.

--- a/doc/source/wuerzburg_de.md
+++ b/doc/source/wuerzburg_de.md
@@ -1,0 +1,53 @@
+# WasteNet Southland
+
+Support for schedules provided by [Abfallkalender Würzburg](https://www.wuerzburg.de/themen/umwelt-verkehr/vorsorge-entsorgung/abfallkalender/32208.Abfallkalender.html), serving the City of Würzburg.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: wuerzburg_de
+      args:
+        district: ADDRESS
+        street: STREET
+        days: DAYS
+```
+
+### Configuration Variables
+
+**district** and **street** can be used independently, only **one** is required. If set, priority will be given to **street**.
+
+**district**<br>
+*(string) (required)* - if *street* is empty
+
+
+**street**<br>
+*(string) (required)* - if *district* is empty
+
+**days**<br>
+*(int) (optional, default: 365)* - number of future days to fetch
+
+## Example
+
+Both examples will yield the same result.
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: wuerzburg_de
+      args:
+        district: "Altstadt"
+```
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: wuerzburg_de
+      args:
+        street: "Juliuspromenade"
+```
+
+## How to get the source argument
+
+The source argument is either district or street as displayed in the web form. Exact match is required.

--- a/info.md
+++ b/info.md
@@ -52,6 +52,7 @@ Currently the following service providers are supported:
 
 - [Abfall.IO / AbfallPlus.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abfall_io.md)
 - [AbfallNavi.de (RegioIT.de)](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abfallnavi_de.md)
+- [Abfallkalender Würzburg](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/wuerzburg_de.md)
 - [Abfallwirtschaft Rendsburg](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/awr_de.md)
 - [Abfallwirtschaft Stuttgart](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/stuttgart_de.md)
 - [Abfallwirtschaft Südholstein](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/awsh_de.md)


### PR DESCRIPTION
Adds waste collection for the city of Würzburg.

I know that `days` will be requiring a discussion: I have to call the API with both `ev[start]` and `ev[end]` dates.
Without them, nothing is returned. With just the start date, only event for this day are returned.
The API by default used approx. 1 year to look into the future.

I could also remove the parameter completely and hard-code the +1 year time interval.

