### PR TITLE
Add types-requests to mypy pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
     rev: v0.901
     hooks:
       - id: mypy
+        additional_dependencies: ["types-requests"]
         args:
           - --pretty
           - --show-error-codes


### PR DESCRIPTION
When developing #142 I wanted to execute `pre-commit` on Python 3.9.9, but was unable to do so, as `requests` was missing in the pre-commit venv.

I got the following error message:
```bash
custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py:3: error:
Library stubs not installed for "requests" (or incompatible with Python 3.9) 
[import]
    import requests
    ^
custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py:3: note: Hint: "python3 -m pip install types-requests"
custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py:3: note: (or run "mypy --install-types" to install all missing stub packages)
custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py:3: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

According to https://github.com/pre-commit/mirrors-mypy, it is best to add the missing dependencies via the pre-commit config.