### PR TITLE
Add support for KWB-Goslar.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Currently the following service providers are supported:
 - [BSR.de / Berliner Stadtreinigungsbetriebe](./doc/source/bsr_de.md)
 - [EGN-Abfallkalender.de](./doc/source/egn_abfallkalender_de.md)
 - [Jumomind.de](./doc/source/jumomind_de.md)
+- [KWB-Goslar.de](./doc/source/kwb_goslar_de.md)
 - [Landkreis-Wittmund.de](./doc/source/landkreis_wittmund_de.md)
 - [Muellmax.de](./doc/source/muellmax_de.md)
 - [MyMuell App](./doc/source/jumomind_de.md)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwb_goslar_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwb_goslar_de.py
@@ -1,0 +1,52 @@
+import requests
+from waste_collection_schedule import Collection
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "KreisWirtschaftsBetriebe Goslar"
+DESCRIPTION = "Source for kwb-goslar.de waste collection."
+URL = "https://www.kwb-goslar.de/Abfallwirtschaft/Abfuhr/"
+TEST_CASES = {
+    "Berliner Straße (Clausthal-Zellerfeld)": {"pois": "2523.602"},
+    "Braunschweiger Straße (Seesen)": {"pois": "2523.409"},
+}
+
+ICON_MAP = {
+    "Baum- und Strauchschnitt": "mdi:leaf",
+    "Biotonne": "mdi:bio",
+    "Blaue Tonne": "mdi:newspaper-variant-multiple",
+    "Gelber Sack": "mdi:recycle",
+    "Restmülltonne": "mdi:trash-can",
+    "Weihnachtsbäume": "mdi:pine-tree",
+}
+
+
+class Source:
+    def __init__(self, pois):
+        self.ics = ICS()
+        self.pois = pois
+
+    def fetch(self):
+        r = requests.get(
+            url="https://www.kwb-goslar.de/output/options.php",
+            params={
+                "ModID": "48",
+                "call": "ical",
+                "pois": self.pois,
+            },
+            headers={
+                "Referer": "https://www.kwb-goslar.de",
+            },
+        )
+
+        if not r.ok:
+            raise Exception(f"Error: failed to fetch url: {r.request.url}")
+
+        dates = self.ics.convert(r.text)
+
+        entries = []
+        for d in dates:
+            date, waste_type = d
+            icon = ICON_MAP.get(waste_type, "mdi:trash-can-outline")
+            entries.append(Collection(date=date, t=waste_type, icon=icon))
+
+        return entries

--- a/doc/source/kwb_goslar_de.md
+++ b/doc/source/kwb_goslar_de.md
@@ -1,0 +1,53 @@
+# KWB-Goslar.de
+
+Support for schedules provided by [KWB-Goslar.de](https://www.kwb-goslar.de/Abfallwirtschaft/Abfuhr/) located in Lower Saxony, Germany.  
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: kwb_goslar_de
+      args:
+        pois: 2523.602 # Berliner Straße (Clausthal-Zellerfeld)
+```
+
+### Configuration Variables
+
+**pois**
+*(string) (required)*
+
+#### How to find the `pois` value
+1. Open [Online-Abfuhrkalender 2022](https://www.kwb-goslar.de/Abfallwirtschaft/Abfuhr/Online-Abfuhrkalender-2022/) (`Abfallwirtschaft -> Abfuhr -> Online-Abfuhrkalender 2022`)
+2. Select your city (`Ort auswählen`)
+3. Select your district/street (`Ortsteil, Straße auswählen`)
+4. Copy the `pois` value out of the url (e.g. `https://www.kwb-goslar.de/Abfallwirtschaft/Abfuhr/Online-Abfuhrkalender-2022/index.php?ModID=48&...&pois=2523.602`)
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: kwb_goslar_de
+      args:
+        pois: 2523.409 # Braunschweiger Straße (Seesen)
+```
+
+Use `sources.customize` to filter or rename the waste types:
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: kwb_goslar_de
+      args:
+        pois: 2523.409 # Braunschweiger Straße (Seesen)
+      calendar_title: Abfuhrtermine - Braunschweiger Straße (Seesen)
+      customize:
+        # rename types to shorter name
+        - type: Restmülltonne
+          alias: Restmüll
+        
+        # hide unwanted types
+        - type: Baum- und Strauchschnitt
+          show: false
+```


### PR DESCRIPTION
Adds support for [KWB-Goslar.de](https://www.kwb-goslar.de/Abfallwirtschaft/Abfuhr/Online-Abfuhrkalender-2022/) (Bad Harzburg, Braunlage, Clausthal-Zellerfeld, Goslar, Langelsheim, Liebenburg, Lutter am Barenberge, Oker, Seesen, Seesen, Vienenburg).