### PR TITLE
Added source for banyule.vic.gov.au

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Currently the following service providers are supported:
 
 ### Australia
 
+- [Banyule City Council](./doc/source/banyule_vic_gov_au.md)
 - [Brisbane City Council](./doc/source/brisbane_qld_gov_au.md)
 - [North Adelaide Waste Management Authority, South Australia](./doc/source/nawma_sa_gov_au.md)
 - [The Hills Council, Sydney](./doc/source/thehills_nsw_gov_au.md)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/banyule_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/banyule_vic_gov_au.py
@@ -1,0 +1,124 @@
+import logging
+import typing
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection
+
+
+TITLE = 'Banyule City Council'
+DESCRIPTION = 'Source for Banyule City Council rubbish collection.'
+URL = 'https://www.banyule.vic.gov.au/binday'
+TEST_CASES = {
+    'Monday A': {'street_address': '6 Mandall Avenue, IVANHOE'},
+    'Monday A Geolocation ID': {'geolocation_id': '4f7ebfca-1526-4363-8b87-df3103a10a87'},
+    'Monday B': {'street_address': '10 Burke Road North, IVANHOE EAST'},
+    'Thursday A': {'street_address': '255 St Helena Road, GREENSBOROUGH'},
+    'Thursday B': {'street_address': '35 Para Road, MONTMORENCY'}
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+ICON_MAP = {
+    'green waste': 'mdi:leaf',
+    'recycling': 'mdi:recycle'
+}
+
+
+class SourceConfigurationError(ValueError):
+    pass
+
+
+class SourceParseError(ValueError):
+    pass
+
+
+class Source:
+    def __init__(self, street_address: typing.Optional[str] = None, geolocation_id: typing.Optional[str] = None):
+        if street_address is None and geolocation_id is None:
+            raise SourceConfigurationError('Either street_address or geolocation_id must have a value')
+
+        self._street_address = street_address
+        self._geolocation_id = geolocation_id
+
+    @property
+    def geolocation_id(self) -> str:
+        if self._geolocation_id is None:
+            # Search for geolocation ID
+            geolocation_response = requests.get(
+                'https://www.banyule.vic.gov.au/api/v1/myarea/search',
+                params={
+                    'keywords': self._street_address,
+                    'maxresults': 1
+                }
+            )
+            geolocation_response.raise_for_status()
+
+            # Pull ID from results
+            geolocation_result = geolocation_response.json()
+            _LOGGER.debug(f"Search response: {geolocation_response!r}")
+
+            if 'success' in geolocation_result and not geolocation_result['success']:
+                raise SourceParseError('Unspecified server-side error when searching address')
+
+            if 'Items' not in geolocation_result or \
+                    geolocation_result['Items'] is None or \
+                    len(geolocation_result['Items']) < 1:
+                raise SourceParseError('Expected list of locations from address search, got empty or missing list')
+
+            geolocation_data = geolocation_result['Items'][0]
+
+            if 'Id' not in geolocation_data:
+                raise SourceParseError('Location in address search result but missing geolocation ID')
+
+            self._geolocation_id = geolocation_data['Id']
+            _LOGGER.info(f"Address {self._street_address} mapped to geolocation ID {self._geolocation_id}")
+
+        return self._geolocation_id
+
+    def fetch(self) -> typing.List[Collection]:
+        # Calendar lookup cares about a cookie, so a Session must be used
+        calendar_session = requests.Session()
+
+        calendar_request = calendar_session.get(
+            'https://www.banyule.vic.gov.au/Waste-environment/Waste-recycling/Bin-collection-services'
+        )
+        calendar_request.raise_for_status()
+
+        calendar_request = calendar_session.get(
+            'https://www.banyule.vic.gov.au/ocapi/Public/myarea/wasteservices',
+            params={
+                'geolocationid': self.geolocation_id,
+                'ocsvclang': 'en-AU'
+            }
+        )
+        calendar_request.raise_for_status()
+
+        calendar_result = calendar_request.json()
+        _LOGGER.debug(f"Calendar response: {calendar_result!r}")
+
+        if 'success' in calendar_result and not calendar_result['success']:
+            raise SourceParseError('Unspecified server-side error when getting calendar')
+
+        # Extract entries from bundled HTML
+        calendar_parser = BeautifulSoup(calendar_result['responseContent'], 'html.parser')
+
+        pickup_entries = []
+
+        for element in calendar_parser.find_all('article'):
+            _LOGGER.debug(f"Parsing collection: {element!r}")
+
+            waste_type = element.h3.string
+
+            # Extract and parse collection date
+            waste_date_str = element.find(class_='next-service').string.strip()
+            waste_date = datetime.strptime(waste_date_str.partition(' ')[2], '%d/%m/%Y')
+
+            # Base icon on type
+            waste_icon = ICON_MAP.get(waste_type.lower(), 'mdi:trash-can')
+
+            pickup_entries.append(Collection(waste_date, waste_type, waste_icon))
+            _LOGGER.info(f"Collection for {waste_type} (icon: {waste_icon}) on {waste_date}")
+
+        return pickup_entries

--- a/doc/source/banyule_vic_gov_au.md
+++ b/doc/source/banyule_vic_gov_au.md
@@ -1,0 +1,47 @@
+# Banyule City Council
+
+Support for schedules provided by [Banyule City Council](https://www.banyule.vic.gov.au/binday). This implementation is heavily based upon the Stonnington City Council parser, as both interfaces appear to use the same back-end.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: banyule_vic_gov_au
+      args:
+        street_address: STREET_ADDRESS
+```
+
+### Configuration Variables
+
+**street_address**<br>
+*(string) (optional)*
+
+**geolocation_id**<br>
+*(string) (optional)*
+
+At least one argument must be provided.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: banyule_vic_gov_au
+      args:
+        street_address: 6 Mandall Avenue, IVANHOE
+```
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: banyule_vic_gov_au
+      args:
+        geolocation_id: 4f7ebfca-1526-4363-8b87-df3103a10a87
+```
+
+## How to get the source arguments
+
+Visit the [Banyule City Council bin collection services](https://www.banyule.vic.gov.au/Waste-environment/Waste-recycling/Bin-collection-services) page and search for your address. The ```street_address``` argument should exactly match the street address shown in the autocomplete result. For unlisted addresses use an adjacent listed address.
+
+The ```geolocation_id``` argument can be used to bypass the initial address lookup on first use. This value can be discovered using the developer console in any modern browser and inspecting the request sent once an address is selected and the search button is clicked. The request URL takes the format: ```https://www.banyule.vic.gov.au/ocapi/Public/myarea/wasteservices?geolocationid=<GEOLOCATION ID>&ocsvclang=en-AU```.

--- a/info.md
+++ b/info.md
@@ -40,6 +40,7 @@ Currently the following service providers are supported:
 
 ### Australia
 
+- [Banyule City Council](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/banyule_vic_gov_au.md)
 - [Brisbane City Council](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/brisbane_qld_gov_au.md)
 - [North Adelaide Waste Management Authority, South Australia](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/nawma_sa_gov_au.md)
 - [The Hills Council, Sydney](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/thehills_nsw_gov_au.md)


### PR DESCRIPTION
Adds a source for Banyule City Council, covering an area of North-East Melbourne, Australia.

Based quite heavily upon the implementation for Stonnington Council in #101; they use almost identical mechanisms for fetching upcoming dates. Only major change is a mechanism to bypass one of the lookups.