### PR TITLE
add source for mrsc.vic.gov.au

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Currently the following service providers are supported:
 - [Brisbane City Council](./doc/source/brisbane_qld_gov_au.md)
 - [North Adelaide Waste Management Authority, South Australia](./doc/source/nawma_sa_gov_au.md)
 - [The Hills Council, Sydney](./doc/source/thehills_nsw_gov_au.md)
+- [Macedon Ranges Shire Council, Melbourne](./doc/source/mrsc_vic_gov_au.md)
 - [Stonnington City Council, Melbourne](./doc/source/stonnington_vic_gov_au.md)
 
 ### Belgium

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mrsc_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mrsc_vic_gov_au.py
@@ -1,0 +1,81 @@
+import logging
+from datetime import datetime
+import re
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+TITLE = "Macedon Ranges Shire Council"
+DESCRIPTION = "Source for Macedon Ranges Shire Council rubbish collection."
+URL = "https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days"
+TEST_CASES = {
+    "Macedon IGA": {"street_address": "20 Victoria Street, Macedon"},
+    "ALDI Gisborne": {"street_address": "45 Aitken Street, Gisborne"},
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+ICON_MAP = {
+    "FOGO bin": "mdi:leaf",
+    "Recycling bin": "mdi:recycle",
+    "Glass-only bin": "mdi:glass-fragile",
+}
+
+
+class Source:
+    def __init__(self, street_address):
+        self._street_address = street_address
+
+    def fetch(self):
+        session = requests.Session()
+
+        response = session.get(
+            "https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days"
+        )
+        response.raise_for_status()
+
+        response = session.get(
+            "https://www.mrsc.vic.gov.au/api/v1/myarea/search",
+            params={"keywords": self._street_address},
+        )
+        response.raise_for_status()
+        addressSearchApiResults = response.json()
+        if (
+            addressSearchApiResults["Items"] is None
+            or len(addressSearchApiResults["Items"]) < 1
+        ):
+            _LOGGER.error(
+                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days"
+            )
+            return []
+
+        addressSearchTopHit = addressSearchApiResults["Items"][0]
+        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
+
+        geolocationid = addressSearchTopHit["Id"]
+        _LOGGER.debug("Geolocationid: %s", geolocationid)
+
+        response = session.get(
+            "https://www.mrsc.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
+            params={"geolocationid": geolocationid},
+        )
+        response.raise_for_status()
+
+        wasteApiResult = response.json()
+        _LOGGER.debug("Waste API result: %s", wasteApiResult)
+
+        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
+
+        entries = []
+        for article in soup.find_all("article"):
+            waste_type = article.h3.string
+            icon = ICON_MAP.get(waste_type, "mdi:trash-can")
+            next_pickup = article.find(class_="next-service").string.strip()
+            if re.match("[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
+                next_pickup_date = datetime.strptime(
+                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
+                ).date()
+                entries.append(Collection(date=next_pickup_date, t=waste_type, icon=icon))
+
+        return entries

--- a/doc/source/mrsc_vic_gov_au.md
+++ b/doc/source/mrsc_vic_gov_au.md
@@ -1,0 +1,32 @@
+# Macedon Ranges Shire Council
+
+Support for schedules provided by [Macedon Ranges Shire Council](https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mrsc_vic_gov_au
+      args:
+        street_address: STREET_ADDRESS
+```
+
+### Configuration Variables
+
+**street_address**<br>
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mrsc_vic_gov_au
+      args:
+        street_address: 45 Aitken Street, Gisborne
+```
+
+## How to get the source arguments
+
+Visit the [Macedon Ranges Shire Council waste and recycling](https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days) page and search for your address. The arguments should exactly match the street address shown in the autocomplete result.

--- a/info.md
+++ b/info.md
@@ -43,6 +43,7 @@ Currently the following service providers are supported:
 - [Brisbane City Council](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/brisbane_qld_gov_au.md)
 - [North Adelaide Waste Management Authority, South Australia](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/nawma_sa_gov_au.md)
 - [The Hills Council, Sydney](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/thehills_nsw_gov_au.md)
+- [Macedon Ranges Shire Council, Melbourne](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/mrsc_vic_gov_au.md)
 - [Stonnington City Council, Melbourne](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/stonnington_vic_gov_au.md)
 
 ### Belgium


### PR DESCRIPTION
Fixes #159 

This new provider is based on the [existing provider for Stonnington City Council](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/waste_collection_schedule/source/stonnington_vic_gov_au.py) as it looks like both councils are using the same publishing software, albeit with their own instances deployed.