### PR TITLE
Add support for fetching data from umweltprofis.at

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/data_umweltprofis_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/data_umweltprofis_at.py
@@ -1,0 +1,34 @@
+import logging
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "UMWELTPROFIS"
+DESCRIPTION = "Source for Umweltprofis"
+URL = "https://www.umweltprofis.at"
+TEST_CASES = {
+    "Ebensee": {"url": "https://data.umweltprofis.at/OpenData/AppointmentService/AppointmentService.asmx/GetIcalWastePickupCalendar?key=KXX_K0bIXDdk0NrTkk3xWqLM9-bsNgIVBE6FMXDObTqxmp9S39nIqwhf9LTIAX9shrlpfCYU7TG_8pS9NjkAJnM_ruQ1SYm3V9YXVRfLRws1"},
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Source:
+    def __init__(self, url):
+        self._url = url
+        self._ics = ICS()
+
+    def fetch(self):
+        r = requests.get(self._url)
+        if r.status_code != 200:
+            _LOGGER.error("Error querying calendar data")
+            return []
+
+        fixed_text = r.text.replace("REFRESH - INTERVAL; VALUE = ", "REFRESH-INTERVAL;VALUE=")
+
+        dates = self._ics.convert(fixed_text)
+
+        entries = []
+        for d in dates:
+            entries.append(Collection(d[0], d[1]))
+        return entries

--- a/doc/source/data_umweltprofis_at.md
+++ b/doc/source/data_umweltprofis_at.md
@@ -1,0 +1,33 @@
+# Umweltprofis.at
+
+Support for schedules provided by [Umweltprofis.at](https://www.umweltprofis.at). 
+
+## Prerequisites
+
+You need to generate your personal iCal Link before you can start using this source. Go to [https://data.umweltprofis.at/opendata/AppointmentService/index.aspx](https://data.umweltprofis.at/opendata/AppointmentService/index.aspx) and fill out the form. At the end, you can generate an iCal link. Copy this link and paste it to configuration.yaml as seen below.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: data_umweltprofis_at
+      args:
+        url: https://data.umweltprofis.at/OpenData/AppointmentService/AppointmentService.asmx/GetIcalWastePickupCalendar?key=xxx
+      customize:
+        - type: "Abholung: Hausabfall"
+          alias: Restmüll
+        - type: "Abholung: Gelbe Tonne"
+          alias: Gelbe Tonne
+        - type: "Abholung: Papiertonne"
+          alias: Papier
+        - type: "Abholung: Biotonne"
+          alias: Biotonne
+          show: false
+```
+
+### Configuration Variables
+
+**url**<br>
+*(url) (required)*
+


### PR DESCRIPTION
As mentioned in #167, the ICS file provided by data.umweltprofis.at needs a fix-up in order to be parsed correctly.