### PR TITLE
skip ssl check for berlin_recycling_de

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berlin_recycling_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berlin_recycling_de.py
@@ -45,7 +45,7 @@ class Source:
         session = requests.session()
 
         # first get returns session specific url
-        r = session.get(SERVICE_URL, allow_redirects=False)
+        r = session.get(SERVICE_URL, allow_redirects=False, verify=False)
 
         # get session id's
         r = session.get(r.url)


### PR DESCRIPTION
Berlin Recycling is currently broken and fails with an SSLCertVerificationError:

Seems the reason is https://kundenportal.berlin-recycling.de has a misconfigured HTTPS server which is not sending the intermediate certificate (Starfield Secure Certificate Authority - G2). Unlike browsers, python does not support automatic fetching of missing intermediates.

fix #186 