### PR TITLE
Update brisbane_qld_gov_au.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/brisbane_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/brisbane_qld_gov_au.py
@@ -103,23 +103,25 @@ class Source:
             if "start" in item:
                 collection_date = date.fromisoformat(item["start"])
                 if (collection_date - today).days >= 0:
-                    # Every collection day includes rubbish
-                    entries.append(
-                        Collection(
-                            date=collection_date, t="Rubbish", icon="mdi:trash-can"
-                        )
-                    )
-                    if item["event_type"] == "recycle":
+                    # Only consider recycle and organic events
+                    if item["event_type"] in ["recycle","organic"]:
+                        # Every collection day includes rubbish
                         entries.append(
                             Collection(
-                                date=collection_date, t="Recycling", icon="mdi:recycle"
+                                date=collection_date, t="Rubbish", icon="mdi:trash-can"
                             )
                         )
-                    if item["event_type"] == "organic":
-                        entries.append(
-                            Collection(
-                                date=collection_date, t="Garden", icon="mdi:leaf"
+                        if item["event_type"] == "recycle":
+                            entries.append(
+                                Collection(
+                                    date=collection_date, t="Recycling", icon="mdi:recycle"
+                                )
                             )
-                        )
+                        if item["event_type"] == "organic":
+                            entries.append(
+                                Collection(
+                                    date=collection_date, t="Garden", icon="mdi:leaf"
+                                )
+                            )
 
         return entries


### PR DESCRIPTION
New event types have started being used, so this update makes sure to only consider recycle and organic events and ignore others (eg special information events).