### PR TITLE
Add new ICS source Gemeinde Zorneding

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ The collection schedule will be automatically integrated into the Home Assistant
 Currently the following service providers are supported:
 
 - [Generic ICS / iCal File](./doc/source/ics.md)
+  * [Limburg.net](./doc/source/ics.md#belgium)
+  * [Müllabfuhr-Deutschland](./doc/source/ics.md#Germany)
+  * [Abfallwirtschaftsamt Bodenseekreis](./doc/source/ics.md#Baden-Württemberg)
+  * [Abfallwirtschaft Kreis Böblingen](./doc/source/ics.md#Baden-Württemberg)
+  * [Abfall Landkreis Stade](./doc/source/ics.md#Baden-Württemberg)
+  * [AVL Ludwigsburg](./doc/source/ics.md#Baden-Württemberg)
+  * [AWB Esslingen](./doc/source/ics.md#Baden-Württemberg)
+  * [AWM München](./doc/source/ics.md#Bayern)
+  * [Awista Starnberg](./doc/source/ics.md#Bayern)
+  * [Gemeinde Zorneding](./doc/source/ics.md#Bayern)
+  * [Erlensee](./doc/source/ics.md#Hessen)
+  * [EAW Rheingau Taunus](./doc/source/ics.md#Hessen)
+  * [Abfallkalender Zollernalbkreis](./doc/source/ics.md#Niedersachsen)
+  * [EDG Entsorgung Dortmund](./doc/source/ics.md#Nordrhein-Westfalen)
+  * [Zweckverband Abfallwirtschaft A.R.T. Trier](./doc/source/ics.md#Rheinland-Pfalz)
+  * [ASR Chemnitz](./doc/source/ics.md#Sachsen)
+  * [Stadtreinigung Leipzig](./doc/source/ics.md#Sachsen)
+  * [Entsorgungsgesellschaft Görlitz-Löbau-Zittau](./doc/source/ics.md#Sachsen)
+  * [NSR Nordvästra Skåne](./doc/source/ics.md#Sweden)
+  * [ReCollect.net](./doc/source/ics.md#United-States-of-America)
+  * [Western Disposal Residential (Colorado)](./doc/source/ics.md#United-States-of-America)
+  * [South Cambridgeshire](./doc/source/ics.md#United-Kingdom)
 
 ### Australia
 

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -24,6 +24,7 @@ This source has been successfully tested with the following service providers:
 
 - [AWM München](https://www.awm-muenchen.de) ([Notes](#awm-münchen))
 - [Awista Starnberg](https://www.awista-starnberg.de/)
+- [Gemeinde Zorneding](https://www.zorneding.de/Wohnen-Leben/Abfall-Energie-Wasser/M%C3%BCllkalender/index.php) ([Notes](#gemeinde-zorneding))
 
 #### Hessen
 
@@ -264,6 +265,69 @@ waste_collection_schedule:
           icon: mdi:trash-can-outline
         - type: Gelber Sack
           icon: mdi:recycle
+```
+
+### Gemeinde Zorneding
+
+Go to the [service provider website](https://www.zorneding.de/Wohnen-Leben/Abfall-Energie-Wasser/M%C3%BCllkalender/index.php) and select location and desired waste types. Afterwards an iCal calender export is provided. Simply click on download and visit the Download URL afterwards. Simply take this URL and use this URL within the configuration.
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ics
+      args:
+        url: https://www.zorneding.de/output/options.php?ModID=48&call=ical&&pois=3094.81&alarm=13
+      customize:
+        - type: Restabfall
+          alias: Restmüll
+          icon: mdi:trash-can
+        - type: BIO
+          alias: Bioabfall
+          icon: mdi:flower-outline
+        - type: Altpapier
+          alias: Papierabfall
+          icon: mdi:trash-can-outline
+        - type: Gelber Sack
+          icon: mdi:recycle
+
+sensor:
+  - platform: waste_collection_schedule
+    name: Restmüll
+    details_format: upcoming
+    count: 4
+    value_template: '{% if value.daysTo == 0 %}Heute{% elif value.daysTo == 1 %}Morgen{% else %}in {{value.daysTo}} Tagen{% endif %}'
+    date_template: '{{value.date.strftime("%d.%m.%Y")}}'
+    types:
+      - 'Restabfall'
+      - 'Restmüll'
+
+  - platform: waste_collection_schedule
+    name: Altpapier
+    details_format: upcoming
+    count: 4
+    value_template: '{% if value.daysTo == 0 %}Heute{% elif value.daysTo == 1 %}Morgen{% else %}in {{value.daysTo}} Tagen{% endif %}'
+    date_template: '{{value.date.strftime("%d.%m.%Y")}}'
+    types:
+      - 'Altpapier'
+
+  - platform: waste_collection_schedule
+    name: Gelber_Sack
+    details_format: upcoming
+    count: 4
+    value_template: '{% if value.daysTo == 0 %}Heute{% elif value.daysTo == 1 %}Morgen{% else %}in {{value.daysTo}} Tagen{% endif %}'
+    date_template: '{{value.date.strftime("%d.%m.%Y")}}'
+    types:
+      - 'Gelber Sack'
+
+  - platform: waste_collection_schedule
+    name: Bioabfall
+    details_format: upcoming
+    count: 4
+    value_template: '{% if value.daysTo == 0 %}Heute{% elif value.daysTo == 1 %}Morgen{% else %}in {{value.daysTo}} Tagen{% endif %}'
+    date_template: '{{value.date.strftime("%d.%m.%Y")}}'
+    types:
+      - 'BIO'
+      - 'Bioabfall'
 ```
 
 ### Abfallkalender Zollernalbkreis

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -309,6 +309,7 @@ sensor:
     date_template: '{{value.date.strftime("%d.%m.%Y")}}'
     types:
       - 'Altpapier'
+      - 'Papierabfall'
 
   - platform: waste_collection_schedule
     name: Gelber_Sack


### PR DESCRIPTION
I was looking everywhere to see my local waste collection in HA, thanks to your ICal variant I can give support for "Gemeinde Zorneding" and confirm its working.

Also to decrease searching for new users if their collection is supported via ICS/iCal I recommend adding a short list about all ICS/Ical supported variants on the main readme (done with this pull request).


Thank you for your great addon!