### PR TITLE
Add source for Cochem-Zell

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Currently the following service providers are supported:
 - [Berlin-Recycling.de](./doc/source/berlin_recycling_de.md)
 - [BSR.de / Berliner Stadtreinigungsbetriebe](./doc/source/bsr_de.md)
 - [C-Trace.de](./doc/source/c_trace_de.md)
+- [Cochem-Zell](./doc/source/cochem_zell_online_de.md)
 - [EGN-Abfallkalender.de](./doc/source/egn_abfallkalender_de.md)
 - [Jumomind.de](./doc/source/jumomind_de.md)
 - [KWB-Goslar.de](./doc/source/kwb_goslar_de.md)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cochem_zell_online_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cochem_zell_online_de.py
@@ -1,0 +1,69 @@
+import contextlib
+from datetime import datetime
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Abfall Cochem-Zell"
+DESCRIPTION = "Source for waste collection in district Cochem-Zell."
+URL = "https://www.cochem-zell-online.de/abfallkalender/"
+TEST_CASES = {
+    "Alf": {"district": "Alf"},
+    "Bullay": {"district": "Bullay"},
+    "Zell-Stadt": {"district": "Zell-Stadt"},
+    "Pünderich": {"district": "Pünderich"},
+}
+
+API_URL = "https://abfallkalender10.app.moba.de/Cochem_Zell/api"
+REMINDER_DAY = 0  # The calendar event should be on the same day as the waste collection
+REMINDER_HOUR = 6  # The calendar event should start on any hour of the correct day, so this does not matter much
+FILENAME = "Abfallkalender.ics"
+ICON_MAP = {
+    "Biotonne": "mdi:leaf",
+    "Gruengut": "mdi:forest",
+    "Papierabfall": "mdi:package-variant",
+    "Restmülltonne": "mdi:trash-can",
+    "Umweltmobil": "mdi:truck",
+    "Verpackungsabfall": "mdi:recycle",
+}
+
+
+class Source:
+    def __init__(self, district: str):
+        self._district = district
+        self._ics = ICS()
+
+    def fetch(self):
+        now = datetime.now()
+        entries = self._fetch_year(now.year)
+
+        if now.month == 12:
+            # also get data for next year if we are already in december
+            with contextlib.suppress(Exception):
+                entries.extend(self._fetch_year(now.year + 1))
+
+        return entries
+
+    def _fetch_year(self, year: int):
+        url = "/".join(
+            str(param)
+            for param in (
+                API_URL,
+                self._district,
+                year,
+                REMINDER_DAY,
+                REMINDER_HOUR,
+                FILENAME,
+            )
+        )
+
+        r = requests.get(url)
+        schedule = self._ics.convert(r.text)
+
+        return [
+            Collection(
+                date=entry[0], t=entry[1], icon=ICON_MAP.get(entry[1], "mdi:trash-can")
+            )
+            for entry in schedule
+        ]

--- a/doc/source/cochem_zell_online_de.md
+++ b/doc/source/cochem_zell_online_de.md
@@ -1,0 +1,34 @@
+# Cochem-Zell
+
+Support for schedules provided by <https://www.cochem-zell-online.de/abfallkalender/>.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cochem_zell_online_de
+      args:
+        district: DISTRICT
+```
+
+### Configuration Variables
+
+**district**<br>
+_(string) (required)_
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cochem_zell_online_de
+      args:
+        district: "Zell-Stadt"
+```
+
+## How to get the source arguments
+
+1. Open <https://www.cochem-zell-online.de/abfallkalender/>.
+2. Click on the selection field named `Ortsteil`.
+3. Enter the name _with correct capitalization_ in the argument `district`.

--- a/info.md
+++ b/info.md
@@ -82,6 +82,7 @@ Currently the following service providers are supported:
 - [Berlin-Recycling.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/berlin_recycling_de.md)
 - [BSR.de / Berliner Stadtreinigungsbetriebe](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/bsr_de.md)
 - [C-Trace.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/c_trace_de.md)
+- [Cochem-Zell](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/cochem_zell_online_de.md)
 - [EGN-Abfallkalender.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/egn_abfallkalender_de.md)
 - [Jumomind.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/jumomind_de.md)
 - [KWB-Goslar.de](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/kwb_goslar_de.md)


### PR DESCRIPTION
Add a new source for "Landkreis Cochem-Zell" based on their ICS calendar feed.