### PR TITLE
Add types to ICS parser and check for None values

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import re
+from typing import Any, List, Optional, Tuple
 
 from icalevents import icalevents
 
@@ -8,14 +9,23 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class ICS:
-    def __init__(self, offset=None, regex=None, split_at=None):
+    def __init__(
+        self,
+        offset: Optional[int] = None,
+        regex: Optional[str] = None,
+        split_at: Optional[str] = None,
+    ):
         self._offset = offset
         self._regex = None
+        self._split_at = None
+
         if regex is not None:
             self._regex = re.compile(regex)
-        self._split_at = split_at
 
-    def convert(self, ics_data):
+        if split_at is not None:
+            self._split_at = re.compile(split_at)
+
+    def convert(self, ics_data: str) -> List[Tuple[datetime.date, str]]:
         # calculate start- and end-date for recurring events
         start_date = datetime.datetime.now().replace(
             hour=0, minute=0, second=0, microsecond=0
@@ -25,33 +35,37 @@ class ICS:
         end_date = start_date.replace(year=start_date.year + 1)
 
         # parse ics data
-        events = icalevents.events(
+        events: List[Any] = icalevents.events(
             start=start_date, end=end_date, string_content=ics_data.encode()
         )
 
-        entries = []
+        entries: List[Tuple[datetime.date, str]] = []
+
         for e in events:
             # calculate date
-            dtstart = None
-            if type(e.start) == datetime.date:
-                dtstart = e.start
-            elif type(e.start) == datetime.datetime:
+            dtstart: Optional[datetime.date] = None
+
+            if isinstance(e.start, datetime.datetime):
                 dtstart = e.start.date()
-            if self._offset is not None:
-                dtstart += datetime.timedelta(days=self._offset)
+            elif isinstance(e.start, datetime.date):
+                dtstart = e.start
 
-            # calculate waste type
-            summary = str(e.summary)
-            if self._regex is not None:
-                match = self._regex.match(summary)
-                if match:
-                    summary = match.group(1)
+            # Only continue if a start date can be found in the entry
+            if dtstart is not None:
+                if self._offset is not None:
+                    dtstart += datetime.timedelta(days=self._offset)
 
-            if self._split_at is not None:
-                summary = re.split(self._split_at, summary)
-                for t in summary:
-                    entries.append((dtstart, t.strip().title()))
-            else:
-                entries.append((dtstart, summary))
+                # calculate waste type
+                summary = str(e.summary)
+
+                if self._regex is not None:
+                    if match := self._regex.match(summary):
+                        summary = match.group(1)
+
+                if self._split_at is not None:
+                    summary = re.split(self._split_at, summary)
+                    entries.extend((dtstart, t.strip().title()) for t in summary)
+                else:
+                    entries.append((dtstart, summary))
 
         return entries


### PR DESCRIPTION
During development of #289, I noticed that the `ICS` class currently has no type annotations. I made the following changes:

- To make it easier in the future to create new ICS-based sources, I added the correct types to the class.
- As a result of this, I was warned by VSCode that the value `dtstart` may be None. Thus, I added corresponding checks and made sure that only entries with a valid start date are returned by the `convert` function.
- I replaced the conditions of `type(e.start)` with corresponding `isinstance(e.start, ...)` calls to enable type inference in modern IDEs. Due to that, I had to change the order of the conditions because `datetime.datetime` inherits from `datetime.date`.
- `split_at` and `regex` were handled differently despite both representing a regular expression pattern. Thus, both are compiled to such a pattern in the init function.