### PR TITLE
Added static source

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The collection schedule will be automatically integrated into the Home Assistant
 Currently the following service providers are supported:
 
 - [Generic ICS / iCal File](./doc/source/ics.md)
+- [Static source](./doc/source/static.md)
 
 ### Australia
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
@@ -1,0 +1,79 @@
+from dateutil.rrule import rrule
+import datetime
+from dateutil import parser
+
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+TITLE = "Static Source"
+DESCRIPTION = "Source for static waste collection schedules."
+URL = None
+TEST_CASES = {
+    "Dates only": {"type": "Dates only", "dates": {"2022-01-01", "2022-02-28"}},
+    "Same date twice": {"type": "Dates only", "dates": {"2022-01-01", "2022-01-01"}},
+    "Recurrence only": {
+        "type": "Recurrence only",
+        "frequency": "MONTHLY",
+        "interval": 1,
+        "start": "2022-01-01",
+        "until": "2022-12-31",
+    },
+    "Recurrence with exception": {
+        "type": "Recurrence with exception",
+        "frequency": "MONTHLY",
+        "interval": 1,
+        "start": "2022-01-01",
+        "until": "2022-12-31",
+        "excludes": {"2022-01-01"},
+        "dates": {"2022-01-02"},
+    },
+}
+
+FREQNAMES = ["YEARLY", "MONTHLY", "WEEKLY", "DAILY"]
+
+
+class Source:
+    def __init__(
+        self,
+        type: str,
+        dates: list[str] = None,
+        frequency: str = None,
+        interval: int = 1,
+        start: datetime.date = None,
+        until: datetime.date = None,
+        excludes: list[str] = None,
+    ):
+        self._type = type
+        self._dates = [parser.isoparse(d).date() for d in dates or []]
+
+        self._recurrence = FREQNAMES.index(frequency) if frequency is not None else None
+        self._interval = interval
+        self._start = parser.isoparse(start).date() if start else None
+        self._until = parser.isoparse(until).date() if until else None
+        self._excludes = [parser.isoparse(d).date() for d in excludes or []]
+
+    def fetch(self):
+        dates = []
+
+        if self._recurrence is not None:
+            ruledates = rrule(
+                freq=self._recurrence,
+                interval=self._interval,
+                dtstart=self._start,
+                until=self._until,
+            )
+
+            for ruleentry in ruledates:
+                date = ruleentry.date()
+
+                if self._excludes is not None and date in self._excludes:
+                    continue
+
+                dates.append(date)
+
+        if self._dates is not None:
+            dates.extend(self._dates)
+
+        dates.sort()
+
+        entries = [Collection(date, self._type) for date in set(dates)]
+        return entries

--- a/doc/source/static.md
+++ b/doc/source/static.md
@@ -1,0 +1,83 @@
+# Static Source
+
+Support for schedules with static dates or recurrences.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: static
+      args:
+        type: TYPE
+        dates: DATES
+        frequency: FREQUENCY
+        interval: INTERVAL
+        start: START
+        until: UNTIL
+        excludes: EXCLUDES
+```
+
+### Configuration Variables
+
+**TYPE**<br>
+*(string) (required)*
+
+The type of this source.
+
+**DATES**<br>
+*(list) (optional)*
+
+A list of dates in format "YYYY-MM-DD" which should be added to the source.
+Dates defined in this list will be added in addition to calculated dates from the recurrence and will not be affected by the exclude-list.
+
+**FREQUENCY**<br>
+*(string) (optional)*
+
+Defines the frequency of the recurrence. Must be one of "DAILY", "WEEKLY", "MONTHLY" or "YEARLY".
+
+**INTERVAL**<br>
+*(int) (optional, default: ```1```)*
+
+Defines the interval of the recurrence.
+
+**START**<br>
+*(string) (optional)*
+
+Defines the start of the recurrence in the format "YYYY-MM-DD".
+Required if *FREQUENCY* is set.
+
+**UNTIL**<br>
+*(string) (optional)*
+
+Defines the end of the recurrence in the format "YYYY-MM-DD".
+Required if *FREQUENCY* is set.
+
+**EXCLUDES**<br>
+*(list) (optional)*
+
+A list of dates in format "YYYY-MM-DD" which should be excluded from the recurrence.
+
+## Example
+
+This example defines a schedule, every 4 weeks starting on Friday, January 14, 2022 until the end of the year.
+Two days are removed from the schedule and two days are added instead, which are outside of the recurrence.
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: static
+      calendar_title: Altpapier
+      args:
+        type: Altpapier
+        frequency: WEEKLY
+        interval: 4
+        start: '2022-01-14'
+        until: '2022-12-31'
+        excludes: # Add exception for the recurrence
+          - '2022-07-29'
+          - '2022-09-23'
+        dates: # Manually define dates that are not part of the recurrence
+          - '2022-07-28'
+          - '2022-09-22'
+```


### PR DESCRIPTION
The static source allows to define static dates or a recurrence.
This is useful if the service provider does not offer an API, nor an ICS file.
It can also simplify the testing of automations by, for example, configuring a daily recurrence.