### PR TITLE
Update RepublicServices.com with Yard Waste Marker

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -38,9 +38,13 @@ class Source:
             if hasattr(r_json[x], "__iter__"):
                 for item in r_json[x]:
                     waste_type = item["wasteTypeDescription"]
+                    container_type = item["containerType"]
                     icon = "mdi:trash-can"
                     if waste_type == "Recycle":
                         icon = "mdi:recycle"
+                        if container_type == "YC":
+                            waste_type = "Yard Waste"
+                            icon = "mdi:sprout"
                     for day in item["nextServiceDays"]:
                         next_pickup = day
                         next_pickup_date = datetime.fromisoformat(next_pickup).date()


### PR DESCRIPTION
Was showing Recycling for Yard Waste because the 'wasteTypeDescription' is set to 'Recycle' for both types in the data. Used 'containerType' to identify Yard Waste.

Snip of Example Data:
 ``` 
"containerId": "41357515",
"containerType": "YC",
"containerSize": "0.30",
"containerStatus": "Open",
"containerCategory": "Residential",
"customerOwnedInd": false,
"productDescription": "YARD WASTE CART 60 GAL",
"onCallInd": false,
"serviceStartDate": "2019-03-16",
"serviceChangeLastDate": "2019-03-16",
"quantityOnSite": 1,
"quantityOrdered": 1,
"wasteTypeDescription": "Recycle",
```