### PR TITLE
Missing richmondshire_gov_uk info added

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Currently the following service providers are supported:
 - [North Somerset Council - n-somerset.gov.uk](./doc/source/nsomerset_gov_uk.md)
 - [Nottingham City Council - nottinghamcity.gov.uk](./doc/source/nottingham_city_gov_uk.md)
 - [Peterborough City Council - peterborough.gov.uk](./doc/source/peterborough_gov_uk.md)
+- [Richmondshire District Council - richmondshire.gov.uk](./doc/source/richmondshire_gov_uk.md)
 - [South Cambridgeshire District Council - scambs.gov.uk](./doc/source/scambs_gov_uk.md)
 - [South Norfolk and Broadland Council - southnorfolkandbroadland.gov.uk](./doc/source/south_norfolk_and_broadland_gov_uk.md)
 - [Stevenage Borough Council - stevenage.gov.uk](./doc/source/stevenage_gov_uk.md)

--- a/doc/source/richmondshire_gov_uk.md
+++ b/doc/source/richmondshire_gov_uk.md
@@ -1,0 +1,33 @@
+# Richmondshire District Council
+
+Support for schedules provided by [Richmondshire District Council](https://www.richmondshire.gov.uk/bins-and-recycling/), serving North Yorkshire, UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: richmondshire_gov_uk
+      args:
+        uprn: UNIQUE_PROPERTY_IDENTIFICATION_NUMBER
+
+```
+
+### Configuration Variables
+
+**UPRN**<br>
+*(integer) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: richmondshire_gov_uk
+      args:
+        uprn: 200001767082
+```
+
+## How to find your `UPRN`
+
+An easy way to find your Unique Property Reference Number (UPRN) is by going to https://www.findmyaddress.co.uk/ and entering in your address details. Or you can visit the Richmondshire page and use the address search. Right-click your entry in the house dropdown, choose Inspect, and copy the UPRN from the value

--- a/info.md
+++ b/info.md
@@ -162,6 +162,7 @@ Currently the following service providers are supported:
 - [North Somerset Council - n-somerset.gov.uk](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/nsomerset_gov_uk.md)
 - [Nottingham City Council - nottinghamcity.gov.uk](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/nottingham_city_gov_uk.md)
 - [Peterborough City Council - peterborough.gov.uk](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/peterborough_gov_uk.md)
+- [Richmondshire District Council - richmondshire.gov.uk](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/richmondshire_gov_uk.md)
 - [Rushmoor Borough Council - rushmoor.gov.uk](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rushmoor_gov_uk.md)
 - [South Cambridgeshire District Council - scambs.gov.uk](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/scambs_gov_uk.md)
 - [South Norfolk and Broadland Council - southnorfolkandbroadland.gov.uk](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/south_norfolk_and_broadland_gov_uk.md)


### PR DESCRIPTION
I'm sure there's a better way of doing this, but here's the missing info for richmondshire_gov_uk:

- README.md
- info.md
- richmondshire_gov_uk.md

These, and the `richmondshire_gov_uk.py` file in #362, should complete that source request.