### PR TITLE
fix: Wiltshire source black box collection day

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wiltshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wiltshire_gov_uk.py
@@ -14,7 +14,9 @@ SEARCH_URLS = {
     "collection_search": "https://ilforms.wiltshire.gov.uk/wastecollectiondays/collectionlist"
 }
 COLLECTIONS = {"Household waste",
-               "Mixed dry recycling (blue lidded bin)"}
+               "Mixed dry recycling (blue lidded bin)", # some addresses may not have a black box collection
+               "Mixed dry recycling (blue lidded bin) and glass (black box or basket)"
+               }
 
 
 class Source:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ icalevents==0.1.25
 recurring_ical_events==1.0.2b0
 requests==2.28.1
 urllib3==1.26.12
+PyYAML==6.0


### PR DESCRIPTION
- Fix addresses which have a black box glass collection.
- Add missing `pyyaml` dependency.

Test:
```
…/hacs_waste_collection_schedule ❯ custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s wiltshire_gov_uk -l
Testing source wiltshire_gov_uk ...
  found 4 entries for house_uprn
    2022-10-06: Mixed dry recycling (blue lidded bin) and glass (black box or basket)
    2022-10-20: Mixed dry recycling (blue lidded bin) and glass (black box or basket)
    2022-10-14: Household waste
    2022-10-28: Household waste
```

Signed-off-by: Russell Hall <owner@russellhall.co.uk>