### PR TITLE
Expanded search to cover next month and added garden waste as collection type

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wiltshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wiltshire_gov_uk.py
@@ -1,6 +1,6 @@
 import requests
 
-from datetime import datetime
+from datetime import datetime, date, timedelta
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection
 
@@ -15,7 +15,8 @@ SEARCH_URLS = {
 }
 COLLECTIONS = {"Household waste",
                "Mixed dry recycling (blue lidded bin)", # some addresses may not have a black box collection
-               "Mixed dry recycling (blue lidded bin) and glass (black box or basket)"
+               "Mixed dry recycling (blue lidded bin) and glass (black box or basket)",
+               "Chargeable garden waste" # some addresses also have a chargeable garden waste collection
                }
 
 
@@ -48,5 +49,30 @@ class Source:
                         collection,
                     )
                 )
+
+        # If current date is within 14 days of month end, also retrieve next month's dates
+        futuredate = date.today() + timedelta(days=14)
+        if futuredate.month != date.today().month:
+            args = {
+                "Postcode": self._postcode,
+                "Uprn": self._uprn,
+                "Month": futuredate.month,
+                "Year": futuredate.year
+            }
+            r = session.post(SEARCH_URLS["collection_search"], params=args)
+            r.raise_for_status()
+            soup = BeautifulSoup(r.text, 'html.parser')
+            for collection in COLLECTIONS:
+                for tag in soup.find_all(
+                        attrs={"data-original-title": collection}
+                ):
+
+                    entries.append(
+                        Collection(
+                            datetime.strptime(
+                                tag['data-original-datetext'], "%A %d %B, %Y").date(),
+                            collection,
+                        )
+                    )
 
         return entries


### PR DESCRIPTION
Currently the source only returns collections for the current month. This fix adds collections for the next month when the current date is within 14 days of the month end.  This is done by utilising a couple of optional parameters in the API (specifying the month and year required).

Also adds the chargeable garden waste collection which is available for some properties.