### PR TITLE
RecycleSmart: fix typo in docs

### DIFF
--- a/doc/source/recyclesmart_com.md
+++ b/doc/source/recyclesmart_com.md
@@ -15,7 +15,7 @@ waste_collection_schedule:
 
 ### Configuration Variables
 
-**username**<br>
+**email**<br>
 *(string) (required)*
 
 **password**<br>


### PR DESCRIPTION
should be `email`