### PR TITLE
fix global calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Create a dedicated calendar for this type.
 
 *(string) (optional, default: ```None```)*
 
-Optional title of the dedicated calendar. If not set, the default of the source will be used.
+Optional title of the dedicated calendar. If not set, the waste type will be used.
 
 ## 2. Add sensor(s) to a source
 
@@ -685,6 +685,14 @@ type: 'custom:garbage-collection-card'
 Prerequisites: You already have dedicated sensors per waste type and want to show the sensor with the next collection in a Lovelace card.
 
 Add `add_days_to: True` to the configuration of all sensors you want to sort. This will add the attribute `daysTo` which can be used by e.g. [auto-entities](https://github.com/thomasloven/lovelace-auto-entities) to sort entities by day of next collection.
+
+### 14. How can I disable the calendar?
+
+If you don't like the calendar provided by Waste Collection Schedule or you have configured some dedicated calendars per waste type and therefore don't need the global calendar any more, you can disable it so that it doesn't show up in the Calendar Dashboard any more:
+
+Go to `Settings` --> `Entities` and select the calendar entity provided by Waste Collection Schedule. Now disable it using the menu items.
+
+[![entities](https://my.home-assistant.io/badges/entities.svg)](https://my.home-assistant.io/redirect/entities/)
 
 ## How to add new sources
 

--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -186,7 +186,7 @@ class ScheduleSensor(SensorEntity):
             return None
 
         upcoming1 = self._scraper.get_upcoming_group_by_day(
-            count=1, types=self._collection_types, include_today=self._include_today,
+            count=1, include_types=self._collection_types, include_today=self._include_today,
         )
 
         self._set_state(upcoming1)
@@ -204,7 +204,7 @@ class ScheduleSensor(SensorEntity):
             upcoming = self._scraper.get_upcoming_group_by_day(
                 count=self._count,
                 leadtime=self._leadtime,
-                types=self._collection_types,
+                include_types=self._collection_types,
                 include_today=self._include_today,
             )
             for collection in upcoming:
@@ -215,7 +215,7 @@ class ScheduleSensor(SensorEntity):
             # show list of collections in details
             for t in collection_types:
                 collections = self._scraper.get_upcoming(
-                    count=1, types=[t], include_today=self._include_today
+                    count=1, include_types=[t], include_today=self._include_today
                 )
                 date = (
                     "" if len(collections) == 0 else self._render_date(collections[0])
@@ -227,7 +227,7 @@ class ScheduleSensor(SensorEntity):
             attributes["upcoming"] = self._scraper.get_upcoming(
                 count=self._count,
                 leadtime=self._leadtime,
-                types=self._collection_types,
+                include_types=self._collection_types,
                 include_today=self._include_today,
             )
             refreshtime = ""


### PR DESCRIPTION
Due to changes for dedicated calendars some time ago, the global calendar went broken. It only showed waste types which appear in the customize list.

This commit recovers the old behaviour. Any waste type that is not displayed in a dedicated calendar is shown in the global calendar again.