### PR TITLE
Add support for ART Trier

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Currently the following service providers are supported:
 - [Abfallwirtschaft Stuttgart](./doc/source/stuttgart_de.md)
 - [Abfallwirtschaft Südholstein](./doc/source/awsh_de.md)
 - [Abfallwirtschaft Zollernalbkreis](./doc/source/abfall_zollernalbkreis_de.md)
+- [ART Trier](./doc/source/art_trier_de.md)
 - [AVL Ludwigsburg](./doc/source/avl_ludwigsburg_de.md)
 - [AWB Bad Kreuznach](./doc/source/awb_bad_kreuznach_de.md)
 - [AWB Esslingen](./doc/source/awb_es_de.md)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/art_trier_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/art_trier_de.py
@@ -1,0 +1,81 @@
+import contextlib
+from datetime import datetime
+from urllib.parse import quote
+from typing import Optional
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Abfall ART Trier"
+DESCRIPTION = "Source for waste collection of ART Trier."
+URL = "https://www.art-trier.de"
+TEST_CASES = {
+    "Trier": {
+        "zip_code": "54296",
+        "district": "Stadt Trier, Universitätsring",
+    },  # # https://www.art-trier.de/ics-feed/54296_trier_universitaetsring_1-1800.ics
+    "Schweich": {
+        "zip_code": "54338",
+        "district": "Schweich (inkl. Issel)",
+    },  # https://www.art-trier.de/ics-feed/54338_schweich_inkl_issel_1-1800.ics
+    "Dreis": {
+        "zip_code": "54518",
+        "district": "Dreis",
+    },  # https://www.art-trier.de/ics-feed/54518_dreis_1-1800.ics
+    "Wittlich Marktplatz": {
+        "zip_code": "54516",
+        "district": "Wittlich, Marktplatz",
+    },  # https://www.art-trier.de/ics-feed/54516_wittlich_marktplatz_1-1800.ics
+    "Wittlich Wengerohr": {
+        "zip_code": "54516",
+        "district": "Wittlich-Wengerohr",
+    },  # https://www.art-trier.de/ics-feed/54516_wittlich%2Dwengerohr_1-1800.ics
+}
+
+API_URL = "https://www.art-trier.de/ics-feed"
+REMINDER_DAY = (
+    "0"  # The calendar event should be on the same day as the waste collection
+)
+REMINDER_TIME = "0600"  # The calendar event should start on any hour of the correct day, so this does not matter much
+ICON_MAP = {
+    "Altpapier": "mdi:package-variant",
+    "Restmüll": "mdi:trash-can",
+    "Gelber Sack": "mdi:recycle",
+}
+SPECIAL_CHARS = {
+    ord("ä"): "ae",
+    ord("ü"): "ue",
+    ord("ö"): "oe",
+    ord("ß"): "ss",
+    ord("("): "",
+    ord(")"): "",
+    ord("."): "",
+}
+
+
+class Source:
+    def __init__(self, district: str, zip_code: str):
+        self._district = quote(
+            district.lower()
+            .removeprefix("stadt ")
+            .replace(" ", "_")
+            .replace(",", "")
+            .translate(SPECIAL_CHARS)
+            .strip()
+        )
+        self._zip_code = zip_code
+        self._ics = ICS(regex=r"^A.R.T. Abfuhrtermin: (.*)", split_at=r" & ")
+
+    def fetch(self):
+        url = f"{API_URL}/{self._zip_code}_{self._district}_{REMINDER_DAY}-{REMINDER_TIME}.ics"
+
+        r = requests.get(url)
+        schedule = self._ics.convert(r.text)
+
+        return [
+            Collection(
+                date=entry[0], t=entry[1], icon=ICON_MAP.get(entry[1], "mdi:trash-can")
+            )
+            for entry in schedule
+        ]

--- a/doc/source/art_trier_de.md
+++ b/doc/source/art_trier_de.md
@@ -1,0 +1,41 @@
+# ART Trier
+
+Support for schedules provided by <https://www.art-trier.de>.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: art_trier_de
+      args:
+        zip_code: ZIP_CODE
+        district: DISTRICT
+```
+
+### Configuration Variables
+
+**district**<br>
+_(string) (required)_
+
+**zip_code**<br>
+_(string) (required)_
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cochem_zell_online_de
+      args:
+        district: "Wittlich, Marktplatz"
+        zip_code: "54516"
+```
+
+## How to get the source arguments
+
+1. Open <https://www.art-trier.de/cms/abfuhrtermine-1002.html>.
+2. Fill out the search field on the right side of the page.
+3. Open one of the matching results (if multiple years are shown, click on either of them, it does not matter).
+4. Copy the _complete_ name of the city on the top left (it may contain a street name or suburbs) and paste it to the field `district`
+5. Enter your ZIP code (Postleitzahl) in the field `zip_code`. This value is also shown next to the district name on the results overview page.

--- a/info.md
+++ b/info.md
@@ -86,6 +86,7 @@ Currently the following service providers are supported:
 - [Abfallwirtschaft Stuttgart](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/stuttgart_de.md)
 - [Abfallwirtschaft Südholstein](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/awsh_de.md)
 - [Abfallwirtschaft Zollernalbkreis](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abfall_zollernalbkreis_de.md)
+- [ART Trier](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/art_trier_de.md)
 - [AVL Ludwigsburg](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/avl_ludwigsburg_de.md)
 - [AWB Bad Kreuznach](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/awb_bad_kreuznach_de.md)
 - [AWB Esslingen](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/awb_es_de.md)


### PR DESCRIPTION
Fixes #383

I added multiple test cases that cover different issues for creating the URL. However, it may be the case that some edge cases are not correctly handled as of now. In the current implementation, an error is thrown if the ICS parser is unable to parse the response.

If desired, I could wrap line 74 with a `try` statement and fail silently. I am not sure how the other sources handle such scenarios (I only dealt with Cochem-Zell so far), but I would tend to keep it this way and throw an error.