### PR TITLE
datetime fix for environmentfirst_co_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/environmentfirst_co_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/environmentfirst_co_uk.py
@@ -96,7 +96,7 @@ class Source:
                     if round_type in i.text.upper():
                         entries.append(
                             Collection(
-                                date = parse(str.split(i.text, ":")[1]),
+                                date = parse(str.split(i.text, ":")[1]).date(),
                                 t = round_type,
                                 icon = ICONS.get(round_type),
                             )


### PR DESCRIPTION
was returning:
```bash
test_sources.py -s environmentfirst_co_uk -i -l
Testing source environmentfirst_co_uk ...
  found 2 entries for houseUPRN
  ERROR: source returns invalid date format (datetime.datetime instead of datetime.date?)
    2022-12-22T00:00:00: RUBBISH [mdi:trash-can]
    2022-12-30T00:00:00: RECYCLING [mdi:recycle]
  found 3 entries for houseNumber
  ERROR: source returns invalid date format (datetime.datetime instead of datetime.date?)
    2023-01-03T00:00:00: RUBBISH [mdi:trash-can]
    2022-12-27T00:00:00: RECYCLING [mdi:recycle]
    2023-01-03T00:00:00: GARDEN WASTE [mdi:leaf]
  found 2 entries for houseName
  ERROR: source returns invalid date format (datetime.datetime instead of datetime.date?)
    2022-12-23T00:00:00: RUBBISH [mdi:trash-can]
    2022-12-28T00:00:00: RECYCLING [mdi:recycle]
```
Now returns:
```bash
test_sources.py -s environmentfirst_co_uk -i -l
Testing source environmentfirst_co_uk ...
  found 2 entries for houseUPRN
    2022-12-22: RUBBISH [mdi:trash-can]
    2022-12-30: RECYCLING [mdi:recycle]
  found 3 entries for houseNumber
    2023-01-03: RUBBISH [mdi:trash-can]
    2022-12-27: RECYCLING [mdi:recycle]
    2023-01-03: GARDEN WASTE [mdi:leaf]
  found 2 entries for houseName
    2022-12-23: RUBBISH [mdi:trash-can]
    2022-12-28: RECYCLING [mdi:recycle]
```