### PR TITLE
image urls changed to absolute references

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,11 +1,11 @@
-<img src="/images/icon.png?raw=true" alt="Waste Collection Schedule logo" title="Waste Collection Schedule" align="right" height="60" />
+<img src="https://raw.githubusercontent.com/mampfes/hacs_waste_collection_schedule/master/images/icon.png?raw=true" alt="Waste Collection Schedule logo" title="Waste Collection Schedule" align="right" height="60" />
 
 # Waste Collection Schedule
-![hacs_badge](https://img.shields.io/badge/HACS-Default-orange) ![hacs installs](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Flauwbier.nl%2Fhacs%2Fwaste_collection_schedule) [![Community Discussion](https://img.shields.io/badge/Home%20Assistant%20Community-Discussion-orange)](https://community.home-assistant.io/t/waste-collection-schedule-framework/186492).
+![hacs_badge](https://img.shields.io/badge/HACS-Default-orange) ![hacs installs](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Flauwbier.nl%2Fhacs%2Fwaste_collection_schedule) [![Community Discussion](https://img.shields.io/badge/Home%20Assistant%20Community-Discussion-orange)](https://community.home-assistant.io/t/waste-collection-schedule-framework/186492)
 
 **A custom component for Home Assistant that retrieves waste collection schedules from a wide range of service providers.**
 
-<img src="/images/wcs_animated.gif?raw=true" alt="Waste Collection Schedule animation" title="Waste Collection Schedule" align="right" height="200" />
+<img src="https://raw.githubusercontent.com/mampfes/hacs_waste_collection_schedule/master/images/wcs_animated.gif" alt="Waste Collection Schedule animation" title="Waste Collection Schedule" align="right" height="200" />
 Waste collection schedules from service provider web sites are updated daily, derived from local ICS/iCal files, or generated from user-specified dates or regularly repeating date patterns. The Home Assistant built-in Calendar is automatically populated with schedules, and there is a high degree of flexibility in how information can be format and displayed in entity cards or pop-ups. The framework can easily be extended to support additional waste collection service providers, or other services which provide schedules.
 
 
@@ -30,4 +30,4 @@ Waste collection schedules from service provider web sites are updated daily, de
 | USA | PGT.ST, Republic Services, Seattle Public Utilities |
 | UK | Bracknell Forest Council, Bradford Metropolitan District Council, Braintree District Council, Cambridge City Council, Canterbury City Council, Cheshire East Council, Chesterfield Borough Council, Colchester Borough Council, Cornwall Council, Derby City Council, Eastbourne Borough Council, Elmbridge Borough Council, Guildford Borough Council, Harborough District Council, Huntingdonshire District Council, The Royal Borough of Kingston, Lewes District Council, London Borough of Lewisham, Manchester City Council, Newcastle City Council, North Somerset Council, Nottingham City Council, Peterborough City Council, Richmondshire District Council, Rushmoor Borough Council, Sheffield City Council, South Cambridgeshire District Council, South Hams, South Norfolk and Broadland Council, Stevenage Borough Council, Tewkesbury Borough Council, City of York Council, Walsall Council, West Berkshire Council, West Devon, Wiltshire Council |
 
-For full details on supported service providers, and more project details, visit us on [GitHub](https://github.com/mampfes/hacs_waste_collection_schedule)
+For full details on supported service providers, and more project details, visit us on [GitHub](https://github.com/mampfes/hacs_waste_collection_schedule).


### PR DESCRIPTION
I'm beginning to see what you meant about HA/HACS rendering of .md files. Looks like using absolute references is what's needed. Hopefully this update sorts the issue out.