### PR TITLE
Fix duplicate entries for buergerportal_de & some other enhancements

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -1,8 +1,14 @@
 import datetime
+from typing import Optional
 
 
 class CollectionBase(dict):  # inherit from dict to enable JSON serialization
-    def __init__(self, date: datetime.date, icon: str = None, picture: str = None):
+    def __init__(
+        self,
+        date: datetime.date,
+        icon: Optional[str] = None,
+        picture: Optional[str] = None,
+    ):
         dict.__init__(self, date=date.isoformat(), icon=icon, picture=picture)
         self._date = date  # store date also as python date object
 
@@ -31,7 +37,11 @@ class CollectionBase(dict):  # inherit from dict to enable JSON serialization
 
 class Collection(CollectionBase):
     def __init__(
-        self, date: datetime.date, t: str, icon: str = None, picture: str = None
+        self,
+        date: datetime.date,
+        t: str,
+        icon: Optional[str] = None,
+        picture: Optional[str] = None,
     ):
         CollectionBase.__init__(self, date=date, icon=icon, picture=picture)
         self["type"] = t

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/art_trier_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/art_trier_de.py
@@ -75,8 +75,6 @@ class Source:
         schedule = self._ics.convert(res.text)
 
         return [
-            Collection(
-                date=entry[0], t=entry[1], icon=ICON_MAP.get(entry[1], "mdi:trash-can")
-            )
+            Collection(date=entry[0], t=entry[1], icon=ICON_MAP.get(entry[1]))
             for entry in schedule
         ]

--- a/doc/source/buergerportal_de.md
+++ b/doc/source/buergerportal_de.md
@@ -14,13 +14,14 @@ waste_collection_schedule:
         subdistrict: SUBDISTRICT
         street: STREET_NAME
         number: HOUSE_NUMBER
+        show_volume: SHOW_VOLUME
 ```
 
 ## Supported Operators
 
-- `cochem_zell`: <https://buerger-portal-cochemzell.azurewebsites.net>
 - `alb_donau`: <https://buerger-portal-albdonaukreisabfallwirtschaft.azurewebsites.net>
 - `biedenkopf`: <https://biedenkopfmzv.buergerportal.digital>
+- `cochem_zell`: <https://buerger-portal-cochemzell.azurewebsites.net>
 
 ### Configuration Variables
 
@@ -38,6 +39,9 @@ _(string|int) (required)_
 
 **subdistrict**\
 _(string) (optional) (default: null)_
+
+**show_volume**\
+_(boolean) (optional) (default: false)_
 
 ## Example
 
@@ -61,3 +65,11 @@ waste_collection_schedule:
 4. Select your `number` (Hausnummer).
 
 All parameters are _case-sensitive_.
+
+## Notes on Container Volumes
+
+By default, this sources does not differentiate between different container sizes.
+If your operator collects large containers (1000 l) on different dates than smaller ones (e.g., 120 l or 240 l), you may set `show_volume: true` in your configuration.
+If you do, the volume will be added to the waste type.
+For example, the collection `Bio` with a volume of 120 l would then be shown as `Bio (120 l)`.
+With this additional information, you can adjust all waste collections to your needs by making use of a source's [`customize` option](../installation.md#configuring-sources).


### PR DESCRIPTION
When adding `buergerportal_de`, I somehow missed that the source returns duplicate entries: It differentiates between different container sizes. This PR uses a set to remove such duplicates since in most cases, these different sizes will still be collected on the same day. If this is not the case for certain areas, it also adds a new option `show_volume` that includes the size of the container in the title of the entry. This way, users can use the built-in `customize` option of the sources configuration to adjust the collection types to their needs. These two changes give maximum freedom while still making the source easy to set up for most use cases. The corresponding documentation has also been updated to explain this new parameter and point users to the `customize` option in case they need it.

As part of this PR, I also removed the default icon of art_trier_de (since this integration provides one anyway) and added the correct `Optional[str]` type to some parameters of the `Collection` class.