### PR TITLE
Fix Braintree Date Parsing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
@@ -49,7 +49,7 @@ class Source:
                 collection_type, collection_date = results.text.strip().split("\n")
                 entries.append(
                     Collection(
-                        date=parser.parse(collection_date, dayfirst=true).date(),
+                        date=parser.parse(collection_date, dayfirst=True).date(),
                         t=collection_type,
                         icon=ICON_MAP[collection_type]
                     )


### PR DESCRIPTION
Apologies, true should have an uppercase T in Python.