### PR TITLE
fix empty args list for grosswangen_ch

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/grosswangen_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/grosswangen_ch.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Source:
-    def __init__(self, args=None):
+    def __init__(self):
         self = None
 
     def fetch(self):

--- a/doc/source/grosswangen_ch.md
+++ b/doc/source/grosswangen_ch.md
@@ -8,8 +8,7 @@ Support for schedules provided by [https://www.grosswangen.ch/institution/detail
 waste_collection_schedule:
   sources:
     - name: grosswangen_ch
-      args:
-      args: None
+      args: {}
 ```
 
 ### Configuration Variables
@@ -23,6 +22,5 @@ but use args as shown in example.
 waste_collection_schedule:
   sources:
     - name: grosswangen_ch
-      args:
-      args: None
+      args: {}
 ```


### PR DESCRIPTION
This source doesn't require any arguments. The correct syntax would be to provide an empty dict.

This PR removes the dummy argument `args` from the source and fixes the source docu.

fix #587