### PR TITLE
fix icon map

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/grosswangen_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/grosswangen_ch.py
@@ -14,9 +14,9 @@ ICON_MAP = {
     "Grüngutabfuhr": "mdi:leaf",
     "Kehricht-Aussentour": "mdi:trash-can-outline",
     "Kartonsammlung": "mdi:recycle",
-    "Altpapiersammlung": "newspaper-variant-multiple-outline",
+    "Altpapiersammlung": "mdi:newspaper-variant-multiple-outline",
     "Häckselservice": "mdi:leaf-off",
-    "Alteisensammlung und Sammlung elektronischer Geräte": "desktop-classic",
+    "Alteisensammlung und Sammlung elektronischer Geräte": "mdi:desktop-classic",
     "Zusätzliche Gratis-Laubabfuhr": "mdi:leaf",
 }
 


### PR DESCRIPTION
Added missing `mdi:` from ICON_MAP

Was:
```python
ICON_MAP = {
    "Grüngutabfuhr": "mdi:leaf",
    "Kehricht-Aussentour": "mdi:trash-can-outline",
    "Kartonsammlung": "mdi:recycle",
    "Altpapiersammlung": "newspaper-variant-multiple-outline",
    "Häckselservice": "mdi:leaf-off",
    "Alteisensammlung und Sammlung elektronischer Geräte": "desktop-classic",
    "Zusätzliche Gratis-Laubabfuhr": "mdi:leaf",
}
```

Now:
```python
ICON_MAP = {
    "Grüngutabfuhr": "mdi:leaf",
    "Kehricht-Aussentour": "mdi:trash-can-outline",
    "Kartonsammlung": "mdi:recycle",
    "Altpapiersammlung": "mdi:newspaper-variant-multiple-outline",     #updated
    "Häckselservice": "mdi:leaf-off",
    "Alteisensammlung und Sammlung elektronischer Geräte": "mdi:desktop-classic",     #updated
    "Zusätzliche Gratis-Laubabfuhr": "mdi:leaf",
}
```