### PR TITLE
Fix example configuration for South Cambs

### DIFF
--- a/doc/source/scambs_gov_uk.md
+++ b/doc/source/scambs_gov_uk.md
@@ -11,7 +11,6 @@ waste_collection_schedule:
       args:
         post_code: POST_CODE
         number: NUMBER
-        version: 2
 
 ```
 


### PR DESCRIPTION
Fix example configuration for South Cambs, which includes an unneeded 'version' parameter (which gives an error).