### PR TITLE
Fix Ashfield & Harlow readmes

### DIFF
--- a/doc/source/ashfield_gov_uk.md
+++ b/doc/source/ashfield_gov_uk.md
@@ -17,8 +17,6 @@ waste_collection_schedule:
 
 ### Configuration Variables
 
-### Configuration Variables
-
 **uprn**<br>
 *(string) (optional)*
 

--- a/doc/source/harlow_gov_uk.md
+++ b/doc/source/harlow_gov_uk.md
@@ -1,4 +1,4 @@
-# Ashfield District Council
+# Harlow Council
 
 Support for schedules provided by [Harlow Council](https://www.harlow.gov.uk/), serving Harlow district in Essex, UK.
 
@@ -11,8 +11,6 @@ waste_collection_schedule:
       args:
         uprn: UNIQUE_PROPERTY_REFERENCE_NUMBER
 ```
-
-### Configuration Variables
 
 ### Configuration Variables
 


### PR DESCRIPTION
Noticed that I had a couple of errors with my recent PRs in the Readme - an extra Configuration heading in each, and I forgot to change the title of Harlow when I copied it from my Ashfield one as an initial template.

This PR fixes both these issues :)