### PR TITLE
Fixed errors in the readme file for gotland_se

### DIFF
--- a/doc/source/gotland_se.md
+++ b/doc/source/gotland_se.md
@@ -1,13 +1,13 @@
 # Region Gotland
 
-Support for schedules provided by [Region Gotland](https://edpfuture.gotland.se/), serving the municipality of Gotland, Sweden.
+Support for schedules provided by [Region Gotland](https://gotland.se/), serving the municipality of Gotland, Sweden.
 
 ## Configuration via configuration.yaml
 
 ```yaml
 waste_collection_schedule:
   sources:
-    - name: region_gotland_se
+    - name: gotland_se
       args:
         uprn: UNIQUE_PROPERTY_REFERENCE_NUMBER
 ```
@@ -22,11 +22,11 @@ waste_collection_schedule:
 ```yaml
 waste_collection_schedule:
   sources:
-    - name: region_gotland_se
+    - name: gotland_se
       args:
         uprn: 0000000000
 ```
 
 ## How to get the source argument
 
-The source argument is the unique number of your property that has a waste collection service. The number can be obtained by logging in [here](https://edpfuture.gotland.se/FutureWeb/MyServices/SelectBuilding) and checking the "Välj anläggnings" dropdown list.
+The uprn argument is the unique number of your property that has an active waste collection service. The number can be obtained by logging in [here](https://edpfuture.gotland.se/FutureWeb/MyServices/SelectBuilding) and checking the "Välj anläggning" dropdown list.


### PR DESCRIPTION
The readme file had references to the old service name (region_gotland_se) plus a spelling error, corrected these.