### PR TITLE
added egst.de (Steinfurt) to AbfallIO wizard

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -2,6 +2,11 @@
 
 
 SERVICE_MAP = [
+     {
+        "title": "egst steinfurth",
+        "url": "https://www.egst.de/",
+        "service_id": "e21758b9c711463552fb9c70ac7d4273",
+    },
     {
         "title": "ALBA Berlin",
         "url": "https://berlin.alba.info/",


### PR DESCRIPTION
Added www.egst.de (Steinfurt) to the AbfallIO wizard

https://github.com/mampfes/hacs_waste_collection_schedule/issues/676#issue-1581329270