### PR TITLE
Adds support for waste event start and endtime

### DIFF
--- a/custom_components/waste_collection_schedule/__init__.py
+++ b/custom_components/waste_collection_schedule/__init__.py
@@ -110,6 +110,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
                 picture=c.get(CONF_PICTURE),
                 use_dedicated_calendar=c.get(CONF_USE_DEDICATED_CALENDAR, False),
                 dedicated_calendar_title=c.get(CONF_DEDICATED_CALENDAR_TITLE, False),
+                start_hours_before=c.get(CONF_START_HOURS_BEFORE, None),
+                end_hours_after=c.get(CONF_END_HOURS_AFTER, None),
             )
         await hass.async_add_executor_job(
             api.add_source_shell,

--- a/custom_components/waste_collection_schedule/__init__.py
+++ b/custom_components/waste_collection_schedule/__init__.py
@@ -40,6 +40,8 @@ CONF_ICON = "icon"
 CONF_PICTURE = "picture"
 CONF_USE_DEDICATED_CALENDAR = "use_dedicated_calendar"
 CONF_DEDICATED_CALENDAR_TITLE = "dedicated_calendar_title"
+CONF_START_HOURS_BEFORE = "start_hours_before"
+CONF_END_HOURS_AFTER = "end_hours_after"
 
 CUSTOMIZE_CONFIG = vol.Schema(
     {
@@ -50,6 +52,8 @@ CUSTOMIZE_CONFIG = vol.Schema(
         vol.Optional(CONF_PICTURE): cv.string,
         vol.Optional(CONF_USE_DEDICATED_CALENDAR): cv.boolean,
         vol.Optional(CONF_DEDICATED_CALENDAR_TITLE): cv.string,
+        vol.Optional(CONF_START_HOURS_BEFORE): cv.string,
+        vol.Optional(CONF_END_HOURS_AFTER): cv.string,
     }
 )
 

--- a/custom_components/waste_collection_schedule/__init__.py
+++ b/custom_components/waste_collection_schedule/__init__.py
@@ -40,8 +40,8 @@ CONF_ICON = "icon"
 CONF_PICTURE = "picture"
 CONF_USE_DEDICATED_CALENDAR = "use_dedicated_calendar"
 CONF_DEDICATED_CALENDAR_TITLE = "dedicated_calendar_title"
-CONF_START_HOURS_BEFORE = "start_hours_before"
-CONF_END_HOURS_AFTER = "end_hours_after"
+CONF_START_HOUR = "start_hour"
+CONF_END_HOUR = "end_hour"
 
 CUSTOMIZE_CONFIG = vol.Schema(
     {
@@ -52,8 +52,8 @@ CUSTOMIZE_CONFIG = vol.Schema(
         vol.Optional(CONF_PICTURE): cv.string,
         vol.Optional(CONF_USE_DEDICATED_CALENDAR): cv.boolean,
         vol.Optional(CONF_DEDICATED_CALENDAR_TITLE): cv.string,
-        vol.Optional(CONF_START_HOURS_BEFORE): cv.string,
-        vol.Optional(CONF_END_HOURS_AFTER): cv.string,
+        vol.Optional(CONF_START_HOUR): cv.string,
+        vol.Optional(CONF_END_HOUR): cv.string,
     }
 )
 
@@ -110,8 +110,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
                 picture=c.get(CONF_PICTURE),
                 use_dedicated_calendar=c.get(CONF_USE_DEDICATED_CALENDAR, False),
                 dedicated_calendar_title=c.get(CONF_DEDICATED_CALENDAR_TITLE, False),
-                start_hours_before=c.get(CONF_START_HOURS_BEFORE, None),
-                end_hours_after=c.get(CONF_END_HOURS_AFTER, None),
+                start_hour=c.get(CONF_START_HOUR, None),
+                end_hour=c.get(CONF_END_HOUR, None),
             )
         await hass.async_add_executor_job(
             api.add_source_shell,

--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -116,6 +116,13 @@ class WasteCollectionCalendar(CalendarEntity):
 
     def _convert(self, collection) -> CalendarEvent:
         """Convert an collection into a Home Assistant calendar event."""
+        if collection.start_hours_before is not None and collection.end_hours_after is not None:
+            return CalendarEvent(
+                summary=collection.type,
+                start=collection.date + timedelta(hours=collection.start_hours_before),
+                end=collection.date + timedelta(hours=collection.end_hours_after),
+            )
+
         return CalendarEvent(
             summary=collection.type,
             start=collection.date,

--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -116,12 +116,12 @@ class WasteCollectionCalendar(CalendarEntity):
 
     def _convert(self, collection) -> CalendarEvent:
         """Convert an collection into a Home Assistant calendar event."""
-        if collection.start_hours_before is not None and collection.end_hours_after is not None:
+        if collection.start_hour is not None and collection.end_hour is not None:
             event_date_time = datetime.combine(collection.date, time(hour=0, minute=0, second=0))
             return CalendarEvent(
                 summary=collection.type,
-                start=event_date_time - timedelta(hours=collection.start_hours_before),
-                end=event_date_time + timedelta(hours=collection.end_hours_after),
+                start=event_date_time + timedelta(hours=collection.start_hour),
+                end=event_date_time + timedelta(hours=collection.end_hour),
             )
 
         return CalendarEvent(

--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -1,7 +1,7 @@
 """Calendar platform support for Waste Collection Schedule."""
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
@@ -117,10 +117,11 @@ class WasteCollectionCalendar(CalendarEntity):
     def _convert(self, collection) -> CalendarEvent:
         """Convert an collection into a Home Assistant calendar event."""
         if collection.start_hours_before is not None and collection.end_hours_after is not None:
+            event_date_time = datetime.combine(collection.date, time(hour=0, minute=0, second=0))
             return CalendarEvent(
                 summary=collection.type,
-                start=collection.date + timedelta(hours=collection.start_hours_before),
-                end=collection.date + timedelta(hours=collection.end_hours_after),
+                start=event_date_time - timedelta(hours=collection.start_hours_before),
+                end=event_date_time + timedelta(hours=collection.end_hours_after),
             )
 
         return CalendarEvent(

--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -1,11 +1,12 @@
 {
   "domain": "waste_collection_schedule",
   "name": "waste_collection_schedule",
-  "codeowners": ["@mampfes"],
-  "dependencies": [],
   "documentation": "https://github.com/mampfes/hacs_waste_collection_schedule#readme",
-  "integration_type": "hub",
+  "requirements": ["icalendar", "recurring_ical_events", "icalevents", "bs4"],
+  "dependencies": [],
+  "codeowners": ["@mampfes"],
   "iot_class": "cloud_polling",
-  "requirements": ["icalendar", "recurring_ical_events", "icalevents", "beautifulsoup4", "lxml"],
-  "version": "1.49.0"
+  "version": "1.34.0",
+  "integration_type": "hub",
+  "loggers": ["custom_components.waste_collection_schedule"]
 }

--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": [],
   "codeowners": ["@mampfes"],
   "iot_class": "cloud_polling",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "integration_type": "hub",
   "loggers": ["custom_components.waste_collection_schedule"]
 }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -9,7 +9,7 @@ class CollectionBase(dict):  # inherit from dict to enable JSON serialization
         icon: Optional[str] = None,
         picture: Optional[str] = None,
     ):
-        dict.__init__(self, date=date.isoformat(), icon=icon, picture=picture, start_hours_before=None, end_hours_after=None)
+        dict.__init__(self, date=date.isoformat(), icon=icon, picture=picture, start_hour=None, end_hour=None)
         self._date = date  # store date also as python date object
 
     @property
@@ -35,18 +35,18 @@ class CollectionBase(dict):  # inherit from dict to enable JSON serialization
         self["picture"] = picture
 
     @property
-    def start_hours_before(self):
-        return self["start_hours_before"]
+    def start_hour(self):
+        return self["start_hour"]
 
-    def set_start_hours_before(self, hours: int):
-        self["start_hours_before"] = int(hours)
+    def set_start_hour(self, hours: int):
+        self["start_hour"] = int(hours)
 
     @property
-    def end_hours_after(self):
-        return self["end_hours_after"]
+    def end_hour(self):
+        return self["end_hour"]
 
-    def set_end_hours_after(self, hours: int):
-        self["end_hours_after"] = int(hours)
+    def set_end_hour(self, hours: int):
+        self["end_hour"] = int(hours)
 
 
 class Collection(CollectionBase):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -38,17 +38,15 @@ class CollectionBase(dict):  # inherit from dict to enable JSON serialization
     def start_hours_before(self):
         return self["start_hours_before"]
 
-    @property
-    def start_hours_before(self, hours: int):
-        self["start_hours_before"] = hours
+    def set_start_hours_before(self, hours: int):
+        self["start_hours_before"] = int(hours)
 
     @property
     def end_hours_after(self):
         return self["end_hours_after"]
 
-    @property
-    def end_hours_after(self, hours: int):
-        self["end_hours_after"] = hours
+    def set_end_hours_after(self, hours: int):
+        self["end_hours_after"] = int(hours)
 
 
 class Collection(CollectionBase):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -9,7 +9,7 @@ class CollectionBase(dict):  # inherit from dict to enable JSON serialization
         icon: Optional[str] = None,
         picture: Optional[str] = None,
     ):
-        dict.__init__(self, date=date.isoformat(), icon=icon, picture=picture)
+        dict.__init__(self, date=date.isoformat(), icon=icon, picture=picture, start_hours_before=None, end_hours_after=None)
         self._date = date  # store date also as python date object
 
     @property
@@ -33,6 +33,22 @@ class CollectionBase(dict):  # inherit from dict to enable JSON serialization
 
     def set_picture(self, picture: str):
         self["picture"] = picture
+
+    @property
+    def start_hours_before(self):
+        return self["start_hours_before"]
+
+    @property
+    def start_hours_before(self, hours: int):
+        self["start_hours_before"] = hours
+
+    @property
+    def end_hours_after(self):
+        return self["end_hours_after"]
+
+    @property
+    def end_hours_after(self, hours: int):
+        self["end_hours_after"] = hours
 
 
 class Collection(CollectionBase):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -21,6 +21,8 @@ class Customize:
         picture=None,
         use_dedicated_calendar=False,
         dedicated_calendar_title=None,
+        start_hours_before=None,
+        end_hours_after=None,
     ):
         self._waste_type = waste_type
         self._alias = alias
@@ -29,6 +31,8 @@ class Customize:
         self._picture = picture
         self._use_dedicated_calendar = use_dedicated_calendar
         self._dedicated_calendar_title = dedicated_calendar_title
+        self._start_hours_before = start_hours_before
+        self._end_hours_after = end_hours_after
 
     @property
     def waste_type(self):
@@ -58,8 +62,16 @@ class Customize:
     def dedicated_calendar_title(self):
         return self._dedicated_calendar_title
 
+    @property
+    def start_hours_before(self):
+        return self._start_hours_before
+
+    @property
+    def end_hours_after(self):
+        return self._end_hours_after
+
     def __repr__(self):
-        return f"Customize{{waste_type={self._waste_type}, alias={self._alias}, show={self._show}, icon={self._icon}, picture={self._picture}}}"
+        return f"Customize{{waste_type={self._waste_type}, alias={self._alias}, show={self._show}, icon={self._icon}, picture={self._picture}, start_hours_before={self._start_hours_before}, end_hours_after={self._end_hours_after}}}"
 
 
 def filter_function(entry: Collection, customize: Dict[str, Customize]):
@@ -79,6 +91,14 @@ def customize_function(entry: Collection, customize: Dict[str, Customize]):
             entry.set_icon(c.icon)
         if c.picture is not None:
             entry.set_picture(c.picture)
+    return entry
+
+
+def start_end_time_function(entry: Collection, customize: Dict[str, Customize]):
+    if customize.start_hours_before is not None:
+        entry.start_hours_before(customize.start_hours_before)
+    if customize.end_hours_after is not None:
+        entry.end_hours_after(customize.end_hours_after)
     return entry
 
 
@@ -148,6 +168,9 @@ class SourceShell:
 
         # customize fetched entries
         entries = map(lambda x: customize_function(x, self._customize), entries)
+
+        # add optional start and end time to a waster event
+        entries = map(lambda x: start_end_time_function(x, self._customize), entries)
 
         self._entries = list(entries)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -95,10 +95,12 @@ def customize_function(entry: Collection, customize: Dict[str, Customize]):
 
 
 def start_end_time_function(entry: Collection, customize: Dict[str, Customize]):
-    if customize.start_hours_before is not None:
-        entry.start_hours_before(customize.start_hours_before)
-    if customize.end_hours_after is not None:
-        entry.end_hours_after(customize.end_hours_after)
+    c = customize.get(entry.type)
+    if c is not None:
+        if c.start_hours_before is not None:
+            entry.set_start_hours_before(c.start_hours_before)
+        if c.end_hours_after is not None:
+            entry.set_end_hours_after(c.end_hours_after)
     return entry
 
 
@@ -166,11 +168,11 @@ class SourceShell:
         # filter hidden entries
         entries = filter(lambda x: filter_function(x, self._customize), entries)
 
-        # customize fetched entries
-        entries = map(lambda x: customize_function(x, self._customize), entries)
-
         # add optional start and end time to a waster event
         entries = map(lambda x: start_end_time_function(x, self._customize), entries)
+
+        # customize fetched entries
+        entries = map(lambda x: customize_function(x, self._customize), entries)
 
         self._entries = list(entries)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -21,8 +21,8 @@ class Customize:
         picture=None,
         use_dedicated_calendar=False,
         dedicated_calendar_title=None,
-        start_hours_before=None,
-        end_hours_after=None,
+        start_hour=None,
+        end_hour=None,
     ):
         self._waste_type = waste_type
         self._alias = alias
@@ -31,8 +31,8 @@ class Customize:
         self._picture = picture
         self._use_dedicated_calendar = use_dedicated_calendar
         self._dedicated_calendar_title = dedicated_calendar_title
-        self._start_hours_before = start_hours_before
-        self._end_hours_after = end_hours_after
+        self._start_hour = start_hour
+        self._end_hour = end_hour
 
     @property
     def waste_type(self):
@@ -63,15 +63,15 @@ class Customize:
         return self._dedicated_calendar_title
 
     @property
-    def start_hours_before(self):
-        return self._start_hours_before
+    def start_hour(self):
+        return self._start_hour
 
     @property
-    def end_hours_after(self):
-        return self._end_hours_after
+    def end_hour(self):
+        return self._end_hour
 
     def __repr__(self):
-        return f"Customize{{waste_type={self._waste_type}, alias={self._alias}, show={self._show}, icon={self._icon}, picture={self._picture}, start_hours_before={self._start_hours_before}, end_hours_after={self._end_hours_after}}}"
+        return f"Customize{{waste_type={self._waste_type}, alias={self._alias}, show={self._show}, icon={self._icon}, picture={self._picture}, start_hour={self._start_hour}, end_hour={self._end_hour}}}"
 
 
 def filter_function(entry: Collection, customize: Dict[str, Customize]):
@@ -97,10 +97,10 @@ def customize_function(entry: Collection, customize: Dict[str, Customize]):
 def start_end_time_function(entry: Collection, customize: Dict[str, Customize]):
     c = customize.get(entry.type)
     if c is not None:
-        if c.start_hours_before is not None:
-            entry.set_start_hours_before(c.start_hours_before)
-        if c.end_hours_after is not None:
-            entry.set_end_hours_after(c.end_hours_after)
+        if c.start_hour is not None:
+            entry.set_start_hour(c.start_hour)
+        if c.end_hour is not None:
+            entry.set_end_hour(c.end_hour)
     return entry
 
 
@@ -168,7 +168,7 @@ class SourceShell:
         # filter hidden entries
         entries = filter(lambda x: filter_function(x, self._customize), entries)
 
-        # add optional start and end time to a waster event
+        # add optional start and end time to a waste event
         entries = map(lambda x: start_end_time_function(x, self._customize), entries)
 
         # customize fetched entries


### PR DESCRIPTION
The MR adds (optional) support for waste event start and endtime.

My local regulations say that I'm allowed to put the waste out between 20:00 (the day before collection) and 18:00 (on collection day). This way the state of the waste calendar in HA is only 'on' when it's allowed.

In my case the configuration looks like this:
```
waste_collection_schedule:
  sources:
    - name: ximmio_nl
      args:
        company: xxxx
        post_code: xxxx
        house_number: 1
      customize:
        - type: PAPER
          alias: Papier
          start_hour: -4
          end_hour: 18
        - type: GREEN
          alias: GFT
          start_hour: -4
          end_hour: 18
        - type: PACKAGES
          alias: Plastic
          start_hour: -4
          end_hour: 18
        - type: RESIDUAL
          alias: Restafval
          start_hour: -4
          end_hour: 18
```