### PR TITLE
Added lkr wug to AbfallIO wizard

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -132,4 +132,9 @@ SERVICE_MAP = [
         "url": "https://www.awb-lm.de/",
         "service_id": "0ff491ffdf614d6f34870659c0c8d917",
     },
+    {
+        "title": "Landkreis Weißenburg-Gunzenhausen",
+        "url": "https://www.landkreis-wug.de",
+        "service_id": "31fb9c7d783a030bf9e4e1994c7d2a91"
+    }
 ]


### PR DESCRIPTION
I added the "Landkreis Weißenburg-Gunzenhausen" to the AbfallIO wizard since the "AbfallApp Altmühlfranken" uses AbfallIO, see here: https://www.landkreis-wug.de/abfall/abfuhrkalender/ 