### PR TITLE
updated c_trace_de to support other than web.ctrace.de urls

### DIFF
--- a/doc/source/c_trace_de.md
+++ b/doc/source/c_trace_de.md
@@ -23,20 +23,13 @@ Name of the service which is specific to your municipality. See the table below 
 
 **ort**  
 *(string) (optional)*
+Needed for most municipalities but no all
 
 **strasse**  
 *(string) (required)*
 
 **hausnummer**  
 *(string) (required)*
-
-**subdomain**  
-*(string) (optional)*
-Defaults to `web` (web.c-trace.de) which works with a lot of locations, but some seem to work with foreexample `app`(app.c-trace.de)
-
-**ical_url_file**  
-*(string) (optional)*
-the end of the ULR to download the ical file defaults to `cal` but especially `app` subdomains seem to use `downloadcal`
 
 ## Example
 
@@ -51,8 +44,6 @@ waste_collection_schedule:
         hausnummer: 5
 ```
 
-with subdomain and ical_url_file:
-
 ```yaml
 waste_collection_schedule:
   sources:
@@ -60,9 +51,7 @@ waste_collection_schedule:
     args:
       strasse: Am Kindergarten
       hausnummer: 1
-      service: web.landau
-      subdomain: apps
-      ical_url_file: downloadcal
+      service: landau
 ```
 
 ## How to get the source arguments
@@ -74,7 +63,21 @@ This source requires the name of a `service` which is specific to your municipal
 |Bremen|`bremenabfallkalender`|
 |AWB Landkreis Augsburg|`augsburglandkreis`|
 |WZV Kreis Segeberg|`segebergwzv-abfallkalender`|
-|Landau|`web.landau` (use subdomain `apps` & ical_url_file `downloadcal`)|
+|Landau|`landau`|
+|Landkreis Roth|`roth`|
+|Landkreis Aurich|`aurich-abfallkalender`|
+|St. Wendel|`stwendel`|
+|Warszawa/Warsaw/Warschau|`lekarowarschau-abfallkalender`|
+|Oberursel|`oberursel`|
+|Main-Tauber-Kreis|`maintauberkreis-abfallkalender`|
+|Dietzenbach|`dietzenbach`|
+|Landkreis Augsburg| `augsburglandkreis`|
+|Rheingau|`rheingauleerungen`|
+|Großgerau|`grossgeraulandkreis-abfallkalender`|
+|Bayreuth|`bayreuthstadt-abfallkalender`|
+|Arnsberg|`arnsberg-abfallkalender`|
+|Overath|`overathabfallkalender`|
+
 
 ## Tip
 
@@ -86,4 +89,4 @@ Link for above image: https://web.c-trace.de/segebergwzv-abfallkalender/(S(ebi2z
 
 From this Link you can extract the following parameters:
 
-`subdomain`.c-trace.de/`service`/some-id/abfallkalender/`ical_url_file`/year?Ort=`ort`&Strasse=`strasse`&Hausnr=`hausnummer`...
+`web|app`.c-trace.de/`(web.)service`/some-id/abfallkalender/`cal|downloadcal`/year?Ort=`ort`&Strasse=`strasse`&Hausnr=`hausnummer`...

--- a/doc/source/c_trace_de.md
+++ b/doc/source/c_trace_de.md
@@ -22,13 +22,21 @@ waste_collection_schedule:
 Name of the service which is specific to your municipality. See the table below to get the right value for your location.
 
 **ort**  
-*(string) (required)*
+*(string) (optional)*
 
 **strasse**  
 *(string) (required)*
 
 **hausnummer**  
 *(string) (required)*
+
+**subdomain**  
+*(string) (optional)*
+Defaults to `web` (web.c-trace.de) which works with a lot of locations, but some seem to work with foreexample `app`(app.c-trace.de)
+
+**ical_url_file**  
+*(string) (optional)*
+the end of the ULR to download the ical file defaults to `cal` but especially `app` subdomains seem to use `downloadcal`
 
 ## Example
 
@@ -43,6 +51,20 @@ waste_collection_schedule:
         hausnummer: 5
 ```
 
+with subdomain and ical_url_file:
+
+```yaml
+waste_collection_schedule:
+  sources:
+  - name: c_trace_de
+    args:
+      strasse: Am Kindergarten
+      hausnummer: 1
+      service: web.landau
+      subdomain: apps
+      ical_url_file: downloadcal
+```
+
 ## How to get the source arguments
 
 This source requires the name of a `service` which is specific to your municipality. Use the following map to get the right value for your district.
@@ -52,6 +74,7 @@ This source requires the name of a `service` which is specific to your municipal
 |Bremen|`bremenabfallkalender`|
 |AWB Landkreis Augsburg|`augsburglandkreis`|
 |WZV Kreis Segeberg|`segebergwzv-abfallkalender`|
+|Landau|`web.landau` (use subdomain `apps` & ical_url_file `downloadcal`)|
 
 ## Tip
 
@@ -63,4 +86,4 @@ Link for above image: https://web.c-trace.de/segebergwzv-abfallkalender/(S(ebi2z
 
 From this Link you can extract the following parameters:
 
-web.c-trace.de/`service`/some-id/abfallkalender/cal/year?Ort=`ort`&Strasse=`strasse`&Hausnr=`hausnummer`...
+`subdomain`.c-trace.de/`service`/some-id/abfallkalender/`ical_url_file`/year?Ort=`ort`&Strasse=`strasse`&Hausnr=`hausnummer`...


### PR DESCRIPTION
I updated c_trace_de to also allow other subdomains (see #697) and formats because there where only a few changes to be made  and I personally think it would not make sense to make a new integration, there are a few more like this one out there (googling: `site:apps.c-trace.de`)

but I'm not sure if this are to many possible arguments. (especially ical_url_file feels kind of janky)  I'm open to changes or other Idears