### PR TITLE
Updated Manchester City Council

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/manchester_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/manchester_uk.py
@@ -10,6 +10,7 @@ DESCRIPTION = "Source for bin collection services for Manchester City Council, U
 URL = "https://www.manchester.gov.uk"
 TEST_CASES = {
     "domestic": {"uprn": "000077065560"},
+    "large_domestic": {"uprn": 77116538},
 }
 
 API_URL = "https://www.manchester.gov.uk/bincollections/"
@@ -18,6 +19,9 @@ ICON_MAP = {
     "Blue Bin": "mdi:recycle",
     "Brown Bin": "mdi:glass-fragile",
     "Green Bin": "mdi:leaf",
+    "Large Blue Container": "mdi:recycle",
+    "Large Brown Container": "mdi:glass-fragile",
+    "Large Domestic Waste Container": "mdi:trash-can",
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class Source:
     def __init__(self, uprn: int):
-        self._uprn = uprn
+        self._uprn = str(uprn).zfill(12)
 
     def fetch(self):
         entries = []
@@ -44,8 +48,8 @@ class Source:
             dates.append(str(date.text).replace("Next collection ", "", 1))
             for date in result.find_all("li"):
                 dates.append(date.text)
-            img_tag = result.find("img")
-            collection_type = img_tag["alt"]
+            h3_tag = result.find("h3")
+            collection_type = h3_tag.text.replace("DUE TODAY", "").strip()
             for current_date in dates:
                 date = datetime.strptime(current_date, "%A %d %b %Y").date()
                 entries.append(


### PR DESCRIPTION
Addresses some issues from #756:

- Uprn  pads to 12 digits if leading `0` is missing
- `h3` text used to identify waste collections rather than `img` alt text
- `DUE TODAY` removed from waste type description , prevents icon mapping issue `2023-03-13: Blue Bin  DUE TODAY [None]`
- New test case added for additional waste types
- Icon map updated with additional waste types

```bash
Testing source manchester_uk ...
  found 15 entries for domestic
    2023-03-13: Blue Bin [mdi:recycle]
    2023-03-27: Blue Bin [mdi:recycle]
    2023-04-10: Blue Bin [mdi:recycle]
    2023-03-20: Brown Bin [mdi:glass-fragile]
    2023-04-03: Brown Bin [mdi:glass-fragile]
    2023-04-17: Brown Bin [mdi:glass-fragile]
    2023-03-20: Green Bin [mdi:leaf]
    2023-03-20: Green Bin [mdi:leaf]
    2023-04-03: Green Bin [mdi:leaf]
    2023-04-03: Green Bin [mdi:leaf]
    2023-04-17: Green Bin [mdi:leaf]
    2023-04-17: Green Bin [mdi:leaf]
    2023-03-20: Black / Grey Bin [mdi:trash-can]
    2023-04-03: Black / Grey Bin [mdi:trash-can]
    2023-04-17: Black / Grey Bin [mdi:trash-can]
  found 21 entries for large_domestic
    2023-03-17: Green Bin [mdi:leaf]
    2023-03-17: Green Bin [mdi:leaf]
    2023-03-31: Green Bin [mdi:leaf]
    2023-03-31: Green Bin [mdi:leaf]
    2023-04-14: Green Bin [mdi:leaf]
    2023-04-14: Green Bin [mdi:leaf]
    2023-03-17: Large Blue Container [mdi:recycle]
    2023-03-31: Large Blue Container [mdi:recycle]
    2023-04-14: Large Blue Container [mdi:recycle]
    2023-03-24: Large Brown Container [mdi:glass-fragile]
    2023-04-07: Large Brown Container [mdi:glass-fragile]
    2023-03-14: Large Domestic Waste Container [mdi:trash-can]
    2023-03-16: Large Domestic Waste Container [mdi:trash-can]
    2023-03-21: Large Domestic Waste Container [mdi:trash-can]
    2023-03-23: Large Domestic Waste Container [mdi:trash-can]
    2023-03-28: Large Domestic Waste Container [mdi:trash-can]
    2023-03-30: Large Domestic Waste Container [mdi:trash-can]
    2023-04-04: Large Domestic Waste Container [mdi:trash-can]
    2023-04-06: Large Domestic Waste Container [mdi:trash-can]
    2023-04-11: Large Domestic Waste Container [mdi:trash-can]
    2023-04-13: Large Domestic Waste Container [mdi:trash-can]
```

@mampfes: Haven't changed the name of the source file so legacy configs will still work, but it should probably be `manchester_gov_uk.py` rather than `manchester_uk.py`