### PR TITLE
fix: add workaround for wrong kwu deployment

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
@@ -106,6 +106,9 @@ class Source:
 
         if ics_url is None:
             raise Exception("ics url not found")
+            
+        if "kwu.lokal" in ics_url:
+            ics_url = ics_url.replace("http://kalender.kwu.lokal", "https://kalender.kwu-entsorgung.de")
 
         # get ics file
         r = session.get(ics_url, headers=HEADERS, verify=False)


### PR DESCRIPTION
adds a workaround for the current issue on the kwu calender, where they have deployed a version pointing to local test system