### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Waste collection schedules in the following formats and countries are supported.
 - [Gemeente Sudwest-Fryslan](/doc/source/hvcgroep_nl.md) / sudwestfryslan.nl
 - [Gemeente Venray](/doc/source/hvcgroep_nl.md) / venray.nl
 - [Gemeente Voorschoten](/doc/source/hvcgroep_nl.md) / voorschoten.nl
-- [Gemeente Wallre](/doc/source/hvcgroep_nl.md) / waalre.nl
+- [Gemeente Waalre](/doc/source/hvcgroep_nl.md) / waalre.nl
 - [Gemeente Westland](/doc/source/ximmio_nl.md) / gemeentewestland.nl
 - [HVC Groep](/doc/source/hvcgroep_nl.md) / hvcgroep.nl
 - [Meerlanden](/doc/source/ximmio_nl.md) / meerlanden.nl


### PR DESCRIPTION
fixed typo for Gemeente Waalre. (was wallre)