### PR TITLE
fixing c_trace_de table

### DIFF
--- a/doc/source/c_trace_de.md
+++ b/doc/source/c_trace_de.md
@@ -58,9 +58,9 @@ waste_collection_schedule:
 
 This source requires the name of a `service` which is specific to your municipality. Use the following map to get the right value for your district.
 
+<!--Begin of service section-->
 |Municipality|service|
 |-|-|
-<!--Begin of service section-->
 | Abfallwirtschaft Rheingau-Taunus-Kreis | `rheingauleerungen` |
 | Abfallwirtschaftsbetrieb Landkreis Augsburg | `augsburglandkreis` |
 | Abfallwirtschaftsbetrieb Landkreis Aurich | `aurich-abfallkalender` |

--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -172,7 +172,7 @@ def update_ctrace_de(modules):
         return
     services = getattr(module, "SERVICE_MAP", [])
 
-    str = ""
+    str = "|Municipality|service|\n|-|-|\n"
     for service in sorted(
         services.keys(), key=lambda service: services[service]["title"]
     ):


### PR DESCRIPTION
the `<!--Begin of service section-->` comment inside the table of [c_trace](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/c_trace_de.md#how-to-get-the-source-arguments) destroyed it somehow
