### PR TITLE
allow integer haunummer arguments in abfallnavi_de

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
@@ -35,11 +35,11 @@ TEST_CASES = {
 
 
 class Source:
-    def __init__(self, service, ort, strasse, hausnummer=None):
+    def __init__(self, service: str, ort: str, strasse: str, hausnummer: str | int | None = None):
         self._api = AbfallnaviDe(service)
         self._ort = ort
         self._strasse = strasse
-        self._hausnummer = hausnummer
+        self._hausnummer = str(hausnummer) if isinstance(hausnummer, int) else hausnummer
 
     def fetch(self):
         dates = self._api.get_dates(self._ort, self._strasse, self._hausnummer)

--- a/doc/source/abfallnavi_de.md
+++ b/doc/source/abfallnavi_de.md
@@ -27,7 +27,7 @@ waste_collection_schedule:
 *(string) (required)*
 
 **hausnummer**  
-*(string) (optional)*
+*(string | Integer) (optional)*
 
 ## Example
 


### PR DESCRIPTION
A general question: how should something like this be handled? Should every argument only allow a single datatype? Especially for house numbers you might accidentaly use an integer instead of a string.
Here in abfallnavi_de if `hausnummer` is an int, it is handles as if `hausnummer` was  `None` (because it does not find the house number in the returned json), but this does not raise an error but returns valid but incomplete or wrong values (see #829)