### PR TITLE
fixing ecoharmonogram_pl to get events from multiple schedule periods

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -44,37 +44,42 @@ class Source:
 
         entries = []
         for sp in schedule_periods:
-            streets = Ecoharmonogram.fetch_streets(sp, town, self.street_input, self.house_number_input)
-            for street in streets:
-                if self.additional_sides_matcher_input.lower() in street.get("sides").lower():
-                    schedules_response = Ecoharmonogram.fetch_schedules(sp, street)
-                    schedules_raw = schedules_response.get('schedules')
-                    schedules_descriptions_dict = dict()
-                    schedules_descriptions_raw = schedules_response.get('scheduleDescription')
+            entries.extend(self._create_entries(sp, town))
+        return entries
+    
+    
+    def _create_entries(self, sp, town):
+        streets = Ecoharmonogram.fetch_streets(sp, town, self.street_input, self.house_number_input)
+        entries = []
+        for street in streets:
+            if self.additional_sides_matcher_input.lower() in street.get("sides").lower():
+                schedules_response = Ecoharmonogram.fetch_schedules(sp, street)
+                schedules_raw = schedules_response.get('schedules')
+                schedules_descriptions_dict = dict()
+                schedules_descriptions_raw = schedules_response.get('scheduleDescription')
 
-                    for sd in schedules_descriptions_raw:
-                        schedules_descriptions_dict[sd.get('id')] = sd
+                for sd in schedules_descriptions_raw:
+                    schedules_descriptions_dict[sd.get('id')] = sd
 
-                    schedules = []
-                    for sr in schedules_raw:
-                        z = sr.copy()
-                        get = schedules_descriptions_dict.get(sr.get('scheduleDescriptionId'))
-                        z['name'] = get.get("name")
-                        schedules.append(z)
+                schedules = []
+                for sr in schedules_raw:
+                    z = sr.copy()
+                    get = schedules_descriptions_dict.get(sr.get('scheduleDescriptionId'))
+                    z['name'] = get.get("name")
+                    schedules.append(z)
 
-                    entries = []
-                    for sch in schedules:
-                        days = sch.get("days").split(';')
-                        month = sch.get("month")
-                        year = sch.get("year")
-                        for d in days:
-                            entries.append(
-                                Collection(
-                                    datetime.date(int(year), int(month), int(d)),
-                                    sch.get('name')
-                                )
+                entries = []
+                for sch in schedules:
+                    days = sch.get("days").split(';')
+                    month = sch.get("month")
+                    year = sch.get("year")
+                    for d in days:
+                        entries.append(
+                            Collection(
+                                datetime.date(int(year), int(month), int(d)),
+                                sch.get('name')
                             )
-                    if self.additional_sides_matcher_input != "":
-                        return entries
-
+                        )
+                if self.additional_sides_matcher_input != "":
+                    return entries
         return entries


### PR DESCRIPTION
fix for #839
The old code iterated over the schedule periods but returned after the first (or returned only the last if additional_sides_matcher is not set). This does not seem to be the wanted behaviour. This increases the found Events (test cases) From:
```
  found 158 entries for Simple test case
  found 234 entries for Sides multi test case
  found 18 entries for Sides test case
  found 397 entries for Sides multi test case with district
  found 156 entries for Simple test with community
```
to
```
  found 158 entries for Simple test case
  found 782 entries for Sides multi test case
  found 78 entries for Sides test case
  found 397 entries for Sides multi test case with district
  found 156 entries for Simple test with community
  ```
Its hard for me to validate if all of them are actually wanted events. @pawelhulek created and improved this source, so maybe he wants to take a look at this before merging.  