### PR TITLE
Update campbelltown_nsw_gov_au.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Waste collection schedules in the following formats and countries are supported.
 - [Banyule City Council](/doc/source/banyule_vic_gov_au.md) / banyule.vic.gov.au
 - [Belmont City Council](/doc/source/belmont_wa_gov_au.md) / belmont.wa.gov.au
 - [Brisbane City Council](/doc/source/brisbane_qld_gov_au.md) / brisbane.qld.gov.au
-- [Campbelltown City Council](/doc/source/campbelltown_nsw_gov_au.md) / campbelltown.nsw.gov.au
+- [Campbelltown City Council (NSW)](/doc/source/campbelltown_nsw_gov_au.md) / campbelltown.nsw.gov.au
 - [Cardinia Shire Council](/doc/source/cardinia_vic_gov_au.md) / cardinia.vic.gov.au
 - [City of Canada Bay Council](/doc/source/canadabay_nsw_gov_au.md) / canadabay.nsw.gov.au
 - [City of Onkaparinga Council](/doc/source/onkaparingacity_com.md) / onkaparingacity.com

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/campbelltown_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/campbelltown_nsw_gov_au.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 from requests.utils import requote_uri
 from waste_collection_schedule import Collection
 
-TITLE = "Campbelltown City Council"
+TITLE = "Campbelltown City Council (NSW)"
 DESCRIPTION = "Source for Campbelltown City Council rubbish collection."
 URL = "https://www.campbelltown.nsw.gov.au/"
 TEST_CASES = {

--- a/doc/source/campbelltown_nsw_gov_au.md
+++ b/doc/source/campbelltown_nsw_gov_au.md
@@ -1,4 +1,4 @@
-# Cambelltown City Council
+# Cambelltown City Council (NSW)
 
 Support for schedules provided by [Cambelltown City Council Waste and Recycling](https://www.campbelltown.nsw.gov.au/ServicesandFacilities/WasteandRecycling).
 
@@ -44,4 +44,14 @@ waste_collection_schedule:
 
 ## How to get the source arguments
 
-Visit the [Cambelltown City Council Waste and Recycling](https://www.campbelltown.nsw.gov.au/ServicesandFacilities/WasteandRecycling) page and search for your address. The arguments should exactly match the results shown for Post Code, Suburb, Street and number portion of the Property.
+Visit the [Cambelltown City Council Waste and Recycling](https://www.campbelltown.nsw.gov.au/ServicesandFacilities/WasteandRecycling) page, follow the quick link to *Check my collection day*, and search for your address. The street address arguments used to configure hacs_waste_collection_schedule should exactly match the street address shown in the autocomplete result.
+
+## How this integration uses Campbelltown Council's APIs
+Two API calls are currently needed to retrieve waste collection schedule results from Campbelltown Council:
+1. The address search API at https://www.campbelltown.nsw.gov.au/api/v1/myarea/search
+2. The waste services API at https://www.campbelltown.nsw.gov.au/ocapi/Public/myarea/wasteservices
+
+This integration does the following:
+1. Calls the address search API to retrieve the "location ID" for the given location. Eg. https://www.campbelltown.nsw.gov.au/api/v1/myarea/search?keywords=10%20brookfield%20road%20minto%202566
+2. Retrieves waste/collection info from the waste services API using the "location ID" retrieved in step #1. Eg. https://www.campbelltown.nsw.gov.au/ocapi/Public/myarea/wasteservices?geolocationid=401ee13b-b04c-4948-82e4-09d274c479a0&ocsvclang=en-AU
+3. Parses the HTML returned by the waste services API in step #2 to extract the data

--- a/info.md
+++ b/info.md
@@ -16,7 +16,7 @@ Waste collection schedules from service provider web sites are updated daily, de
 |--|--|
 | Generic | ICS / iCal files |
 | Static | User-defined dates or repeating date patterns |<!--Begin of country section-->
-| Australia | Banyule City Council, Belmont City Council, Brisbane City Council, Campbelltown City Council, Cardinia Shire Council, City of Canada Bay Council, City of Onkaparinga Council, Gold Coast City Council, Hume City Council, Inner West Council (NSW), Ipswich City Council, Ku-ring-gai Council, Lake Macquarie City Council, Macedon Ranges Shire Council, Maribyrnong Council, Maroondah City Council, Melton City Council, Nillumbik Shire Council, North Adelaide Waste Management Authority, RecycleSmart, Stonnington City Council, The Hills Shire Council, Sydney, Whittlesea City Council, Wollongong City Council, Wyndham City Council, Melbourne |
+| Australia | Banyule City Council, Belmont City Council, Brisbane City Council, Campbelltown City Council (NSW), Cardinia Shire Council, City of Canada Bay Council, City of Onkaparinga Council, Gold Coast City Council, Hume City Council, Inner West Council (NSW), Ipswich City Council, Ku-ring-gai Council, Lake Macquarie City Council, Macedon Ranges Shire Council, Maribyrnong Council, Maroondah City Council, Melton City Council, Nillumbik Shire Council, North Adelaide Waste Management Authority, RecycleSmart, Stonnington City Council, The Hills Shire Council, Sydney, Whittlesea City Council, Wollongong City Council, Wyndham City Council, Melbourne |
 | Austria | Burgenländischer Müllverband, infeo, Stadtservice Korneuburg, Umweltprofis, WSZ Moosburg |
 | Belgium | Hygea, Recycle! |
 | Canada | City of Toronto |


### PR DESCRIPTION
Added (NSW) to the page title as there's also a Campbelltown Council in South Australia (SA).

Updated the text to reflect the new structure of the Council's Waste and Recycling page.

Added a section about how Campbelltown Council's APIs work, using the example address (a shopping mall) already used in this documentation and in the plugin.