### PR TITLE
Update ReCollect docs and tests with new split_at regex

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -77,9 +77,13 @@ TEST_CASES = {
         },
         "year_field": "year",
     },
-    "Recollect, Ottawa": {
+    "ReCollect, Ottawa": {
         "url": "https://recollect.a.ssl.fastly.net/api/places/BCCDF30E-578B-11E4-AD38-5839C200407A/services/208/events.en.ics",
-        "split_at": "\\, [and ]*",
+        "split_at": "\\, (?:and )?|(?: and )",
+    },
+    "ReCollect, Simcoe County": {
+        "url": "https://recollect.a.ssl.fastly.net/api/places/08E862E8-8190-11E2-A8A6-C758AE7205AF/services/226/events.en.ics",
+        "split_at": "\\, (?:and )?|(?: and )",
     },
     "Erlensee, Am Haspel": {
         "url": "https://sperrmuell.erlensee.de/?type=reminder",

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -211,13 +211,13 @@ waste_collection_schedule:
 
 ### ReCollect
 
-To get the URL, search your address in the recollect form of your home town, click "Get a calendar", then "Add to iCal". Finally, the URL under "Subscribe to calendar" is your ICS calendar link:
+To get the URL, search your address in the recollect form of your home town, click "Get a calendar", then "Add to Google Calendar". The URL shown is your ICS calendar link, for example:
 
 ```url
-webcal://recollect.a.ssl.fastly.net/api/places/BCCDF30E-578B-11E4-AD38-5839C200407A/services/208/events.en.ics?client_id=6FBD18FE-167B-11EC-992A-C843A7F05606
+https://recollect.a.ssl.fastly.net/api/places/BCCDF30E-578B-11E4-AD38-5839C200407A/services/208/events.en.ics?client_id=6FBD18FE-167B-11EC-992A-C843A7F05606
 ```
 
-Strip the client ID and change the protocol to https, and you have a valid ICS URL.
+You can strip the client ID URL parameter to get the final URL:
 
 ```yaml
 waste_collection_schedule:
@@ -225,7 +225,7 @@ waste_collection_schedule:
     - name: ics
       args:
         url: "https://recollect.a.ssl.fastly.net/api/places/BCCDF30E-578B-11E4-AD38-5839C200407A/services/208/events.en.ics"
-        split_at: "\\, [and ]*"
+        split_at: "\\, (?:and )?|(?: and )"
 ```
 
 ***


### PR DESCRIPTION
This fixes the regex to allow for collections with exactly two waste types. The current regex does not split these correctly (no comma before the "and").
It seems that Ottawa always has at least 3 waste types per event, so the issue does not occur there.

I've added Simcoe County as a test case that uses two waste type events as the norm.

This also addresses a comment in #77 where a user was looking for the correct regex to use in this case.