### PR TITLE
nuernberger_land_de: add filter to include all events

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nuernberger_land_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nuernberger_land_de.py
@@ -12,6 +12,7 @@ TEST_CASES = {
 }
 
 API_URL = "https://abfuhrkalender.nuernberger-land.de/waste_calendar"
+FILTER = "rm:bio:p:dsd:poison"
 
 ICON_MAP = {
     "Restmüll": "mdi:trash-can",
@@ -21,7 +22,6 @@ ICON_MAP = {
     "Giftmobil": "mdi:biohazard",
 }
 
-
 class Source:
     def __init__(self, id):
         self._id = id
@@ -29,7 +29,7 @@ class Source:
 
     def fetch(self):
         # fetch the ical
-        r = requests.get(f"{API_URL}/ical?id={self._id}")
+        r = requests.get(f"{API_URL}/ical?id={self._id}&filter={FILTER}")
         r.raise_for_status()
 
         # replace non-ascii character in UID, otherwise ICS converter will fail


### PR DESCRIPTION
As `mahe112` noted in [this](https://github.com/mampfes/hacs_waste_collection_schedule/pull/549#issuecomment-1552076989) comment, I prepared this PR to fix the issue of missing events in the source: `nuernberger_land_de`.