### PR TITLE
fixed error where update_docu_links fails in windown.

### DIFF
--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -132,7 +132,7 @@ def browse_ics_yaml():
     files = yaml_dir.glob("*.yaml")
     sources = []
     for f in files:
-        with open(f) as stream:
+        with open(f, encoding="utf-8") as stream:
             # write markdown file
             filename = (md_dir / f.name).with_suffix(".md")
             data = yaml.safe_load(stream)
@@ -179,7 +179,7 @@ def write_ics_md_file(filename, data):
         md += multiline_indent(yaml.dump(tc).rstrip("\n"), 8) + "\n"
         md += "```\n"
         # md += "\n"
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(md)
 
 
@@ -302,7 +302,7 @@ def update_citiesapps_com(modules):
 
 def _patch_file(filename, section_id, str):
     # read entire file
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         md = f.read()
 
     section = Section(section_id)
@@ -314,7 +314,7 @@ def _patch_file(filename, section_id, str):
     md = md[:start_pos] + str + md[end_pos:]
 
     # write entire file
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(md)
 
 


### PR DESCRIPTION
Caused by charset issues

https://github.com/mampfes/hacs_waste_collection_schedule/pull/984#issuecomment-1555934082

@StefanHuettenmoser wrote in #984:
> I tried to run the `update_docu_links.py` script, but it crashed with the following output:
> 
> ```
> $ python update_docu_links.py
> Traceback (most recent call last):
>   File "C:\Users\tobias\p\projekte\2023_05_20_hassio_real_waste\hacs_waste_collection_schedule\update_docu_links.py", line 424, in <module>
>     main()
>   File "C:\Users\tobias\p\projekte\2023_05_20_hassio_real_waste\hacs_waste_collection_schedule\update_docu_links.py", line 66, in main
>     update_readme_md(countries)
>   File "C:\Users\tobias\p\projekte\2023_05_20_hassio_real_waste\hacs_waste_collection_schedule\update_docu_links.py", line 241, in update_readme_md
>     _patch_file("README.md", "country", str)
>   File "C:\Users\tobias\p\projekte\2023_05_20_hassio_real_waste\hacs_waste_collection_schedule\update_docu_links.py", line 311, in _patch_file
>     start_pos = md.index(section.start) + len(section.start) + 1
> ValueError: substring not found
> ```
> 
> Also there seems to be an issue with the german characters (sz and umlaut) when I run the script on my machine. They all get converted to �.
> 
> (Running on Windows 11, Python 3.10.11)

For my Linux installation everything worked fine, but I could reproduce this error in Windows. Setting the encoding to "utf-8" every  time it opens a file fixed the issue in Windows and it still works perfectly fine on Linux.