### PR TITLE
Method does not work in Firefox/Safari in south_norfolk_and_broadland…

### DIFF
--- a/doc/source/south_norfolk_and_broadland_gov_uk.md
+++ b/doc/source/south_norfolk_and_broadland_gov_uk.md
@@ -17,7 +17,7 @@ waste_collection_schedule:
 **address_payload**<br/>
 *(dict) (required)*
 
-This is the only configuration variable and is required. It is very easy to fetch.
+This is the only configuration variable and is required. It is very easy to fetch using Google Chrome or a Chromium-based browser. (This method does not work in Firefox or Safari).
 1. Go to https://area.southnorfolkandbroadland.gov.uk/
 2. Input your postcode and select your address
 3. Paste the following code snippet into your browser console (right click -> inspect element -> console)


### PR DESCRIPTION
…_gov_uk.md

The javascript returns an error on the first line for both Firefox and Safari-based browsers, but works as intended on Chromium. Added a clarification as I cannot fix the js myself.