### PR TITLE
Fix variable names (typo) and update search to support Garden Waste Collections in eastherts_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastherts_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastherts_gov_uk.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 
 import requests
 from bs4 import BeautifulSoup
@@ -25,19 +26,30 @@ ICON_MAP = {
 
 API_URL = "https://uhte-wrp.whitespacews.com/"
 
+_LOGGER = logging.getLogger(__name__)
 
 class Source:
     def __init__(
         self,
+        address_name_numer=None,
         address_name_number=None,
         address_street=None,
         street_town=None,
         address_postcode=None,
     ):
-        self._address_name_number = address_name_number
+        self._address_name_number = address_name_number if address_name_number is not None else address_name_numer
         self._address_street = address_street
         self._street_town = street_town
         self._address_postcode = address_postcode
+
+        if address_name_numer is not None:
+            _LOGGER.warning("address_name_numer is deprecated. Use address_name_number instead.")
+
+        if address_street is not None:
+            _LOGGER.warning("address_street is deprecated. Only address_name_number and address_postcode are required")
+
+        if street_town is not None:
+            _LOGGER.warning("street_town is deprecated. Only address_name_number and address_postcode are required")
 
     def fetch(self):
         session = requests.Session()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastherts_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastherts_gov_uk.py
@@ -10,18 +10,17 @@ URL = "https://www.eastherts.gov.uk"
 TEST_CASES = {
     "Example": {
         "address_postcode": "SG9 9AA",
-        "address_name_numer": "1 Trove House",
-        "address_street": "Baldock Road",
+        "address_name_number": "1",
     },
     "Example No Postcode Space": {
         "address_postcode": "SG99AA",
-        "address_name_numer": "1 Trove House",
-        "address_street": "Baldock Road",
+        "address_name_number": "1",
     },
 }
 ICON_MAP = {
     "Refuse": "mdi:trash-can",
-    "Recycling": "mdi:recycle"
+    "Recycling": "mdi:recycle",
+    "Garden Waste": "mdi:leaf"
 }
 
 API_URL = "https://uhte-wrp.whitespacews.com/"
@@ -30,12 +29,12 @@ API_URL = "https://uhte-wrp.whitespacews.com/"
 class Source:
     def __init__(
         self,
-        address_name_numer=None,
+        address_name_number=None,
         address_street=None,
         street_town=None,
         address_postcode=None,
     ):
-        self._address_name_numer = address_name_numer
+        self._address_name_number = address_name_number
         self._address_street = address_street
         self._street_town = street_town
         self._address_postcode = address_postcode
@@ -59,9 +58,7 @@ class Source:
         nextpageurl = alink["href"].replace("seq=1", "seq=2")
 
         data = {
-            "address_name_numer": self._address_name_numer,
-            "address_street": self._address_street,
-            "street_town": self._street_town,
+            "address_name_number": self._address_name_number,
             "address_postcode": self._address_postcode,
         }
 

--- a/doc/source/eastherts_gov_uk.md
+++ b/doc/source/eastherts_gov_uk.md
@@ -16,7 +16,7 @@ waste_collection_schedule:
 ```
 
 ### Configuration Variables
-You only need to supply the house name/number and post code
+You only need to supply the house name/number and post code.
 
 Test this out manually first at [East Herts Council](https://www.eastherts.gov.uk/bins-waste-and-recycling) if you are not sure which are needed.
 

--- a/doc/source/eastherts_gov_uk.md
+++ b/doc/source/eastherts_gov_uk.md
@@ -10,30 +10,23 @@ waste_collection_schedule:
     - name: eastherts_gov_uk
       args:
         address_postcode: POST_CODE
-        address_name_numer: HOUSE_NAME_NUMER,
-        address_street: ADDRESS_STREET,
-        street_town: STREET_TOWN
+        address_name_number: HOUSE_NAME_NUMBER
         version: 1
 
 ```
 
 ### Configuration Variables
-You must supply enough address details for the search to find your property as the first match.
+You only need to supply the house name/number and post code
 
 Test this out manually first at [East Herts Council](https://www.eastherts.gov.uk/bins-waste-and-recycling) if you are not sure which are needed.
 
 
 **ADDRESS_POSTCODE**  
-*(string) (optional)*
+*(string) (required)*
 
-**ADDRESS_NAME_NUMER**  
-*(string) (optional)*
+**ADDRESS_NAME_NUMBER**  
+*(string) (required)*
 
-**ADDRESS_STREET**  
-*(string) (optional)*
-
-**STREET_TOWN**  
-*(string) (optional)*
 
 ## Example
 
@@ -43,6 +36,5 @@ waste_collection_schedule:
     - name: eastherts_gov_uk
       args:
         address_postcode: "SG9 9AA"
-        address_name_numer: "1 Trove House"
-        address_street: "Baldock Road"
+        address_name_number: "1"
 ```


### PR DESCRIPTION
**BREAKING CHANGE (for this source)**

East Herts operate a paid-for Garden Waste collection service. Only properties that have paid for this service will be offered the next collection dates on the lookup. I pay for this service, yet wasn't receiving any dates for the next collection.

In my debugging, I noticed that the council's website has been updated with the following guidance on the search:

> Please enter your property name/number and postcode ONLY. Please do NOT enter your street.

The component was previously providing the street name which was resulting in it ignoring the house number and returning all 35 properties in the post code and selecting the first returned property by default. That property does not subscribe to the garden waste service, hence my problem.

I have removed the option to supply a street name (quite why the council hasn't removed this from the search is beyond me) and also noticed a typo in the house name/number variable, so the data was never being injected in the web page.

This PR now adds the ability to return Garden Waste collections (for those properties subscribed) and fixes the typos so the actual address lookup will take effect. I have also updated the docs accordingly.

Unfortunately this does introduce a breaking change as the configuration for HA's `sensor.yaml` has changed from:

`house_name_numer:` to `house_name_number:`

Could this be included in the release notes, should the change be approved please?