### PR TITLE
Issue 1005

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -12,6 +12,7 @@ TEST_CASES = {
     "Scott Country Clerk": {"street_address": "101 E Main St, Georgetown, KY 40324"},
     "Branch County Clerk": {"street_address": "31 Division St. Coldwater, MI 49036"},
     "Contract Collection": {"street_address": "8957 Park Meadows Dr, Elk Grove, CA 95624"},
+    "Residential Collection": {"street_address": "117 Roxie Ln, Georgetown, KY 40324"},
 
 }
 DELAYS = {
@@ -38,13 +39,9 @@ class Source:
             params={"addressLine1": self._street_address},
         )
         r0_json = json.loads(r0.text)["data"][0]
-
         address_hash = r0_json["addressHash"]
         longitude = r0_json["longitude"]
         latitude = r0_json["latitude"]
-        # postal = r0_json["postalCode"]
-        service = ""
-        day_offset = 0
 
         # get raw schedule and build dict
         r1 = requests.get(
@@ -52,7 +49,7 @@ class Source:
             params={"siteAddressHash": address_hash},
         )
         r1_json = json.loads(r1.text)["data"]
-
+        service = ""
         schedule = {}
         for service_type in r1_json:
             if hasattr(service_type, "__iter__") and service_type != "isColaAccount":
@@ -73,13 +70,13 @@ class Source:
                         i += 1
 
         # compile holidays that impact collections
-        r3 = s.get(f"https://www.republicservices.com/api/v3/holidaySchedules/schedules", params={"latitude": latitude, "longitude": longitude})
-        r3_json = json.loads(r3.text)["data"]
-
+        r2 = s.get(f"https://www.republicservices.com/api/v3/holidaySchedules/schedules", params={"latitude": latitude, "longitude": longitude})
+        r2_json = json.loads(r2.text)["data"]
+        day_offset = 0
         i = 0
         holidays = {}
-        for item in r3_json:
-            if item["serviceImpacted"] == True and item["LOB"] == service:
+        for item in r2_json:
+            if item["serviceImpacted"] == "true" and item["LOB"] == service:
                 for delay in DELAYS:
                     if delay in item["description"]:
                         day_offset = DELAYS[delay]
@@ -107,7 +104,6 @@ class Source:
                     if date_difference <= 5 and date_difference >=0: # is this right???
                         revised_date = p + timedelta(days = d)
                         schedule[pickup]["date"] = revised_date
-                        # increment marker
                         changes += 1
             if changes == 0:
                 break

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -1,8 +1,7 @@
-import re
 import requests
 import json
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Republic Services"
@@ -15,30 +14,109 @@ TEST_CASES = {
     "Contract Collection": {"street_address": "8957 Park Meadows Dr, Elk Grove, CA 95624"},
 
 }
-REGEX = r"Service will resume on (\d+\/\d+\/\d+)"
+DELAYS = {
+    " one ": 1,
+    " two ": 2,
+    " three ": 3,
+    " four ": 4,
+    " five ": 5,
+    " six ": 6,
+    " seven ": 7,
+}
+
 
 class Source:
     def __init__(self, street_address):
         self._street_address = street_address
 
     def fetch(self):
-        response1 = requests.get(
+        s = requests.Session()
+
+        # get adddress data
+        r0 = requests.get(
             "https://www.republicservices.com/api/v1/addresses",
             params={"addressLine1": self._street_address},
         )
+        r0_json = json.loads(r0.text)["data"][0]
 
-        address_hash = json.loads(response1.text)["data"][0]["addressHash"]
-        longitude = json.loads(response1.text)["data"][0]["longitude"]
-        latitude = json.loads(response1.text)["data"][0]["latitude"]
-        postal = json.loads(response1.text)["data"][0]["postalCode"]
+        address_hash = json.loads(r0.text)["addressHash"]
+        longitude = json.loads(r0.text)["longitude"]
+        latitude = json.loads(r0.text)["latitude"]
+        postal = json.loads(r0.text)["postalCode"]
+        service = ""
+        day_offset = 0
 
-        response2 = requests.get(
+        # get raw schedule and build dict
+        r1 = requests.get(
             "https://www.republicservices.com/api/v1/publicPickup",
             params={"siteAddressHash": address_hash},
         )
+        r1_json = json.loads(r1.text)["data"]
 
-        r_json = json.loads(response2.text)["data"]
+        SCHEDULE = {}
+        for service_type in r1_json:
+            if hasattr(service_type, "__iter__") and service_type != "isColaAccount":
+                i = 0
+                for item in r1_json[service_type]:
+                    for day in item["nextServiceDays"]:
+                        dt = datetime.strptime(day, "%Y-%m-%d").date()
+                        service = item["containerCategory"]
+                        SCHEDULE.update(
+                            {i: {
+                                "date": dt,
+                                "waste_type": item["wasteTypeDescription"],
+                                "waste_description": item["productDescription"],
+                                "service": service,
+                                }
+                            }
+                        )
+                        i += 1
 
+        # compile holidays that impact collections
+        r3 = s.get(f"https://www.republicservices.com/api/v3/holidaySchedules/schedules", params={"latitude": latitude, "longitude": longitude})
+        r3_json = json.loads(r3.text)["data"]
+
+        i = 0
+        HOLIDAYS = {}
+        for item in r3_json:
+            if item["serviceImpacted"] == True and item["LOB"] == service:
+                for delay in DELAYS:
+                    if delay in item["description"]:
+                        day_offset = DELAYS[delay]
+                dt = datetime.strptime(item["date"], "%Y-%m-%dT00:00:00.0000000Z").date()
+                HOLIDAYS.update(
+                    {i: {
+                        "date": dt,
+                        "name": item["name"],
+                        "description": item["description"],
+                        "delay": day_offset,
+                        }
+                    }
+                )
+                i += 1
+
+        # keep adjusting dates until they're not impacted by holidays
+        while True:
+            changes = 0
+            for pickup in SCHEDULE:
+                i = SCHEDULE[pickup]["date"]
+                for holiday in HOLIDAYS:
+                    h = HOLIDAYS[holiday]["date"]
+                    d = HOLIDAYS[holiday]["delay"]
+                    date_difference = (h - i).days
+                    if date_difference <= 5 and date_difference >=0: # is this right???
+                        revised_date = i.timedelta(day = d)
+                        SCHEDULE[pickup]["date"] = revised_date
+                        # increment marker
+                        changes += 1
+            if changes == 0:
+                break
+
+        for item in SCHEDULE:
+            print(SCHEDULE[item])
+
+
+        # build final schedule
         entries = []
 
         for x in r_json:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -33,7 +33,7 @@ class Source:
     def fetch(self):
         s = requests.Session()
 
-        # get address data
+        # Get address data
         r0 = requests.get(
             "https://www.republicservices.com/api/v1/addresses",
             params={"addressLine1": self._street_address},
@@ -43,7 +43,7 @@ class Source:
         longitude = r0_json["longitude"]
         latitude = r0_json["latitude"]
 
-        # get raw schedule and build dict
+        # Get raw schedule and build dict
         r1 = requests.get(
             "https://www.republicservices.com/api/v1/publicPickup",
             params={"siteAddressHash": address_hash},
@@ -69,7 +69,7 @@ class Source:
                         )
                         i += 1
 
-        # compile holidays that impact collections
+        # Compile holidays that impact collections
         r2 = s.get(f"https://www.republicservices.com/api/v3/holidaySchedules/schedules", params={"latitude": latitude, "longitude": longitude})
         r2_json = json.loads(r2.text)["data"]
         day_offset = 0
@@ -92,7 +92,7 @@ class Source:
                 )
                 i += 1
 
-        # keep adjusting dates until they're not impacted by holidays
+        # Adjust dates until they're not impacted by holidays
         while True:
             changes = 0
             for pickup in schedule:
@@ -101,14 +101,14 @@ class Source:
                     h = holidays[holiday]["date"]
                     d = holidays[holiday]["delay"]
                     date_difference = (h - p).days
-                    if date_difference <= 5 and date_difference >=0: # is this right???
+                    if date_difference <= 5 and date_difference >= 0: # is this right???
                         revised_date = p + timedelta(days = d)
                         schedule[pickup]["date"] = revised_date
                         changes += 1
             if changes == 0:
                 break
 
-        # build final schedule (implements original logic for assigning icon)
+        # Build final schedule (implements original logic for assigning icon)
         entries = []
         for item in schedule:
             if "RECYCLE" in schedule[item]["waste_description"]:


### PR DESCRIPTION
Updated Republic Services to try and account for collection delays resulting from public holidays, as per #1005.
Just needed to wait for a public holiday to test using results pulled back from the api.

Previous test cases were all commercial collections that didn't appear to be impacted by public holidays. A `Residential Collection` test case was added as a sanity check. As an illustration, the collection originally planned for 6th July is delayed until the 7th July due to the 4th July holiday. The script now returns the delayed collection date of 7th July.

![image](https://github.com/mampfes/hacs_waste_collection_schedule/assets/86194065/484111d7-48b9-4026-b27d-580008912510)


Given the range of service types, waste formats, and regional variations in whether holidays impact schedules, I'm sure further tweaks will be required at some point.

```bash
Testing source republicservices_com ...
  found 1 entries for Scott Country Clerk
    2023-07-07 : Solid Waste [mdi:trash-can]
  found 1 entries for Branch County Clerk
    2023-07-03 : Solid Waste [mdi:trash-can]
  found 7 entries for Contract Collection
    2023-07-04 : Recycle [mdi:leaf]
    2023-07-11 : Recycle [mdi:recycle]
    2023-07-25 : Recycle [mdi:recycle]
    2023-08-08 : Recycle [mdi:recycle]
    2023-08-22 : Recycle [mdi:recycle]
    2023-09-05 : Recycle [mdi:recycle]
    2023-07-04 : Solid Waste [mdi:trash-can]
  found 1 entries for Residential Collection
    2023-07-07 : Solid Waste [mdi:trash-can]
```