### PR TITLE
Change URL of bielefeld_de to new URL

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
@@ -16,7 +16,7 @@ TEST_CASES = {
     },
 }
 SERVLET = (
-    "https://anwendungen.bielefeld.de/WasteManagementBielefeld/WasteManagementServlet"
+    "https://anwendungen.bielefeld.de/WasteManagementBielefeldTest/WasteManagementServlet"
 )
 
 # Parser for HTML input (hidden) text


### PR DESCRIPTION
Bielefeld changed it's url form 
```

https://anwendungen.bielefeld.de/WasteManagementBielefeld/WasteManagementServlet
```

to 
```
https://anwendungen.bielefeld.de/WasteManagementBielefeldTest/WasteManagementServlet
```

Yes, unbelievable but true. They added "Test" to their production URL. Also the URL on their [Main site](https://service.bielefeld.de/detail/-/vr-bis-detail/dienstleistung/3329451/show) refers to that link. 
The above mentioned URL  
```
https://anwendungen.bielefeld.de/WasteManagementBielefeldTest/WasteManagementServlet
```

is not callable in a Browser directly. In the Browser it requires some parameters. 
```
https://anwendungen.bielefeld.de/WasteManagementBielefeldTest/WasteManagementServlet?SubmitAction=wasteDisposalServices
```
But the Integration is working again after that change. I've tested it. 

It may be possible that they will change that back in the near future. I will monitor it and perhaps change that back. 