### PR TITLE
New Source: Dunedin, Otago, NZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ Waste collection schedules in the following formats and countries are supported.
 
 - [Auckland Council](/doc/source/aucklandcouncil_govt_nz.md) / aucklandcouncil.govt.nz
 - [Christchurch City Council](/doc/source/ccc_govt_nz.md) / ccc.govt.nz
+- [Dunedin District Council](/doc/source/dunedin_govt_nz.md) / dunedin.govt.nz
 - [Gore, Invercargill & Southland](/doc/source/wastenet_org_nz.md) / wastenet.org.nz
 - [Horowhenua District Council](/doc/source/horowhenua_govt_nz.md) / horowhenua.govt.nz
 - [Waipa District Council](/doc/source/waipa_nz.md) / waipadc.govt.nz

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dunedin_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dunedin_govt_nz.py
@@ -1,0 +1,127 @@
+import json
+import requests
+
+from  datetime import datetime, timedelta
+from waste_collection_schedule import Collection
+
+TITLE = "Dunedin District Council"
+DESCRIPTION = "Source for Dunedin District Council Rubbish & Recycling collection."
+URL = "https://www.dunedin.govt.nz/"
+TEST_CASES = {
+    "No Collection": {"address": "3 Farm Road West Berwick"},
+    "Calendar 1": {"address": "5 Bennett Road Ocean View"},
+    "Calendar 2": {"address": "2 Council Street Dunedin"},
+    "All Week": {"address": "118 High Street Dunedin"},
+    "Collection 'c'": {"address": "2 - 90 Harbour Terrace Dunedin"},
+}
+DAYS = {
+    "Monday" : 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+    "Saturday": 5,
+    "Sunday": 6,
+}
+HEADERS = {
+    "user-agent": "Mozilla/5.0",
+}
+ICON_MAP = {
+    "BLACK BAG": "mdi:trash-can",
+    "BLUE BIN": "mdi:bottle-soda",
+    "YELLOW BIN": "mdi:recycle",
+}
+
+# _LOGGER = logging.getLogger(__name__)
+
+
+class Source:
+    def __init__(self, address):
+        self._address = str(address).replace(" ", "+").strip()
+
+    def fetch(self):
+        # Get collection json
+        s = requests.Session()
+        r = s.get(
+            f"https://www.dunedin.govt.nz/design/rubbish-and-collection-days-search/lookup/_nocache?query={self._address}",
+            headers=HEADERS
+        )
+        r_json = json.loads(r.text)[0]["attributes"]
+
+        # Work out the date of the next collection(s)
+        collection_dates = []
+        today = datetime.now().date()
+        if r_json["collectionDay"] == "No Collection":
+            raise Exception("No collection service for that address")
+        elif r_json["collectionDay"] == "Today":
+            collection_dates.append(today)
+        elif r_json["collectionDay"] == "Tomorrow":
+            collection_dates.append(today + timedelta(days=1))
+        elif r_json["collectionDay"] == "All Week":  # assume this means weekdays only, not weekends
+            collection_date = today
+            counter = 0 
+            while counter <= 7:
+                if collection_date.strftime("%A") in "Monday Tuesday Wednesday Thursday Friday":
+                    collection_dates.append(collection_date)
+                collection_date = collection_date + timedelta(days=1)
+                counter +=1
+        else:  # find date of next matching weekday
+            collection_date = today
+            while collection_date.strftime("%A") != r_json["collectionDay"]:
+                collection_date = collection_date + timedelta(days=1)
+            collection_dates.append(collection_date)
+
+        # Adjust dates impacted by public holidays
+        '''
+        Note: A json of the public holiday potentially impacting collections can be retrieved from:
+        https://www.dunedin.govt.nz/__data/assets/js_file/0005/875336/publicHolidayData.js
+        At the time of writing (2023), none of the listed public holidays impact collection days
+        so it's not known how to account for any impact on collection day/date.
+        '''
+
+        # Now work out which waste types need to be displayed
+        '''
+        Note: r_json["CurrentWeek"] contains the collection code for the current calendar week.
+        If the collection day hasn't passed, then the collection code should be correct.
+        If the collection occurred earlier in the week, the collection code needs
+        to be switched to next week's collection code.
+        The collection seem to translate to :
+        b -> Blue bin & Black bag
+        c -> Blue bin, Yellow bin & Black bag
+        y -> Yellow bin & Black bag
+        n -> Black bag
+        These are likely to change in 2024 when new waste types are introduced, see:
+        https://www.dunedin.govt.nz/council/council-projects/waste-futures/the-future-of-rubbish-and-recycling-in-dunedin
+        '''
+        if r_json["collectionDay"] != "All Week":
+            if today.weekday() > DAYS[r_json["collectionDay"]]:  # collection should have happened
+                if r_json["CurrentWeek"] == "c":  # not strictly needed, included for completeness
+                    r_json["CurrentWeek"] = "c"
+                if r_json["CurrentWeek"] == "y":
+                    r_json["CurrentWeek"] = "b"
+                elif r_json["CurrentWeek"] != "n" and r_json["CurrentWeek"] != "c":
+                    r_json["CurrentWeek"] = "y"
+
+        waste_types = []
+        if r_json["CurrentWeek"] == "n":
+            waste_types.append("Black Bag")
+        elif r_json["CurrentWeek"] == "y":
+            waste_types.extend(("Black Bag", "Yellow Bin"))
+        elif r_json["CurrentWeek"] == "b":
+            waste_types.extend(("Black Bag", "Blue Bin"))
+        elif r_json["CurrentWeek"] == "c":
+            waste_types.extend(("Black Bag", "Yellow Bin", "Blue Bin"))
+
+        # Now build schedule
+        entries = []
+        for waste in waste_types:
+            for schedule in collection_dates:
+                entries.append(
+                    Collection(
+                        date = schedule,
+                        t=waste,
+                        icon=ICON_MAP.get(waste.upper()),
+                    )
+                )
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dunedin_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dunedin_govt_nz.py
@@ -8,7 +8,7 @@ TITLE = "Dunedin District Council"
 DESCRIPTION = "Source for Dunedin District Council Rubbish & Recycling collection."
 URL = "https://www.dunedin.govt.nz/"
 TEST_CASES = {
-    "No Collection": {"address": "3 Farm Road West Berwick"},
+    # "No Collection": {"address": "3 Farm Road West Berwick"},  # Useful for troubleshooting, elicits a "No Collection" response from website
     "Calendar 1": {"address": "5 Bennett Road Ocean View"},
     "Calendar 2": {"address": "2 Council Street Dunedin"},
     "All Week": {"address": "118 High Street Dunedin"},
@@ -85,7 +85,7 @@ class Source:
         If the collection day hasn't passed, then the collection code should be correct.
         If the collection occurred earlier in the week, the collection code needs
         to be switched to next week's collection code.
-        The collection seem to translate to :
+        The collection codes seem to translate to:
         b -> Blue bin & Black bag
         c -> Blue bin, Yellow bin & Black bag
         y -> Yellow bin & Black bag

--- a/doc/source/dunedin_govt_nz.md
+++ b/doc/source/dunedin_govt_nz.md
@@ -1,4 +1,4 @@
-# Horowhenua District Council
+# Dunedin District Council
 
 Support for schedules provided by [Dunedin District Council Kerbside Rubbish & Recycling Services](https://www.dunedin.govt.nz/do-it-online/search/collection-days).
 

--- a/doc/source/dunedin_govt_nz.md
+++ b/doc/source/dunedin_govt_nz.md
@@ -1,0 +1,33 @@
+# Horowhenua District Council
+
+Support for schedules provided by [Dunedin District Council Kerbside Rubbish & Recycling Services](https://www.dunedin.govt.nz/do-it-online/search/collection-days).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: dunedin_govt_nz
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**  
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: dunedin_govt_nz
+      args:
+        address: "118 High Street Dunedin"
+```
+
+## How to get the source argument
+Visit the [Dunedin District Council Kerbside Collection Days](https://www.dunedin.govt.nz/do-it-online/search/collection-days) page and search for your address. The `address` argument should match how the website displays address alongside your next collection details.
+
+Note: For addresses with hyphenated numbers, the whitespace is important. For example, the website tends to use the format "2 - 6 Random Road Dunedin", so resist changing it to "2-6 Random Road Dunedin".

--- a/info.md
+++ b/info.md
@@ -24,7 +24,7 @@ Waste collection schedules from service provider web sites are updated daily, de
 | Lithuania | Kauno švara |
 | Luxembourg | Esch-sur-Alzette |
 | Netherlands | ACV Group, Alpen an den Rijn, Area Afval, Avalex, Avri, Bar Afvalbeheer, Circulus, Cyclus NV, Dar, Den Haag, GAD, Gemeente Almere, Gemeente Berkelland, Gemeente Cranendonck, Gemeente Hellendoorn, Gemeente Lingewaard, Gemeente Meppel, Gemeente Middelburg + Vlissingen, Gemeente Peel en Maas, Gemeente Schouwen-Duiveland, Gemeente Sudwest-Fryslan, Gemeente Venray, Gemeente Voorschoten, Gemeente Waalre, Gemeente Westland, HVC Groep, Meerlanden, Mijn Blink, PreZero, Purmerend, RAD BV, Reinis, Spaarnelanden, Twente Milieu, Waardlanden, Ximmio, ZRD |
-| New Zealand | Auckland Council, Christchurch City Council, Gore, Invercargill & Southland, Horowhenua District Council, Waipa District Council, Wellington City Council |
+| New Zealand | Auckland Council, Christchurch City Council, Dunedin District Council, Gore, Invercargill & Southland, Horowhenua District Council, Waipa District Council, Wellington City Council |
 | Norway | Min Renovasjon, Movar IKS, Oslo Kommune, ReMidt Orkland muni, Stavanger Kommune, Trondheim |
 | Poland | Ecoharmonogram, Poznań/Koziegłowy/Objezierze/Oborniki, Warsaw, Wrocław |
 | Slovenia | Moji odpadki, Ljubljana |


### PR DESCRIPTION
New source, as requested in #1074

Test case "No Collection" is intended to fail, there is (currently) no collection service for that address.
I think the other test cases cover the different schedules that exist, but the website only provides details for _Calendar 1 & 2_ where Black/Blue and Black/Yellow are collected on alternate weeks. _All Week_ and _Collection 'c'_ are inferred from picking random addresses.

```bash
Testing source dunedin_govt_nz ...
  No Collection failed: No collection service for that address
  found 2 entries for Calendar 1
    2023-07-20 : Black Bag [mdi:trash-can]
    2023-07-20 : Blue Bin [mdi:bottle-soda]
  found 2 entries for Calendar 2
    2023-07-19 : Black Bag [mdi:trash-can]
    2023-07-19 : Yellow Bin [mdi:recycle]
  found 5 entries for All Week
    2023-07-17 : Black Bag [mdi:trash-can]
    2023-07-18 : Black Bag [mdi:trash-can]
    2023-07-19 : Black Bag [mdi:trash-can]
    2023-07-20 : Black Bag [mdi:trash-can]
    2023-07-21 : Black Bag [mdi:trash-can]
  found 3 entries for Collection 'c'
    2023-07-18 : Black Bag [mdi:trash-can]
    2023-07-18 : Yellow Bin [mdi:recycle]
    2023-07-18 : Blue Bin [mdi:bottle-soda]
```