### PR TITLE
disable ssl for basingstroke_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/basingstoke_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/basingstoke_gov_uk.py
@@ -1,8 +1,16 @@
 from datetime import datetime
 
 import requests
+# With verify=True the POST fails due to a SSLCertVerificationError.
+# Using verify=False works, but is not ideal. The following links may provide a better way of dealing with this:
+# https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
+# https://urllib3.readthedocs.io/en/1.26.x/user-guide.html#ssl
+# These two lines areused to suppress the InsecureRequestWarning when using verify=False
+import urllib3
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+urllib3.disable_warnings()
 
 TITLE = "Basingstoke and Deane Borough Council"
 DESCRIPTION = "Source for basingstoke.gov.uk services for Basingstoke and Deane Borough Council, UK."
@@ -37,6 +45,7 @@ class Source:
             "https://www.basingstoke.gov.uk/bincollections",
             headers=HEADERS,
             cookies=REQUEST_COOKIES,
+            verify=False,
         )
         r.raise_for_status()
 


### PR DESCRIPTION
fix for #1125

fixes `unable to get local issuer certificate` with disableing ssl all together

not ideal 