### PR TITLE
fix samilio_se

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/samiljo_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/samiljo_se.py
@@ -115,7 +115,7 @@ class Source:
         adresslistalines = adresslist.text.lower().splitlines()
         for line in adresslistalines:
             if streetcityjoined in line:
-                A = line.split("|")[-1]
+                A = line.split("|")[3]
 
         payload = {"hsG": self.street, "hsO": self.city, "nrA": A}
         payload_str = urllib.parse.urlencode(payload, encoding="cp1252")


### PR DESCRIPTION
fix for #1133 

Taking the 3rd element like the javascript on the website (https://webbservice.indecta.se/kunder/sam/kalender/basfiler/skript/jq.eget.js) `$('#anlnr').val(data[3]);` instead of the last (-1) fixed the error.
They probably added an additional number on the end indecating something different