### PR TITLE
Fix: Exeter Council

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
@@ -10,7 +10,7 @@ TITLE = "Exeter City Council"
 DESCRIPTION = "Source for Exeter City services for Exeter City Council, UK."
 URL = "https://exeter.gov.uk/"
 TEST_CASES = {
-    "Test_001": {"uprn": "10013049539"},
+    "Test_001": {"uprn": "100040227486"},
     "Test_002": {"uprn": "10013043921"},
     "Test_003": {"uprn": 10023120282},
     "Test_004": {"uprn": 100040241022},
@@ -21,7 +21,7 @@ ICON_MAP = {
     "GARDEN WASTE": "mdi:leaf",
     "FOOD WASTE": "mdi:food"
 }
-REGEX_ORDINALS = r"(st|nd|rd|th) "
+REGEX_ORDINALS = r"\d(st|nd|rd|th) "
 
 class Source:
     def __init__(self, uprn):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
@@ -1,9 +1,9 @@
-import requests
 import json
 import re
-
-from bs4 import BeautifulSoup
 from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Exeter City Council"
@@ -19,9 +19,10 @@ ICON_MAP = {
     "REFUSE": "mdi:trash-can",
     "RECYCLING": "mdi:recycle",
     "GARDEN WASTE": "mdi:leaf",
-    "FOOD WASTE": "mdi:food"
+    "FOOD WASTE": "mdi:food",
 }
 REGEX_ORDINALS = r"\d(st|nd|rd|th) "
+
 
 class Source:
     def __init__(self, uprn):
@@ -30,7 +31,9 @@ class Source:
     def fetch(self):
 
         s = requests.Session()
-        r = s.get(f"https://exeter.gov.uk/repositories/hidden-pages/address-finder/?qsource=UPRN&qtype=bins&term={self._uprn}")
+        r = s.get(
+            f"https://exeter.gov.uk/repositories/hidden-pages/address-finder/?qsource=UPRN&qtype=bins&term={self._uprn}"
+        )
 
         json_data = json.loads(r.text)[0]["Results"]
         soup = BeautifulSoup(json_data, "html.parser")
@@ -41,11 +44,12 @@ class Source:
         for (b, d) in zip(bins, dates):
             entries.append(
                 Collection(
-                    date=datetime.strptime(re.compile(REGEX_ORDINALS).sub("",d.text),"%A, %d%B %Y").date(),
+                    date=datetime.strptime(
+                        re.compile(REGEX_ORDINALS).sub("", d.text), "%A, %d%B %Y"
+                    ).date(),
                     t=b.text.replace(" collection", ""),
                     icon=ICON_MAP.get(b.text.replace(" collection", "").upper()),
                 )
             )
-
 
         return entries

--- a/doc/source/exeter_gov_uk.md
+++ b/doc/source/exeter_gov_uk.md
@@ -30,7 +30,7 @@ waste_collection_schedule:
 
 ## How to find your UPRN
 
-An easy way to discover your Unique Property Reference Number (UPRN) is by looking at the url of you collection schedule on the Exeter City Council website. The set of numbers at teh end of the url are your uprn.
+An easy way to discover your Unique Property Reference Number (UPRN) is by looking at the url of you collection schedule on the Exeter City Council website. The set of numbers at the end of the url are your uprn.
 
 For example: 
 _exeter.gov.uk/bins-and-recycling/bin-collections/when-is-my-bin-collected/?UPRN=`10013049539`_


### PR DESCRIPTION
Regex updated to prevent ordinals being removed from month names.
Corrects issue mentioned in #1145.

```bash
Testing source exeter_gov_uk ...
  found 4 entries for Test_001
    2023-08-02 : Refuse [mdi:trash-can]
    2023-08-01 : Recycling [mdi:recycle]
    2023-08-01 : Garden waste [mdi:leaf]
    2023-08-01 : Food waste [mdi:food]
  found 3 entries for Test_002
    2023-08-02 : Refuse [mdi:trash-can]
    2023-08-01 : Recycling [mdi:recycle]
    2023-08-01 : Garden waste [mdi:leaf]
  found 3 entries for Test_003
    2023-08-01 : Refuse [mdi:trash-can]
    2023-08-02 : Recycling [mdi:recycle]
    2023-08-02 : Garden waste [mdi:leaf]
  found 4 entries for Test_004
    2023-08-02 : Refuse [mdi:trash-can]
    2023-08-01 : Recycling [mdi:recycle]
    2023-08-01 : Garden waste [mdi:leaf]
    2023-08-01 : Food waste [mdi:food]
```