### PR TITLE
Fix error caused by Lake Mac no longer providing bulk waste date

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lakemac_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lakemac_nsw_gov_au.py
@@ -58,7 +58,10 @@ class Source:
 
         waste_date = []
         for tag in soup.find_all("div", {"class": "next-service"}):
-            date_object = datetime.strptime(tag.text.strip(), "%a %d/%m/%Y").date()
+            try:
+                date_object = datetime.strptime(tag.text.strip(), "%a %d/%m/%Y").date()
+            except:
+                continue    
             waste_date.append(date_object)
 
         waste = list(zip(waste_type, waste_date))


### PR DESCRIPTION
Lake Macquarie Council no longer provides a date for bulk waste collection, which causes lakemac_nsw_gov_au source to fail

![Bulk waste no longer displayed on Lake Mac website](https://i.imgur.com/dxRr9hh.png)

To solve this, I'm proposing simply wrapping creating the `date_object` creation in a try/except statement, and simply ignoring the `next-service` tag if it can't be parsed.

Test before this proposed change:

```
python3 test_sources.py -s lakemac_nsw_gov_au
Testing source lakemac_nsw_gov_au ...
  TestcaseI failed: time data '' does not match format '%a %d/%m/%Y'
  TestcaseII failed: time data '' does not match format '%a %d/%m/%Y'
```

Test after this proposed change:

```
python3 test_sources.py -s lakemac_nsw_gov_au
Testing source lakemac_nsw_gov_au ...
  found 3 entries for TestcaseI
  found 3 entries for TestcaseII
```