### PR TITLE
Update guildford_gov_uk.py to fix type issues

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/guildford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/guildford_gov_uk.py
@@ -10,7 +10,7 @@ URL = "https://guildford.gov.uk"
 TEST_CASES = {
     "GU12": {"uprn": "10007060305"},
     "GU1": {"uprn": "100061398158"},
-    "GU2": {"uprn": "100061391831"},
+    "GU2": {"uprn": 100061391831},
 }
 
 ICON_MAP = {


### PR DESCRIPTION
Line 34 caused an issue with type errors, so I've cast it to a string when reading it in initially:

`fetch failed for source Guildford Borough Council: Traceback (most recent call last): File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py", line 134, in fetch entries = self._source.fetch() ^^^^^^^^^^^^^^^^^^^^ File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source/guildford_gov_uk.py", line 34, in fetch "message=%7B%22actions%22%3A%5B%7B%22id%22%3A%22291%3Ba%22%2C%22descriptor%22%3A%22apex%3A%2F%2FBinScheduleDisplayCmpController%2FACTION%24GetBinSchedules%22%2C%22callingDescriptor%22%3A%22markup%3A%2F%2Fc%3ABinScheduleDisplay%22%2C%22params%22%3A%7B%22database%22%3A%22domestic%22%2C%22UPRN%22%3A%22" TypeError: can only concatenate str (not "int") to str`
