### PR TITLE
Sensor event index

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
@@ -33,6 +33,7 @@ class CollectionAggregator:
         include_types=None,
         exclude_types=None,
         include_today=False,
+        start_index=None,
     ):
         """Return list of all entries, limited by count and/or leadtime.
 
@@ -47,6 +48,7 @@ class CollectionAggregator:
             include_types=include_types,
             exclude_types=exclude_types,
             include_today=include_today,
+            start_index=start_index,
         )
 
     def get_upcoming_group_by_day(
@@ -56,6 +58,7 @@ class CollectionAggregator:
         include_types=None,
         exclude_types=None,
         include_today=False,
+        start_index=None,
     ):
         """Return list of all entries, grouped by day, limited by count and/or leadtime."""
         entries = []
@@ -73,6 +76,8 @@ class CollectionAggregator:
 
         for key, group in iterator:
             entries.append(CollectionGroup.create(list(group)))
+        if start_index is not None:
+            entries = entries[start_index:]
         if count is not None:
             entries = entries[:count]
 
@@ -86,6 +91,7 @@ class CollectionAggregator:
         include_types=None,
         exclude_types=None,
         include_today=False,
+        start_index=None,
     ):
         # remove unwanted waste types from include list
         if include_types is not None:
@@ -115,6 +121,8 @@ class CollectionAggregator:
         entries.sort(key=lambda e: e.date)
 
         # remove surplus entries
+        if start_index is not None:
+            entries = entries[start_index:]
         if count is not None:
             entries = entries[:count]
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -126,6 +126,33 @@ value_template: '{{value.types|join(", ")}}'
 </details>
 
 <details>
+<summary>How do I configure sensors which show the first, second, third collection?</summary>
+<p>
+
+Set `event_index` within the sensor configuration:
+
+```yaml
+sensor:
+  - platform: waste_collection_schedule
+    name: first_garbage_collection
+    event_index: 0
+    value_template: '{{value.types|join(", ")}} in {{ value.daysTo }} days'
+
+  - platform: waste_collection_schedule
+    name: second_garbage_collection
+    event_index: 1
+    value_template: '{{value.types|join(", ")}} in {{ value.daysTo }} days'
+
+  - platform: waste_collection_schedule
+    name: third_garbage_collection
+    event_index: 3
+    value_template: '{{value.types|join(", ")}} in {{ value.daysTo }} days'
+```
+
+</p>
+</details>
+
+<details>
 <summary>How do I configure a sensor to show only collections of a specific waste type?
 </summary>
 <p>

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -113,6 +113,7 @@ sensor:
     value_template: VALUE_TEMPLATE
     date_template: DATE_TEMPLATE
     add_days_to: ADD_DAYS_TO
+    event_index: EVENT_INDEX
     types:
       - Waste Type 1
       - Waste Type 2
@@ -129,6 +130,7 @@ sensor:
 | value_template | string | optional | Uses Home Assistant templating to format the state information of an entity. See [template variables](#template-variables-for-value_template-and-date_template-parameters) for further details |
 | date_template | string | optional | Uses Home Assistant templating to format the dates appearing within the _more info_ popup information of an entity. See [template variables](#template-variables-for-value_template-and-date_template-parameters) for further details |
 | add_days_to | boolean | optional | Adds a `daysTo` attribute to the source entity state containing the number of days to  the next collection |
+| event_index | int | optional | Used to assign a sensor to a specific pickup date index. The next pickup date has event_index 0. Useful if you want to have dedicated sensors for next collection, second collection, third collection, ... |
 | types | list of strings | optional | Used to filter waste types. The sensor will only display collections matching these waste types |
 
 ## Options for _details_format_ parameter


### PR DESCRIPTION
adding the ability to show the Nth collection date for a sensor wanted by #1099

I haven't spent that much time in the homeassistant custom components code (except for sources) so I might have missed stuff that also need to be changed but after a bit of testing everything seems to work.

I'm also not sure if  `event_index` is a good name for this parameter but I couldn't think of a better name.
Feel free to change the name and the documentation if you like