### PR TITLE
config typo corrected

### DIFF
--- a/doc/source/okc_gov.md
+++ b/doc/source/okc_gov.md
@@ -7,7 +7,7 @@ Support for schedules provided by [City of Oklahoma City](https://www.okc.gov/),
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: okc.gov
+    - name: okc_gov
       args:
         objectID: UNIQUE_PROPERTY_IDENTIFIER
 ```
@@ -22,7 +22,7 @@ waste_collection_schedule:
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: okc.gov
+    - name: okc_gov
       args:
         objectID: "1781151"
 ```


### PR DESCRIPTION
updated okc_gov.md: `name: okc.gov` corrected to `name: okc_gov`
as mentioned in recent [comment](https://github.com/mampfes/hacs_waste_collection_schedule/pull/856#issuecomment-1698525012)