### PR TITLE
recyclecoach fix: no longer displays moved events

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -174,6 +174,8 @@ class Source:
             for month in year["months"]:
                 for event in month["events"]:
                     for collection in event["collections"]:
+                        if collection["status"] == "is_none":
+                            continue
                         ct = collection_types["collection-" + str(collection["id"])]
                         c = Collection(
                             datetime.strptime(event["date"], date_format).date(),
@@ -181,5 +183,4 @@ class Source:
                             ICON_MAP.get(ct["title"]),
                         )
                         entries.append(c)
-
         return entries


### PR DESCRIPTION
fix for #1227
Fix: displayed event even if status was "is_none" indecating that it was moved or not planned anymore. 

noremal events have status ""
moved events on another day have status is_change