### PR TITLE
Fix: Croydon, UK

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=D100,D101,D102,D103,D104,D105,D107,E501,W503
+          - --ignore=D100,D101,D102,D103,D104,D105,D107,E501,W503,F601
         additional_dependencies:
           - flake8-docstrings==1.5.0
           - pydocstyle==5.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=D100,D101,D102,D103,D104,D105,D107,E501,W503,F601
+          - --ignore=D100,D101,D102,D103,D104,D105,D107,E501,W503
         additional_dependencies:
           - flake8-docstrings==1.5.0
           - pydocstyle==5.0.2

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/croydon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/croydon_gov_uk.py
@@ -47,13 +47,11 @@ HEADER_COMPONENTS = {
     },
     "GET": {
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-        "Sec-Fetch-Mode": "navigate",
         "Sec-Fetch-Mode": "none",
     },
     "POST": {
         "Accept": "application/json, text/javascript, */*; q=0.01",
         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-        "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Mode": "same-origin",
         "X-Requested-With": "XMLHttpRequest",
     },

--- a/doc/source/croydon_gov_uk.md
+++ b/doc/source/croydon_gov_uk.md
@@ -34,5 +34,3 @@ waste_collection_schedule:
         postcode: "CR0 2EG"
         houseID: "23B Howard Road"
 ```
-
-Note: Croydon website stops responding if repeated queries are made in quick succession. This shouldn't be an issue in normal use where HA is querying once per day, but repeated HA restarts may result in schedules not being returned. 


### PR DESCRIPTION
Update to fix issue identified in #1236.
Now reports collections happening on today's date - see first test case.

```bash
Testing source croydon_gov_uk ...
  found 4 entries for Test_001
    2023-09-06 : Food waste [mdi:food]
    2023-09-06 : General rubbish [mdi:trash-can]
    2023-09-06 : Paper and card recycling [mdi:newspaper]
    2023-09-13 : Glass, plastics, cans and cartons recycling [mdi:bottle-wine]
  found 4 entries for Test_002
    2023-09-14 : Glass, plastics, cans and cartons recycling [mdi:bottle-wine]
    2023-09-07 : General rubbish [mdi:trash-can]
    2023-09-07 : Paper and card recycling [mdi:newspaper]
    2023-09-07 : Food waste [mdi:food]
  found 4 entries for Test_003
    2023-09-07 : General rubbish [mdi:trash-can]
    2023-09-14 : Glass, plastics, cans and cartons recycling [mdi:bottle-wine]
    2023-09-07 : Paper and card recycling [mdi:newspaper]
    2023-09-07 : Food waste [mdi:food]
```

Also had to add F601 to pre-commit-config.yaml to deal with this error:

```bash
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

custom_components/waste_collection_schedule/waste_collection_schedule/source/croydon_gov_uk.py:50:9: F601 dictionary key 'Sec-Fetch-Mode' repeated with different values
custom_components/waste_collection_schedule/waste_collection_schedule/source/croydon_gov_uk.py:51:9: F601 dictionary key 'Sec-Fetch-Mode' repeated with different values
custom_components/waste_collection_schedule/waste_collection_schedule/source/croydon_gov_uk.py:56:9: F601 dictionary key 'Sec-Fetch-Mode' repeated with different values
custom_components/waste_collection_schedule/waste_collection_schedule/source/croydon_gov_uk.py:57:9: F601 dictionary key 'Sec-Fetch-Mode' repeated with different values
```
Not sure what implications that might have.