### PR TITLE
Haveafald new triggers also with "240 L" description

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/renosyd_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/renosyd_dk.py
@@ -107,7 +107,7 @@ class Source:
             elements = row.find_all("td")
 
             result = re.search(
-                r"^(\d{1,2}\s?x\s?)([A-Za-z\/]*)(\s*\d{1,4}L)?$",
+                r"^(\d{1,2}\s?x\s?)([A-Za-z\/]*)(\s*\d{1,4}\s?L)?$",
                 elements[0].contents[0].strip(),
             )
             if result is None:


### PR DESCRIPTION
The description on renosyd is as following:
1 x Restaffald 240L 
1 x Papir/Pap 240L 
1 x Emballage 240L 
1 x Haveaffald 240 L 
1 x Storskrald 

The space between 240 and L in Haveaffald didn't trigger before, fixed it with \s?