### PR TITLE
Fix Rushmoor Food Waste Schedule

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushmoor_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushmoor_gov_uk.py
@@ -53,12 +53,12 @@ class Source:
                         )
                     )
 
-                    # Always add Food as that is collected weekly
-                    entries.append(
-                        Collection(
-                            d[0],
-                            "Food",
-                            icon=ICON_MAP.get("Food"),
-                        )
-                    )
+            # Always add Food as that is collected weekly
+            entries.append(
+                Collection(
+                    d[0],
+                    "Food",
+                    icon=ICON_MAP.get("Food"),
+                )
+            )
         return entries


### PR DESCRIPTION
The `rushmoor_gov_uk` integration is supposed to return a "Food" collection each week, however it currently only adds it when the "Refuse" bin is due. Unindenting the block to be outside the `if` statement seems to bring the intended effect.