### PR TITLE
Update source SRV återvinning api endpoint

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/srvatervinning_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/srvatervinning_se.py
@@ -28,7 +28,7 @@ class Source:
             "city": "",
         }
         r = requests.get(
-            "https://www.srvatervinning.se/rest-api/srv-slamsok-rest-new/search", params
+            "https://www.srvatervinning.se/rest-api/core/sewagePickup/search?query", params
         )
         r.raise_for_status()
 


### PR DESCRIPTION
It seems SRV source has changed api endpoint (and data structure?)
from: https://www.srvatervinning.se/rest-api/srv-slamsok-rest-new/search?query=Vidjestigen+7
to: https://www.srvatervinning.se/rest-api/core/sewagePickup/search?query=Vidjestigen+7

Old endpoint responds with 400 Bad Request:

{
    "success": false,
    "type": "invalidParameter",
    "description": "An invalid parameter (query or request body) was specified",
    "message": "No RestApp found for /rest-api/srv-slamsok-rest-new/search"
}
New responds with 200 OK:

{
   "multipleAddresses": false,
   "customerAddresses": [],
   "results": [
      {
         "customerId": "111111",
         "zipCode": "13672",
         "containers": [
            {
               "zipCode": "13672",
               "address": "Vidjestigen 7",
               "city": "VENDELSÖ",
               "containerType": "Kärl 140 liter brunt",
               "firstCalendarDate": "2023-10-03",
               "frequency": "Varannan vecka",
               "searchByClient": false,
               "propertyCode": "VENDELSÖ 15:13",
               "hasFrequency": true,
               "calendars": [
                  {
                     "weeks": null,
                     "dayName": "Tisdag",
                     "startDateHuman": "Tisdag 3 oktober 2023",
                     "endDate": null,
                     "jobTemplate": "Tömning",
                     "id": 7049388,
                     "dateMobile": "03/10/2023",
                     "isActive": true,
                     "startDate": "2023-10-03",
                     "validDays": 1
                  }
               ],
               "customerId": "111111",
               "containerId": "11111111",
               "contentType": "Matavfall",
               "propertyNumber": ""
            }
         ],
         "address": "Vidjestigen 7",
         "city": "VENDELSÖ"
      }
   ]
}
contentType can be Kärl 1, Kärl 2 or Matavfall

I tested to replace the endpoint in https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/waste_collection_schedule/source/srvatervinning_se.py#L31 and it worked again.