### PR TITLE
fix docu for stoke_gov_uk

### DIFF
--- a/doc/source/stoke_gov_uk
+++ b/doc/source/stoke_gov_uk
@@ -7,7 +7,7 @@ Support for schedules provided by [Stoke-on-Trent Council](https://stoke.gov.uk/
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: stoke_on_trent_gov_uk
+    - name: stoke_gov_uk
       args:
         uprn: UNIQUE_PROPERTY_REFERENCE_NUMBER
 ```
@@ -24,7 +24,7 @@ This is required to unambiguously identify the property.
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: stoke_on_trent_gov_uk
+    - name: stoke_gov_uk
       args:
         uprn: "100060685712"
 ```


### PR DESCRIPTION
Issues fixed by this PR:
1. Markdown file name didn't match source file name.
2. Source file name in docu didn't match source file name.