### PR TITLE
Update southglos_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southglos_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southglos_gov_uk.py
@@ -32,8 +32,11 @@ class Source:
         r.raise_for_status()
         output = r.text.strip('[]')
         output = json.loads(output)
-        recycling_and_food_bin_dates = [output['C1'], output['C2'], output['C3']]
+        # Recycling and food are fields starting with C and R
+        recycling_and_food_bin_dates = [output['C1'], output['C2'], output['C3'], output['R1'], output['R2'], output['R3']]
+        # Black bin dates are fields starting R
         black_bin_dates = [output['R1'], output['R2'], output['R3']]
+        # Garden bin dates are fields starting G
         garden_bin_dates = [output['G1'], output['G2'], output['G3']]
         entries = []  # List that holds collection schedule
 


### PR DESCRIPTION
Recycling is every week.  I've checked the endpoint for a number of address across South Glos (including the provided test cases, and this change would fix the issue on all of them.

It looks like the underlying endpoint is using:

- Cx = Recycling + Food
- Rx = Bin, Recycling + Food
- Gx = Garden

Fixes #1305 