### PR TITLE
Update whittlesea_vic_gov_au.py - DST Fix

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/whittlesea_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/whittlesea_vic_gov_au.py
@@ -121,9 +121,9 @@ class Source:
 
         for item in data["rows"]:
             if "cartodb_id" in item:
-                # adding 10 hours to the date to fix timezone issue
+                # adding 1 day to the date to fix timezone issue (covers AEST and AEDST)
                 # https://github.com/mampfes/hacs_waste_collection_schedule/issues/912 
-                collection_date = (parse(item["date"]) + timedelta(hours=10)).date()
+                collection_date = (parse(item["date"]) + timedelta(days=1)).date()
                 entries.append(
                     Collection(
                         date=collection_date,


### PR DESCRIPTION
Referring to https://github.com/mampfes/hacs_waste_collection_schedule/issues/912

previous fix was to apply 10 hours, however due to DST time zone is now GMT+11 and issue has reappeared.

fix is to offset by 1 day as opposed to hours. I did test 11 hours but this issue would reappear in April (when DST ends)