### PR TITLE
Reorder innerwest_nsw_gov_au APIs to work around duplicate data

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
@@ -29,8 +29,8 @@ HEADERS = {"user-agent": "Mozilla/5.0"}
 # Inner West council merged 3 existing councils, but still hasn't merged their
 # data so details need to be found from one of three different databases.
 APIS = [
-    "https://marrickville.waste-info.com.au/api/v1",
     "https://leichhardt.waste-info.com.au/api/v1",
+    "https://marrickville.waste-info.com.au/api/v1",
     "https://ashfield.waste-info.com.au/api/v1",
 ]
 


### PR DESCRIPTION
Reorder Inner West Council possible APIs to attempt old Leichhardt Council before attempting old Marrickville Council.

A single suburb is duplicated between the 3 lists: "Leichhardt" appears in both Leichhardt and Marrickville API endpoints. Only a single street in Leichhardt is listed by the Marrickville endpoint, and that with only a single property; this is likely bad data.

This is not a lasting fix, as it doesn't protect against future duplicates, but there are thousands of properties in "true" Leichhardt, and only one in "false" Leichhardt, so at least this reordering fixes for most people.