### PR TITLE
fix for calgary requiring separate quadrant declaration

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
@@ -8,7 +8,7 @@ TITLE = "Calgary (AB)"
 DESCRIPTION = "Source for Calgary waste collection"
 URL = "https://www.calgary.ca"
 
-# ADDRESSES MUST BE ALL CAPS and INCLUDE A QUADRANT
+# ADDRESSES MUST BE ALL CAPS and INCLUDE A QUADRANT (quadrant must always be the last "word" and be separated by spaces)
 TEST_CASES = {"42 AUBURN SHORES WY SE": {"street_address": "42 AUBURN SHORES WY SE"}}
 
 SCHEDULE_LOOKUP_URL = "https://data.calgary.ca/resource/jq4t-b745.json"
@@ -33,6 +33,9 @@ WEEKDAYS = [
 class Source:
     def __init__(self, street_address):
         self._street_address = street_address.upper()
+        # Extract the quadrant from the street address.
+        # This assumes the quadrant is always the last "word" in the street address string.
+        self._quadrant = self._street_address.split()[-1]
 
     def daterange(self, start_date, end_date):
         for n in range(int((end_date - start_date).days)):
@@ -60,7 +63,7 @@ class Source:
         # lookup the schedule key for the address
         schedule_download = requests.get(
             SCHEDULE_LOOKUP_URL,
-            params={"address": self._street_address},
+            params={"address": self._street_address, "quadrant": self._quadrant},
         )
         schedule = json.loads(schedule_download.content.decode("utf-8"))
         entries = []


### PR DESCRIPTION
Removal of quadrant from the request made in pull https://github.com/mampfes/hacs_waste_collection_schedule/pull/1209 results in errors and no data being populated. Possibly this is an upstream issue somewhere else in the code rather than the city's json, but restoring the quadrant in the street_address arg resolves the issue and that's what I went with.

These changes assume that the quadrant will always be the last "word" (separated by spaces) in the street_address string. This is always the case with Calgary addresses, to my knowledge. There are no changes required to be made by users in their configuration's street_address arg.