### PR TITLE
pgh.st now requires https

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pgh_st.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pgh_st.py
@@ -27,7 +27,7 @@ class Source:
     def fetch(self):
         # get json file
         r = requests.get(
-            f"http://pgh.st/locate/{self._house_number}/{quote(self._street_name)}/{self._zipcode}"
+            f"https://pgh.st/locate/{self._house_number}/{quote(self._street_name)}/{self._zipcode}"
         )
 
         # extract data from json


### PR DESCRIPTION
pgh.st was down for a while, and just came back up. Seems that it only responds to requests on https now, not http.