### PR TITLE
Fix for Bristol nextCollectionDate timestamp

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bristol_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bristol_gov_uk.py
@@ -78,7 +78,7 @@ class Source:
             for collection in item["collection"]:
                 for collection_date_key in ["nextCollectionDate", "lastCollectionDate"]:
                     date_string = collection[collection_date_key].replace(
-                        "T00:00:00", "" 
+                        "T00:00:00", ""
                     ).replace(
                         "T10:00:00", ""
                     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bristol_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bristol_gov_uk.py
@@ -78,7 +78,7 @@ class Source:
             for collection in item["collection"]:
                 for collection_date_key in ["nextCollectionDate", "lastCollectionDate"]:
                     date_string = collection[collection_date_key].replace(
-                        "T00:00:00", ""
+                        "T00:00:00", "" 
                     ).replace(
                         "T10:00:00", ""
                     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bristol_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bristol_gov_uk.py
@@ -79,6 +79,8 @@ class Source:
                 for collection_date_key in ["nextCollectionDate", "lastCollectionDate"]:
                     date_string = collection[collection_date_key].replace(
                         "T00:00:00", ""
+                    ).replace(
+                        "T10:00:00", ""
                     )
                     entries.append(
                         Collection(


### PR DESCRIPTION
Fix for nextCollectionDate timestamp from API containing `T01:00:00` and breaking the integration