### PR TITLE
add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,82 @@
+name: Bug Report
+description: Report a bug with a source, sensor or the integration in general
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this Bug Report!
+  - type: dropdown
+    id: error
+    attributes:
+      label: "I Have A Problem With:"
+      options:
+        - A specific source
+        - Sensor configuration
+        - The integration in general
+      multiple: true
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What's Your Problem
+      description: Describe your problem as detailed as possible
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Source (if relevant)
+      description: Which source are you using?
+      placeholder: ex. broxtowe_gov_uk
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Please provide relevant logs from Home Assistant if no relevant logs are available please write "no relevant logs" (please remove sensitive information or use example addresses)
+      render: Shell
+    validations:
+      required: false
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Relevant Configuration
+      description: Please provide your configuration (source/sensor) if relevant (please remove sensitive information or use example addresses)
+      render: YAML
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist-source
+    attributes:
+      label: Checklist Source Error
+      description: Have you tried the following?
+      options:
+        - label: Use the example parameters for your source (often available in the documentation) (don't forget to restart Home Assistant after changing the configuration)
+          required: false
+        - label: Checked that the website of your service provider is still working
+          required: false
+        - label: Tested my attributes on the service provider website (if possible)
+          required: false
+        - label: I have tested with the latest version of the integration (master) (for HACS in the 3 dot menu of the integration click on "Redownload" and choose master as version)
+          required: true
+  - type: checkboxes
+    id: checklist-sensor
+    attributes:
+      label: Checklist Sensor Error
+      description: Have you tried the following?
+      options:
+        - label: Checked in the Home Assistant Calendar tab if the event names match the types names (if types argument is used) 
+          required: false
+  - type: checkboxes
+    id: checklist-general
+    attributes:
+      label: Required
+      description: "Please make sure you agree with these statements:"
+      options:
+        - label: I have searched past (closed AND opened) issues to see if this bug has already been reported, and it hasn't been.
+          required: true
+        - label: I understand that people give their precious time for free, and thus I've done my very best to make this problem as easy as possible to investigate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest a new feature or improvement for the integration
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this Feature Request!
+  - type: dropdown
+    id: type
+    attributes:
+      label: "I propose a feature for:"
+      options:
+        - Sources
+        - Sensors
+        - The integration in general
+      multiple: true
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your wanted feature
+      description: Describe your wanted feature as detailed as possible
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/SOURCE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/SOURCE-REQUEST.yml
@@ -1,0 +1,56 @@
+name: Source Request
+description: Request that a municipality or region is supported
+title: "[Source Request]: "
+labels: ["source request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this source request!
+  - type: input
+    id: region
+    attributes:
+      label: Municipality / Region
+      description: Which municipality or region should be supported in the future?
+      placeholder: ex. Berlin, Germany
+    validations:
+      required: true
+  - type: input
+    id: collection-url
+    attributes:
+      label: Collection Calendar Webpage 
+      description: Where are information about bin collections listed (preferred ULR)
+      placeholder: https://example.com
+    validations:
+      required: false
+  - type: textarea
+    id: example-address
+    attributes:
+      label: Example Address
+      description: (preferred) An address or other needed parameter for getting your collection info (not your own)
+      placeholder: ex. Gundelfinger Str. 4, 10318 Berlin
+    validations:
+      required: false
+  - type: dropdown
+    id: format
+    attributes:
+      label: Collection Data Format
+      description: In which format does your service provider provides collection dates.
+      options:
+        - As ICS/ICAL file
+        - As html on a webpage
+        - Dedicated IOS/Android APP
+        - As PDF Download
+        - As documented API
+        - Something different (add to additional information) 
+      multiple: true
+    validations:
+      required: true
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: (optional) additional information that might be helpful to implement a source for the municipality / region
+      placeholder: Additional information
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question/Help wanted
+    about: Ask the community a question
+    url: https://github.com/mampfes/hacs_waste_collection_schedule/discussions/categories/q-a


### PR DESCRIPTION
adding these issue forms could help to get better Bug reports and source requests.

@dt215git and @mampfes please provide feedback if this is a good idea/implementation.

issue forms documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms

>  Note: Issue forms are currently in beta and subject to change.


try these templates at https://github.com/5ila5/template_test (feel free to add create issues)

This disables the possibiltiy to create "normal" issues so please provide feedback about this if we should use this or if we should change something