### PR TITLE
Fix "Date not available" error for stockton_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stockton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stockton_gov_uk.py
@@ -108,6 +108,10 @@ class Source:
                     ]
 
                 for date_node in date_nodes:
+                    # If date is "Date not available" then skip (Winter period)
+                    if date_node.text.strip() == "Date not available":
+                        continue
+
                     # Remove ordinal suffixes from date string
                     date_string = re.sub(
                         r"(?<=[0-9])(?:st|nd|rd|th)", "", date_node.text.strip()


### PR DESCRIPTION
Fixed an issue where the date returned from stockton_gov_uk would be "Date not available" during winter months for garden waste. This would cause an error when converting it to a date string.