### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ soupsieve==2.4.1
 urllib3==2.0.4
 x-wr-timezone==0.0.5
 zope.interface==6.0
-jinja2=3.1.2
+jinja2==3.1.2


### PR DESCRIPTION
Fix syntax of requirements.txt to allow for `pip install -r requirements.txt` to properly work again.