### PR TITLE
Fixed duplicate collections for southampton_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southampton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southampton_gov_uk.py
@@ -6,9 +6,7 @@ from datetime import datetime
 from waste_collection_schedule import Collection
 
 TITLE = "Southampton City Council"
-DESCRIPTION = (
-    "Source for southampton.gov.uk services for Southampton City Council"
-)
+DESCRIPTION = "Source for southampton.gov.uk services for Southampton City Council"
 URL = "https://southampton.gov.uk"
 TEST_CASES = {
     "UPRN_001": {"uprn": "100060731893"},
@@ -20,7 +18,7 @@ ICON_MAP = {
     "Glass": "mdi:glass-fragile",
     "Recycling": "mdi:recycle",
     "General Waste": "mdi:trash-can",
-    "Garden Waste": "mdi:leaf"
+    "Garden Waste": "mdi:leaf",
 }
 REGEX = (
     "(Glass|Recycling|General Waste|Garden Waste).*?([0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4})"
@@ -35,18 +33,25 @@ class Source:
 
     def fetch(self):
         s = requests.Session()
-        r = s.get(f"https://www.southampton.gov.uk/whereilive/waste-calendar?UPRN={self._uprn}")
+        r = s.get(
+            f"https://www.southampton.gov.uk/whereilive/waste-calendar?UPRN={self._uprn}"
+        )
         r.raise_for_status()
 
-        results = re.findall(REGEX, r.text)
+        # Limit search scope to avoid duplicates
+        calendar_view_only = re.search(
+            r"#calendar1.*listView", r.text, flags=re.DOTALL
+        ).group(0)
+
+        results = re.findall(REGEX, calendar_view_only)
 
         entries = []
         for item in results:
             entries.append(
                 Collection(
-                    date = datetime.strptime(item[1], "%m/%d/%Y").date(),
-                    t = item[0],
-                    icon = ICON_MAP.get(item[0]),
+                    date=datetime.strptime(item[1], "%m/%d/%Y").date(),
+                    t=item[0],
+                    icon=ICON_MAP.get(item[0]),
                 )
             )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southampton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southampton_gov_uk.py
@@ -40,8 +40,8 @@ class Source:
 
         # Limit search scope to avoid duplicates
         calendar_view_only = re.search(
-            r"#calendar1.*listView", r.text, flags=re.DOTALL
-        ).group(0)
+            r"#calendar1.*?listView", r.text, flags=re.DOTALL
+        )[0]
 
         results = re.findall(REGEX, calendar_view_only)
 


### PR DESCRIPTION
Southampton City Council source was using a regex to parse the whole page, which created duplicate entries, due to the page having both list view and calendar view tabs showing the same events. I have prefiltered page text with a simple regex that only matches one of the tabs and removes all duplicates.