### PR TITLE
Fix year wraparound bug + month misspelt in Renosyd.dk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/renosyd_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/renosyd_dk.py
@@ -36,7 +36,7 @@ DANISH_MONTHS = [
     "feb",
     "mar",
     "apr",
-    "may",
+    "maj",
     "jun",
     "jul",
     "aug",
@@ -97,7 +97,7 @@ class Source:
             months.append(datetime.date(this_year, DANISH_MONTHS.index(value), 1))
 
             if value == "dec":
-                this_year = +1
+                this_year += 1
 
         entries = []
 


### PR DESCRIPTION
Now next year's schedule appears on Renosyd's website the year wraparound bug was revealed. Also I can't spell 🙂