### PR TITLE
correct dependency on `beautifulsoup4` instead of `bs4`

### DIFF
--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/mampfes/hacs_waste_collection_schedule#readme",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["icalendar", "recurring_ical_events", "icalevents", "bs4", "lxml"],
+  "requirements": ["icalendar", "recurring_ical_events", "icalevents", "beautifulsoup4", "lxml"],
   "version": "1.44.0"
 }


### PR DESCRIPTION
[`bs4`][1] is a placeholder for [`beautifulsoup4`][2] to prevent typo-squatting. From the description of the `bs4` package on PyPI:

> This is a dummy package managed by the developer of Beautiful Soup to prevent name squatting. The official name of PyPI’s Beautiful Soup Python package is [beautifulsoup4](https://pypi.python.org/pypi/beautifulsoup4). This package ensures that if you type pip install bs4 by mistake you will end up with Beautiful Soup.

While the placeholder does prevent a malicious actor from hijacking the package, it's not a good idea to rely on this.

This **does not** affect the imports like:

```python
from bs4 import BeautifulSoup
```

[1]: https://pypi.org/project/bs4/
[2]: https://pypi.org/project/beautifulsoup4/