### PR TITLE
wirral_gov_uk: fix for crash introduced due to extra text for Christmas schedule

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wirral_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wirral_gov_uk.py
@@ -1,3 +1,4 @@
+import re
 import requests
 
 from bs4 import BeautifulSoup
@@ -23,7 +24,7 @@ WASTES = {
     "Garden waste (brown bin)",
     "Paper and packaging (grey bin)",
 }
-
+DATE_REGEX="^([0-9]{1,2} [A-Za-z]+ [0-9]{4})"
 
 class Source:
     def __init__(self, street, suburb):
@@ -43,13 +44,15 @@ class Source:
             dates = soup.findAll("li")
             if len(dates) != 0:
                 for item in dates:
-                    entries.append(
-                        Collection(
-                            date=datetime.strptime(item.text, "%d %B %Y").date(),
-                            t=waste,
-                            icon=ICON_MAP.get(waste.upper()),
+                    match = re.match(DATE_REGEX, item.text)
+                    if match:
+                        entries.append(
+                            Collection(
+                                date=datetime.strptime(match.group(1), "%d %B %Y").date(),
+                                t=waste,
+                                icon=ICON_MAP.get(waste.upper()),
+                            )
                         )
-                    )
         
         return entries
     

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wirral_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wirral_gov_uk.py
@@ -1,8 +1,8 @@
 import re
-import requests
-
-from bs4 import BeautifulSoup
 from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Wirral Council"
@@ -24,7 +24,8 @@ WASTES = {
     "Garden waste (brown bin)",
     "Paper and packaging (grey bin)",
 }
-DATE_REGEX="^([0-9]{1,2} [A-Za-z]+ [0-9]{4})"
+DATE_REGEX = "^([0-9]{1,2} [A-Za-z]+ [0-9]{4})"
+
 
 class Source:
     def __init__(self, street, suburb):
@@ -33,7 +34,7 @@ class Source:
 
     def fetch(self):
         s = requests.Session()
-        #Loop through waste types
+        # Loop through waste types
         entries = []
         for waste in WASTES:
             r = s.get(
@@ -48,11 +49,12 @@ class Source:
                     if match:
                         entries.append(
                             Collection(
-                                date=datetime.strptime(match.group(1), "%d %B %Y").date(),
+                                date=datetime.strptime(
+                                    match.group(1), "%d %B %Y"
+                                ).date(),
                                 t=waste,
                                 icon=ICON_MAP.get(waste.upper()),
                             )
                         )
-        
+
         return entries
-    


### PR DESCRIPTION
wirral_gov_uk source uses a scraper which expects a list of dates like "30 December 2023". For the Christmas schedule they added some extra descriptive text like "30 December 2023 (Saturday) in lieu of 01 January 2024", which caused an exception to be thrown in the date parsing.

This PR adds a regex to pre-validate the scraped rows and discard any extra trailing text.
