### PR TITLE
Fix Landkreis Göttingen in app_abfallplus_de

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -419,9 +419,11 @@ class AppAbfallplusDe:
                 self._bundesland_id = bundesland["id"]
                 return
 
-    def get_landkreise(self):
-        data = {"id_bundesland": self._bundesland_id}
-        r = self._request("landkreis/", data=data)
+    def get_landkreise(self, region_key_name="landkreis"):
+        data = {}
+        if self._bundesland_id:
+            data["id_bundesland"] = self._bundesland_id
+        r = self._request(f"{region_key_name}/", data=data)
         r.raise_for_status()
         landkreise = []
         for a in extract_onclicks(r):
@@ -431,6 +433,8 @@ class AppAbfallplusDe:
                     "name": a[1],
                 }
             )
+        if region_key_name == "landkreis" and landkreise == []:
+            return self.get_landkreise(region_key_name="region")
         return landkreise
 
     def select_landkreis(self, landkreis=None):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
@@ -76,6 +76,15 @@ TEST_CASES = {
     #     "strasse": "Ahornstraße",
     #     "hnr": "Alle Hausnummern",
     #     "city": "Bad Boll",
+    # },
+    # # This test case will probably fail in 2025, due to harmonization of waste collection services
+    # # https://www.landkreisgoettingen.de/themen-leistungen/abfall-entsorgung/harmonisierung-der-abfallwirtschaften 
+    # "de.k4systems.lkgoettingen Altkreis Osterode": {
+    #     "app_id": "de.k4systems.lkgoettingen",
+    #     "landkreis": "Abfallwirtschaft Altkreis Osterode am Harz",
+    #     "city": "Osterode am Harz",
+    #     "strasse": "Kornmarkt",
+    #     "bezirk": "Osterode am Harz"
     # }
 }
 


### PR DESCRIPTION
Landkreis Göttingen merged with Altkreis Osterode years ago and still has separate waste collection services, modeled as 2 Landkreise.

The app requests to select the landkreis first, which was not supported in app_abfallplus_de.

I also added a test case, because this seems to be a corner case.