### PR TITLE
fix abfallnavi_de for affected regions

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -138,9 +138,16 @@ class AbfallnaviDe:
     def __init__(self, service_domain):
         self._service_domain = service_domain
         self._service_url = f"https://{service_domain}-abfallapp.regioit.de/abfall-app-{service_domain}/rest"
+        self._service_url_fallback = (
+            f"https://abfallapp.regioit.de/abfall-app-{service_domain}/rest"
+        )
 
     def _fetch(self, path, params=None):
-        r = requests.get(f"{self._service_url}/{path}", params=params)
+        try:
+            r = requests.get(f"{self._service_url}/{path}", params=params)
+        except requests.exceptions.ConnectionError:
+            self._service_url = self._service_url_fallback
+            r = requests.get(f"{self._service_url}/{path}", params=params)
         r.encoding = "utf-8"  # requests doesn't guess the encoding correctly
         return r.text
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
@@ -38,6 +38,11 @@ TEST_CASES = {
         "ort": "Norderstedt",
         "strasse": "Distelweg",
     },
+    "una Bergkamen, Agnes-Miegel-Str.": {
+        "service": "unna",
+        "ort": "Bergkamen",
+        "strasse": "Agnes-Miegel-Str.",
+    },
 }
 
 


### PR DESCRIPTION
Fix Unna and other regions who might be affected and provide theire API at `https://abfallapp.regioit.de/abfall-app-{service_domain}/rest` istead of `https://{service_domain}-abfallapp.regioit.de/abfall-app-{service_domain}/rest`

this fixes #1554