### PR TITLE
zolleralbkreis_de: remove types, allow city/street name

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_zollernalbkreis_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_zollernalbkreis_de.py
@@ -1,6 +1,8 @@
+import logging
 from datetime import datetime
 
 import requests
+from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.service.ICS import ICS
 
@@ -11,65 +13,74 @@ TEST_CASES = {
     "Ebingen": {
         "city": "2,3,4",
         "street": "3",
-        "types": [
-            "restmuell",
-            "gelbersack",
-            "papiertonne",
-            "biomuell",
-            "gruenabfall",
-            "schadstoffsammlung",
-            "altpapiersammlung",
-            "schrottsammlung",
-            "weihnachtsbaeume",
-            "elektrosammlung",
-        ],
     },
     "Erlaheim": {
         "city": "79",
         "street": "",
-        "types": [
-            "restmuell",
-            "gelbersack",
-            "papiertonne",
-            "biomuell",
-            "gruenabfall",
-            "schadstoffsammlung",
-            "altpapiersammlung",
-            "schrottsammlung",
-            "weihnachtsbaeume",
-            "elektrosammlung",
-        ],
+    },
+    "Ebingen names": {
+        "city": "Ebingen",
+        "street": "Am schnecklesfelsen",
+    },
+    "Schlatt names": {
+        "city": "Schlatt",
     },
 }
 
 ICON_MAP = {
     "Restmüll": "mdi:trash-can",
-    "Grünabfall" : "mdi:leaf",
-    "Gelber Sack" : "mdi:sack",
-    "Papiertonne" : "mdi:package-variant",
-    "Bildschirm-/Kühlgeräte" : "mdi:television-classic",
-    "Schadstoffsammlung" : "mdi:biohazard",
-    "altmetalle" : "mdi:nail",
-} 
+    "Grünabfall": "mdi:leaf",
+    "Biomüll": "mdi:leaf",
+    "Gelber Sack": "mdi:sack",
+    "Papiertonne": "mdi:package-variant",
+    "Bildschirm-/Kühlgeräte": "mdi:television-classic",
+    "Schadstoffsammlung": "mdi:biohazard",
+    "altmetalle": "mdi:nail",
+}
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Source:
-    def __init__(self, city, types, street=None):
+    def __init__(self, city, types=None, street=None):
         self._city = city
         self._street = street
-        self._types = types
+        if types:
+            LOGGER.warning(
+                "you provided types parameter but filtering should be done by using the customize argument. Ignoring types"
+            )
+
         self._ics = ICS()
 
+    def get_ids(self, soup, id, copmare):
+        options = soup.find("select", id=id).findAll("option")
+        for option in options:
+            if option.text.lower().strip() == copmare.lower().strip():
+                return option["value"]
+        raise Exception(f"{id.capitalize()} {copmare} not found")
+
     def fetch(self):
+        r = requests.get("https://www.abfallkalender-zak.de")
+        soup = BeautifulSoup(r.text, "html.parser")
+        types = [t["value"] for t in soup.findAll("input", attrs={"name": "types[]"})]
+
+        if not self._city.replace(" ", "").replace(",", "").isnumeric():
+            # city is not a number, so we need to get the id
+            self._city = self.get_ids(soup, "city", self._city)
+        if (
+            self._street
+            and not self._city.replace(" ", "").replace(",", "").isnumeric()
+        ):
+            # city is not a number, so we need to get the id
+            self._street = self.get_ids(soup, "street", self._street)
+
         now = datetime.now()
-        entries = self.fetch_year(now.year, self._city, self._street, self._types)
+        entries = self.fetch_year(now.year, self._city, self._street, types)
         if now.month == 12:
             # also get data for next year if we are already in december
             try:
                 entries.extend(
-                    self.fetch_year(
-                        (now.year + 1), self._city, self._street, self._types
-                    )
+                    self.fetch_year((now.year + 1), self._city, self._street, types)
                 )
             except Exception:
                 # ignore if fetch for next year fails
@@ -95,7 +106,13 @@ class Source:
         for d in dates:
             waste_type = d[1]
             next_pickup_date = d[0]
-            
-            entries.append(Collection(date=next_pickup_date, t=waste_type, icon=ICON_MAP.get(waste_type)))
+
+            entries.append(
+                Collection(
+                    date=next_pickup_date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type.split(" ")[0]),
+                )
+            )
 
         return entries

--- a/doc/source/abfall_zollernalbkreis_de.md
+++ b/doc/source/abfall_zollernalbkreis_de.md
@@ -11,17 +11,6 @@ waste_collection_schedule:
       args:
         city: CITY
         street: STREET
-        types:
-          - "restmuell"
-          - "gelbersack"
-          - "papiertonne"
-          - "biomuell"
-          - "gruenabfall"
-          - "schadstoffsammlung"
-          - "altpapiersammlung"
-          - "schrottsammlung"
-          - "weihnachtsbaeume"
-          - "elektrosammlung"
 ```
 
 ### Configuration Variables
@@ -30,10 +19,9 @@ waste_collection_schedule:
 *(string) (required)*
 
 **street**  
-*(integer) (optional)*
+*(string) (optional)*
 
-**types**  
-*(list of string) (required)*
+**types** (not supported anymore use [customize](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/installation.md#configuring-sources) parameter instead)
 
 ## Example
 
@@ -42,24 +30,27 @@ waste_collection_schedule:
   sources:
     - name: abfall_zollernalbkreis_de
       args:
-        city: "2,3,4"
-        street: 3
-        types:
-          - "restmuell"
-          - "gelbersack"
-          - "papiertonne"
-          - "biomuell"
-          - "gruenabfall"
-          - "schadstoffsammlung"
-          - "altpapiersammlung"
-          - "schrottsammlung"
-          - "weihnachtsbaeume"
-          - "elektrosammlung"
+        city: "Ebingen"
+        street: "Am schnecklesfelsen"
+```
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: abfall_zollernalbkreis_de
+      args:
+        city: "Schlatt"
 ```
 
 ## How to get the source arguments
 
-### Hardcore Variant: Extract arguments from website
+### Using city/street names
+
+1. Open [https://www.abfallkalender-zak.de/](https://www.abfallkalender-zak.de/).
+2. Enter your data
+3. Use the city and street names as arguments (write them exactly like in the dropdown menu).
+
+### Using city/street IDs: Hardcore Variant: Extract arguments from website
 
 Another way get the source arguments is to extract the arguments from the website using a (desktop) browser with developer tools, e.g. Google Chrome:
 
@@ -69,4 +60,4 @@ Another way get the source arguments is to extract the arguments from the websit
 4. Now click the "ICS Download" button.
 5. You should see (amongst other's) one POST entry to Host `https://www.abfallkalender-zak.de/` labeled `/` in the network recording.
 6. Select `/` on the left hand side and click on Request on the right hand side.
-7. At the `Form Data` you can find the values for `city` and `street` etc..
+7. At the `Form Data` you can find the values for `city` and `street`.


### PR DESCRIPTION
abfall_zolleralbkreis_de now supports city/streat names isntad of ids. removed types argument as this should be done by the customize argrument