### PR TITLE
Update sepan_remondis_pl.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sepan_remondis_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sepan_remondis_pl.py
@@ -6,8 +6,8 @@ import xml.etree.ElementTree
 import requests
 from waste_collection_schedule import Collection
 
-TITLE = "Poznań/Koziegłowy/Objezierze/Oborniki"
-DESCRIPTION = "Source for Poznań/Koziegłowy/Objezierze/Oborniki city garbage collection"
+TITLE = "Poznań"
+DESCRIPTION = "Source for Poznań city garbage collection"
 URL = "https://sepan.remondis.pl"
 TEST_CASES = {
     "Street Name": {
@@ -20,7 +20,9 @@ TEST_CASES = {
 _LOGGER = logging.getLogger(__name__)
 
 
-API_URL = "https://sepan.remondis.pl/harmonogram"
+API_URL = "https://sepan.remondis.pl/harmonogram2024"
+
+
 
 NAME_MAP = {
     1: "Zmieszane odpady komunalne",


### PR DESCRIPTION
Updated API_URL to 2024 schedule URL and removed Cities that are no longer supported from Title and Description. It might be that when new year comes they will change URLs again, as of now, there are two one for 2023 and one for 2024