### PR TITLE
Tewkesbury Borough Council API URL change + remove postcode option

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tewkesbury_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tewkesbury_gov_uk.py
@@ -8,12 +8,10 @@ TITLE = "Tewkesbury Borough Council"
 DESCRIPTION = "Home waste collection schedule for Tewkesbury Borough Council"
 URL = "https://www.tewkesbury.gov.uk"
 TEST_CASES = {
-    "Council Office": {"postcode": "GL20 5TT"},
-    "Council Office No Spaces": {"postcode": "GL205TT"},
     "UPRN example": {"uprn": 100120544973},
 }
 
-API_URL = "https://api-2.tewkesbury.gov.uk/general/rounds/%s/nextCollection"
+API_URL = "https://api-2.tewkesbury.gov.uk/incab/rounds/%s/next-collection"
 
 ICON_MAP = {
     "Refuse": "mdi:trash-can",
@@ -24,15 +22,15 @@ ICON_MAP = {
 
 
 class Source:
-    def __init__(self, postcode: str = None, uprn: str = None):
-        self._post_or_uprn = str(uprn) if uprn else postcode
+    def __init__(self, uprn: str = None):
+        self.urpn = str(uprn)
 
     def fetch(self):
-        if self._post_or_uprn is None:
-            raise Exception("postcode not set")
+        if self.urpn is None:
+            raise Exception("UPRN not set")
 
-        encoded_postcode = urlquote(self._post_or_uprn)
-        request_url = API_URL % encoded_postcode
+        encoded_urpn = urlquote(self.urpn)
+        request_url = API_URL % encoded_urpn
         response = requests.get(request_url)
 
         response.raise_for_status()

--- a/doc/source/tewkesbury_gov_uk.md
+++ b/doc/source/tewkesbury_gov_uk.md
@@ -1,16 +1,8 @@
 # Tewkesbury City Council
 
-Support for upcoming schedules provided by [Tewkesbury City Council](https://www.tewkesbury.gov.uk/waste-and-recycling), serving Tewkesbury (UK) and areas of Gloucestershire.
+Support for upcoming schedules provided by [Tewkesbury City Council](https://tewkesbury.gov.uk/services/waste-and-recycling/), serving Tewkesbury (UK) and areas of Gloucestershire.
 
 ## Configuration via configuration.yaml
-
-```yaml
-waste_collection_schedule:
-    sources:
-    - name: tewkesbury_gov_uk
-      args:
-        postcode: POSTCODE
-```
 
 ```yaml
 waste_collection_schedule:
@@ -22,24 +14,10 @@ waste_collection_schedule:
 
 ### Configuration Variables
 
-**POSTCODE**  
-*(string) (optional)*  
-Not all addresses are supported by postcode. Then you have to provide a UPRN.
-
 **UPRN**  
-*(string) (optional)*
-
-Either `postcode` or `uprn` must be provided.
+*(string) (required)*
 
 ## Example
-
-```yaml
-waste_collection_schedule:
-    sources:
-    - name: tewkesbury_gov_uk
-      args:
-        postcode: "GL20 5TT"
-```
 
 ```yaml
 waste_collection_schedule:


### PR DESCRIPTION
Tewkesbury Borough Council recently changed their API URL, and now accepts UPRN only.

Therefore, I have updated the API URL and removed the UPRN option, and validated that this is working on my install.