### PR TITLE
Fix new digit format in Abfallwirtschaft Nuernberger Land from 2024 on (Issue: 2065307965)

### DIFF
--- a/doc/source/nuernberger_land_de.md
+++ b/doc/source/nuernberger_land_de.md
@@ -15,7 +15,7 @@ waste_collection_schedule:
 ### Configuration Variables
 
 **id**
-_(integer) (required)_ : The unique 8-digit identifier of your street section
+_(integer) (required)_ : The unique 11-digit identifier of your street section
 
 ## Example
 
@@ -24,12 +24,12 @@ waste_collection_schedule:
   sources:
     - name: nuernberger_land_de
       args:
-        id: 14579001
+        id: 88-14592001
 ```
 
 ## How to get the source arguments
 
 1. Open <https://abfuhrkalender.nuernberger-land.de/#waste_calendar/calendar>.
 2. Fill out the filter fields on the page.
-3. Right click the button "Termine in den Kalender importieren" and select "Copy link address". You should get something like this `https://abfuhrkalender.nuernberger-land.de/waste_calendar/ical?id=14579001`
-4. Copy the id number at the end of the link to your configuration file.
+3. Right click the button "Termine in den Kalender importieren" and select "Copy link address". You should get something like this `https://abfuhrkalender.nuernberger-land.de/waste_calendar/ical?id=88-14592001&filter=rm:bio:p:dsd:poison`
+4. Copy the id number out of the link to your configuration file.


### PR DESCRIPTION
The ID format to identify your street / collection tour has changed from 8 digits to 2-8 digits from 2024 on. Fixed the documentation. 