### PR TITLE
abfallnavi_de md shows service id

### DIFF
--- a/doc/source/abfallnavi_de.md
+++ b/doc/source/abfallnavi_de.md
@@ -43,6 +43,42 @@ waste_collection_schedule:
 
 ## How to get the source arguments
 
+Your serviceID can be found in the list below. `ort`, `strasse` and `hausnummer` (only supply if needed) should match the values of the serviceproviders search form.
+
+<!--Begin of service section-->
+|Region|service|
+|-|-|
+| Stadt Aachen | aachen |
+| Abfallwirtschaft Stadt Nürnberg | nuernberg |
+| Abfallwirtschaftsbetrieb Bergisch Gladbach | aw-bgl2 |
+| AWA Entsorgungs GmbH | zew2 |
+| AWG Kreis Warendorf | krwaf |
+| Bergischer Abfallwirtschaftverbund | bav |
+| Kreis Coesfeld | coe |
+| Stadt Cottbus | cottbus |
+| Dinslaken | din |
+| Stadt Dorsten | dorsten |
+| EGW Westmünsterland | wml2 |
+| Gütersloh | gt2 |
+| Halver | hlv |
+| Kreis Heinsberg | krhs |
+| Kronberg im Taunus | kronberg |
+| Gemeinde Lindlar | lindlar |
+| Stadt Norderstedt | nds |
+| Kreis Pinneberg | pi |
+| Gemeinde Roetgen | roe |
+| Stadt Solingen | solingen |
+| STL Lüdenscheid | stl |
+| GWA - Kreis Unna mbH | unna |
+| Kreis Viersen | viersen |
+| WBO Wirtschaftsbetriebe Oberhausen | oberhausen |
+| ZEW Zweckverband Entsorgungsregion West | zew2 |
+<!--End of service section-->
+
+
+
+### Using the wizard
+
 There is a script with an interactive command line interface which generates the required source configuration:
 
 [https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfallnavi_de.py](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfallnavi_de.py).

--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -120,6 +120,7 @@ def browse_sources():
     update_ctrace_de(modules)
     update_citiesapps_com(modules)
     update_app_abfallplus_de(modules)
+    update_abfallnavi_de(modules)
 
     return sources
 
@@ -334,6 +335,20 @@ def update_app_abfallplus_de(modules):
         str += f"| {app_id} | {regions} |\n"
 
     _patch_file("doc/source/app_abfallplus_de.md", "service", str)
+
+
+def update_abfallnavi_de(modules):
+    module = modules.get("abfallnavi_de")
+    if not module:
+        print("app_abfallplus_de not found")
+        return
+    services = getattr(module, "SERVICE_DOMAINS", {})
+
+    str = "|Region|service|\n|-|-|\n"
+    for region in services:
+        str += f"| {region['title']} | {region['service_id']} |\n"
+
+    _patch_file("doc/source/abfallnavi_de.md", "service", str)
 
 
 def _patch_file(filename, section_id, str):


### PR DESCRIPTION
abfallnavi_de now shows the service id table to be bale to configure the source without needing to run the wizzard

addresses problems mentioned in #1628