### PR TITLE
fix Geelong Australia boolean logic error from reformat

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
@@ -50,9 +50,9 @@ class Source:
 
         if (
             not viewstate
-            or isinstance(viewstate, Tag)
+            or not isinstance(viewstate, Tag)
             or not eventvalidation
-            or isinstance(eventvalidation, Tag)
+            or not isinstance(eventvalidation, Tag)
         ):
             raise Exception("could not get valid data from geelongaustralia.com.au")
 


### PR DESCRIPTION
When this was reformatted in #1509 it flipped whether it was an error based on the type or not. This should fix it up and match the preferred formatting.