### PR TITLE
fix: add regex to edg_de documentation example

### DIFF
--- a/doc/ics/edg_de.md
+++ b/doc/ics/edg_de.md
@@ -8,6 +8,8 @@ EDG Entsorgung Dortmund is supported by the generic [ICS](/doc/source/ics.md) so
 - Goto <https://www.edg.de/de/entsorgungsdienstleistungen/rein-damit/abfallkalender/abfallkalender.htm> and select your location and press `weiter`.  
 - Click on `URL in die Zwischenablage kopieren` to copy the ical url.
 - Replace the `url` in the example configuration with this link.
+- Leave the `regex` untouched
+- You can use the different types as `Bioabfall`, `Altpapier`, `Restabfall` and `Wertstoffe`
 
 ## Examples
 
@@ -19,4 +21,5 @@ waste_collection_schedule:
     - name: ics
       args:
         url: https://kundenportal.edg.de/WasteManagementDortmund/WasteManagementServiceServlet?ApplicationName=Calendar&SubmitAction=sync&StandortID=1271001001&AboID=66930&Fra=P;R;B;W
+        regex: "^(\\w*) \\d* .*"
 ```

--- a/doc/ics/edg_de.md
+++ b/doc/ics/edg_de.md
@@ -20,6 +20,6 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
+        regex: ^(\w*) \d* .*
         url: https://kundenportal.edg.de/WasteManagementDortmund/WasteManagementServiceServlet?ApplicationName=Calendar&SubmitAction=sync&StandortID=1271001001&AboID=66930&Fra=P;R;B;W
-        regex: "^(\\w*) \\d* .*"
 ```

--- a/doc/ics/yaml/edg_de.yaml
+++ b/doc/ics/yaml/edg_de.yaml
@@ -4,6 +4,9 @@ howto: |
    - Goto <https://www.edg.de/de/entsorgungsdienstleistungen/rein-damit/abfallkalender/abfallkalender.htm> and select your location and press `weiter`.  
    - Click on `URL in die Zwischenablage kopieren` to copy the ical url.
    - Replace the `url` in the example configuration with this link.
+   - Leave the `regex` untouched
+   - You can use the different types as `Bioabfall`, `Altpapier`, `Restabfall` and `Wertstoffe`
 test_cases:
    Baackweg 1:
       url: "https://kundenportal.edg.de/WasteManagementDortmund/WasteManagementServiceServlet?ApplicationName=Calendar&SubmitAction=sync&StandortID=1271001001&AboID=66930&Fra=P;R;B;W"
+      regex: "^(\\w*) \\d* .*"


### PR DESCRIPTION
This pull request updates the documentation of the EDG in Germany, as discussed in #1584 since they changed the format of the ics file.

Thanks to @Xento for the idea!