### PR TITLE
calgary_ca add logger message to move to recollect ics source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime, timedelta
 
 import requests
@@ -29,6 +30,8 @@ WEEKDAYS = [
     "Sunday",
 ]
 
+LOGGER = logging.getLogger(__name__)
+
 
 class Source:
     def __init__(self, street_address):
@@ -57,6 +60,9 @@ class Source:
         return False
 
     def fetch(self):
+        LOGGER.warning(
+            "looks like calgary moved to recollect and not all collections are visible using this source anymore. https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/ics/recollect.md"
+        )
         # lookup the schedule key for the address
         schedule_download = requests.get(
             SCHEDULE_LOOKUP_URL,

--- a/doc/source/calgary_ca.md
+++ b/doc/source/calgary_ca.md
@@ -2,6 +2,10 @@
 
 Support for schedules provided by [City of Calgary](https://www.calgary.ca/waste/residential/garbage-schedule.html).
 
+# Deprecated not all collections are being returned use recollect instead
+
+<https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/ics/recollect.md>
+
 ## Configuration via configuration.yaml
 
 ```yaml


### PR DESCRIPTION
calgary_ca seems to not return all collections anymore (#1659). They moved to displaying a recollect window.
This adds a message (markdown and logger.warning) to use the recollect ICS configuration instead. 