### PR TITLE
feat: add `details_format`: `hidden`

### DIFF
--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -38,6 +38,7 @@ class DetailsFormat(Enum):
     upcoming = "upcoming"  # list of "<date> <type1, type2, ...>"
     appointment_types = "appointment_types"  # list of "<type> <date>"
     generic = "generic"  # all values in separate attributes
+    hidden = "hidden" # hide details
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -124,7 +124,7 @@ sensor:
 | platform |  | required | waste_collection_schedule |
 | source_index | int | optional | Used to assign a sensor to a specific source. Only needed if multiple sources are defined. The first source defined is source_index 0, the second source_index 1, etc. If no value is supplied, the default of 0 is used.<br><br>If you want to have a sensor which combines the data from multiple sources, just add a list of sources here. [Example](#combine-data-from-multiple-sources) |
 | name | string | required | The name Home Assistant used for this sensor |
-| details_format | string | optional | Specifies the format used to display info in Home Assistant's _more info_ pop-up. Valid values are: `upcoming`, `appointment_types` and `generic`. If no value is supplied, the default of "upcoming" is used. See [options for details_format](#options-for-details_format-parameter) for more details |
+| details_format | string | optional | Specifies the format used to display info in Home Assistant's _more info_ pop-up. Valid values are: `upcoming`, `appointment_types`, `generic` and `hidden`. If no value is supplied, the default of "upcoming" is used. See [options for details_format](#options-for-details_format-parameter) for more details |
 | count | int | optional | Limits Home Assistant's _more info_ popup to displaying the next _int_ collections |
 | leadtime | int | optional | Limits Home Assistant's _more info_ popup to only displaying collections happening within the next _leadtime_ days|
 | value_template | string | optional | Uses Home Assistant templating to format the state information of an entity. See [template variables](#template-variables-for-value_template-and-date_template-parameters) for further details |
@@ -137,10 +137,10 @@ sensor:
 
 Possible choices:
 
-| upcoming | appointment_types | generic |
-|--|--|--|
-| shows a list of upcoming collections |shows a list of waste types and their next collection date | provides all attributes as generic Python data types. |
-| ![Upcoming](/images/more-info-upcoming.png) | ![Waste Types](/images/more-info-appointment-types.png) | ![Generic](/images/more-info-generic.png) |
+| upcoming | appointment_types | generic | hidden |
+|--|--|--|--|
+| shows a list of upcoming collections |shows a list of waste types and their next collection date | provides all attributes as generic Python data types. | hide attributes of upcoming collections |
+| ![Upcoming](/images/more-info-upcoming.png) | ![Waste Types](/images/more-info-appointment-types.png) | ![Generic](/images/more-info-generic.png) | |
 
 ## Template variables for _value_template_ and _date_template_ parameters
 


### PR DESCRIPTION
I would like to suggest an additional option for `details_format` to hide all information about upcoming collections in the attributes.