### PR TITLE
Stadtreinigung Leipzig - Fix ics download

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_leipzig_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_leipzig_de.py
@@ -44,6 +44,8 @@ class Source:
         # get ics file
         params = {
             "position_nos": id,
+            "name": f"{self._street} {self._house_number}",
+            "mode": "download",
         }
         r = requests.get(
             "https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/ical.ics",

--- a/doc/ics/stadtreinigung_leipzig_de.md
+++ b/doc/ics/stadtreinigung_leipzig_de.md
@@ -19,5 +19,5 @@ waste_collection_schedule:
     - name: ics
       args:
         regex: (.*), .*
-        url: https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/ical.ics?position_nos=38296&name=Sandgrubenweg
+        url: https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/ical.ics?position_nos=38296&name=Sandgrubenweg 27&mode=download
 ```

--- a/doc/ics/stadtreinigung_leipzig_de.md
+++ b/doc/ics/stadtreinigung_leipzig_de.md
@@ -19,5 +19,5 @@ waste_collection_schedule:
     - name: ics
       args:
         regex: (.*), .*
-        url: https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/ical.ics?position_nos=38296&name=Sandgrubenweg 27&mode=download
+        url: https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/ical.ics?position_nos=38296&name=Sandgrubenweg&mode=download
 ```

--- a/doc/ics/stadtreinigung_leipzig_de.md
+++ b/doc/ics/stadtreinigung_leipzig_de.md
@@ -5,8 +5,8 @@ Stadtreinigung Leipzig is supported by the generic [ICS](/doc/source/ics.md) sou
 
 ## How to get the configuration arguments
 
-- Goto <https://stadtreinigung-leipzig.de/> and select your location.  
-- Click on `Abonnieren` to get a webcal link.
+- Goto <https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/>, select your location and click on "Termine anzeigen".  
+- Copy the address of the link 'Herunterladen' to get a webcal link.
 - Replace the `url` in the example configuration with this link.
 
 ## Examples

--- a/doc/ics/yaml/stadtreinigung_leipzig_de.yaml
+++ b/doc/ics/yaml/stadtreinigung_leipzig_de.yaml
@@ -6,5 +6,5 @@ howto: |
    - Replace the `url` in the example configuration with this link.
 test_cases:
    Sandgrubenweg 27:
-       url: "https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/ical.ics?position_nos=38296&name=Sandgrubenweg"
+       url: "https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/ical.ics?position_nos=38296&name=Sandgrubenweg&mode=download"
        regex: "(.*), .*"

--- a/doc/ics/yaml/stadtreinigung_leipzig_de.yaml
+++ b/doc/ics/yaml/stadtreinigung_leipzig_de.yaml
@@ -1,8 +1,8 @@
 title: Stadtreinigung Leipzig
 url: https://stadtreinigung-leipzig.de/
 howto: |
-   - Goto <https://stadtreinigung-leipzig.de/> and select your location.  
-   - Click on `Abonnieren` to get a webcal link.
+   - Goto <https://stadtreinigung-leipzig.de/wir-kommen-zu-ihnen/abfallkalender/>, select your location and click on "Termine anzeigen".  
+   - Copy the address of the link 'Herunterladen' to get a webcal link.
    - Replace the `url` in the example configuration with this link.
 test_cases:
    Sandgrubenweg 27:


### PR DESCRIPTION
This PR fixes the error "Curently in Maintenance Mode." when downloading the ics.

The download request got two new parameter:
1. Street and street_number
2. mode=download

Thx for your review and overall work.
