### PR TITLE
Source Exeter_gov_uk: Add check for missing collection dates

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
@@ -29,7 +29,6 @@ class Source:
         self._uprn = str(uprn)
 
     def fetch(self):
-
         s = requests.Session()
         r = s.get(
             f"https://exeter.gov.uk/repositories/hidden-pages/address-finder/?qsource=UPRN&qtype=bins&term={self._uprn}"
@@ -41,15 +40,17 @@ class Source:
         dates = soup.findAll("h3")
 
         entries = []
-        for (b, d) in zip(bins, dates):
-            entries.append(
-                Collection(
-                    date=datetime.strptime(
-                        re.compile(REGEX_ORDINALS).sub("", d.text), "%A, %d %B %Y"
-                    ).date(),
-                    t=b.text.replace(" collection", ""),
-                    icon=ICON_MAP.get(b.text.replace(" collection", "").upper()),
+        for b, d in zip(bins, dates):
+            # check cases where no date is given for a collection
+            if d and len(d.text.split(",")) > 1:
+                entries.append(
+                    Collection(
+                        date=datetime.strptime(
+                            re.compile(REGEX_ORDINALS).sub("", d.text), "%A, %d %B %Y"
+                        ).date(),
+                        t=b.text.replace(" collection", ""),
+                        icon=ICON_MAP.get(b.text.replace(" collection", "").upper()),
+                    )
                 )
-            )
 
         return entries


### PR DESCRIPTION
This is to fix issue: #1642 
A check for missing dates was added.

In the users example, the date for Garden waste collection was missing.