### PR TITLE
Fix: Core - Add check for unknown source

### DIFF
--- a/custom_components/waste_collection_schedule/__init__.py
+++ b/custom_components/waste_collection_schedule/__init__.py
@@ -198,14 +198,15 @@ class WasteCollectionApi:
         source_args,
         calendar_title,
     ):
-        self._source_shells.append(
-            SourceShell.create(
-                source_name=source_name,
-                customize=customize,
-                source_args=source_args,
-                calendar_title=calendar_title,
-            )
+        new_shell = SourceShell.create(
+            source_name=source_name,
+            customize=customize,
+            source_args=source_args,
+            calendar_title=calendar_title,
         )
+
+        if new_shell:
+            self._source_shells.append(new_shell)
 
     def _fetch(self, *_):
         for shell in self._source_shells:


### PR DESCRIPTION
If an unknown source is in the configuration, multiple exceptions are raised. Reason is that None is added to the source_shell list. This adds a check to prevent this.

Example exception:
```
  File "/custom_components/waste_collection_schedule/calendar.py", line 35, in async_setup_platform
    dedicated_calendar_types = shell.get_dedicated_calendar_types()
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_dedicated_calendar_types'
```