### PR TITLE
Add dependency on calendars to manifest.json

### DIFF
--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -2,7 +2,7 @@
   "domain": "waste_collection_schedule",
   "name": "waste_collection_schedule",
   "codeowners": ["@mampfes"],
-  "dependencies": [],
+  "dependencies": ["calendar"],
   "documentation": "https://github.com/mampfes/hacs_waste_collection_schedule#readme",
   "integration_type": "hub",
   "iot_class": "cloud_polling",


### PR DESCRIPTION
This integration has a calendar platform, therefore it should wait for that platform to be ready before initialising.

