### PR TITLE
adur_worthing_gov_uk fixed address match error + imporved error message

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/adur_worthing_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/adur_worthing_gov_uk.py
@@ -46,10 +46,12 @@ class Source:
                 found_address = address
 
         if found_address is None:
-            raise ValueError("Address not found")
+            raise ValueError(
+                f"Address not found. searched for {self._address} but, should be one of {[a.get_text() for a in addresses_select.find_all('option')]}"
+            )
 
         collections_request = s.get(
-            f"https://www.adur-worthing.gov.uk/bin-day/?brlu-selected-address={address['value']}&return-url=/bin-day/",
+            f"https://www.adur-worthing.gov.uk/bin-day/?brlu-selected-address={found_address['value']}&return-url=/bin-day/",
             headers=HEADERS,
         )
         html_collections = collections_request.content


### PR DESCRIPTION
@jonathh21 in https://github.com/mampfes/hacs_waste_collection_schedule/commit/6895b577feb9bef7239de5eca8165116411e8077#commitcomment-138314023

> Hi, I am not saying this is related, but my adur lookup stopped working recently, and this is the only change I can see.
> 
> The error i see in the logs is "Address not found" and that seemingly only occurs if no entry is found after the for loop.
> 
> Curiously, this change, which seem innocuous enough, appears to be to make it case insensitive - but i had a capitalised address all along and it worked fine.
> 
> Any word on what this was trying to solve?
> Interestingly - if i replace the variable usages in the urls for self._postcode and {address['value']} with actual values from adurs website.. it works fine.

- This fixes an error where the last address of the postcode area is used instead of the right one.
- Improved error Message to list available addresses

This should not fix an error where a `Address not found` was thrown, but the more detailed error message might help debug the problem



