### PR TITLE
fix: start_date and end_date in ICS.convert for leap years

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -31,9 +31,11 @@ class ICS:
 
     def convert(self, ics_data: str) -> List[Tuple[datetime.date, str]]:
         # calculate start- and end-date for recurring events
-        start_date = datetime.datetime.now().replace(
+        today = datetime.datetime.now().replace(
             hour=0, minute=0, second=0, microsecond=0
         )
+
+        start_date = today.replace(day=1)
         if self._offset is not None:
             start_date -= datetime.timedelta(days=self._offset)
         end_date = start_date.replace(year=start_date.year + 1)


### PR DESCRIPTION
Replacing the year on todays `start_date` (29.02) causes exceptions on leap years. My suggestion just uses the first of a month for calculating `start_date` and `end_date`

fixes #1844 #1846 #1847