### PR TITLE
fix stavanger_no

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stavanger_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stavanger_no.py
@@ -38,6 +38,7 @@ class Source:
         headers = {"referer": "https://www.stavanger.kommune.no"}
 
         params = {
+            "ids": self._id,
             "id": self._id,
             "municipality": self._municipality,
             "gnumber": self._gnumber,


### PR DESCRIPTION
fixes #1869

They changed the request parameter name from `id` to `ids`. I kept `id` as it does not seem to change anything and might prevent breakage if they ever decide to go back to the old name.