### PR TITLE
Update braintree_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
@@ -16,7 +16,7 @@ TEST_CASES = {
 ICON_MAP = {
     "Grey Bin": "mdi:trash-can",
     "Clear Sack": "mdi:recycle",
-    "Green Bin": "mdi:leaf",
+    "Garden Bin": "mdi:leaf",
     "Food Bin": "mdi:food-apple",
 }
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
@@ -26,12 +26,15 @@ class Source:
         self.post_code = post_code
         self.house_number = house_number
         self.url = f"{URL}/xfp/form/554"
+
+    def initialize_form_data(self):
         self.form_data = {
-            "qe15dda0155d237d1ea161004d1839e3369ed4831_0_0": (None, post_code),
+            "qe15dda0155d237d1ea161004d1839e3369ed4831_0_0": (None, self.post_code),
             "page": (None, 5730),
         }
 
     def fetch(self):
+        self.initialize_form_data()  # Re-initialize form data before each fetch otherwise subsequent fetchs fail 
         address_lookup = requests.post(
             "https://www.braintree.gov.uk/xfp/form/554", files=self.form_data
         )


### PR DESCRIPTION
Proposal of two fixes for source "braintree_gov_uk.py"

1. Only the first fetch after a HA reboot would actually succeed. Tracked this down to self.form_data keeping data from previous fetches which caused subsequent fetches to fail. My proposed fix is a re-initialize of self.form_data upon every fetch. (See commit f5a92b99f9f1756115b0fa9eeefe9f56f550b6a9)
2. Braintree council have changed the name of their "Green Bin" to "Garden Bin". Have updated this in the ICON_MAP. (See commit 3c6f70416a51071e95626686eb52a6f450d88ae7)