### PR TITLE
add icons.joson with fetch_data service icon

### DIFF
--- a/custom_components/waste_collection_schedule/icons.json
+++ b/custom_components/waste_collection_schedule/icons.json
@@ -1,0 +1,5 @@
+{
+  "services": {
+    "fetch_data": "mdi:database-sync"
+  }
+}


### PR DESCRIPTION
adding icon for fetch_data service to satisfy hassfest.

Does sound optional though:

https://developers.home-assistant.io/blog/2024/01/19/icon-translations/