### PR TITLE
Braintree - Feature allow int as house number

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
@@ -7,7 +7,7 @@ TITLE = "Braintree District Council"
 DESCRIPTION = "Braintree District Council, UK - Waste Collection"
 URL = "https://www.braintree.gov.uk"
 TEST_CASES = {
-    "30 Boars Tye Road": {"house_number": "30", "post_code": "CM8 3QE"},
+    "30 Boars Tye Road": {"house_number": 30, "post_code": "CM8 3QE"},
     "64 Silver Street": {"house_number": "64", "post_code": "CM8 3QG"},
     "18 St Mary's Road": {"house_number": "1", "post_code": "CM8 3PE"},
     "20 Peel Crescent": {"house_number": "20", "post_code": "CM7 2RS"},
@@ -25,7 +25,7 @@ ICON_MAP = {
 class Source:
     def __init__(self, post_code: str, house_number: str):
         self.post_code = post_code
-        self.house_number = house_number
+        self.house_number = str(house_number)
         self.url = f"{URL}/xfp/form/554"
 
     def initialize_form_data(self):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
@@ -11,6 +11,7 @@ TEST_CASES = {
     "64 Silver Street": {"house_number": "64", "post_code": "CM8 3QG"},
     "18 St Mary's Road": {"house_number": "1", "post_code": "CM8 3PE"},
     "20 Peel Crescent": {"house_number": "20", "post_code": "CM7 2RS"},
+    "Causeway House": {"house_number": "Causeway House", "post_code": "CM7 9HB"},
 }
 
 ICON_MAP = {
@@ -34,7 +35,7 @@ class Source:
         }
 
     def fetch(self):
-        self.initialize_form_data()  # Re-initialize form data before each fetch otherwise subsequent fetchs fail 
+        self.initialize_form_data()  # Re-initialize form data before each fetch otherwise subsequent fetchs fail
         address_lookup = requests.post(
             "https://www.braintree.gov.uk/xfp/form/554", files=self.form_data
         )
@@ -61,7 +62,15 @@ class Source:
             "div", class_="date_display"
         ):
             try:
-                collection_type, collection_date = results.text.strip().split("\n")
+                collection_info = results.text.strip().split("\n")
+                collection_type = collection_info[0].strip()
+
+                # Skip if no collection date is found
+                if len(collection_info) < 2:
+                    continue
+
+                collection_date = collection_info[1].strip()
+
                 entries.append(
                     Collection(
                         date=parser.parse(collection_date, dayfirst=True).date(),


### PR DESCRIPTION
I got stuck for a while on setting this up due to missing quotes in my `yml` config.
I figured it'd be nice to allow integers.


Merge this first 
https://github.com/mampfes/hacs_waste_collection_schedule/pull/1920