### PR TITLE
Fix v2: Source: AppAbfallPlusDE - Add user-agent to request

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -252,7 +252,7 @@ def random_hex(length: int = 1) -> str:
 
 API_BASE = "https://app.abfallplus.de/{}"
 API_ASSISTANT = API_BASE.format("assistent/{}")  # ignore: E501
-USER_AGENT = "ABFALL+/9.1.0.0 CFNetwork/1496.0.4 Darwin/23.5.0"
+USER_AGENT = "%/9.1.0.0 iOS/17.5 Device/iPhone Screen/1170x2532"
 
 
 def extract_onclicks(
@@ -307,17 +307,8 @@ class AppAbfallplusDe:
         strasse_id=None,
         hnr_id=None,
     ):
-        self._client = (
-            random_hex(8)
-            + "-"
-            + random_hex(4)
-            + "-"
-            + random_hex(4)
-            + "-"
-            + random_hex(4)
-            + "-"
-            + random_hex(12)
-        )
+        self._client = random_hex(48)
+
         self._app_id = app_id
         self._session = requests.Session()
         self._bundesland_search = bundesland

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
@@ -16,6 +16,7 @@ TEST_CASES = {
     # Failing TODO: To be removed?
     "de.k4systems.bonnorange Auf dem Hügel": {
         "app_id": "de.k4systems.bonnorange",
+        "city": "A",  # First letter of street required
         "strasse": "Auf dem Hügel",
         "hnr": 6,
     },

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
@@ -13,6 +13,7 @@ TEST_CASES = {
         "strasse": "Hauptstraße",
         "hnr": "7A",
     },
+    # Failing TODO: To be removed?
     "de.k4systems.bonnorange Auf dem Hügel": {
         "app_id": "de.k4systems.bonnorange",
         "strasse": "Auf dem Hügel",
@@ -56,10 +57,10 @@ TEST_CASES = {
         "bezirk": "Adelebsen",
     },
     # MORE TEST CASES UNCOMMENT IF NEEDED FOR DEBUGGING
-    # "de.k4systems.zakb Fürth Ahornweg 3 A": {
+    # "de.k4systems.zakb Fürth Ahornweg 3": {
     #     "app_id": "de.k4systems.zakb",
     #     "strasse": "Ahornweg",
-    #     "hnr": "3 A",
+    #     "hnr": "3",
     #     "city": "Fürth",
     # },
     # "de.k4systems.avea Leverkusen Haberstr.": {
@@ -75,7 +76,7 @@ TEST_CASES = {
     # "de.k4systems.abfallappfuerth Großhabersdorf Am Dürren Grund 1 a": {
     #     "app_id": "de.k4systems.abfallappfuerth",
     #     "strasse": "Am Dürren Grund",
-    #     "hnr": "1 a",
+    #     "hnr": "1",
     #     "city": "Großhabersdorf",
     # },
     # "de.k4systems.awbgp Bad Boll Ahornstraße Alle Hausnummern": {
@@ -83,6 +84,23 @@ TEST_CASES = {
     #     "strasse": "Ahornstraße",
     #     "hnr": "Alle Hausnummern",
     #     "city": "Bad Boll",
+    # },
+    # "de.k4systems.abfalllkbz Hoyerswerda bezirk: WK VIII": {
+    #     "app_id": "de.k4systems.abfalllkbz",
+    #     "bezirk": "WK VIII",
+    #     "city": "Hoyerswerda",
+    # },
+    # "de.idcontor.abfallwbd Duisburg, Rahm Am Junkersknappen 6": {
+    #     "app_id": "de.idcontor.abfallwbd",
+    #     "strasse": "Am Junkersknappen",
+    #     "bezirk": "Rahm",
+    #     "hnr": "6",
+    #     "city": "Duisburg",
+    # },
+    # "de.k4systems.awbrastatt Muggensturm Adlergasse": {
+    #     "app_id": "de.k4systems.awbrastatt",
+    #     "strasse": "Adlergasse",
+    #     "city": "Muggensturm",
     # },
     # # This test case will probably fail in 2025, due to harmonization of waste collection services
     # # https://www.landkreisgoettingen.de/themen-leistungen/abfall-entsorgung/harmonisierung-der-abfallwirtschaften


### PR DESCRIPTION
This is the next try to fix issue: #1989 

- User-agent headers added to make sure the API delivers the data back.
- Client_id changed from guid to random_hex(48)
- added more test cases, fixed a few tests, Bonn orange is failing (~~needs to be removed in a follow up PR, I will open an issue~~ needs to be checked again...)

Test report:
```
Testing source app_abfallplus_de ...
  found 36 entries for de.albagroup.app Braunschweig Hauptstraße 7A  
  de.k4systems.bonnorange Auf dem Hügel failed: Street 'Auf dem Hügel' not found., available: []
  found 192 entries for de.ucom.abfallavr Brühl Habichtstr. 4A
  found 66 entries for de.k4systems.abfallappwug Bergen hauptstr. 1
  found 109 entries for de.k4systems.abfallappcux Wurster Nordseeküste Aakweg Alle Hausnummern
  found 57 entries for de.abfallwecker Mutzschen, Am Lindigt 1
  found 66 entries for de.k4systems.leipziglk Brandis Brandis
  found 91 entries for de.k4systems.lkgoettingen, Abfallwirtschaft Altkreis Göttingen,  Adelebsen, Alle Straßen
  found 65 entries for de.k4systems.zakb Fürth Ahornweg 3
  found 289 entries for de.k4systems.avea Leverkusen Haberstr.
  found 52 entries for de.k4systems.abfallappog Bad Peterstal-Griesbach alle Straßen
  found 79 entries for de.k4systems.abfallappfuerth Großhabersdorf Am Dürren Grund 1 a
  found 87 entries for de.k4systems.awbgp Bad Boll Ahornstraße Alle Hausnummern
  found 157 entries for de.k4systems.abfalllkbz Hoyerswerda bezirk: WK VIII
  found 77 entries for de.idcontor.abfallwbd Duisburg, Rahm Am Junkersknappen 6
  found 141 entries for de.k4systems.awbrastatt Muggensturm Adlergasse

```