### PR TITLE
Fix: Source: AWLNeuss_DE - change to full year load

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awlneuss_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awlneuss_de.py
@@ -20,6 +20,7 @@ TEST_CASES = {  # Insert arguments for test cases to be used by test_sources.py 
         "street_name": "Bismarckstrasse",
         "building_number": 52,
     },
+    "Neuss, Karlsstrasse 1 (5200)": {"street_code": "5200", "building_number": 1},
 }
 
 API_URL = "https://buergerportal.awl-neuss.de/api/v1/calendar"
@@ -70,8 +71,8 @@ class Source:
 
         now = datetime.datetime.now()
         args["startMonth"] = now.year
-        args["isTreeMonthRange"] = "true"
-        args["isYear"] = "false"
+        args["isTreeMonthRange"] = "false"
+        args["isYear"] = "true"
 
         # get json file
         r = requests.get(API_URL, params=args)


### PR DESCRIPTION
The current implementation is loading the first three months of the year only. 

Fix: Change to full year load
Releated issue: #2014 

```
Testing source awlneuss_de ...
  found 143 entries for Neuss, Theodor-Heuss-Platz 13
  found 143 entries for Neuss, Niederstrasse 42
  found 143 entries for Neuss, Bahnhofstrasse 67
  found 143 entries for Neuss, Bismarckstrasse 52
  found 143 entries for Neuss, Karlsstrasse 1 (5200)
```