### PR TITLE
wermelskirchen ics API service down

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wermelskirchen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wermelskirchen_de.py
@@ -4,7 +4,7 @@ import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.service.ICS import ICS
 
-TITLE = "Wermelskirchen"
+TITLE = "Wermelskirchen (Service Down)"
 DESCRIPTION = "Source for Abfallabholung Wermelskirchen, Germany"
 URL = "https://www.wermelskirchen.de"
 TEST_CASES = {

--- a/doc/source/wermelskirchen_de.md
+++ b/doc/source/wermelskirchen_de.md
@@ -1,5 +1,7 @@
 # Wermelskirchen Abfallkalender
 
+!!!! The IT service provider was hit by a disastrous cyber attack in October of 2023. Since then this API does not work anymore and might never in the future (at least in the same form). !!!!
+
 Support for schedules provided by [Abfallkalender Wermelskirchen](https://www.wermelskirchen.de/rathaus/buergerservice/formulare-a-z/abfallkalender-online/) located in NRW, Germany.
 
 ## Limitations


### PR DESCRIPTION
The IT service provider for this API was hit by a disastrous cyber attack in October of 2023. Since then this API does not work anymore and might never in the future (at least in the same form).