### PR TITLE
Gedling Borough Council: Fix typo on iCal calendar example

### DIFF
--- a/doc/ics/gedling_gov_uk.md
+++ b/doc/ics/gedling_gov_uk.md
@@ -57,12 +57,12 @@ waste_collection_schedule:
       args:
         url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_wednesday_c_garden_bin_schedule.ics
 ```
-### Friday F (Garden waste collection)
+### Friday E (Garden waste collection)
 
 ```yaml
 waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_f_garden_bin_schedule.ics
+        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_e_garden_bin_schedule.ics
 ```

--- a/doc/ics/yaml/gedling_gov_uk.yaml
+++ b/doc/ics/yaml/gedling_gov_uk.yaml
@@ -16,6 +16,5 @@ test_cases:
        url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_monday_a_garden_bin_schedule.ics"
    Wednesday C (Garden waste collection):
        url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_wednesday_c_garden_bin_schedule.ics"
-   Friday F (Garden waste collection):
-       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_f_garden_bin_schedule.ics"
-   
+   Friday E (Garden waste collection):
+       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_e_garden_bin_schedule.ics"


### PR DESCRIPTION
A small update, one of the calendar example names and path was incorrect for the docs. This has been corrected in this pull request.