### PR TITLE
add source specifc day_offset parameter

### DIFF
--- a/custom_components/waste_collection_schedule/__init__.py
+++ b/custom_components/waste_collection_schedule/__init__.py
@@ -41,6 +41,8 @@ CONF_PICTURE = "picture"
 CONF_USE_DEDICATED_CALENDAR = "use_dedicated_calendar"
 CONF_DEDICATED_CALENDAR_TITLE = "dedicated_calendar_title"
 
+CONF_DAY_OFFSET = "day_offset"
+
 CUSTOMIZE_CONFIG = vol.Schema(
     {
         vol.Optional(CONF_TYPE): cv.string,
@@ -61,6 +63,7 @@ SOURCE_CONFIG = vol.Schema(
             cv.ensure_list, [CUSTOMIZE_CONFIG]
         ),
         vol.Optional(CONF_SOURCE_CALENDAR_TITLE): cv.string,
+        vol.Optional(CONF_DAY_OFFSET, default=0): vol.Coerce(int),
     }
 )
 
@@ -113,6 +116,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
             customize,
             source.get(CONF_SOURCE_ARGS, {}),
             source.get(CONF_SOURCE_CALENDAR_TITLE),
+            source.get(CONF_DAY_OFFSET, 0),
         )
 
     # store api object
@@ -192,17 +196,14 @@ class WasteCollectionApi:
         return self._day_switch_time
 
     def add_source_shell(
-        self,
-        source_name,
-        customize,
-        source_args,
-        calendar_title,
+        self, source_name, customize, source_args, calendar_title, day_offset
     ):
         new_shell = SourceShell.create(
             source_name=source_name,
             customize=customize,
             source_args=source_args,
             calendar_title=calendar_title,
+            day_offset=day_offset,
         )
 
         if new_shell:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -34,6 +34,10 @@ class CollectionBase(dict):  # inherit from dict to enable JSON serialization
     def set_picture(self, picture: str):
         self["picture"] = picture
 
+    def set_date(self, date: datetime.date):
+        self._date = date
+        self["date"] = date.isoformat()
+
 
 class Collection(CollectionBase):
     def __init__(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -82,6 +82,11 @@ def customize_function(entry: Collection, customize: Dict[str, Customize]):
     return entry
 
 
+def apply_day_offset(entry: Collection, day_offset: int):
+    entry.set_date(entry.date + datetime.timedelta(days=day_offset))
+    return entry
+
+
 class SourceShell:
     def __init__(
         self,
@@ -92,6 +97,7 @@ class SourceShell:
         url: Optional[str],
         calendar_title: Optional[str],
         unique_id: str,
+        day_offset: int,
     ):
         self._source = source
         self._customize = customize
@@ -102,6 +108,7 @@ class SourceShell:
         self._unique_id = unique_id
         self._refreshtime = None
         self._entries: List[Collection] = []
+        self._day_offset = day_offset
 
     @property
     def refreshtime(self):
@@ -127,6 +134,10 @@ class SourceShell:
     def unique_id(self):
         return self._unique_id
 
+    @property
+    def day_offset(self):
+        return self._day_offset
+
     def fetch(self):
         """Fetch data from source."""
         try:
@@ -148,6 +159,10 @@ class SourceShell:
 
         # customize fetched entries
         entries = map(lambda x: customize_function(x, self._customize), entries)
+
+        # apply day offset
+        if self._day_offset != 0:
+            entries = map(lambda x: apply_day_offset(x, self._day_offset), entries)
 
         self._entries = list(entries)
 
@@ -182,6 +197,7 @@ class SourceShell:
         customize: Dict[str, Customize],
         source_args,
         calendar_title: Optional[str] = None,
+        day_offset: int = 0,
     ):
         # load source module
         try:
@@ -204,6 +220,7 @@ class SourceShell:
             url=source_module.URL,  # type: ignore[attr-defined]
             calendar_title=calendar_title,
             unique_id=calc_unique_source_id(source_name, source_args),
+            day_offset=day_offset,
         )
 
         return g

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -64,6 +64,7 @@ waste_collection_schedule:
           picture: PICTURE
           use_dedicated_calendar: USE_DEDICATED_CALENDAR
           dedicated_calendar_title: DEDICATED_CALENDAR_TITLE
+      day_offset: DAY_OFFSET
       calendar_title: CALENDAR_TITLE
   fetch_time: FETCH_TIME
   random_fetch_time_offset: RANDOM_FETCH_TIME_OFFSET
@@ -78,6 +79,7 @@ waste_collection_schedule:
 | random_fetch_time_offset | int | optional | randomly offsets the `fetch_time` by up to _int_ minutes. Can be used to distribute Home Assistant fetch commands over a longer time frame to avoid peak loads at service providers |
 | day_switch_time | time | optional | time of the day in "HH:MM" that Home Assistant dismisses the current entry and moves to the next entry. If no time if provided, the default of "10:00" is used. |
 | separator | string | optional | Used to join entries if the multiple values for a single day are returned by the source. If no value is entered, the default of ", " is used |
+| day_offset | int | optional | Offset in days to add to the collection date (can be negative). If no value is entered, the default of 0 is used |
 
 ## Attributes for _sources_
 


### PR DESCRIPTION
Add the option to set a day_offset in the source configuration like for the ics source. This might be helpfull for sources that do fetch the elements correctly from the webpage, but the website is wrong.

fixes #2112
and addresses option to temporarly fix issues like #2113