### PR TITLE
improve error message if source_index is out of range

### DIFF
--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -74,7 +74,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     source_index = config[CONF_SOURCE_INDEX]
     if not isinstance(source_index, list):
         source_index = [source_index]
-    aggregator = CollectionAggregator([api.get_shell(i) for i in source_index])
+
+    shells = []
+    for i in source_index:
+        shell = api.get_shell(i)
+        if shell is None:
+            raise ValueError(
+                f"source_index {i} out of range (0-{len(api.shells) - 1}) please check your sensor configuration"
+            )
+        shells.append(shell)
+
+    aggregator = CollectionAggregator(shells)
 
     entities = []
 


### PR DESCRIPTION
prevents bug reports like: #2107

Previouse error message on source_index out of range: `AttributeError: 'NoneType' object has no attribute '_entries'`

New Error message (if one index is 3 but only 2 sources are configured): `ValueError: source_index 3 out of range (0-2) please check your sensor configuration`


