### PR TITLE
fix bug where random_fetch_time_offset: 0 leads to an error because random.randrange(0, 0) is called

### DIFF
--- a/custom_components/waste_collection_schedule/__init__.py
+++ b/custom_components/waste_collection_schedule/__init__.py
@@ -225,7 +225,9 @@ class WasteCollectionApi:
     def _fetch_callback(self, *_):
         async_call_later(
             self._hass,
-            randrange(0, 60 * self._random_fetch_time_offset),
+            randrange(0, 60 * self._random_fetch_time_offset)
+            if self._random_fetch_time_offset > 0
+            else 0,
             self._fetch_now_callback,
         )
 


### PR DESCRIPTION
`random.randrange(0, 0)` results in `ValueError: empty range in randrange(0, 0)`