### PR TITLE
Update haringey_gov_uk as a result of site changes to waste type names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
@@ -14,10 +14,10 @@ TEST_CASES = {
     "Test_004": {"uprn": 100021202131},
 }
 ICON_MAP = {
-    "General Waste": "mdi:trash-can",
-    "Collect Domestic Recycling": "mdi:recycle",
+    "Non-Recyclable Waste": "mdi:trash-can",
+    "Recycling": "mdi:recycle",
     "Food Waste": "mdi:food-apple",
-    "Collect Paid Domestic Garden": "mdi:leaf",
+    "Garden Waste": "mdi:leaf",
 }
 
 


### PR DESCRIPTION
Fixes #2125

Test output following changes:
```
$ ./test_sources.py -s haringey_gov_uk -i -l
Testing source haringey_gov_uk ...
  found 3 entries for Test_001
    2024-06-05 : Recycling [mdi:recycle]
    2024-06-05 : Non-Recyclable Waste [mdi:trash-can]
    2024-06-05 : Food Waste [mdi:food-apple]
  found 4 entries for Test_002
    2024-06-07 : Recycling [mdi:recycle]
    2024-06-07 : Non-Recyclable Waste [mdi:trash-can]
    2024-06-07 : Food Waste [mdi:food-apple]
    2024-06-07 : Garden Waste [mdi:leaf]
  found 3 entries for Test_003
    2024-06-07 : Food Waste [mdi:food-apple]
    2024-06-07 : Recycling [mdi:recycle]
    2024-06-07 : Non-Recyclable Waste [mdi:trash-can]
  found 3 entries for Test_004
    2024-06-04 : Non-Recyclable Waste [mdi:trash-can]
    2024-06-04 : Food Waste [mdi:food-apple]
    2024-06-04 : Recycling [mdi:recycle]
```