### PR TITLE
Update domain for Gedling Borough Council source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1271,7 +1271,7 @@ Waste collection schedules in the following formats and countries are supported.
 - [Flintshire](/doc/source/flintshire_gov_uk.md) / flintshire.gov.uk
 - [Fylde Council](/doc/source/fylde_gov_uk.md) / fylde.gov.uk
 - [Gateshead Council](/doc/source/gateshead_gov_uk.md) / gateshead.gov.uk
-- [Gedling Borough Council (unofficial)](/doc/ics/gedling_gov_uk.md) / github.com/jamesmacwhite/gedling-borough-council-bin-calendars
+- [Gedling Borough Council (unofficial)](/doc/ics/gedling_gov_uk.md) / gbcbincalendars.co.uk
 - [Glasgow City Council](/doc/source/glasgow_gov_uk.md) / glasgow.gov.uk
 - [Guildford Borough Council](/doc/source/guildford_gov_uk.md) / guildford.gov.uk
 - [Gwynedd](/doc/source/gwynedd_gov_uk.md) / gwynedd.gov.uk

--- a/doc/ics/gedling_gov_uk.md
+++ b/doc/ics/gedling_gov_uk.md
@@ -8,7 +8,7 @@ Gedling Borough Council (unofficial) is supported by the generic [ICS](/doc/sour
 - Gedling Borough Council does not provide bin collections in the iCal calendar format directly.
 - The iCal calendar files have been generated from the official printed calendars and hosted on GitHub for use.
 - Go to the Gedling Borough Council [Refuse Collection Days](https://apps.gedling.gov.uk/refuse/search.aspx) site and enter your street name to find your bin day/garden waste collection schedule. e.g. "Wednesday G2".
-- Find the [required collection schedule](https://jamesmacwhite.github.io/gedling-borough-council-bin-calendars/) and use the "Copy to clipboard" button for the URL of the .ics file.
+- Find the [required collection schedule](https://www.gbcbincalendars.co.uk) and use the "Copy iCal URL" button for the URL of the .ics file.
 
 ## Examples
 
@@ -19,7 +19,7 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_monday_g1_bin_schedule.ics
+        url: https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_monday_g1_bin_schedule.ics
 ```
 ### Wednesday G2 (General bin collection)
 
@@ -28,7 +28,7 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_wednesday_g2_bin_schedule.ics
+        url: https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_wednesday_g2_bin_schedule.ics
 ```
 ### Friday G3 (General bin collection)
 
@@ -37,7 +37,7 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_g3_bin_schedule.ics
+        url: https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_friday_g3_bin_schedule.ics
 ```
 ### Monday A (Garden waste collection)
 
@@ -46,7 +46,7 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_monday_a_garden_bin_schedule.ics
+        url: https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_monday_a_garden_bin_schedule.ics
 ```
 ### Wednesday C (Garden waste collection)
 
@@ -55,7 +55,7 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_wednesday_c_garden_bin_schedule.ics
+        url: https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_wednesday_c_garden_bin_schedule.ics
 ```
 ### Friday E (Garden waste collection)
 
@@ -64,5 +64,5 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_e_garden_bin_schedule.ics
+        url: https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_friday_e_garden_bin_schedule.ics
 ```

--- a/doc/ics/yaml/gedling_gov_uk.yaml
+++ b/doc/ics/yaml/gedling_gov_uk.yaml
@@ -1,20 +1,20 @@
 title: Gedling Borough Council (unofficial)
-url: https://github.com/jamesmacwhite/gedling-borough-council-bin-calendars
+url: https://www.gbcbincalendars.co.uk
 howto: |
    - Gedling Borough Council does not provide bin collections in the iCal calendar format directly.
    - The iCal calendar files have been generated from the official printed calendars and hosted on GitHub for use.
    - Go to the Gedling Borough Council [Refuse Collection Days](https://apps.gedling.gov.uk/refuse/search.aspx) site and enter your street name to find your bin day/garden waste collection schedule. e.g. "Wednesday G2".
-   - Find the [required collection schedule](https://jamesmacwhite.github.io/gedling-borough-council-bin-calendars/) and use the "Copy to clipboard" button for the URL of the .ics file.
+   - Find the [required collection schedule](https://www.gbcbincalendars.co.uk) and use the "Copy iCal URL" button for the URL of the .ics file.
 test_cases:
    Monday G1 (General bin collection):
-       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_monday_g1_bin_schedule.ics"
+       url: "https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_monday_g1_bin_schedule.ics"
    Wednesday G2 (General bin collection):
-       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_wednesday_g2_bin_schedule.ics"
+       url: "https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_wednesday_g2_bin_schedule.ics"
    Friday G3 (General bin collection):
-       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_g3_bin_schedule.ics"
+       url: "https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_friday_g3_bin_schedule.ics"
    Monday A (Garden waste collection):
-       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_monday_a_garden_bin_schedule.ics"
+       url: "https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_monday_a_garden_bin_schedule.ics"
    Wednesday C (Garden waste collection):
-       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_wednesday_c_garden_bin_schedule.ics"
+       url: "https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_wednesday_c_garden_bin_schedule.ics"
    Friday E (Garden waste collection):
-       url: "https://raw.githubusercontent.com/jamesmacwhite/gedling-borough-council-bin-calendars/main/ical/gedling_borough_council_friday_e_garden_bin_schedule.ics"
+       url: "https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_friday_e_garden_bin_schedule.ics"

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -247,7 +247,7 @@ This source has been successfully tested with the following service providers:
 
 - [Anglesey](/doc/ics/anglesey_gov_wales.md) / anglesey.gov.wales
 - [Falkirk](/doc/ics/falkirk_gov_uk.md) / falkirk.gov.uk
-- [Gedling Borough Council (unofficial)](/doc/ics/gedling_gov_uk.md) / github.com/jamesmacwhite/gedling-borough-council-bin-calendars
+- [Gedling Borough Council (unofficial)](/doc/ics/gedling_gov_uk.md) / gbcbincalendars.co.uk
 - [Westmorland & Furness Council, Barrow area](/doc/ics/barrowbc_gov_uk.md) / barrowbc.gov.uk
 - [Westmorland & Furness Council, South Lakeland area](/doc/ics/southlakeland_gov_uk.md) / southlakeland.gov.uk
 


### PR DESCRIPTION
I have restructured the original repository to allow the iCal files to be hosted properly through GitHub pages, this updates the original docs information to point to the custom domain https://www.gbcbincalendars.co.uk. The iCal files can now be directly downloaded and referenced as proper hosted URLs, in sync with the deployment process behind the GitHub pages site.

Using GitHub raw content paths is no longer required, however they will still work as .ics paths, so it wouldn't break any existing usage.

I have tested the new ics paths within my own Home Assistant installation e.g. https://www.gbcbincalendars.co.uk/ical/gedling_borough_council_wednesday_g2_bin_schedule.ics and everything works fine.