### PR TITLE
awn_de: Skip cert verification on POST requests as well

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
@@ -89,6 +89,7 @@ class Source:
         r = session.post(
             SERVLET,
             data=args,
+            verify=False,
         )
         r.raise_for_status()
 
@@ -106,6 +107,7 @@ class Source:
         r = session.post(
             SERVLET,
             data=args,
+            verify=False,
         )
         r.raise_for_status()
 
@@ -114,6 +116,7 @@ class Source:
         r = session.post(
             SERVLET,
             data=args,
+            verify=False,
         )
         r.raise_for_status()
 


### PR DESCRIPTION
Similar to #1333, I've seen SSL cert verification issues on the latest HassOS. After disabling verification to the `POST` requests in addition to the `GET` request that was done in the aforementioned issue, the component is successfully downloading ICS data for me again.