### PR TITLE
abfallnavi make street an optional parameter if only one street (like alle Straßen is returned)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -186,6 +186,12 @@ class AbfallnaviDe:
         may return multiple on change of id (may occur on year change)
         """
         streets = self.get_streets(city_id)
+        if len(streets) == 1:
+            return list(streets.keys())
+        if street is None:
+            raise Exception(
+                f"Multiple streets found for city: {city_id} please specify street, one of: {streets.values()}"
+            )
         return [id for id, name in streets.items() if name == street]
 
     def get_house_numbers(self, street_id):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
@@ -43,12 +43,21 @@ TEST_CASES = {
         "ort": "Bergkamen",
         "strasse": "Agnes-Miegel-Str.",
     },
+    "Pinneberg Kummerfeld no Street": {
+        "service": "pi",
+        "ort": "Kummerfeld",
+        "strasse": "alle Straßen",
+    },
 }
 
 
 class Source:
     def __init__(
-        self, service: str, ort: str, strasse: str, hausnummer: str | int | None = None
+        self,
+        service: str,
+        ort: str,
+        strasse: str | None = None,
+        hausnummer: str | int | None = None,
     ):
         self._api = AbfallnaviDe(service)
         self._ort = ort

--- a/doc/source/abfallnavi_de.md
+++ b/doc/source/abfallnavi_de.md
@@ -24,7 +24,8 @@ waste_collection_schedule:
 *(string) (required)*
 
 **strasse**  
-*(string) (required)*
+*(string) (optional)*  
+*required if the service provider website requests it*
 
 **hausnummer**  
 *(string | Integer) (optional)*


### PR DESCRIPTION
noticed that strasse may be optional and not prpperly exposed to the user if street is "alle Straßen" (#2172)