### PR TITLE
Gather cumulative entries, no duplicates.

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -127,6 +127,12 @@ class Source:
             entries.extend(self._create_entries(sp, town))
         return entries
 
+    def _entry_exists(self, dmy, name, entries: [Collection]):
+        for e in entries:
+            if dmy == e.date and name == e.type:
+                return True
+        return False
+
     def _create_entries(self, sp, town):
         streets = Ecoharmonogram.fetch_streets(
             sp, town, self.street_input, self.house_number_input
@@ -157,18 +163,17 @@ class Source:
                         z["name"] = get.get("name")
                         schedules.append(z)
 
-                    entries = []
                     for sch in schedules:
                         days = sch.get("days").split(";")
                         month = sch.get("month")
                         year = sch.get("year")
                         for d in days:
-                            entries.append(
-                                Collection(
-                                    datetime.date(int(year), int(month), int(d)),
-                                    sch.get("name"),
+                            dmy = datetime.date(int(year), int(month), int(d))
+                            name = sch.get("name")
+                            if not self._entry_exists(dmy, name, entries):
+                                entries.append(
+                                    Collection(dmy, name)
                                 )
-                            )
                 if self.additional_sides_matcher_input != "":
                     return entries
         return entries


### PR DESCRIPTION
This fixes the problem of using only last collection list, instead using all downloaded entries.
It also does not allow duplicated entries, that I noticed for my location.