### PR TITLE
fix source landkreis_rhoen_grabfeld

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_rhoen_grabfeld.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_rhoen_grabfeld.py
@@ -22,7 +22,8 @@ EVENT_BLACKLIST = ['Wertstoffhof Mellrichstadt',
                    'Wertstoffsammelstelle Bischofsheim']
 
 ICON_MAP = {
-    "Restmüll/Gelber Sack/Biotonne": "mdi:trash-can",
+    "Restmüll/Biotonne": "mdi:trash-can",
+    "Gelbe Tonne": "mdi:recycle-variant",
     "Papiersammlung": "mdi:package-variant",
     "Problemmüllsammlung": "mdi:biohazard"
 }

--- a/doc/source/landkreis_rhoen_grabfeld.md
+++ b/doc/source/landkreis_rhoen_grabfeld.md
@@ -5,7 +5,8 @@ Support for schedules provided by [AbfallInfo Rhön Grabfeld](https://www.abfall
 Api in the background is provided by Offizium.
 
 Possibles types are:
-- Restmüll/Gelber Sack/Biotonne
+- Restmüll/Biotonne
+- Gelbe Tonne
 - Papiersammlung
 - Problemmüllsammlung
 


### PR DESCRIPTION
The API for source "Landkreis Rhön Grabfeld" recently split the trash type "Restmüll/Gelber Sack/Biotonne" into two distinct types:
- "Restmüll/Biotonne"
- "Gelbe Tonne"

This PR updates the source and related documentation accordingly.