### PR TITLE
Fixed documentation source name error

### DIFF
--- a/doc/source/gastrikeatervinnare_se.md
+++ b/doc/source/gastrikeatervinnare_se.md
@@ -26,7 +26,7 @@ waste_collection_schedule:
 ```yaml
 waste_collection_schedule:
   sources:
-    - name: tekniskaverken_se
+    - name: gastrikeatervinnare_se
       args:
         street: Bryggargatan 6
         city: Sandviken


### PR DESCRIPTION
Fixed wrong source name in gastrikeatervinnare source (copy paste error from when I created the source)