### PR TITLE
Remove unneccesary fetch test

### DIFF
--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -8,7 +8,6 @@ from typing import Any
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import (
@@ -59,13 +58,6 @@ async def async_setup_entry(hass: HomeAssistant, entry) -> bool:
         entry.data[const.CONF_SOURCE_ARGS],
         options.get(const.CONF_SOURCE_CALENDAR_TITLE),
     )
-
-    try:
-        await hass.async_add_executor_job(shell.fetch)
-    except Exception as err:  # pylint: disable=broad-except
-        ex = ConfigEntryNotReady()
-        ex.__cause__ = err
-        raise ex
 
     coordinator = WCSCoordinator(
         hass,


### PR DESCRIPTION
fixes #2243

coordinator.async_config_entry_first_refresh() does excactly the same:
test if fetch is successfull and if not raise ConfigEntryNotReady