### PR TITLE
set minimum HA version to 2023.12.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Waste Collection Schedule",
   "domains": ["sensor"],
-  "iot_class": "cloud_polling"
+  "iot_class": "cloud_polling",
+  "homeassistant": "2023.12.0"
 }


### PR DESCRIPTION
After GUI update, there are some incompatibilities with older version of HA:

- everything since 2023.9.0 works with YAML but config_flow fails
- everything since 2023.12.0 works without any issues