### PR TITLE
Add support for Borås sweden

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
@@ -41,6 +41,18 @@ TEST_CASES = {
         "street_address": "Frögatan 76 -150",
         "service_provider": "skelleftea",
     },
+    "Borås - Test1": {
+        "street_address": "Länghemsgatan 10",
+        "service_provider": "boras",
+    },
+    "Borås - Test2": {
+        "street_address": "Yttre Näs 1, Seglora",
+        "service_provider": "boras",
+    },
+    "Borås - Test3": {
+        "street_address": "Stora Hyberg 1, Brämhult",
+        "url": "https://kundportal.borasem.se/EDPFutureWeb/SimpleWastePickup",
+    },
 }
 
 COUNTRY = "se"
@@ -53,7 +65,7 @@ ICON_MAP = {
     "Deponi": "mdi:recycle",
     "Restavfall": "mdi:trash-can",
     "Matavfall": "mdi:food-apple",
-    "Slam": "",
+    "Slam": "mdi:emoticon-poop",
     "Trädgårdsavfall": "mdi:leaf",
 }
 
@@ -98,6 +110,11 @@ SERVICE_PROVIDERS = {
         "title": "Uppsala Vatten",
         "url": "https://uppsalavatten.se",
         "api_url": "https://futureweb.uppsalavatten.se/Uppsala/FutureWeb/SimpleWastePickup",
+    },
+    "boras": {
+        "title": "Borås Energi och Miljö",
+        "url": "https://www.borasem.se",
+        "api_url": "https://kundportal.borasem.se/EDPFutureWeb/SimpleWastePickup",
     },
 }
 

--- a/doc/source/edpevent_se.md
+++ b/doc/source/edpevent_se.md
@@ -92,3 +92,4 @@ To find your correct address, search for it on your service providers website:
 - [Skellefteå](https://skelleftea.se/invanare/startsida/bygga-bo-och-miljo/avfall-och-atervinning/sophamtning---nar-toms-soporna)
 - [SSAM](https://ssam.se/mitt-ssam/hamtdagar.html)
 - [Uppsala Vatten](https://www.uppsalavatten.se/sjalvservice/hamtningar-och-berakningar/dag-for-sophamtning-och-slamtomning)
+- [Borås](https://www.borasem.se/webb/privat/avfallochatervinning/abonnemangforhushallsavfall/nastatomningsdag.4.5a231a8f188bd840a1327da.html)


### PR DESCRIPTION
This fixes issue #2333 / discussion #2329

the output of test script: (i've removed all the outputs above for the other less relevant edpevent providers)
```bash
  found 2 entries for Borås - Test1
    2024-07-29 : Kärl 1, Kärl 370.0L [mdi:help]
    2024-08-07 : Kärl 2, Kärl 370.0L [mdi:help]
  found 2 entries for Borås - Test2
    2024-08-06 : Kärl 1, Kärl 370.0L [mdi:help]
    2024-08-13 : Kärl 2, Kärl 370.0L [mdi:help]
  found 2 entries for Borås - Test3
    2024-07-29 : Kärl 1, Kärl 370.0L [mdi:help]
    2024-08-01 : Kärl 2, Kärl 370.0L [mdi:help]
```
I could not run the _update_docu_links.py since i got an error for the ahk_heidekreis_de.py source:
```bash
/waste_collection_schedule/source/ahk_heidekreis_de.py", line 82
    if f"{item["houseNr"]}{item["houseNrAdd"]}" == self._house_number
                ^^^^^^^
SyntaxError: f-string: unmatched '['
```

I've opened a pull request with a potential fix for this: #2336 