### PR TITLE
config_flow fetching source returns unstripped waste types

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -536,7 +536,7 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
 
             if len(resp) == 0:
                 errors["base"] = "fetch_empty"
-            self._fetched_types = list({x.type for x in resp})
+            self._fetched_types = list({x.type.strip() for x in resp})
         except Exception as e:
             errors["base"] = "fetch_error"
             description_placeholders["fetch_error_message"] = str(e)


### PR DESCRIPTION
but the source setup later will strip whitespaces at the start/end,
Currently the suggested waste types may have a space at the end or beginning,
while these will be removed later and the sensor does not match the type anymore


fixes #2325