### PR TITLE
Initial support for Slam (Sludge) pickup/week handling

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
@@ -331,14 +331,32 @@ class Source:
         for item in data["RhServices"]:
             waste_type = ""
             next_pickup = item["NextWastePickup"]
+
+            # When no explicit pickup date is provided (e.g. for sludge/slam),
+            # fall back to the week number given in the frequency, e.g. "Vecka 27".
+            if not next_pickup and "v" in item["WastePickupFrequency"].lower():
+                next_pickup = item["WastePickupFrequency"]
             try:
-                if "v" in next_pickup:
+                if "v" in next_pickup.lower():
                     date_parts = next_pickup.split()
-                    month = MONTH_MAP[date_parts[1]]
-                    date_joined = "-".join([date_parts[0], str(month), date_parts[2]])
-                    next_pickup_date = datetime.strptime(
-                        date_joined, "v%W-%m-%Y"
-                    ).date()
+                    # "Vecka 27": derive a date from the ISO week number.
+                    if date_parts[0].lower() == "vecka":
+                        current_year = datetime.now().year
+                        next_pickup_date = datetime.strptime(
+                            f"{current_year} {date_parts[1]} 1", "%Y %W %w"
+                        ).date()
+                    # "v32 Aug 2024": derive a date from week, month and year.
+                    elif date_parts[1] in MONTH_MAP:
+                        month = MONTH_MAP[date_parts[1]]
+                        date_joined = "-".join(
+                            [date_parts[0], str(month), date_parts[2]]
+                        )
+                        next_pickup_date = datetime.strptime(
+                            date_joined, "v%W-%m-%Y"
+                        ).date()
+                    else:
+                        _LOGGER.warning("Failed to parse pickup date: %s", next_pickup)
+                        continue
                 elif not next_pickup:
                     continue
                 else:


### PR DESCRIPTION
I got a question if it was possible to also get the sludge pickup date. I looked into it with the Borås Test 3 address. It does not return a NextWastePickup date but it does return a week number in WastePickupFrequency eg "Vecka 27".
There was already an implementation when i merged SSAM into edpevent_se where the NextWastePickup can be returned as "v32 Aug 2024". The previous implementation checked if it contained the letter "v" and then created a date from the string using a month map etc. I built on top of this to also work with a simple "Vecka 27" return value.

Not sure if this is the optimal solution for this? I guess this is a bit hard to solve for everything since different municipalities might write their NextWastePickup in a different way. 