### PR TITLE
Add generic ICS for GDA Amstetten (gda.gv.at)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [Gattendorf](/doc/source/citiesapps_com.md) / gattendorf.at
 - [GAUL Laa an der Thaya](/doc/source/umweltverbaende_at.md) / laa.umweltverbaende.at
 - [GAUM Mistelbach](/doc/source/umweltverbaende_at.md) / mistelbach.umweltverbaende.at
-- [GDA Amstetten](/doc/source/umweltverbaende_at.md) / amstetten.umweltverbaende.at
+- [GDA Amstetten](/doc/ics/gda_gv_at.md) / gda.gv.at
 - [Gemeindeverband Horn](/doc/source/umweltverbaende_at.md) / horn.umweltverbaende.at
 - [Gitschtal](/doc/source/citiesapps_com.md) / gitschtal.gv.at
 - [Gitschtal](/doc/ics/muellapp_com.md) / muellapp.com

--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -856,7 +856,7 @@
     },
     {
       "title": "GDA Amstetten",
-      "module": "umweltverbaende_at",
+      "module": "ics",
       "default_params": {}
     },
     {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
@@ -10,11 +10,11 @@ DESCRIPTION = (
 )
 URL = "https://www.umweltverbaende.at/"
 EXTRA_INFO = [
-    {
-        "title": "GDA Amstetten",
-        "url": "https://amstetten.umweltverbaende.at/",
-        "country": "at",
-    },
+    # { --> Schedules supported via generic ICS source [GDA Amstetten](/doc/ics/gda_gv_at.md)
+    #     "title": "GDA Amstetten",
+    #     "url": "https://gda.gv.at/",
+    #     "country": "at",
+    # },
     {
         "title": "GABL",
         "url": "https://bruck.umweltverbaende.at/",
@@ -143,7 +143,6 @@ TEST_CASES = {
         "municipal": "Langenlois",
         "calendar": "Gobelsburg, Mittelberg, Reith, Schiltern, Zöbing",
     },
-    # "Amstetten": {"district": "amstetten", "municipal": "?"}, # No schedules listed on website
     "Bruck/Leitha": {"district": "bruck", "municipal": "Berg"},
     "Baden": {"district": "baden", "municipal": "Hernstein"},
     "Gmünd": {"district": "gmuend", "municipal": "Weitra"},

--- a/doc/ics/gda_gv_at.md
+++ b/doc/ics/gda_gv_at.md
@@ -1,0 +1,31 @@
+# GDA Amstetten
+
+GDA Amstetten is supported by the generic [ICS](/doc/source/ics.md) source. For all available configuration options, please refer to the source description.
+
+
+## How to get the configuration arguments
+
+- Goto <https://gda.gv.at/abholtermine> and select your location.  
+- Copy the link of the `iCal` Button.
+- Replace the `url` in the example configuration with this link.
+
+## Examples
+
+### Markt 47, 3365 Allhartsberg
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ics
+      args:
+        url: https://gda.abfuhrtermine.at/webcalzip/Markt/47/3365/03171/30501
+```
+### Schlossstraße 2, 3311 Zeillern
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ics
+      args:
+        url: https://gda.abfuhrtermine.at/webcalzip/Schlossstra%C3%9Fe/2/3311/03349/30544
+```

--- a/doc/ics/yaml/gda_gv_at.yaml
+++ b/doc/ics/yaml/gda_gv_at.yaml
@@ -1,0 +1,11 @@
+title: GDA Amstetten
+url: https://gda.gv.at
+howto: |
+   - Goto <https://gda.gv.at/abholtermine> and select your location.  
+   - Copy the link of the `iCal` Button.
+   - Replace the `url` in the example configuration with this link.
+test_cases:
+   Markt 47, 3365 Allhartsberg:
+      url: "https://gda.abfuhrtermine.at/webcalzip/Markt/47/3365/03171/30501"
+   Schlossstraße 2, 3311 Zeillern:
+      url: "https://gda.abfuhrtermine.at/webcalzip/Schlossstra%C3%9Fe/2/3311/03349/30544"

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -35,6 +35,7 @@ This source has been successfully tested with the following service providers:
 - [Ferndorf](/doc/ics/muellapp_com.md) / muellapp.com
 - [Finkenstein am Faaker See](/doc/ics/muellapp_com.md) / muellapp.com
 - [Frauenstein](/doc/ics/muellapp_com.md) / muellapp.com
+- [GDA Amstetten](/doc/ics/gda_gv_at.md) / gda.gv.at
 - [Gitschtal](/doc/ics/muellapp_com.md) / muellapp.com
 - [Globasnitz](/doc/ics/muellapp_com.md) / muellapp.com
 - [Gmünd in Kärnten](/doc/ics/muellapp_com.md) / muellapp.com

--- a/doc/source/umweltverbaende_at.md
+++ b/doc/source/umweltverbaende_at.md
@@ -153,4 +153,8 @@ waste_collection_schedule:
 
 ## Missing Districts
 
-Amstetten, Laa/Thaya, Neunkirchen, Stadt St. Pölten and Wiener Neustadt serve their waste collection scheduled from local municipality web sites using different back-ends and aren't supported by this script.
+Laa/Thaya, Neunkirchen, Wiener Neustadt serve their waste collection scheduled from local municipality web sites using different back-ends and aren't supported by this script.
+
+## Districts supported via generic ICS source
+* [GDA Amstetten](/doc/ics/gda_gv_at.md)
+* [Abfallwirtschaft der Stadt St. Pölten](/doc/ics/st-poelten_at.md)


### PR DESCRIPTION
GDA Amstetten provides a ICS for each address in the district, selectable via a website.

The official homepage moved from https://amstetten.umweltverbaende.at to https://gda.gv.at.

I kept the EXTRA_INFO value in `umweltverbaende_at.py` as GDA Amstetten is still part of NÖ Umweltverbände but maintains its own homepage as listed in https://www.umweltverbaende.at/verbaende.