### PR TITLE
Wokingham source includes "Today" rather than day name

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wokingham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wokingham_gov_uk.py
@@ -100,10 +100,10 @@ class Source:
         for card in cards:
             # Cope with Garden waste suffixed with (week 1) or (week 2)
             waste_type = " ".join(card.find("h3").text.strip().split()[:2])
-            waste_date = card.find("span").text.strip()
+            waste_date = card.find("span").text.strip().split()[-1]
             entries.append(
                 Collection(
-                    date=datetime.strptime(waste_date, "%A %d/%m/%Y").date(),
+                    date=datetime.strptime(waste_date, "%d/%m/%Y").date(),
                     t=waste_type,
                     icon=ICON_MAP.get(waste_type.upper()),
                 )


### PR DESCRIPTION
If a collection is today, the web page says for example, "Today 13/08/2024" rather than "Tuesday 13/08/2024". So update waste_date to just look at the date itself and not the text part in the span text.

Fixes:
```
2024-08-13 19:06:17.747 ERROR (SyncWorker_7) [waste_collection_schedule.source_shell] fetch failed for source Wokingham Borough Council:
Traceback (most recent call last):
  File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py", line 145, in fetch
    entries = self._source.fetch()
              ^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source/wokingham_gov_uk.py", line 109, in fetch
    date=datetime.strptime(waste_date, "%A %d/%m/%Y").date(),
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/_strptime.py", line 554, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/_strptime.py", line 333, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data 'Today 13/08/2024' does not match format '%A %d/%m/%Y'
```