### PR TITLE
Update GitHub workflow

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v4"
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies


### PR DESCRIPTION
Update the version of the github actions used to fix the nodejs deprecation/replacement annotation.
This PR also updates the used python version to 3.12 as it is the version currently used by HomeAssistant.

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

![image](https://github.com/user-attachments/assets/a77b62df-18b7-4c1f-8c6b-3adbb5526493)
![image](https://github.com/user-attachments/assets/a6b87582-40fe-4d24-a0bd-f46de48a0985)
