### PR TITLE
Adding sica lu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ If your service provider is not listed, feel free to open a [source request issu
 <summary>Luxembourg</summary>
 
 - [Esch-sur-Alzette](/doc/source/esch_lu.md) / esch.lu
+- [SICA](/doc/source/sica_lu.md) / sica.lu
 </details>
 
 <details>

--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -6551,6 +6551,11 @@
       "title": "Esch-sur-Alzette",
       "module": "esch_lu",
       "default_params": {}
+    },
+    {
+      "title": "SICA",
+      "module": "sica_lu",
+      "default_params": {}
     }
   ],
   "Netherlands": [

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
@@ -1,5 +1,6 @@
-import requests
 import datetime
+
+import requests
 from waste_collection_schedule import Collection
 
 TITLE = "SICA"
@@ -7,18 +8,19 @@ DESCRIPTION = "Source script for sica.lu served municipalities"
 URL = "https://sica.lu"
 TEST_CASES = {
     "Bertrange": {"municipality": "Bertrange"},
-    "Capellen": {"municipality": "Capellen"},
+    "Capellen": {"municipality": "capellen"},
     "Garnich": {"municipality": "Garnich"},
-    "Holzem": {"municipality": "Holzem"},
-    "Kehlen": {"municipality": "Kehlen"},
-    "Koerich": {"municipality": "Koerich"},
-    "Kopstal": {"municipality": "Kopstal"},
-    "Mamer": {"municipality": "Mamer"},
-    "Septfontaines": {"municipality": "Septfontaines"},
-    "Steinfort": {"municipality": "Steinfort"},
+    "Holzem": {"municipality": "holzem"},
+    # For testing purposes:
+    # "Kehlen": {"municipality": "Kehlen"},
+    # "Koerich": {"municipality": "Koerich"},
+    # "Kopstal": {"municipality": "Kopstal"},
+    # "Mamer": {"municipality": "Mamer"},
+    # "Septfontaines": {"municipality": "Septfontaines"},
+    # "Steinfort": {"municipality": "Steinfort"},
 }
 
-API_URL = f"http://sicaapp.lu/wp-json/wp/v2"
+API_URL = "http://sicaapp.lu/wp-json/wp/v2"
 ICON_MAP = {
     "Residual waste": "mdi:trash-can",
     "Valorlux packaging": "mdi:recycle",
@@ -31,24 +33,28 @@ ICON_MAP = {
 }
 
 MUNICIPALITIES = {
-    "Bertrange": 28,
-    "Capellen": 138,
-    "Garnich": 29,
-    "Holzem": 139,
-    "Kehlen": 30,
-    "Koerich": 31,
-    "Kopstal": 24,
-    "Mamer": 137,
-    "Septfontaines": 26,
-    "Steinfort": 27,
+    "bertrange": 28,
+    "capellen": 138,
+    "garnich": 29,
+    "holzem": 139,
+    "kehlen": 30,
+    "koerich": 31,
+    "kopstal": 24,
+    "mamer": 137,
+    "septfontaines": 26,
+    "steinfort": 27,
 }
 
 
 class Source:
-    def __init__(self, municipality):
+    def __init__(self, municipality: str):
         # https://sicaapp.lu/wp-json/wp/v2/locations/
 
-        self._municipality = MUNICIPALITIES.get(municipality)
+        self._municipality = MUNICIPALITIES.get(municipality.lower())
+        if not self._municipality:
+            raise ValueError(
+                f"Unknown municipality: {municipality}, use one of {list(MUNICIPALITIES.keys())}"
+            )
 
     def fetch(self):
         headers = {"User-Agent": "SicaAPP", "Accept": "application/json"}

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
@@ -57,11 +57,12 @@ class Source:
 
         # Retrieve specified municipality from API as JSON
         r = requests.get(url, headers)
-        r.raise_for_status()
+        if r.status_code != 200:
+            r.raise_for_status()
         try:
             data = r.json()
-        except:
-            return []
+        except ValueError as e:
+            raise ValueError(f"Error decoding JSON from SICA API: {e} - {r.text}")
 
         # Extract collection dates
         entries = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
@@ -1,0 +1,81 @@
+import requests
+import datetime
+from waste_collection_schedule import Collection
+
+TITLE = "SICA"
+DESCRIPTION = "Source script for sica.lu served municipalities"
+URL = "https://sica.lu"
+TEST_CASES = {
+    "Bertrange": {"municipality": "Bertrange"},
+    "Capellen": {"municipality": "Capellen"},
+    "Garnich": {"municipality": "Garnich"},
+    "Holzem": {"municipality": "Holzem"},
+    "Kehlen": {"municipality": "Kehlen"},
+    "Koerich": {"municipality": "Koerich"},
+    "Kopstal": {"municipality": "Kopstal"},
+    "Mamer": {"municipality": "Mamer"},
+    "Septfontaines": {"municipality": "Septfontaines"},
+    "Steinfort": {"municipality": "Steinfort"},
+}
+
+API_URL = f"http://sicaapp.lu/wp-json/wp/v2"
+ICON_MAP = {
+    "Residual waste": "mdi:trash-can",
+    "Valorlux packaging": "mdi:recycle",
+    "Organic waste": "mdi:leaf",
+    "Glass": "mdi:bottle-wine-outline",
+    "Paper - Cartons": "mdi:newspaper",
+    "Scrap and electrical appliances": "mdi:washing-machine",
+    "Clothing and Shoes": "mdi:tshirt-crew",
+    "Trees, shrubs and hedges": "mdi:tree",
+}
+
+MUNICIPALITIES = {
+    "Bertrange": 28,
+    "Capellen": 138,
+    "Garnich": 29,
+    "Holzem": 139,
+    "Kehlen": 30,
+    "Koerich": 31,
+    "Kopstal": 24,
+    "Mamer": 137,
+    "Septfontaines": 26,
+    "Steinfort": 27,
+}
+
+
+class Source:
+    def __init__(self, municipality):
+        # https://sicaapp.lu/wp-json/wp/v2/locations/
+
+        self._municipality = MUNICIPALITIES.get(municipality)
+
+    def fetch(self):
+        headers = {"User-Agent": "SicaAPP", "Accept": "application/json"}
+        year = datetime.datetime.now().year
+        url = f"{API_URL}/calendaryear/{self._municipality}/{year}"
+
+        # Retrieve specified municipality from API as JSON
+        r = requests.get(url, headers)
+        r.raise_for_status()
+        try:
+            data = r.json()
+        except:
+            return []
+
+        # Extract collection dates
+        entries = []
+        for month in data:
+            for day in month["schedule"]:
+                pickup_date = datetime.datetime.strptime(day["date"], "%Y%m%d").date()
+                for pickup in day["pickupTypes"]:
+                    entries.append(
+                        Collection(
+                            date=pickup_date,
+                            t=pickup["name"],
+                            icon=ICON_MAP.get(pickup["name"]),
+                            picture=pickup["img"],
+                        )
+                    )
+
+        return entries

--- a/doc/source/sica_lu.md
+++ b/doc/source/sica_lu.md
@@ -1,0 +1,42 @@
+# SICA
+
+Support for municipalities being part of "**S**yndicat **I**ntercommunal pour l'hygiène publique du canton de **CA**pellen"
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: sica_lu
+      args:
+        municipality: Steinfort
+```
+
+### Configuration Variables
+The only configuration needed is the name of the municipality or town.
+
+**municipality**
+*(string) (required)*
+
+Valid values is one of the following:
+- Bertrange
+- Capellen
+- Garnich
+- Holzem
+- Kehlen
+- Koerich
+- Kopstal
+- Mamer
+- Septfontaines
+- Steinfort
+
+## Sensor setup
+Types of collections included:
+- Clothing and Shoes
+- Glass
+- Organic waste
+- Paper - Cartons
+- Residual waste
+- Scrap and electrical appliances
+- Trees, shrubs and hedges
+- Valorlux packaging

--- a/doc/source/sica_lu.md
+++ b/doc/source/sica_lu.md
@@ -13,12 +13,14 @@ waste_collection_schedule:
 ```
 
 ### Configuration Variables
+
 The only configuration needed is the name of the municipality or town.
 
 **municipality**
 *(string) (required)*
 
 Valid values is one of the following:
+
 - Bertrange
 - Capellen
 - Garnich
@@ -30,8 +32,8 @@ Valid values is one of the following:
 - Septfontaines
 - Steinfort
 
-## Sensor setup
-Types of collections included:
+## Included collection types
+
 - Clothing and Shoes
 - Glass
 - Organic waste

--- a/info.md
+++ b/info.md
@@ -28,7 +28,7 @@ Waste collection schedules from service provider web sites are updated daily, de
 | Hungary | FKF Budapest, FKF Budaörs, ÉTH (Érd, Diósd, Nagytarcsa, Sóskút, Tárnok) |
 | Italy | CIDIU S.p.A., Contarina S.p.A, Il Rifiutologo |
 | Lithuania | Kauno švara, Telšių keliai |
-| Luxembourg | Esch-sur-Alzette |
+| Luxembourg | Esch-sur-Alzette, SICA |
 | Netherlands | 's-Hertogenbosch, ACV Group, Afvalstoffendienst.nl, Alpen an den Rijn, Altena, Area Afval, Avalex, Avri, Bar Afvalbeheer, Bernheze, Circulus, Cyclus NV, Dar, Den Haag, GAD, Gemeente Almere, Gemeente Berkelland, Gemeente Cranendonck, Gemeente Hellendoorn, Gemeente Lingewaard, Gemeente Meppel, Gemeente Middelburg + Vlissingen, Gemeente Peel en Maas, Gemeente Schouwen-Duiveland, Gemeente Sudwest-Fryslan, Gemeente Venray, Gemeente Voorschoten, Gemeente Waalre, Gemeente Westland, Goes, Heusden, HVC Groep, Meerlanden, Mijn Blink, Oisterwijk, PreZero, Purmerend, RAD BV, Rd4, Reinis, Spaarnelanden, Twente Milieu, Vught, Waardlanden, Ximmio, ZRD, Ôffalkalinder van Noardeast-Fryslân & Dantumadiel |
 | New Zealand | Auckland Council, Christchurch City Council, Dunedin District Council, Gore, Invercargill & Southland, Hamilton City Council, Horowhenua District Council, Hutt City Council, Porirua City, Rotorua Lakes Council, Tauranga City Council, Waipa District Council, Wellington City Council |
 | Norway | BIR (Bergensområdets Interkommunale Renovasjonsselskap), Fosen Renovasjon, IRiS, Min Renovasjon, Movar IKS, Oslo Kommune, ReMidt Orkland muni, Sandnes Kommune, Stavanger Kommune, Trondheim |


### PR DESCRIPTION
Add source for municipalities in Luxembourg served by [SICA](https://www.sica.lu) 

`sica_lu.py` and `sica_lu.md` were created as per documentation.
`update_docu_links.py` was run and updated `README.md` and `info.md` are included.

Output from test run:
```
./test_sources.py -s sica_lu
Testing source sica_lu ...
  found 67 entries for Bertrange
  found 67 entries for Capellen
  found 66 entries for Garnich
  found 67 entries for Holzem
  found 68 entries for Kehlen
  found 68 entries for Koerich
  found 66 entries for Kopstal
  found 68 entries for Mamer
  found 67 entries for Septfontaines
  found 69 entries for Steinfort
```

This source adds the following municipalities / towns:
- Bertrange
- Capellen
- Garnich
- Holzem
- Kehlen
- Koerich
- Kopstal
- Mamer
- Septfontaines
- Steinfort

The following collection types are supported:
- Clothing and Shoes
- Glass
- Organic waste
- Paper - Cartons
- Residual waste
- Scrap and electrical appliances
- Trees, shrubs and hedges
- Valorlux packaging
- 