### PR TITLE
Oxford city: Support shortened month name

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oxford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oxford_gov_uk.py
@@ -58,9 +58,13 @@ class Source:
             matches = re.match(r"^(\w+) Next Collection: (.*)", paragraph.text)
             if matches:
                 collection_type, date_string = matches.groups()
+                try:
+                    date = datetime.strptime(date_string, "%A %d %B %Y").date()
+                except ValueError:
+                    date = datetime.strptime(date_string, "%A %d %b %Y").date()
                 entries.append(
                     Collection(
-                        date=datetime.strptime(date_string, "%A %d %B %Y").date(),
+                        date=date,
                         t=collection_type,
                         icon=ICON_MAP.get(collection_type),
                     )


### PR DESCRIPTION
For whatever reason, Oxford City are inconsistent in their date string format:

> Refuse Next Collection: xx xx Sep 2024
> Recycling Next Collection: xx xx August 2024

This PR tries both formats.

Terminal output shows before and after
```
vscode ➜ /workspaces/hacs_waste_collection_schedule $ python ./custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s oxford_gov_uk
Testing source oxford_gov_uk ...
  Magdalen Road failed: time data 'Thursday 05 Sep 2024' does not match format '%A %d %B %Y'
  found 4 entries for Oliver Road (brown bin too)
vscode ➜ /workspaces/hacs_waste_collection_schedule $ python ./custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s oxford_gov_uk
Testing source oxford_gov_uk ...
  found 3 entries for Magdalen Road
  found 4 entries for Oliver Road (brown bin too)
```

I don't think any changes are needed to supporting files, but let me know!