### PR TITLE
version bump manifest.json before release

### DIFF
--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "requirements": ["icalendar", "recurring_ical_events", "icalevents", "beautifulsoup4", "lxml", "pycryptodome"],
-  "version": "2.1.0"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
Trying to figure out if HACS the still offers an update to 2.2.0