### PR TITLE
#2643 upgrade icalevents to 0.1.29

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4>=4.12.2
 DateTime>=4.9
 icalendar>=4.0.9
-icalevents>=0.1.27
+icalevents>=0.1.29
 python-dateutil>=2.8.2
 pytz>=2021.3
 PyYAML>=6.0.1


### PR DESCRIPTION
icalevents 0.1.28 is broken, setting dependency to 0.1.29 to force an upgrade on all affected instances