### PR TITLE
Fix: victoriapark_wa_gov_au

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
@@ -48,7 +48,7 @@ def clean_months(start_date, date_str):
     date_cleaned = re.sub(r"Dec?e?m?b?e?r?", "Dec", date_cleaned, flags=re.IGNORECASE)
     # deal with dates that span months like "31 Aug Sep 2024"
     date_elements: list = date_cleaned.split(" ")
-    date_cleaned: str = f"{date_elements[0]} {date_elements[1]} {date_elements[-1]}"
+    date_cleaned = f"{date_elements[0]} {date_elements[1]} {date_elements[-1]}"
     return date_cleaned
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
@@ -46,7 +46,11 @@ def clean_months(start_date, date_str):
     date_cleaned = re.sub(r"Octo?b?e?r?", "Oct", date_cleaned, flags=re.IGNORECASE)
     date_cleaned = re.sub(r"Nov?e?m?b?e?r?", "Nov", date_cleaned, flags=re.IGNORECASE)
     date_cleaned = re.sub(r"Dec?e?m?b?e?r?", "Dec", date_cleaned, flags=re.IGNORECASE)
+    # deal with dates that span months like "31 Aug Sep 2024"
+    date_elements:list  = date_cleaned.split(" ")
+    date_cleaned: str = f"{date_elements[0]} {date_elements[1]} {date_elements[-1]}"
     return date_cleaned
+
 
 
 class Source:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
@@ -47,10 +47,9 @@ def clean_months(start_date, date_str):
     date_cleaned = re.sub(r"Nov?e?m?b?e?r?", "Nov", date_cleaned, flags=re.IGNORECASE)
     date_cleaned = re.sub(r"Dec?e?m?b?e?r?", "Dec", date_cleaned, flags=re.IGNORECASE)
     # deal with dates that span months like "31 Aug Sep 2024"
-    date_elements:list  = date_cleaned.split(" ")
+    date_elements: list = date_cleaned.split(" ")
     date_cleaned: str = f"{date_elements[0]} {date_elements[1]} {date_elements[-1]}"
     return date_cleaned
-
 
 
 class Source:


### PR DESCRIPTION
Fix for issue raised in  #2684 

before fix:
```bash
  Wednesday failed: time data '31 Aug Sep 2024' does not match format '%d %b %Y'
  found 5 entries for Park Centre (Thurs)
    2024-09-19 : Rubbish [mdi:trash-can]
    2024-09-19 : Recycling [mdi:recycle]
    2024-09-26 : Go Bin [mdi:leaf]
    2024-07-06 : Green Waste [mdi:tree]
    2024-08-17 : Bulk Waste [mdi:microwave]
  Aqualife (Thurs) failed: time data '31 Aug Sep 2024' does not match format '%d %b %Y'
```

after fix:
```bash
  found 5 entries for Wednesday
    2024-09-18 : Rubbish [mdi:trash-can]
    2024-09-18 : Recycling [mdi:recycle]
    2024-09-25 : Go Bin [mdi:leaf]
    2024-07-20 : Green Waste [mdi:tree]
    2024-08-31 : Bulk Waste [mdi:microwave]
  found 5 entries for Park Centre (Thurs)
    2024-09-19 : Rubbish [mdi:trash-can]
    2024-09-19 : Recycling [mdi:recycle]
    2024-09-26 : Go Bin [mdi:leaf]
    2024-07-06 : Green Waste [mdi:tree]
    2024-08-17 : Bulk Waste [mdi:microwave]
  found 5 entries for Aqualife (Thurs)
    2024-09-19 : Rubbish [mdi:trash-can]
    2024-09-26 : Recycling [mdi:recycle]
    2024-09-19 : Go Bin [mdi:leaf]
    2024-07-20 : Green Waste [mdi:tree]
    2024-08-31 : Bulk Waste [mdi:microwave]
```