### PR TITLE
Added uid to events added to calendar

### DIFF
--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -1,7 +1,7 @@
 """Calendar platform support for Waste Collection Schedule."""
 
-import uuid
 import logging
+import uuid
 from datetime import datetime, timedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent

--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -1,5 +1,6 @@
 """Calendar platform support for Waste Collection Schedule."""
 
+import uuid
 import logging
 from datetime import datetime, timedelta
 
@@ -107,6 +108,7 @@ class WasteCollectionCalendar(CalendarEntity):
             summary=collection.type,
             start=collection.date,
             end=collection.date + timedelta(days=1),
+            uid=uuid.uuid4(),
         )
 
 


### PR DESCRIPTION
uid was missing from events being added to the local calendar. This leads to other systems (eg. Google calendar) not being able to import the calendar due to all events having the same uid of 'None'

https://github.com/mampfes/hacs_waste_collection_schedule/issues/1479 and https://github.com/mampfes/hacs_waste_collection_schedule/issues/1105 are blocked without a change such as this

With this change, something like https://github.com/JosephAbbey/ha_calendar_export can be used to export events to other systems