### PR TITLE
Fix: Ku-Ring_gai

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kuringgai_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kuringgai_nsw_gov_au.py
@@ -60,14 +60,6 @@ ICON_MAP = {
     "Green Waste": "mdi:leaf",
 }
 
-ROUNDS = {
-    "General Waste": "General Waste",
-    "Recycling": "Recycling",
-    "Green Waste": "Green Waste",
-}
-
-# _LOGGER = logging.getLogger(__name__)
-
 
 class Source:
     def __init__(
@@ -133,10 +125,7 @@ class Source:
             entries.append(
                 Collection(
                     date=date,
-                    # t=waste_type,  # api returns GeneralWaste, Recycling, GreenWaste
-                    t=ROUNDS.get(
-                        waste_type
-                    ),  # returns user-friendly General Waste, Recycling, Green Waste
+                    t=waste_type,
                     icon=ICON_MAP.get(waste_type),
                 )
             )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kuringgai_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kuringgai_nsw_gov_au.py
@@ -55,15 +55,15 @@ HEADERS = {
 }
 
 ICON_MAP = {
-    "GeneralWaste": "mdi:trash-can",
+    "General Waste": "mdi:trash-can",
     "Recycling": "mdi:recycle",
-    "GreenWaste": "mdi:leaf",
+    "Green Waste": "mdi:leaf",
 }
 
 ROUNDS = {
-    "GeneralWaste": "General Waste",
+    "General Waste": "General Waste",
     "Recycling": "Recycling",
-    "GreenWaste": "Green Waste",
+    "Green Waste": "Green Waste",
 }
 
 # _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #2846 
Not sure how, but the space characters in the  in the ICON-MAP and ROUNDS dict keys had been removed.

```
Testing source kuringgai_nsw_gov_au ...
  found 3 entries for randomHouse
    2024-10-16 : General Waste [mdi:trash-can]
    2024-10-23 : Recycling [mdi:recycle]
    2024-10-16 : Green Waste [mdi:leaf]
  found 3 entries for randomAppartment
    2024-10-18 : General Waste [mdi:trash-can]
    2024-10-18 : Recycling [mdi:recycle]
    2024-10-18 : Green Waste [mdi:leaf]
  found 3 entries for randomMultiunit
    2024-10-17 : General Waste [mdi:trash-can]
    2024-10-17 : Recycling [mdi:recycle]
    2024-10-17 : Green Waste [mdi:leaf]
  found 3 entries for 1 Latona St
    2024-10-22 : General Waste [mdi:trash-can]
    2024-10-22 : Recycling [mdi:recycle]
    2024-10-22 : Green Waste [mdi:leaf]
  found 3 entries for 1A Latona St
    2024-10-22 : General Waste [mdi:trash-can]
    2024-10-22 : Recycling [mdi:recycle]
    2024-10-22 : Green Waste [mdi:leaf]
```