### PR TITLE
Update merton_gov_uk.py - Add support for garden waste

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/merton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/merton_gov_uk.py
@@ -25,6 +25,7 @@ ICON_MAP = {
     "Rubbish": "mdi:trash-can",
     "Textiles": "mdi:hanger",
     "Household batteries": "mdi:battery",
+    "Garden waste": "mdi:tree",
 }
 
 
@@ -51,6 +52,7 @@ class Source:
                 "rubbish-wheelie",
                 "textiles",
                 "batteries",
+                "garden",
             ),
         )
         if not collections:


### PR DESCRIPTION
Tiny change - simply add support for garden waste which was mised by the original implementation (I assume the original developer did not have garden waste?)