### PR TITLE
add argument double to test_sources script to verify that fetch() resulst are consistant with future calls of fetch()

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py
@@ -23,6 +23,12 @@ def main():
         "-l", "--list", action="store_true", help="List retrieved entries"
     )
     parser.add_argument(
+        "-d",
+        "--double",
+        action="store_true",
+        help="Run the fetch method twice and check that the second result is the same as the first one, should be run if fetching modifies the source object",
+    )
+    parser.add_argument(
         "-i", "--icon", action="store_true", help="Show waste type icon"
     )
     parser.add_argument("--sorted", action="store_true", help="Sort output by date")
@@ -127,6 +133,22 @@ def test_fetch(module, name, tc, args):
     try:
         source = module.Source(**tc)
         result = source.fetch()
+        if args.double:
+            result2 = source.fetch()
+            if result != result2:
+                print(
+                    f"{bcolors.FAIL}  ERROR: source.fetch() does not return the same result on second call"
+                )
+                for collection in result:
+                    try:
+                        idx = result2.index(collection)
+                        result2.pop(idx)
+                    except ValueError:
+                        print(f"  {collection} not in second result")
+                for collection in result2:
+                    print(f"  {collection} not in first result")
+                print(bcolors.ENDC, end="")
+
         count = len(result)
         if count > 0:
             print(f"  found {bcolors.OKGREEN}{count}{bcolors.ENDC} entries for {name}")

--- a/doc/contributing_source.md
+++ b/doc/contributing_source.md
@@ -243,6 +243,7 @@ The script supports the following options:
 | `-l`   | -        | List all found dates. |
 | `-i`   | -        | Add icon name to output. Only effective together with `-l`. |
 | `-t`   | -        | Show extended exception info and stack trace. |
+| `-d`   | -        | Runs the fetch method twice and checks if the resulsts differ, should be used if the fetch method modifies the Source object. |
 
 For debugging purposes of a single source, it is recommended to use the `-s SOURCE` option. If used without any arguments provided, the script tests every script in the `/custom_components/waste_collection_schedule/waste_collection_schedule/source` folder and all yaml configurations in the folder `/doc/ics/yaml` and prints the number of found entries for every test case.
 


### PR DESCRIPTION
This makes it easy to verify, that a source saving some arguments works as excpected on future fetch calls