### PR TITLE
Update southtyneside_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southtyneside_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southtyneside_gov_uk.py
@@ -73,7 +73,7 @@ class Source:
                 entries.append(
                     Collection(
                         date=datetime.strptime(
-                            monthyear["DateofCollection"], "%Y-%m-%dT00:00:00").date(),
+                            monthyear["DateofCollection"], "%Y-%m-%dT%H:%M:%S").date(),
                         t=monthyear["TypeClass"],
                         icon=ICON_MAP.get(monthyear["TypeClass"].upper()),
                     )


### PR DESCRIPTION
Fix for timestamp format issue:

The source returned an invalid response: "time data '2024-10-23T07:00:00' does not match format '%Y-%m-%dT00:00:00'". Please check the provided arguments and try again.