### PR TITLE
Fix postcode parameter translation for Windsor and Maidenhead, UK source

### DIFF
--- a/custom_components/waste_collection_schedule/translations/de.json
+++ b/custom_components/waste_collection_schedule/translations/de.json
@@ -15998,7 +15998,7 @@
         "description": "Konfiguriere deinen Service Provider. Mehr details: https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rbwm_gov_uk.md",
         "data": {
           "calendar_title": "Kalender Titel",
-          "postcode": "(Leave Empty)",
+          "postcode": "(Leer lassen)",
           "uprn": "UPRN"
         },
         "data_description": {
@@ -16011,7 +16011,7 @@
         "description": "Konfiguriere deinen Service Provider. Mehr details: https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rbwm_gov_uk.md",
         "data": {
           "calendar_title": "Kalender Titel",
-          "postcode": "(Leave Empty)",
+          "postcode": "(Leer lassen)",
           "uprn": "UPRN"
         },
         "data_description": {

--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -16011,7 +16011,7 @@
         "description": "Configure your service provider. More details: https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rbwm_gov_uk.md.",
         "data": {
           "calendar_title": "Calendar Title",
-          "postcode": "(Leer lassen)",
+          "postcode": "(Leave Empty)",
           "uprn": "UPRN"
         },
         "data_description": {
@@ -16024,7 +16024,7 @@
         "description": "Configure your service provider. More details: https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rbwm_gov_uk.md.",
         "data": {
           "calendar_title": "Calendar Title",
-          "postcode": "(Leer lassen)",
+          "postcode": "(Leave Empty)",
           "uprn": "UPRN"
         },
         "data_description": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
@@ -24,11 +24,11 @@ ICON_MAP = {
 
 PARAM_TRANSLATIONS = {
     "de": {
-        "postcode": "(Leave Empty)",
+        "postcode": "(Leer lassen)",
         "uprn": "UPRN",
     },
     "en": {
-        "postcode": "(Leer lassen)",
+        "postcode": "(Leave Empty)",
         "uprn": "UPRN",
     },
     "it": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import requests
 from bs4 import BeautifulSoup
 from dateutil.parser import parse
@@ -46,7 +48,7 @@ HEADERS = {
 
 class Source:
     # postcode was previously required by this source. This is no longer the case but argument kept for backwards compatibility
-    def __init__(self, uprn: str | int, postcode=None):
+    def __init__(self, uprn: str | int, postcode: Optional[str] = None):
         self._uprn: str = str(uprn).zfill(12)
 
     def fetch(self):


### PR DESCRIPTION
Still works as expected:
```
$ ./test_sources.py -s rbwm_gov_uk -l -i
Testing source rbwm_gov_uk ...
  found 10 entries for Windsor 1
    2024-10-22 : Recycling [mdi:recycle]
    2024-10-22 : Refuse [mdi:trash-can]
    2024-10-29 : Garden Waste [mdi:leaf]
    2024-10-29 : Recycling [mdi:recycle]
    2024-11-05 : Recycling [mdi:recycle]
    2024-11-05 : Refuse [mdi:trash-can]
    2024-11-12 : Garden Waste [mdi:leaf]
    2024-11-12 : Recycling [mdi:recycle]
    2024-11-19 : Recycling [mdi:recycle]
    2024-11-19 : Refuse [mdi:trash-can]
  found 10 entries for Windsor 2
    2024-10-22 : Recycling [mdi:recycle]
    2024-10-22 : Refuse [mdi:trash-can]
    2024-10-29 : Garden Waste [mdi:leaf]
    2024-10-29 : Recycling [mdi:recycle]
    2024-11-05 : Recycling [mdi:recycle]
    2024-11-05 : Refuse [mdi:trash-can]
    2024-11-12 : Garden Waste [mdi:leaf]
    2024-11-12 : Recycling [mdi:recycle]
    2024-11-19 : Recycling [mdi:recycle]
    2024-11-19 : Refuse [mdi:trash-can]
  found 10 entries for Maidenhead 1
    2024-10-22 : Garden Waste [mdi:leaf]
    2024-10-22 : Recycling [mdi:recycle]
    2024-10-29 : Recycling [mdi:recycle]
    2024-10-29 : Refuse [mdi:trash-can]
    2024-11-05 : Garden Waste [mdi:leaf]
    2024-11-05 : Recycling [mdi:recycle]
    2024-11-12 : Recycling [mdi:recycle]
    2024-11-12 : Refuse [mdi:trash-can]
    2024-11-19 : Garden Waste [mdi:leaf]
    2024-11-19 : Recycling [mdi:recycle]
  found 10 entries for Maidenhead 2
    2024-10-24 : Recycling [mdi:recycle]
    2024-10-24 : Refuse [mdi:trash-can]
    2024-10-31 : Garden Waste [mdi:leaf]
    2024-10-31 : Recycling [mdi:recycle]
    2024-11-07 : Recycling [mdi:recycle]
    2024-11-07 : Refuse [mdi:trash-can]
    2024-11-14 : Garden Waste [mdi:leaf]
    2024-11-14 : Recycling [mdi:recycle]
    2024-11-21 : Recycling [mdi:recycle]
    2024-11-21 : Refuse [mdi:trash-can]
```