### PR TITLE
source shell improve error message when a import inside the source script fails

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -217,8 +217,15 @@ class SourceShell:
             source_module: SourceModule = importlib.import_module(
                 f"waste_collection_schedule.source.{source_name}"
             )
-        except ImportError:
-            _LOGGER.error(f"source not found: {source_name}")
+        except ImportError as e:
+            if str(e).startswith(
+                f"No module named 'waste_collection_schedule.source.{source_name}'"
+            ):
+                _LOGGER.error(f"source not found: {source_name}")
+            else:
+                _LOGGER.error(
+                    f"error loading source {source_name}:\n{e} \n{traceback.format_exc()}"
+                )
             return None
 
         # create source


### PR DESCRIPTION
old error message would also show source not found even though the import error is caused in the source not from importing the source

will improve debuggin for cases like #2907