### PR TITLE
fix dependency issue with icalendar and icalevents

### DIFF
--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/mampfes/hacs_waste_collection_schedule#readme",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["icalendar", "recurring_ical_events", "icalevents!=0.1.28", "beautifulsoup4", "lxml", "pycryptodome"],
+  "requirements": ["icalendar", "recurring_ical_events", "icalevents>=0.1.26,!=0.1.28", "beautifulsoup4", "lxml", "pycryptodome"],
   "version": "2.4.0"
 }


### PR DESCRIPTION
Old approach may download an old version of icalevents and the newest (>=6.0.0) yet incompatible version of icalendar

addresses #2907 and simmilar issues