### PR TITLE
Fix static schedule params validation

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
@@ -72,7 +72,7 @@ def validate_params(user_input):
             errors["weekdays"] = "invalid_weekday"
         return errors
 
-    if not isinstance(weekdays, dict):
+    if isinstance(weekdays, dict):
         for wday, count in weekdays.items():
             if wday not in WEEKDAY_MAP:
                 errors["weekdays"] = "invalid_weekday"


### PR DESCRIPTION
Validation for the static schedule is wrong. It works when specifying weekdays as strings, but no when specifying weekdays as dictionary