### PR TITLE
Update Typo in faq.md

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -145,7 +145,7 @@ sensor:
 
   - platform: waste_collection_schedule
     name: third_garbage_collection
-    event_index: 3
+    event_index: 2
     value_template: '{{value.types|join(", ")}} in {{ value.daysTo }} days'
 ```
 


### PR DESCRIPTION
There was a typo in the next shedules FAQ.
first event_index = 0, 
second event_index = 1, 
third event_index = 3
Updated the event_index of the third one to 2.

Thanks for the wonderful implementation!