### PR TITLE
Fix Bracknell Forest Collections

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
@@ -15,10 +15,10 @@ TEST_CASES = {
 }
 
 ICON_MAP = {
-    "General Waste": "mdi:trash-can",
-    "Recycling": "mdi:recycle",
-    "Garden": "mdi:leaf",
-    "Food": "mdi:food-apple",
+    "general waste": "mdi:trash-can",
+    "recycling": "mdi:recycle",
+    "garden": "mdi:leaf",
+    "food": "mdi:food-apple",
 }
 
 
@@ -73,22 +73,17 @@ class Source:
         collection_lookup.raise_for_status()
         collections = collection_lookup.json()["response"]["collections"]
         entries = []
-        for waste_type in ICON_MAP.keys():
+        for collection_entry in collections:
             try:
-                entries.append(
-                    Collection(
-                        date=parser.parse(
-                            next(
-                                collection
-                                for collection in collections
-                                if collection["round"].lower() == waste_type.lower()
-                            )["firstDate"]["date"]
-                        ).date(),
-                        t=waste_type,
-                        icon=ICON_MAP.get(waste_type),
-                    )
+                coll_day = parser.parse(collection_entry["firstDate"]["date"]).date()
+            except KeyError:
+                continue
+            entries.append(
+                Collection(
+                    date=coll_day,
+                    t=collection_entry["round"],
+                    icon=ICON_MAP.get(collection_entry["round"].lower()),
                 )
-            except (StopIteration, TypeError):
-                pass
+            )
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
@@ -81,7 +81,7 @@ class Source:
                             next(
                                 collection
                                 for collection in collections
-                                if collection["round"] == waste_type
+                                if collection["round"].lower() == waste_type.lower()
                             )["firstDate"]["date"]
                         ).date(),
                         t=waste_type,


### PR DESCRIPTION
Bracknell Forest decided to change `General Waste` to `General waste`, breaking this integration. This change implements checking in a case-insensitive way.

Test results:

Before:
```
$ ./test_sources.py -s bracknell_forest_gov_uk
Testing source bracknell_forest_gov_uk ...
  found 2 entries for 44 Kennel Lane
  found 2 entries for 28 Kennel Lane
  found 2 entries for 32 Ashbourne
  found 3 entries for 1 Acacia Avenue
```

After:
```
$ ./test_sources.py -s bracknell_forest_gov_uk
Testing source bracknell_forest_gov_uk ...
  found 3 entries for 44 Kennel Lane
  found 3 entries for 28 Kennel Lane
  found 3 entries for 32 Ashbourne
  found 4 entries for 1 Acacia Avenue
```