### PR TITLE
Fix: Day_Offset missing in yaml schema

### DIFF
--- a/custom_components/waste_collection_schedule/init_yaml.py
+++ b/custom_components/waste_collection_schedule/init_yaml.py
@@ -40,6 +40,7 @@ SOURCE_CONFIG = vol.Schema(
             cv.ensure_list, [CUSTOMIZE_CONFIG]
         ),
         vol.Optional(const.CONF_SOURCE_CALENDAR_TITLE): cv.string,
+        vol.Optional(const.CONF_DAY_OFFSET, default=const.CONF_DAY_OFFSET_DEFAULT): int,
     }
 )
 


### PR DESCRIPTION
The "day_offset" setting is missing in the yaml-schema. Looks like that got lost around june-2nd.

fixes: #3027 