### PR TITLE
Fix: Junaavfall_se date format parsing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/juneavfall_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/juneavfall_se.py
@@ -9,6 +9,7 @@ URL = "https://www.juneavfall.se"
 TEST_CASES = {
     "Storgatan 12": {"street_address": "Storgatan 12, Huskvarna"},
     "Smedjegatan 20": {"street_address": "Smedjegatan 20, Jönköping"},
+    "Västra Ubbarp 20, Barnarp": {"street_address": "Västra Ubbarp 20, Barnarp"},
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/juneavfall_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/juneavfall_se.py
@@ -19,7 +19,7 @@ class Source:
     def fetch(self):
         r = requests.post(
             "https://minasidor.juneavfall.se/FutureWebJuneBasic/SimpleWastePickup/SearchAdress",
-            {"searchText": self._street_address}
+            {"searchText": self._street_address},
         )
         r.raise_for_status()
 
@@ -35,7 +35,7 @@ class Source:
         params = {"address": address}
         r = requests.get(
             "https://minasidor.juneavfall.se/FutureWebJuneBasic/SimpleWastePickup/GetWastePickupSchedule",
-            params=params
+            params=params,
         )
         r.raise_for_status()
 
@@ -48,9 +48,15 @@ class Source:
             if waste_type == "Matavfall":
                 icon = "mdi:leaf"
             next_pickup = item["NextWastePickup"]
-            next_pickup_date = datetime.fromisoformat(next_pickup).date()
-            entries.append(
-                Collection(date=next_pickup_date, t=waste_type, icon=icon)
-            )
+            if next_pickup.startswith("v"):
+                week_str, _, year_str = next_pickup[1:].split()
+                next_pickup_date = datetime.strptime(
+                    # W=weeknum, 1=Monday
+                    f"{year_str}-W{week_str}-1",
+                    "%G-W%V-%u",
+                ).date()
+            else:
+                next_pickup_date = datetime.fromisoformat(next_pickup).date()
+            entries.append(Collection(date=next_pickup_date, t=waste_type, icon=icon))
 
         return entries


### PR DESCRIPTION
This PR fixes #2996.

Added handling for `"NextWastePickup":"v47 Nov 2024",`  v47 is the week number.
Added special test case

Tests:
```
testing source juneavfall_se ...
  found 3 entries for Storgatan 12
    2024-11-25 : FNI Kärl 1
    2024-12-09 : FNI Kärl 2
    2025-04-23 : Trädgårdsavfall
  found 2 entries for Smedjegatan 20
    2024-11-18 : Matavfall
    2024-11-18 : Restavfall
  found 7 entries for Västra Ubbarp 20, Barnarp
    2024-11-15 : FNI Kärl 1
    2024-11-25 : FNI Kärl 2
    2024-11-15 : Restavfall
    2024-11-15 : Restavfall
    2024-11-15 : Matavfall
    2024-11-15 : Matavfall
    2024-11-18 : Slam

```