### PR TITLE
Fix: Switch Awg_de to legacy session handling

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
@@ -6,9 +6,9 @@ import random
 import re
 import string
 
-import requests
 from waste_collection_schedule import Collection
 from waste_collection_schedule.service.ICS import ICS
+from waste_collection_schedule.service.SSLError import get_legacy_session
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -118,7 +118,8 @@ class Source:
         return self._ics.convert(ics_response.text)
 
     def fetch(self):
-        session = requests.Session()
+        session = get_legacy_session()
+
         init_request = session.get(
             f"{API_URL}?SubmitAction=wasteDisposalServices&InFrameMode=true"
         ).text


### PR DESCRIPTION
Problem: The ssl config of wastemanagement.awg.de has changed and the cert-chain is [incomplete](https://www.ssllabs.com/ssltest/analyze.html?d=wastemanagement.awg.de).
Solution: Switch to legacy_session
Fixes: #3052 

Tests:
```
Testing source awg_de ...
  found 16 entries for Achslach Aign 1 
  found 24 entries for Böbrach Bärnerauweg 10A
  found 40 entries for Am Bäckergütl 1, 94094 Malching
```