### PR TITLE
Fix renamed containers in source abfallwirtschaft_pforzheim_de

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
@@ -100,11 +100,13 @@ class Source:
         r.raise_for_status()
 
         args["SubmitAction"] = "forward"
-        args["ContainerGewaehltRM"] = "on"
-        args["ContainerGewaehltBM"] = "on"
-        args["ContainerGewaehltLVP"] = "on"
-        args["ContainerGewaehltPA"] = "on"
-        args["ContainerGewaehltPrMuell"] = "on"
+        args["ContainerGewaehlt_1"] = "on"
+        args["ContainerGewaehlt_2"] = "on"
+        args["ContainerGewaehlt_3"] = "on"
+        args["ContainerGewaehlt_4"] = "on"
+        args["ContainerGewaehlt_5"] = "on"
+        args["ContainerGewaehlt_6"] = "on"
+        args["ContainerGewaehlt_7"] = "on"
         r = session.post(
             API_URL,
             data=args,


### PR DESCRIPTION
It seems that the container names were changed and thus the test cases fail. This commit fixes this change. All tests run successfully afterwards.

All container types of the source are selected with this change, including specialties like christmas tree collection in early January.
If this is not correct please let me know.

Thanks!

Fixes #3055 