### PR TITLE
Fix: Warwickdc_gov_uk date parsing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/warwickdc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/warwickdc_gov_uk.py
@@ -39,7 +39,7 @@ class Source:
         for box in infoboxes:
             items = box.findAll("p")
             waste_type = items[0].text.strip().split(" ")[0].strip()
-            dates = [datetime.strptime(d.text, "%d/%m/%Y").date() for d in items[1:]]
+            dates = [self.parse_date(d.text).date() for d in items[1:]]
             for date in dates:
                 entries.append(
                     Collection(
@@ -50,3 +50,9 @@ class Source:
                 )
 
         return entries
+
+    def parse_date(self, date_string):
+        try:
+            return datetime.strptime(date_string, "%a %d/%m/%Y")
+        except ValueError:
+            return datetime.strptime(date_string, "%d/%m/%Y")


### PR DESCRIPTION
Fixes: #3081 
Error: Exceptional collection are shown with a different date format
Solution: Additional date parsing

Test:
```
Testing source warwickdc_gov_uk ...
  found 16 entries for Test_001
  found 16 entries for Test_002
  found 16 entries for Test_003
```
