### PR TITLE
Fix holiday schedule for republicservices

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -118,6 +118,9 @@ class Source:
                 i += 1
 
         # Cycle through schedule and holidays incorporating delays
+        # According to Republic Waste "Holidays typically push our residential pickup 
+        # schedules back one day with regular schedules resuming the following week."
+        # Source: https://www.republicservices.com/customer-support/faq
         while True:
             changes = 0
             for holiday in holidays:
@@ -126,8 +129,10 @@ class Source:
                     d = holidays[holiday]["delay"]
                     for pickup in schedule:
                         p = schedule[pickup]["date"]
-                        date_difference = (p - h).days
-                        if date_difference <= 5 and date_difference >= 0:
+                        # Calculate the next Sunday since Sunday should reset the
+                        # scheduled pickup date
+                        ns = h + timedelta(days=6 - h.weekday())
+                        if h <= p < ns:
                             revised_date = p + timedelta(days=d)
                             schedule[pickup]["date"] = revised_date
                             holidays[holiday]["incorporated"] = True


### PR DESCRIPTION
I commented on #1430 that I was having a similar issue. After some self doubt I decided to create a pull request. Below is my comment from the bug for convenience. 

After I made the comment I called and spoke with a customer service rep and the confirmed what was on their site and my understanding of the issue. 

> After a lot of reviewing the Republic Waste site I found this:
> 
> > Holiday schedules vary by service location. Residential collection may be delayed due to these and other holidays:
> > 
> > Memorial Day
> > July 4th
> > Labor Day
> > Thanksgiving Day
> > Christmas Day
> > New Year's Day
> > 
> > Holidays typically push our residential pickup schedules back one day with regular schedules resuming the following > week.
> 
> Currently, the integration is showing my garbage pickup is December 2. However, since Thanksgiving is November 28 it is shifting to December 3. I believe based on their website shifting to a new week should “reset” the delay.
> 
> Now this may be a different issue than the original post since in that case it is moving it two days. I am curious if at that time the day after Thanksgiving was considered a holiday at that point in time. I have no way of knowing since it appears (both via api and browsing the Republic site) that this year it is not considered a holiday.
