### PR TITLE
AWB Emsland request this AND next years data instead of only next years

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
@@ -75,7 +75,6 @@ class Source:
         self._suffix = address_suffix
         self._ics = ICS()
 
-
     def get_zeitraum_values(self):
         try:
             session = requests.session()
@@ -87,18 +86,21 @@ class Source:
             response.raise_for_status()
 
             # Parse the HTML content
-            soup = BeautifulSoup(response.text, 'html.parser')
+            soup = BeautifulSoup(response.text, "html.parser")
 
             # Find all input elements with the name "Zeitraum"
-            input_elements = soup.find_all('input', {'name': 'Zeitraum'})
+            input_elements = soup.find_all("input", {"name": "Zeitraum"})
 
             # Extract values
-            values = [input_elem.get('value') for input_elem in input_elements if input_elem.get('value')]
+            values = [
+                input_elem.get("value")
+                for input_elem in input_elements
+                if input_elem.get("value")
+            ]
             return values
 
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException:
             return []
-    
 
     def fetch(self):
         available_years = self.get_zeitraum_values()
@@ -111,12 +113,11 @@ class Source:
                 values.extend(result)
 
             return values
-        
+
         else:
             return self.fetch_year()
 
-
-    def fetch_year(self, year=None):    
+    def fetch_year(self, year=None):
         session = requests.session()
 
         r = session.get(
@@ -178,4 +179,3 @@ class Source:
             entries.append(Collection(d[0], bin_type, icon=ICON_MAP.get(bin_type)))
 
         return entries
-

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
@@ -55,23 +55,36 @@ class HiddenInputParser(HTMLParser):
 
 
 PARAM_TRANSLATIONS = {
+    "en": {
+        "year_override": "Request period override",
+    },
     "de": {
         "city": "Ort",
         "street": "Straße",
         "house_number": "Hausnummer",
         "address_suffix": "Hausnummerzusatz",
-    }
+        "year_override": "Abfragezeitraum überschreiben",
+    },
 }
 
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "year_override": "Request period override",
+    },
+    "de": {
+        "year_override": "Abfragezeitraum überschreiben",
+    },
+}
 
 class Source:
     def __init__(
-        self, city: str, street: str, house_number: int, address_suffix: str = ""
+        self, city: str, street: str, house_number: int, address_suffix: str = "", year_override: str = ""
     ):
         self._city = city
         self._street = street
         self._hnr = house_number
         self._suffix = address_suffix
+        self._year_override = year_override
         self._ics = ICS()
 
     def fetch(self):
@@ -93,6 +106,10 @@ class Source:
         args["Hausnummer"] = str(self._hnr)
         args["Hausnummerzusatz"] = self._suffix
         args["SubmitAction"] = "CITYCHANGED"
+
+        if self._year_override:
+            args["Zeitraum"] = self._year_override
+
         r = session.post(
             SERVLET,
             data=args,
@@ -132,3 +149,4 @@ class Source:
             entries.append(Collection(d[0], bin_type, icon=ICON_MAP.get(bin_type)))
 
         return entries
+

--- a/doc/source/awb_emsland_de.md
+++ b/doc/source/awb_emsland_de.md
@@ -13,6 +13,7 @@ waste_collection_schedule:
         street: STREET
         house_number: HNR
         address_suffix: HNR_SUFFIX
+        year_override: YEAR_OVERRIDE
 ```
 
 ### Configuration Variables
@@ -27,6 +28,9 @@ waste_collection_schedule:
 *(integer) (required)*
 
 **address_suffix**  
+*(string) (optional) (default: "")*
+
+**year_override**  
 *(string) (optional) (default: "")*
 
 ## Example
@@ -55,4 +59,7 @@ waste_collection_schedule:
 ## How to get the source arguments
 
 These values are the location you want to query for. Make sure, the writing is exactly as it is on <https://www.awb-emsland.de/service/abfuhrkalender/>. Typos will result in an parsing error which is printed in the log. As `house_number` expects a numeric input, address suffixes have to be provided via the `address_suffix` argument.
+
 `address_suffix` could be for example a alphanumeric character "A" or a additional house number like "/1".
+
+`year_override` can be used to override the default request period, defined by the awb emsland server. Example: to query the data for the year 2024, enter "Jahresübersicht 2024" here.

--- a/doc/source/awb_emsland_de.md
+++ b/doc/source/awb_emsland_de.md
@@ -13,7 +13,6 @@ waste_collection_schedule:
         street: STREET
         house_number: HNR
         address_suffix: HNR_SUFFIX
-        year_override: YEAR_OVERRIDE
 ```
 
 ### Configuration Variables
@@ -28,9 +27,6 @@ waste_collection_schedule:
 *(integer) (required)*
 
 **address_suffix**  
-*(string) (optional) (default: "")*
-
-**year_override**  
 *(string) (optional) (default: "")*
 
 ## Example
@@ -61,5 +57,3 @@ waste_collection_schedule:
 These values are the location you want to query for. Make sure, the writing is exactly as it is on <https://www.awb-emsland.de/service/abfuhrkalender/>. Typos will result in an parsing error which is printed in the log. As `house_number` expects a numeric input, address suffixes have to be provided via the `address_suffix` argument.
 
 `address_suffix` could be for example a alphanumeric character "A" or a additional house number like "/1".
-
-`year_override` can be used to override the default request period, defined by the awb emsland server. Example: to query the data for the year 2024, enter "Jahresübersicht 2024" here.


### PR DESCRIPTION
This PR tries to fix https://github.com/mampfes/hacs_waste_collection_schedule/issues/3131 by adding a new (optional) parameter, in which the corresponding request period can be entered to override the default request period.

Therefore, for the specific issue, you can enter "Jahresübersicht 2024" to get the waste collection schedule for the current year.