### PR TITLE
adding check if item is True in list

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -99,7 +99,7 @@ class Source:
         i = 0
         holidays = {}
         for item in r2_json:
-            if item["serviceImpacted"] is True and item["LOB"] == service:
+            if item and item["serviceImpacted"] is True and item["LOB"] == service:
                 for delay in DELAYS:
                     if delay in item["description"]:
                         day_offset = DELAYS[delay]


### PR DESCRIPTION
During testing, `rs_json` was loading as a single item array with `None` as the item. This fix adds a check to ensure the item is truthy before proceeding to other checks. This change was tested and verified locally.

Fixes #3152