### PR TITLE
Fix date parsing for kingston.gov.uk. Fixes #3224

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_gov_uk.py
@@ -40,14 +40,14 @@ class Source:
         self._uprn = str(uprn)
 
     def interpret_date(self, date_string):
-        now = datetime.now()
-        date = datetime.strptime(date_string + f" {now.year}", "%A %d %B %Y")
+        now = datetime.now().date()
+        date = datetime.strptime(date_string + f" {now.year}", "%A %d %B %Y").date()
 
         if date < now:
             # This means the next collection crosses a year boundary
             date = date.replace(year=now.year+1)
 
-        return date.date()
+        return date
 
     def fetch(self):
         s = requests.Session()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_gov_uk.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import requests
 from waste_collection_schedule import Collection
@@ -45,7 +45,7 @@ class Source:
 
         if date < now:
             # This means the next collection crosses a year boundary
-            date = date + timedelta(weeks = 52)
+            date = date.replace(year=now.year+1)
 
         return date.date()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_gov_uk.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import requests
 from waste_collection_schedule import Collection
@@ -39,6 +39,16 @@ class Source:
     def __init__(self, uprn: str):
         self._uprn = str(uprn)
 
+    def interpret_date(self, date_string):
+        now = datetime.now()
+        date = datetime.strptime(date_string + f" {now.year}", "%A %d %B %Y")
+
+        if date < now:
+            # This means the next collection crosses a year boundary
+            date = date + timedelta(weeks = 52)
+
+        return date.date()
+
     def fetch(self):
         s = requests.Session()
 
@@ -76,9 +86,7 @@ class Source:
         if "echo_refuse_next_date" in data and data["echo_refuse_next_date"]:
             entries.append(
                 Collection(
-                    date=datetime.strptime(
-                        data["echo_refuse_next_date"], "%Y/%m/%d %H:%M:%S"
-                    ).date(),
+                    date=self.interpret_date(data["echo_refuse_next_date"]),
                     t="refuse bin",
                     icon="mdi:trash-can",
                 )
@@ -87,20 +95,16 @@ class Source:
         if "echo_food_waste_next_date" in data and data["echo_food_waste_next_date"]:
             entries.append(
                 Collection(
-                    date=datetime.strptime(
-                        data["echo_food_waste_next_date"], "%Y/%m/%d %H:%M:%S"
-                    ).date(),
+                    date=self.interpret_date(data["echo_food_waste_next_date"]),
                     t="food waste bin",
                     icon="mdi:trash-can",
                 )
             )
-        
+
         if "echo_paper_and_card_next_date" in data and data["echo_paper_and_card_next_date"]:
             entries.append(
                 Collection(
-                    date=datetime.strptime(
-                        data["echo_paper_and_card_next_date"], "%Y/%m/%d %H:%M:%S"
-                    ).date(),
+                    date=self.interpret_date(data["echo_paper_and_card_next_date"]),
                     t="paper and card recycling bin",
                     icon="mdi:recycle",
                 )
@@ -109,20 +113,16 @@ class Source:
         if "echo_mixed_recycling_next_date" in data and data["echo_mixed_recycling_next_date"]:
             entries.append(
                 Collection(
-                    date=datetime.strptime(
-                        data["echo_mixed_recycling_next_date"], "%Y/%m/%d %H:%M:%S"
-                    ).date(),
+                    date=self.interpret_date(data["echo_mixed_recycling_next_date"]),
                     t="mixed recycling bin",
                     icon="mdi:recycle",
                 )
             )
-        
+
         if "echo_garden_waste_next_date" in data and data["echo_garden_waste_next_date"]:
             entries.append(
                 Collection(
-                    date=datetime.strptime(
-                        data["echo_garden_waste_next_date"], "%Y/%m/%d %H:%M:%S"
-                    ).date(),
+                    date=self.interpret_date(data["echo_garden_waste_next_date"]),
                     t="garden waste bin",
                     icon="mdi:leaf",
                 )


### PR DESCRIPTION
Date parsing is now in its own function because it has grown in complexity. Kingston has stopped including years in their dates, so we have to add them manually and account for year boundaries.
