### PR TITLE
Fix: Stirling WA api url

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
@@ -23,7 +23,7 @@ ICON_MAP = {
 }
 
 
-API_URL = "https://www.stirling.wa.gov.au/aapi/map"
+API_URL = "https://www.stirling.wa.gov.au/bincollectioncheck/getresult"
 
 
 class Source:


### PR DESCRIPTION
Fixes #3215 

```bash
Testing source stirling_wa_gov_au ...
  found 4 entries for -31.9034183 115.8320855
    2024-12-25 : Red [mdi:trash-can]
    2024-12-25 : Yellow [mdi:recycle]
    2025-01-01 : Green [mdi:leaf]
    2024-11-04 : GreenVerge [mdi:pine-tree]
  found 4 entries for -31.878331, 115.815553
    2024-12-25 : Red [mdi:trash-can]
    2025-01-01 : Yellow [mdi:recycle]
    2024-12-25 : Green [mdi:leaf]
    2024-10-21 : GreenVerge [mdi:pine-tree]
```