### PR TITLE
fix: Merton UK has changed the format of the dates

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/merton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/merton_gov_uk.py
@@ -12,7 +12,7 @@ URL = "https://www.merton.gov.uk/"
 
 TEST_CASES = {
     "test 1": {"property": "25884617"},
-    "test 2": {"property": "25861170"}
+    "test 2": {"property": "25861170"},
 }
 
 API_URL = "https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServices.aspx"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/merton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/merton_gov_uk.py
@@ -11,8 +11,8 @@ DESCRIPTION = "Source for www.merton.gov.uk services for London Borough of Merto
 URL = "https://www.merton.gov.uk/"
 
 TEST_CASES = {
-    "test 1": {"property": "28186366"},
-    "test 2": {"property": "28166100"},
+    "test 1": {"property": "25884617"},
+    "test 2": {"property": "25861170"}
 }
 
 API_URL = "https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServices.aspx"
@@ -66,7 +66,7 @@ class Source:
             # Add data to the main JSON Wrapper
             entries.append(
                 Collection(
-                    date=datetime.strptime(collectionDate, "%d %B %Y").date(),
+                    date=datetime.strptime(collectionDate, "%A %d %B %Y").date(),
                     t=title,
                     icon=ICON_MAP.get(title),
                 )

--- a/doc/source/merton_gov_uk.md
+++ b/doc/source/merton_gov_uk.md
@@ -21,7 +21,7 @@ Unique number the London Borough of Merton uses to identify your property.
 
 #### How to find your `PROPERTY_ID`
 
-Serach for your waste collection schedule at (https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServicesSearch.aspx). Your `PROPERTY_ID` is the set of numbers at the end of the url when your schedule is being displayed.
+Search for your waste collection schedule at (https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServicesSearch.aspx). Your `PROPERTY_ID` is the set of numbers at the end of the url when your schedule is being displayed.
 
 For example: myneighbourhood.merton.gov.uk/Wasteservices/WasteServices.aspx?ID=`28166109`
 


### PR DESCRIPTION
Also updated the test cases as they don't seem to be valid IDs any more.

Tested with `python custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s merton_gov_uk -lit` and the tests now pass successfully 