### PR TITLE
Fix: Darebin, Australia

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
@@ -10,6 +10,9 @@ TEST_CASES = {
     "274 Gower Street PRESTON 3072": {
         "property_location": "274 Gower Street PRESTON 3072"
     },
+    "116 HAROLD STREET THORNBURY 3071": {
+        "property_location": "116 HAROLD STREET THORNBURY 3071"
+    },
 }
 API_URL = "https://services-ap1.arcgis.com/1WJBRkF3v1EEG5gz/arcgis/rest/services/Waste_Collection_Date2/FeatureServer/0/query"
 WEEKDAY_MAP = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
@@ -11,8 +11,7 @@ TEST_CASES = {
         "property_location": "274 Gower Street PRESTON 3072"
     },
 }
-
-API_URL = "https://services-ap1.arcgis.com/1WJBRkF3v1EEG5gz/arcgis/rest/services/Waste_Collection_Date/FeatureServer/0/query"
+API_URL = "https://services-ap1.arcgis.com/1WJBRkF3v1EEG5gz/arcgis/rest/services/Waste_Collection_Date2/FeatureServer/0/query"
 WEEKDAY_MAP = {
     "Monday": 0,
     "Tuesday": 1,


### PR DESCRIPTION
Fixes #3321

original api url:
```bash
Testing source darebin_vic_gov_au ...
  274 Gower Street PRESTON 3072 failed: 'NoneType' object is not subscriptable
```

updated api url:
```bash
Testing source darebin_vic_gov_au ...
  found 156 entries for 274 Gower Street PRESTON 3072
  found 156 entries for 116 HAROLD STREET THORNBURY 3071
```