### PR TITLE
Fix tauranga_govt_nz date

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tauranga_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tauranga_govt_nz.py
@@ -115,7 +115,10 @@ class Source:
                         year=datetime.now().year + 1
                     ).date()
 
-                pickup_date = pickup_datetime.replace(year=datetime.now().year).date()
+                else:
+                    pickup_date = pickup_datetime.replace(
+                        year=datetime.now().year
+                    ).date()
 
             for bin_type in bin_types:
                 entries.append(


### PR DESCRIPTION
Bugfix -  Add a missing else clause which is causing new year pickups to show in the incorrect year.