### PR TITLE
Refactor Nottingham City to pull only one date per bin type

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
@@ -39,8 +39,10 @@ class Source:
 
         next_collections = data["nextCollections"]
 
-        # filter next_collections to ensure there's only one entry for
-        # colectionType, getting the entry with the soonest collection
+        # Sometimes the Nottingham City Council API returns multiple collections
+        # for the same bin type, with different dates.
+        # (e.g. Recycling next Tuesday and Recycling in 400 years time)
+        # We want to keep the closest date only for each bin type.
 
         revised_next_collections = {}  # type: dict[str, datetime.datetime]
 
@@ -51,8 +53,9 @@ class Source:
             )
 
             if bin_type in revised_next_collections:
-                if next_collection_date < revised_next_collections[bin_type]:
-                    revised_next_collections[bin_type] = next_collection_date
+                revised_next_collections[bin_type] = min(
+                    next_collection_date, revised_next_collections[bin_type]
+                )
             else:
                 revised_next_collections[bin_type] = next_collection_date
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
@@ -44,18 +44,17 @@ class Source:
 
         for collection in next_collections:
             bin_type = collection["collectionType"]
-            collection_date = datetime.datetime.fromisoformat(
+            props = BINS[bin_type]
+            next_collection_date = datetime.datetime.fromisoformat(
                 collection["collectionDate"]
             )
 
-            if collection_date > datetime.datetime.now() + datetime.timedelta(years=1):
+            if next_collection_date > datetime.datetime.now() + datetime.timedelta(years=1):
                 continue
-
-            props = BINS[bin_type]
 
             entries.append(
                 Collection(
-                    date=collection_date.date(),
+                    date=next_collection_date.date(),
                     t=props["name"],
                     icon=props["icon"],
                 )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
@@ -39,32 +39,23 @@ class Source:
 
         next_collections = data["nextCollections"]
 
-        # Sometimes the Nottingham City Council API returns multiple collections
-        # for the same bin type, with different dates.
-        # (e.g. Recycling next Tuesday and Recycling in 400 years time)
-        # We want to keep the closest date only for each bin type.
-
-        revised_next_collections = {}  # type: dict[str, datetime.datetime]
+        # Sometimes the Nottingham City Council API returns collections
+        # far in the future, so let's only consider the next 12 months
 
         for collection in next_collections:
             bin_type = collection["collectionType"]
-            next_collection_date = datetime.datetime.fromisoformat(
+            collection_date = datetime.datetime.fromisoformat(
                 collection["collectionDate"]
             )
 
-            if bin_type in revised_next_collections:
-                revised_next_collections[bin_type] = min(
-                    next_collection_date, revised_next_collections[bin_type]
-                )
-            else:
-                revised_next_collections[bin_type] = next_collection_date
+            if collection_date > datetime.datetime.now() + datetime.timedelta(years=1):
+                continue
 
-        for bin_type, next_collection_date in revised_next_collections.items():
             props = BINS[bin_type]
 
             entries.append(
                 Collection(
-                    date=next_collection_date.date(),
+                    date=collection_date.date(),
                     t=props["name"],
                     icon=props["icon"],
                 )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nottingham_city_gov_uk.py
@@ -39,14 +39,25 @@ class Source:
 
         next_collections = data["nextCollections"]
 
+        # filter next_collections to ensure there's only one entry for
+        # colectionType, getting the entry with the soonest collection
+
+        revised_next_collections = {}  # type: dict[str, datetime.datetime]
+
         for collection in next_collections:
             bin_type = collection["collectionType"]
-
-            props = BINS[bin_type]
-
             next_collection_date = datetime.datetime.fromisoformat(
                 collection["collectionDate"]
             )
+
+            if bin_type in revised_next_collections:
+                if next_collection_date < revised_next_collections[bin_type]:
+                    revised_next_collections[bin_type] = next_collection_date
+            else:
+                revised_next_collections[bin_type] = next_collection_date
+
+        for bin_type, next_collection_date in revised_next_collections.items():
+            props = BINS[bin_type]
 
             entries.append(
                 Collection(


### PR DESCRIPTION
Nottingham City API sometimes give multiple dates for bins, particularly just after collection date. Locally, it makes sense to only use the smallest of these dates as we want the NEXT collection only.


Here's an example API response which is causing the issue:

```json
{
  "uprn": "200001405145",
  "address": "FLAT 2 3 CAMERON STREET",
  "postcode": "NG5 2HS",
  "binTypes": [
    "CommunalRecycling",
    "Waste",
    "Garden",
    "Recycling"
  ],
  "nextCollections": [
    {
      "collectionType": "Waste",
      "collectionDate": "2025-01-07T07:00:00",
      "collectionDay": "Tuesday"
    },
    {
      "collectionType": "Recycling",
      "collectionDate": "2025-01-14T07:00:00",
      "collectionDay": "Tuesday"
    },
    {
      "collectionType": "Recycling",
      "collectionDate": "2400-01-11T00:00:00",
      "collectionDay": "Tuesday"
    },
    {
      "collectionType": "Garden",
      "collectionDate": "2900-01-19T00:00:00",
      "collectionDay": "Tuesday"
    }
  ],
  "hasWaste": true,
  "hasRecycling": true,
  "hasGarden": true,
  "hasFood": false,
  "isCommunal": true,
  "nextBinIsWaste": true,
  "nextBinIsRecycling": false,
  "nextBinIsGarden": false,
  "nextBinIsFood": false,
  "recyclingWeek": "Recycling Week A",
  "nextCollectionType": "Waste",
  "nextCollectionDate": "2025-01-07T07:00:00",
  "oldStyleCategoryForMyProperty": "waste-hasgarden",
  "collectionDay": "Tuesday",
  "calendarDay": "Tuesday",
  "contextJobs": null
}
```