### PR TITLE
Fix for new API for abfall_havelland_de

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
@@ -1,6 +1,5 @@
 # There was an ICS source but the ICS file was not stored permanently and would be removed after a few days.
 import requests
-from bs4 import BeautifulSoup, Tag
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.service.ICS import ICS
 
@@ -13,14 +12,11 @@ TEST_CASES = {
         "strasse": "Drosselgasse",
     },
     "Milow Friedhofstr.": {"ort": "Milow", "strasse": "Friedhofstr."},
-    "Falkensee Ahornstr.": {
-        "ort": "Falkensee",
-        "strasse": "Ahornstr."
-    },
+    "Falkensee Ahornstr.": {"ort": "Falkensee", "strasse": "Ahornstr."},
     "Falkensee complex street name": {
         "ort": "Falkensee",
-        "strasse": "Karl-Marx-Str. (von Friedrich-Hahn-Str. bis Am Schlaggraben)"
-    }
+        "strasse": "Karl-Marx-Str. (von Friedrich-Hahn-Str. bis Am Schlaggraben)",
+    },
 }
 
 ICON_MAP = {
@@ -31,6 +27,7 @@ ICON_MAP = {
 }
 
 API_URL = "https://www.abfall-havelland.de/ics.php"
+
 
 class Source:
     def __init__(self, ort: str, strasse: str):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
@@ -13,8 +13,15 @@ TEST_CASES = {
         "strasse": "Drosselgasse",
     },
     "Milow Friedhofstr.": {"ort": "Milow", "strasse": "Friedhofstr."},
+    "Falkensee Ahornstr.": {
+        "ort": "Falkensee",
+        "strasse": "Ahornstr."
+    },
+    "Falkensee complex street name": {
+        "ort": "Falkensee",
+        "strasse": "Karl-Marx-Str. (von Friedrich-Hahn-Str. bis Am Schlaggraben)"
+    }
 }
-
 
 ICON_MAP = {
     "mülltonne": "mdi:trash-can",
@@ -23,10 +30,7 @@ ICON_MAP = {
     "gelbe": "mdi:recycle",
 }
 
-
-API_URL = "https://www.abfall-havelland.de//groups/public/modules/ajax_tourenplan.php"
-BASE_URL = "https://www.abfall-havelland.de/"
-
+API_URL = "https://www.abfall-havelland.de/ics.php"
 
 class Source:
     def __init__(self, ort: str, strasse: str):
@@ -37,19 +41,9 @@ class Source:
     def fetch(self) -> list[Collection]:
         args = {"city": self._ort, "street": self._strasse}
 
-        # get json file
+        # ics content
         r = requests.get(API_URL, params=args)
         r.raise_for_status()
-        soup = BeautifulSoup(r.text, "html.parser")
-        ics_link_tag = soup.find("a", id="ical")
-        if not isinstance(ics_link_tag, Tag):
-            raise Exception("No ics link found")
-        ics_link = ics_link_tag.attrs["onclick"].split("'")[1]
-        if not isinstance(ics_link, str):
-            raise Exception("No ics link found")
-        r = requests.get(BASE_URL + ics_link)
-        r.raise_for_status()
-        r.encoding = "utf-8"
         dates = self._ics.convert(r.text)
         entries = []
         for d in dates:


### PR DESCRIPTION
Abfall Havelland has changed its API. It`s now even simpler to retrieve the data.
I created two specific testcases (one with a more complex street name) and they where ok.
Would be nice if you could integrate this PR very soon because i see UNKNOWN in my HomeAssistant otherwise :/

Tests:

Testing source abfall_havelland_de ...
  found 78 entries for Wustermark Drosselgasse
  found 77 entries for Milow Friedhofstr.
  found 79 entries for Falkensee Ahornstr.                     <--- new testcase
  found 78 entries for Falkensee complex street name   <--- new testcase