### PR TITLE
Deduplicate entries in ALW-WF

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/alw_wf_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/alw_wf_de.py
@@ -115,6 +115,10 @@ class Source:
             )
 
         termine = termine["result"][0]["result"]
+
+        # The API started to return every entry twice, so deduplicate them
+        processed_entries = set()
+
         for termin in termine:
             ts = int(termin["DatumLong"]) / 1000
             # Timestamps are unix with milliseconds but not UTC...
@@ -124,6 +128,10 @@ class Source:
             types = int(termin["Abfallwert"])
             for art in arten:
                 if types & art:
+                    e = f"{ts};{art}"
+                    if e in processed_entries:
+                        continue
+                    processed_entries.add(e)
                     entries.append(Collection(date, arten[art]))
 
         return entries


### PR DESCRIPTION
The ALW Wolfenbüttel API has started to return every entry twice (since 2025-01-01). This causes this integration to also add them to the calender and sesnors twice.

This PR deduplicates the returned entries by creating a "hash" (haha) from the timestamp + bin type so we add every bin type and timestamp combination only once.