### PR TITLE
Update binzone_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/binzone_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/binzone_uk.py
@@ -29,7 +29,7 @@ TEST_CASES = {
 ICON_MAP = {
     "GREY BIN": "mdi:trash-can",
     "GREEN BIN": "mdi:recycle",
-    "GARDEN WASTE": "mdi:leaf",
+    "GARDEN WASTE BIN": "mdi:leaf",
     "SMALL ELECTRICAL ITEMS": "mdi:hair-dryer",
     "FOOD BIN": "mdi:food-apple",
     "TEXTILES": "mdi:hanger",


### PR DESCRIPTION
WARNING: BREAKING CHANGE if you have custom rules or rely on matching the GARDEN WASTE events
"GARDEN WASTE" will change to "GARDEN WASTE BIN"

Change ICON_MAP "GARDEN WASTE" to "GARDEN WASTE BIN". Binzone list the bin as "GARDEN WASTE BIN" but post a message 'No garden waste collection due to xx' for reasons such as Christmas / new year which caused false positives

