### PR TITLE
Heidelberg: Ignore timezones when parsing christmas collecion date

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
@@ -216,7 +216,7 @@ class Source:
         for waste_type in WASTE_TYPES:
             if waste_type == WASTE_TYPES["christmas"]:
                 collection_date = date_parser.parse(
-                    raw_collection_data[waste_type][0]["collection_date"]
+                    raw_collection_data[waste_type][0]["collection_date"], ignoretz=True
                 )
                 ruleset = rruleset()
                 ruleset.rdate(collection_date)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
@@ -309,6 +309,4 @@ class Source:
         return entries
 
 
-CONFIG_FLOW_TYPES = {
-    "street": {"type": "SELECT", "values": Source.get_available_streets()}
-}
+

--- a/doc/source/heidelberg_de.md
+++ b/doc/source/heidelberg_de.md
@@ -17,7 +17,7 @@ waste_collection_schedule:
 ### Configuration Variables
 
 **street**  
-*(string) (required)* The street you want to get the waste collection schedule for. This value must match with an [entry from the API](https://garbage.datenplattform.heidelberg.de/streetnames). If you use the GUI to set up this source, we automatically get all available street names and provide you a drop-down list where you can choose the appropriate entry.
+*(string) (required)* The street you want to get the waste collection schedule for. This value must match with an entry from the API (see section ["How to get the source arguments"](#how-to-get-the-source-arguments)). If you use the GUI to set up this source, we automatically get all available street names and provide you a drop-down list where you can choose the appropriate entry.
 
 **collect_residual_waste_weekly**  
 *(bool)* By default, the city collects residual waste on a weekly basis. If you decided to switch to a bi-weekly schedule to save some money, set this value to False. If you live on a rural street where the waste is only being collected biweekly, you don't need to change anything here as it's being taken into account automatically.


### PR DESCRIPTION
Were not fast enough to fix this little bug when parsing the Christmas tree collection date before your merge. My branch wasn't up-to-date anyway, that's why I closed #3497 and tried again.

Sorry for any inconvenience!