### PR TITLE
Heidelberg: Revert pre-fill of streets and ignore timezone on Christmas tree collection parse

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
@@ -216,7 +216,7 @@ class Source:
         for waste_type in WASTE_TYPES:
             if waste_type == WASTE_TYPES["christmas"]:
                 collection_date = date_parser.parse(
-                    raw_collection_data[waste_type][0]["collection_date"]
+                    raw_collection_data[waste_type][0]["collection_date"], ignoretz=True
                 )
                 ruleset = rruleset()
                 ruleset.rdate(collection_date)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
@@ -199,7 +199,7 @@ class Source:
         self._even_house_number = even_house_number
 
     @staticmethod
-    def get_available_streets() -> list[str]:
+    def _get_available_streets() -> list[str]:
         streets_request = requests.get(STREETNAMES_API_URL)
         streets_request.raise_for_status()
 
@@ -278,7 +278,7 @@ class Source:
             raise SourceArgumentRequiredWithSuggestions(
                 "street",
                 "It's required to specify your street.",
-                self.get_available_streets(),
+                self._get_available_streets(),
             )
 
         collections_request = requests.get(self._api_url)
@@ -287,7 +287,7 @@ class Source:
 
         if len(raw_collection_data["collections"]) == 0:
             raise SourceArgumentNotFoundWithSuggestions(
-                "street", self._street, self.get_available_streets()
+                "street", self._street, self._get_available_streets()
             )
 
         collection_data = self._extract_collection_data(raw_collection_data)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
@@ -307,8 +307,3 @@ class Source:
                 )
 
         return entries
-
-
-CONFIG_FLOW_TYPES = {
-    "street": {"type": "SELECT", "values": Source.get_available_streets()}
-}

--- a/doc/source/heidelberg_de.md
+++ b/doc/source/heidelberg_de.md
@@ -17,7 +17,7 @@ waste_collection_schedule:
 ### Configuration Variables
 
 **street**  
-*(string) (required)* The street you want to get the waste collection schedule for. This value must match with an [entry from the API](https://garbage.datenplattform.heidelberg.de/streetnames). If you use the GUI to set up this source, we automatically get all available street names and provide you a drop-down list where you can choose the appropriate entry.
+*(string) (required)* The street you want to get the waste collection schedule for. This value must match with an [entry from the API](https://garbage.datenplattform.heidelberg.de/streetnames). If you use the GUI to set up this source and your input doesn't match, we automatically suggest you entries based on the API response.
 
 **collect_residual_waste_weekly**  
 *(bool)* By default, the city collects residual waste on a weekly basis. If you decided to switch to a bi-weekly schedule to save some money, set this value to False. If you live on a rural street where the waste is only being collected biweekly, you don't need to change anything here as it's being taken into account automatically.


### PR DESCRIPTION
During inspection of the failed CI pipeline on my last pull request (#3497 / #3498), I recognized that using `CONFIG_FLOW_TYPES` with a public method call has unexpected side effects. Whenever the file is being imported (e.g., by running `test_sources.py` or `update_docu_links.py`), the `Source.get_available_streets()` method is being called in order to fill the `CONFIG_FLOW_TYPES` dictionary even without access to values of the dictionary at all. This leads to unnecessary and maybe excessive calls to the public API. [It's visible in this pipeline run here](https://github.com/mampfes/hacs_waste_collection_schedule/actions/runs/12674155047/job/35323279820#step:7:12).

First, I thought about answering calls from both test/debug scripts with an empty list using this workaround:
```python
import inspect

[...]

    @staticmethod
    def get_available_streets() -> list[str]:
        if ("update_docu_links.py" or "test_sources.py") in inspect.stack()[-1].filename:
            return list()
```

But, honestly, I'm pretty sure there may be cases the file is being imported by HA/HACS I'm not aware of right now. And checking the stack-trace on runtime in production environments is pretty nasty. Therefore, I decided to revert this change entirely. In case the street entered by the user isn't correct, I call the API anyway and present the result as suggestions.

Additionally, I ignore the local timezone information now when parsing the Christmas tree collection date in order to avoid shifting it to another date unexpectedly.

Sorry for any inconvenience I caused!