### PR TITLE
Update calendar url for Seon (Switzerland)

### DIFF
--- a/doc/ics/seon_ch.md
+++ b/doc/ics/seon_ch.md
@@ -18,5 +18,5 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://www.seon.ch/public/upload/assets/5125/Entsorgungskalender%202024%20Google.ics?fp=2
+        url: https://www.seon.ch/public/upload/assets/7330/Entsorgungskalender_Outlook%202025.ics?fp=1
 ```

--- a/doc/ics/yaml/seon_ch.yaml
+++ b/doc/ics/yaml/seon_ch.yaml
@@ -14,4 +14,4 @@ howto:
 test_cases:
   Oberdorfstrasse 11, 5703 Seon:
     url: 
-      https://www.seon.ch/public/upload/assets/5125/Entsorgungskalender%202024%20Google.ics?fp=2
+      https://www.seon.ch/public/upload/assets/7330/Entsorgungskalender_Outlook%202025.ics?fp=1


### PR DESCRIPTION
Update with new calendar url for 2025