### PR TITLE
Fix: Swale, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -1,13 +1,8 @@
-# import json
-# import re
-
 from datetime import date, datetime, timedelta
 from time import sleep as sleep
 
 import requests
 from bs4 import BeautifulSoup
-
-# from dateutil.parser import parse
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Swale Borough Council"
@@ -43,13 +38,6 @@ PARAM_DESCRIPTIONS = {
         "postcode": "Postcode of the property",
     },
 }
-
-# DATE_KEYS = {
-#     "NextDateUTC",
-#     "FollowingDateUTC",
-#     "Following2DateUTC",
-#     "Following3DateUTC",
-# }
 
 
 class Source:
@@ -150,54 +138,4 @@ class Source:
                 )
             )
 
-        # collection_soup = BeautifulSoup(collection_response.text, "html.parser")
-
-        # # get details of next collection
-        # next_date = collection_soup.find("strong", {"id": "SBC-YBD-collectionDate"})
-        # next_wastes = collection_soup.find("div", {"id": "SBCFirstBins"})
-        # next_items = next_wastes.find_all("li")
-        # print(next_date, next_items)
-
-        # # get details of future collection
-        # future_collection = collection_soup.find("div", {"id": "FutureCollections"})
-        # future_date = future_collection.text.split(", ")[-1]
-        # future_wastes = collection_soup.find("ul", {"id": "FirstFutureBins"})
-        # future_items = future_wastes.find_all("li")
-        # print(future_date, future_items)
-
-        # section = collection_soup.find("section", id="SBC-YBD-collectionDate")
-        # if not section:
-        #     raise ValueError(
-        #         "Could not find SBC-YBD_main section. Most likely html has changed"
-        #     )
-        # script = section.find("script", recursive=False)
-        # if not script:
-        #     raise ValueError(
-        #         "Could not find script entry. Most likely html has changed"
-        #     )
-
-        # bin_data = re.search(
-        #     r"var BIN_DAYS = Object\.entries\(JSON\.parse\('(.+)'\)\);", script.string
-        # )
-        # if not bin_data:
-        #     raise ValueError(
-        #         "Could not find BIN_DAYS in response. Most likely html has changed"
-        #     )
-        # bin_days = json.loads(bin_data.group(1))
-        # for bin in bin_days:
-        #     bin_details = bin_days[bin]
-        #     if bin_details["Active"] == "Y":
-        #         for dateKey in DATE_KEYS:
-        #             if dateKey in bin_details:
-        #                 entries.append(
-        #                     Collection(
-        #                         date=parse(bin_details[dateKey]).date(),
-        #                         t=bin,
-        #                         icon=ICON_MAP.get(bin),
-        #                     )
-        #                 )
-        # if not entries:
-        #     raise ValueError(
-        #         "Could not get collections for the given combination of UPRN and Postcode."
-        #     )
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -1,20 +1,22 @@
 # import json
 # import re
 
-from time import sleep as sleep
+# from time import sleep as sleep
 
 import requests
-from bs4 import BeautifulSoup
 
 # from dateutil.parser import parse
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+# from bs4 import BeautifulSoup
+
 
 TITLE = "Swale Borough Council"
 DESCRIPTION = "Source for swale.gov.uk services for Swale, UK."
 URL = "https://swale.gov.uk"
 TEST_CASES = {
-    # "Swale House": {"uprn": 100062375927, "postcode": "ME10 3HT"},
-    "1 Harrier Drive": {"uprn": 100061091726, "postcode": "ME10 4UY"},
+    "Swale House": {"uprn": 100062375927, "postcode": "ME10 3HT"},
+    # "1 Harrier Drive": {"uprn": 100061091726, "postcode": "ME10 4UY"},
 }
 
 HEADERS = {
@@ -59,44 +61,47 @@ class Source:
         entries: list = []
 
         session = requests.Session()
-        session.headers.update(HEADERS)
+        # session.headers.update(HEADERS)
 
         first_form_data = {
             "SQ_FORM_485465_PAGE": "1",
-            "form_email_485465_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day-v2",
+            "form_email_485465_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
             "q485476:q1": self._postcode,
-            "form_email_485465_submit": "Choose Your Address &#10140;",
+            "form_email_485465_submit": "Choose Your Address &#10140",
         }
 
-        resp = session.post(API_URL, data=first_form_data)
+        resp = session.post(API_URL, headers=HEADERS, data=first_form_data)
         resp.raise_for_status()
-        sleep(10)
+        # print(resp.content)
+        # sleep(10)
 
         second_form_data = {
             "SQ_FORM_485465_PAGE": "2",
-            "form_email_485465_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day-v2",
+            "form_email_485465_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
             "q485480:q1": self._uprn,
-            "form_email_485465_submit": "Get Bin Days &#10140;",
+            "form_email_485465_submit": "Get Bin Days &#10140",
         }
 
-        collection_response = session.post(API_URL, data=second_form_data)
+        collection_response = session.post(
+            API_URL, data=second_form_data, headers=HEADERS
+        )
         collection_response.raise_for_status()
         print(collection_response.content)
 
-        collection_soup = BeautifulSoup(collection_response.text, "html.parser")
+        # collection_soup = BeautifulSoup(collection_response.text, "html.parser")
 
-        # get details of next collection
-        next_date = collection_soup.find("strong", {"id": "SBC-YBD-collectionDate"})
-        next_wastes = collection_soup.find("div", {"id": "SBCFirstBins"})
-        next_items = next_wastes.find_all("li")
-        print(next_date, next_items)
+        # # get details of next collection
+        # next_date = collection_soup.find("strong", {"id": "SBC-YBD-collectionDate"})
+        # next_wastes = collection_soup.find("div", {"id": "SBCFirstBins"})
+        # next_items = next_wastes.find_all("li")
+        # print(next_date, next_items)
 
-        # get details of future collection
-        future_collection = collection_soup.find("div", {"id": "FutureCollections"})
-        future_date = future_collection.text.split(", ")[-1]
-        future_wastes = collection_soup.find("ul", {"id": "FirstFutureBins"})
-        future_items = future_wastes.find_all("li")
-        print(future_date, future_items)
+        # # get details of future collection
+        # future_collection = collection_soup.find("div", {"id": "FutureCollections"})
+        # future_date = future_collection.text.split(", ")[-1]
+        # future_wastes = collection_soup.find("ul", {"id": "FirstFutureBins"})
+        # future_items = future_wastes.find_all("li")
+        # print(future_date, future_items)
 
         # section = collection_soup.find("section", id="SBC-YBD-collectionDate")
         # if not section:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -1,16 +1,19 @@
-import json
-import re
+# import json
+# import re
+
+from time import sleep as sleep
 
 import requests
 from bs4 import BeautifulSoup
-from dateutil.parser import parse
+
+# from dateutil.parser import parse
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Swale Borough Council"
 DESCRIPTION = "Source for swale.gov.uk services for Swale, UK."
 URL = "https://swale.gov.uk"
 TEST_CASES = {
-    "Swale House": {"uprn": 100062375927, "postcode": "ME10 3HT"},
+    # "Swale House": {"uprn": 100062375927, "postcode": "ME10 3HT"},
     "1 Harrier Drive": {"uprn": 100061091726, "postcode": "ME10 4UY"},
 }
 
@@ -53,64 +56,81 @@ class Source:
         self._postcode = postcode
 
     def fetch(self) -> list[Collection]:
-        entries = []
+        entries: list = []
 
         session = requests.Session()
         session.headers.update(HEADERS)
 
         first_form_data = {
-            "SQ_FORM_462397_PAGE": "1",
-            "q462406:q1": self._postcode,
-            "form_email_462397_submit": "Next &#10140;",
+            "SQ_FORM_485465_PAGE": "1",
+            "form_email_485465_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day-v2",
+            "q485476:q1": self._postcode,
+            "form_email_485465_submit": "Choose Your Address &#10140;",
         }
 
         resp = session.post(API_URL, data=first_form_data)
         resp.raise_for_status()
+        sleep(10)
 
         second_form_data = {
-            "SQ_FORM_462397_PAGE": "2",
-            "q462407:q3": self._uprn,
-            "form_email_462397_submit": "Get Bin Days &#10140;",
+            "SQ_FORM_485465_PAGE": "2",
+            "form_email_485465_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day-v2",
+            "q485480:q1": self._uprn,
+            "form_email_485465_submit": "Get Bin Days &#10140;",
         }
 
         collection_response = session.post(API_URL, data=second_form_data)
         collection_response.raise_for_status()
+        print(collection_response.content)
 
         collection_soup = BeautifulSoup(collection_response.text, "html.parser")
 
-        section = collection_soup.find("section", id="SBC-YBD_main")
-        if not section:
-            raise ValueError(
-                "Could not find SBC-YBD_main section. Most likely html has changed"
-            )
-        script = section.find("script", recursive=False)
-        if not script:
-            raise ValueError(
-                "Could not find script entry. Most likely html has changed"
-            )
+        # get details of next collection
+        next_date = collection_soup.find("strong", {"id": "SBC-YBD-collectionDate"})
+        next_wastes = collection_soup.find("div", {"id": "SBCFirstBins"})
+        next_items = next_wastes.find_all("li")
+        print(next_date, next_items)
 
-        bin_data = re.search(
-            r"var BIN_DAYS = Object\.entries\(JSON\.parse\('(.+)'\)\);", script.string
-        )
-        if not bin_data:
-            raise ValueError(
-                "Could not find BIN_DAYS in response. Most likely html has changed"
-            )
-        bin_days = json.loads(bin_data.group(1))
-        for bin in bin_days:
-            bin_details = bin_days[bin]
-            if bin_details["Active"] == "Y":
-                for dateKey in DATE_KEYS:
-                    if dateKey in bin_details:
-                        entries.append(
-                            Collection(
-                                date=parse(bin_details[dateKey]).date(),
-                                t=bin,
-                                icon=ICON_MAP.get(bin),
-                            )
-                        )
-        if not entries:
-            raise ValueError(
-                "Could not get collections for the given combination of UPRN and Postcode."
-            )
+        # get details of future collection
+        future_collection = collection_soup.find("div", {"id": "FutureCollections"})
+        future_date = future_collection.text.split(", ")[-1]
+        future_wastes = collection_soup.find("ul", {"id": "FirstFutureBins"})
+        future_items = future_wastes.find_all("li")
+        print(future_date, future_items)
+
+        # section = collection_soup.find("section", id="SBC-YBD-collectionDate")
+        # if not section:
+        #     raise ValueError(
+        #         "Could not find SBC-YBD_main section. Most likely html has changed"
+        #     )
+        # script = section.find("script", recursive=False)
+        # if not script:
+        #     raise ValueError(
+        #         "Could not find script entry. Most likely html has changed"
+        #     )
+
+        # bin_data = re.search(
+        #     r"var BIN_DAYS = Object\.entries\(JSON\.parse\('(.+)'\)\);", script.string
+        # )
+        # if not bin_data:
+        #     raise ValueError(
+        #         "Could not find BIN_DAYS in response. Most likely html has changed"
+        #     )
+        # bin_days = json.loads(bin_data.group(1))
+        # for bin in bin_days:
+        #     bin_details = bin_days[bin]
+        #     if bin_details["Active"] == "Y":
+        #         for dateKey in DATE_KEYS:
+        #             if dateKey in bin_details:
+        #                 entries.append(
+        #                     Collection(
+        #                         date=parse(bin_details[dateKey]).date(),
+        #                         t=bin,
+        #                         icon=ICON_MAP.get(bin),
+        #                     )
+        #                 )
+        # if not entries:
+        #     raise ValueError(
+        #         "Could not get collections for the given combination of UPRN and Postcode."
+        #     )
         return entries


### PR DESCRIPTION
Fixes #3492 

```bash
Testing source swale_gov_uk ...
  found 4 entries for Swale House
    2025-01-16 : Recycling [mdi:recycle]
    2025-01-16 : Food [mdi:food-apple]
    2025-01-23 : Refuse [mdi:trash-can]
    2025-01-23 : Food [mdi:food-apple]
  found 4 entries for 1 Harrier Drive
    2025-01-16 : Refuse [mdi:trash-can]
    2025-01-16 : Food [mdi:food-apple]
    2025-01-23 : Recycling [mdi:recycle]
    2025-01-23 : Food [mdi:food-apple]
  found 5 entries for garden waste test
    2025-01-16 : Garden [mdi:leaf]
    2025-01-16 : Refuse [mdi:trash-can]
    2025-01-16 : Food [mdi:food-apple]
    2025-01-23 : Recycling [mdi:recycle]
    2025-01-23 : Food [mdi:food-apple]
```

Website has a fairly aggressive limit of request frequency, so running the test cases, or restarting HA a lot of times is quick succession, may end up generating `429 Too Many Requests` messages. The headers don't indicate what the acceptable request rate is.