### PR TITLE
Republic Services recognizes the "MIXED ORGANICS" waste type

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -147,7 +147,7 @@ class Source:
             for item in schedule:
                 if "RECYCLE" in schedule[item]["waste_description"]:
                     icon = "mdi:recycle"
-                elif "YARD" in schedule[item]["waste_description"]:
+                elif ("YARD" in schedule[item]["waste_description"] or "ORGANICS" in schedule[item]["waste_description"]):
                     icon = "mdi:leaf"
                 else:
                     icon = "mdi:trash-can"
@@ -162,18 +162,19 @@ class Source:
             self._method == 2
         ):  # Updated to report yard waste as a separate category to recycling
             for item in schedule:
-                if "YARD" in schedule[item]["waste_description"]:
+                if ("YARD" in schedule[item]["waste_description"] or "ORGANICS" in schedule[item]["waste_description"]):
                     icon = "mdi:leaf"
                     schedule[item]["waste_type"] = "Yard Waste"
-                if "BULK SERVICE" in schedule[item]["waste_description"]:
+                elif "BULK SERVICE" in schedule[item]["waste_description"]:
                     icon = "mdi:leaf"
                     schedule[item]["waste_type"] = "Bulk Waste"
                 elif "RECYCLE" in schedule[item]["waste_description"]:
                     icon = "mdi:recycle"
-                elif "YARD" in schedule[item]["waste_description"]:
-                    icon = "mdi:leaf"
+                    schedule[item]["waste_type"] = "Recycle"
                 else:
                     icon = "mdi:trash-can"
+                    schedule[item]["waste_type"] = "Solid Waste"
+
                 entries.append(
                     Collection(
                         date=schedule[item]["date"],


### PR DESCRIPTION
The Republic Services source integration will now recognize the "MIXED ORGANICS" waste type as a type of "yard waste" instead of recognizing it with a `wasteTypeDescription` of "Recycle".  This is helpful because the blue bin (cardboard/plastic/metal co-mingled recycling) and the green bin (organic waste) are collected on different schedules, but they both have the same `wasteTypeDescription` of "Recycle" in the Republic Services API response, which makes it difficult to understand when this integration reports that the "Recycle" bin will be collected tomorrow because it could be referring to either the blue bin or the green bin.

Here's an example API response that shows the `MIXED ORGANICS` productDescription:
```json
{
  "statusCode": 200,
  "data": {
    "commercial": [],
    "residential": [
      {
        "containerId": "65822574",
        "containerType": "OR",
        "containerSize": "0.48",
        "containerStatus": "Open",
        "containerCategory": "Residential",
        "customerOwnedInd": false,
        "productDescription": "MIXED ORGANICS CART 95/96 GAL",
        "onCallInd": false,
        "serviceStartDate": "2024-04-01",
        "serviceChangeLastDate": "2024-04-01",
        "quantityOnSite": 1,
        "quantityOrdered": 1,
        "wasteTypeDescription": "Recycle",
        "mondayPickups": 1,
        "tuesdayPickups": 0,
        "wednesdayPickups": 0,
        "thursdayPickups": 0,
        "fridayPickups": 0,
        "saturdayPickups": 0,
        "sundayPickups": 0,
        "numberOfPickupsPeriodLength": 1,
        "numberOfPickupsPeriodUnit": "W",
        "numberOfPickupsTotal": 1,
        "poRequiredInd": false,
        "contractGroupNumber": "9",
        "municipalFranchiseContractNumber": "1",
        "revenueDistributionCode": "7O",
        "sharedId": "",
        "liftsPerCycle": "1 Every  Week",
        "numberOfShares": 0,
        "receiptRequiredInd": false,
        "receiptRequiredDesc": "NO RECEIPT NEEDED",
        "receiptRequiredCode": "N",
        "accountType": "S",
        "disposalCode": "",
        "disposalPriceCode": "",
        "cityAccount": "",
        "infoProContainerId": "88464453000000107",
        "summaryRoutingFlag": "N",
        "specialHandlingFlag": " ",
        "nextServiceDays": ["2025-01-20"],
        "lawsonDivisionNumber": "4884",
        "linkedEligibilityFlag": "C",
        "routeDetails": [
          {
            "routeNumber": "1583",
            "stopServiceCode": "C",
            "stopSequenceNumber": "1023000000",
            "rdUUID": "2ccd5001-5dda-1a40-90e5-0004ac1c862d",
            "serviceCode": "REG",
            "routeDescription": "71909GANICS OUT TIME 16:15",
            "nextServiceDays": ["2025-01-20"],
            "isRouteSuspended": false
          }
        ],
        "individualAccountFlag": "Y",
        "individualInvoicesRequiredFlag": "N",
        "billingTypeFlag": "C",
        "containerGroup": "7",
        "isServiceInterrupt": false
      }
    ]
  }
}
```
