### PR TITLE
fix(Bordeaux-metropole/Villenave d'ornon): Allow cities without geo_shape

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/opendata_bordeauxmetropole_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/opendata_bordeauxmetropole_fr.py
@@ -315,8 +315,8 @@ class Source:
         list_of_infos = [
             i
             for i in json.loads(response.text)
-            if i["geo_shape"]
-            and self._is_within_geo_shape(i["geo_shape"], address_params)
+            # For the cities not having geo_shape, all the city is concerned
+            if not i["geo_shape"] or self._is_within_geo_shape(i["geo_shape"], address_params)
         ]
 
         filtered_responses: dict[str, list[str]] = {}


### PR DESCRIPTION
There are a few cities without geoshape, which means that all the city is impacted by the scheduling (like Villenave d'Ornon).

It has been tested on my HA instance