### PR TITLE
fix missing data for AWB Bad Kreuznach

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_bad_kreuznach_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_bad_kreuznach_de.py
@@ -206,8 +206,7 @@ class Source:
                     dtstart=datetime.fromtimestamp(cal_entry["fromDate"] / 1000),
                     until=datetime.fromtimestamp(cal_entry["toDate"] / 1000)
                     if cal_entry["toDate"]
-                    else None,
-                    count=365 // cal_entry["frequency"],
+                    else to_time,
                 )
             )
 


### PR DESCRIPTION
fixes #3381

The API returns calendar entries from 2024. An extended `until` for calculation is necessary to get entries for 2025.
According to the [documentation](https://dateutil.readthedocs.io/en/stable/rrule.html) `until` and `count` are deprecated when used together, so I removed the count completely.