### PR TITLE
Fix: oslokommune

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oslokommune_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oslokommune_no.py
@@ -8,14 +8,13 @@ TITLE = "Oslo Kommune"
 DESCRIPTION = "Oslo Kommune (Norway)."
 URL = "https://www.oslo.kommune.no"
 
-# **street_code:** \
-# **county_id:** \
+# **street_id:** \
 # Can be found with this REST-API call.
 # ```
 # https://ws.geonorge.no/adresser/v1/#/default/get_sok
 # https://ws.geonorge.no/adresser/v1/sok?sok=Min%20Gate%2012
 # ```
-# "street_id" equals to "adressekode" and "county_id" equals to "kommunenummer".
+# "street_id" equals to "adressekode".
 
 TEST_CASES = {
     "Villa Paradiso": {

--- a/doc/source/oslokommune_no.md
+++ b/doc/source/oslokommune_no.md
@@ -5,7 +5,7 @@
 - Webgui: https://ws.geonorge.no/adresser/v1/#/default/get_sok
 - API: https://ws.geonorge.no/adresser/v1/sok?sok=Min%20Gate%2012
 
-`street_code` equals to `adressekode` and `county_id` equals to `kommunenummer`.
+`street_id` is equal to `adressekode`.
 
 ```yaml
 waste_collection_schedule:


### PR DESCRIPTION
Fixes #3759

OsloKommune documentation was showing references to args that were not used, as well as a confusing reference to both street_id and street_code. This looks like it was due to  oslokommune_no being based on the code for minrenovasjon_no which does use those args and the differences hadn't been cleaned up in the documentation.