### PR TITLE
Fix: Sunderland_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sunderland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sunderland_gov_uk.py
@@ -11,16 +11,16 @@ URL = "https://www.sunderland.gov.uk/"
 API_URL = "https://webapps.sunderland.gov.uk/WEBAPPS/WSS/Sunderland_Portal/Forms/bindaychecker.aspx"
 HEADERS = {"user-agent": "Mozilla/5.0"}
 TEST_CASES = {
-    "Test_001": {"postcode": "SR4 7PU", "address": "191 Cleveland Road"},
-    "Test_002": {"postcode": "SR3 2DW", "address": "43 Hill Street"},
-    "Test_003": {"postcode": "SR4 8RJ", "address": "17 Sutherland Drive"},
+    "Test_001": {"postcode": "SR4 7PU", "address": "191, Cleveland Road"},
+    "Test_002": {"postcode": "SR3 2DW", "address": "43, Hill Street"},
+    "Test_003": {"postcode": "SR4 8RJ", "address": "17, Sutherland Drive"},
 }
 ICON_MAP = {"Recycle": "mdi:recycle", "House": "mdi:trash-can", "Garden": "mdi:leaf"}
 
 
 class Source:
     def __init__(self, postcode: str, address: str):
-        self._postcode = str(postcode).replace(" ", "+")
+        self._postcode = str(postcode)
         self._address = str(address)
         self._ddlAddress: str | None = None
 

--- a/doc/source/sunderland_gov_uk.md
+++ b/doc/source/sunderland_gov_uk.md
@@ -29,5 +29,5 @@ waste_collection_schedule:
     - name: sunderland_gov_uk
       args:
         postcode: "SR4 8RJ"
-        house_number: "17 Sutherland Drive"
+        address: "17, Sutherland Drive"
 ```


### PR DESCRIPTION
Fixes #3791 

Currently returning no results. Looks like a slight change to the API. 
-The postcode no longer requires a + in the space.
-The list of addresses that are returned includes a comma after the house number.

This PR fixes it, but requires users to enter the address in a specific way, ie with the comma included. The address matching would also work with just the house number or name so it may be worth changing to use that rather than include the road name too. The documentation also included a reference to house_number rather than address so it may have been tried like this previously?

```
Testing source sunderland_gov_uk ...
  found 2 entries for Test_001
    2025-02-19 : Recycle
    2025-02-26 : House
  found 2 entries for Test_002
    2025-02-21 : Recycle
    2025-02-28 : House
  found 2 entries for Test_003
    2025-02-20 : Recycle
    2025-02-27 : House
```
