### PR TITLE
ecoharmonogram_pl: return if sides_matcher is empty when creating entries in loop

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -12,7 +12,7 @@ TEST_CASES = {
     "Sides multi test case": {
         "town": "Częstochowa",
         "street": "Boczna",
-        "additional_sides_matcher": "wie",
+        "additional_sides_matcher": "zab. jedn.",
     },
     "Sides test case": {
         "town": "Częstochowa",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -198,6 +198,6 @@ class Source:
                             name = sch.get("name")
                             if not self._entry_exists(dmy, name, entries):
                                 entries.append(Collection(dmy, name))
-                if self.additional_sides_matcher_input != "":
+                if self.additional_sides_matcher_input == "":
                     return entries
         return entries


### PR DESCRIPTION
fixes a logical error, where it loop over every side when side_matcher is not provided and it would return on first found side when side_matcher is provided

that meant that if side_matcher didn't match against first found side,
there would be no entries found

one schedule provider in test cases also updated names for sides, so I updated this test accordingly