### PR TITLE
Add Dinhard Switzerland

### DIFF
--- a/README.md
+++ b/README.md
@@ -2077,6 +2077,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [Berg](/doc/source/a_region_ch.md) / a-region.ch
 - [Bühler](/doc/source/a_region_ch.md) / a-region.ch
 - [Canton of Zürich](/doc/ics/openerz_metaodi_ch.md) / openerz.metaodi.ch
+- [Dinhard](https://www.dinhard.ch/verwaltung/veranstaltungen.html/167) / dinhard.ch
 - [Eggersriet](/doc/source/a_region_ch.md) / a-region.ch
 - [Gais](/doc/source/a_region_ch.md) / a-region.ch
 - [Gaiserwald](/doc/source/a_region_ch.md) / a-region.ch

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dinhard_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dinhard_ch.py
@@ -1,0 +1,83 @@
+import requests
+from datetime import date, timedelta
+from icalendar import Calendar
+from waste_collection_schedule import Collection
+
+TITLE = "Municipality of Dinhard Waste Collection"
+DESCRIPTION = "Waste collection schedule for the municipality of Dinhard (regular waste, organic waste, paper/cardboard)"
+URL = "https://www.dinhard.ch/verwaltung/veranstaltungen.html/167"
+TEST_CASES = {
+    "Dinhard": {}
+}
+
+ICS_URLS = {
+    "Grüngutabfuhr": "https://www.dinhard.ch/route/core-iCalendar-generate/entityid/1507/entitytypeid/215",
+    "Altpapier/Karton": "https://www.dinhard.ch/route/core-iCalendar-generate/entityid/2741/entitytypeid/215",
+    "Verschiebedatum Kehricht": "https://www.dinhard.ch/route/core-iCalendar-generate/entityid/2745/entitytypeid/215"
+}
+
+FEIERTAGE = [
+    date(2025, 1, 1),   # New Year's Day
+    date(2025, 4, 18),  # Good Friday
+    date(2025, 4, 21),  # Easter Monday
+    date(2025, 5, 29),  # Ascension Day
+    date(2025, 6, 9),   # Whit Monday
+    date(2025, 12, 25), # Christmas
+    date(2025, 12, 26)  # St. Stephen's Day
+]
+
+class Source:
+    def __init__(self, **_):
+        pass
+
+    def fetch(self):
+        entries = []
+
+        today = date.today()
+        monday = self.next_weekday(today, 0)
+
+        for _ in range(52):
+            if monday in FEIERTAGE:
+                rescheduled_date = self.get_verschiebedatum(monday)
+                if rescheduled_date:
+                    entries.append(Collection(date=rescheduled_date, t="Regular Waste Collection (rescheduled)"))
+                else:
+                    entries.append(Collection(date=monday, t="Regular Waste Collection (holiday, not rescheduled)"))
+            else:
+                entries.append(Collection(date=monday, t="Regular Waste Collection"))
+
+            monday += timedelta(weeks=1)
+
+        for name, url in ICS_URLS.items():
+            for collection in self.fetch_from_ics(url, name):
+                entries.append(collection)
+
+        return entries
+
+    def fetch_from_ics(self, url, waste_type_filter):
+        response = requests.get(url)
+        response.raise_for_status()
+        calendar = Calendar.from_ical(response.content)
+        collections = []
+        for event in calendar.walk("vevent"):
+            event_date = event.get("dtstart").dt
+            summary = str(event.get("summary"))
+            if waste_type_filter in summary:
+                collections.append(Collection(date=event_date, t=summary))
+        return collections
+
+    def get_verschiebedatum(self, holiday_date):
+        response = requests.get(ICS_URLS["Verschiebedatum Kehricht"])
+        response.raise_for_status()
+        calendar = Calendar.from_ical(response.content)
+        for event in calendar.walk("vevent"):
+            event_date = event.get("dtstart").dt
+            if event_date == holiday_date:
+                return event_date
+        return None
+
+    def next_weekday(self, start_date, weekday):
+        days_ahead = weekday - start_date.weekday()
+        if days_ahead <= 0:
+            days_ahead += 7
+        return start_date + timedelta(days=days_ahead)

--- a/doc/source/dinhard_ch.md
+++ b/doc/source/dinhard_ch.md
@@ -1,0 +1,20 @@
+# Municipality of Dinhard Waste Collection
+
+## Description
+This source retrieves the official waste collection dates for the municipality of Dinhard directly from the official iCalendar feeds.
+The following waste types are supported:
+
+- Regular waste collection (with holiday adjustments)
+- Organic waste collection ("Grüngutabfuhr")
+- Paper and cardboard collection
+
+## Configuration
+No arguments required.
+
+### Example YAML Configuration
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: dinhard_ch
+      args: {}
+```


### PR DESCRIPTION
Add waste collection source for Municipality of Dinhard.

This adds support for waste collection in the municipality of Dinhard, Switzerland.
Supported waste types: regular waste (with holiday adjustments), organic waste (Grüngutabfuhr), and paper/cardboard collection.
