### PR TITLE
fix(source): GVU Melk (umweltverbaende_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
@@ -405,6 +405,7 @@ PARAM_TRANSLATIONS = {
 POSSIBLE_COLLECTION_PATHS = (
     "fuer-die-bevoelkerung/abholtermine/",
     "abfall-entsorgung/abfuhrtermine/",
+    "fuer-die-bevoelkerung/abfuhrterminkalender/",
 )
 
 


### PR DESCRIPTION
Currently, trying to use the source "Austria > GVU Melk" gives an empty response error.
![Screenshot 2025-03-06 094027](https://github.com/user-attachments/assets/cb30049d-7c79-4492-ad77-19bd797b2f73)

Checking [their website](https://melk.umweltverbaende.at/fuer-die-bevoelkerung/abfuhrterminkalender/), I saw that they use a different URL path.

Adding the path makes it work in my Home Assistant.
