### PR TITLE
Fix oxford_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oxford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oxford_gov_uk.py
@@ -13,10 +13,8 @@ TEST_CASES = {
     "Oliver Road (brown bin too)": {"uprn": "100120831804", "postcode": "OX4 2JH"},
 }
 
-API_URLS = {
-    "get_session": "https://www.oxford.gov.uk/mybinday",
-    "collection": "https://www.oxford.gov.uk/xfp/form/142",
-}
+API_URL = "https://www.oxford.gov.uk/xfp/form/142"
+
 ICON_MAP = {
     "Refuse": "mdi:trash-can",
     "Recycling": "mdi:recycle",
@@ -34,8 +32,8 @@ class Source:
         entries: list[Collection] = []
         session = requests.Session()
 
-        token_response = session.get(API_URLS["get_session"])
-        soup = BeautifulSoup(token_response.text, "html.parser")
+        form_landing_response = session.get(API_URL)
+        soup = BeautifulSoup(form_landing_response.text, "html.parser")
         token = soup.find("input", {"name": "__token"}).attrs["value"]
         if not token:
             raise ValueError(
@@ -51,7 +49,7 @@ class Source:
             "next": "Next",
         }
 
-        collection_response = session.post(API_URLS["collection"], data=form_data)
+        collection_response = session.post(API_URL, data=form_data)
 
         collection_soup = BeautifulSoup(collection_response.text, "html.parser")
         for paragraph in collection_soup.find("div", class_="editor").find_all("p"):


### PR DESCRIPTION
csrf token no longer present on a separate landing page, so now have to load the form page and submit that for the csrf token.

After this change, I've re-run the tests and they now pass:

```
$ git log --oneline | head -n1
e590679d Fix oxford_gov_uk
$ python test_sources.py -s oxford_gov_uk -t
Testing source oxford_gov_uk ...
  found 6 entries for Magdalen Road
  found 8 entries for Oliver Road (brown bin too)
```