### PR TITLE
Fix: Redbridge, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/redbridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/redbridge_gov_uk.py
@@ -41,7 +41,7 @@ class Source:
                 table = page.extract_table()
                 tables.append(table)
 
-        collections = []
+        entries = []
         
         # Month and year regex pattern
         month_year_pattern = r"\b([A-Za-z]+) \d{4}\b"
@@ -62,7 +62,7 @@ class Source:
                 elif isCollection:
                     date_waste_type = e
                     try:
-                        collections.append(
+                        entries.append(
                             Collection(
                                 date=datetime.strptime(f"{date_waste_type.split("\n")[0]} {month_year}", "%d %B %Y"),
                                 t=f"{date_waste_type.split("\n")[1]}",
@@ -71,7 +71,7 @@ class Source:
                         )
                         # In case we have multiple collections of the same day
                         if date_waste_type.split("\n")[1] != date_waste_type.split("\n")[-1]:
-                            collections.append(
+                            entries.append(
                                 Collection(
                                     date=datetime.strptime(f"{date_waste_type.split("\n")[0]} {month_year}", "%d %B %Y"),
                                     t=f"{date_waste_type.split("\n")[-1]}",
@@ -81,4 +81,4 @@ class Source:
                     except:
                         pass
 
-        return collections
+        return entries


### PR DESCRIPTION
Fixes #3965 

Looks like the collections PDF is still available to public (without an account). It requires the UPRN to be provided in the GET request.

Since the response is a PDF file, we are now extracting collections details from the tables downloaded from the council's website. List of changes below:

- Removed BeautifulSoup import (not used anymore)
- Added pdfplumber, BytesIO and logging to the imports
- Updated one of the test cases' UPRN number, due to the old one not returning "Garden" collections anymore
- Updated the API URL