### PR TITLE
Update awigo_de.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
@@ -49,7 +49,7 @@ class Source:
     def fetch(self):
         s = requests.Session()
         args = {
-            "eID": "awigoCalendar",
+            "legacy_eID": "awigoCalendar",
             "calendar[method]": "getCities",
             "calendar[rest]": 1,
             "calendar[paper]": 1,


### PR DESCRIPTION
The parameter 'eID' has changed to 'legacy_eID'.

Even though the name implies more changes will be due at one point, local test of this verified that querying works again.

Related to #3993 and #4010; I assume #3447 might have been about a different problem.