### PR TITLE
Add Garden Waste Support for North Somerset

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsomerset_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsomerset_gov_uk.py
@@ -20,6 +20,7 @@ TEST_CASES = {
 ICON_MAP = {
     "RUBBISH": "mdi:trash-can",
     "RECYCLING": "mdi:recycle",
+    "GARDEN WASTE": "mdi:flower",
     "FOOD": "mdi:food",
 }
 


### PR DESCRIPTION
Simple PR for adding Garden Waste item, newly added to the council data table