### PR TITLE
resolves #3447 - updates awigo_de.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
@@ -47,70 +47,72 @@ class Source:
         self._ics = ICS()
 
     def fetch(self):
-        s = requests.Session()
-        args = {
-            "eID": "awigoCalendar",
-            "calendar[method]": "getCities",
-            "calendar[rest]": 1,
-            "calendar[paper]": 1,
-            "calendar[yellow]": 1,
-            "calendar[brown]": 1,
-            "calendar[mobile]": 1,
-        }
-
-        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, features="html.parser")
-        for option in soup.findAll("option"):
-            if compare_cities(self._ort, option.text):
-                args["calendar[cityID]"] = option.get("value")
-                break
-        if "calendar[cityID]" not in args:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "ort", self._ort, [option.text for option in soup.findAll("option")]
-            )
-
-        args["calendar[method]"] = "getStreets"
-
-        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, features="html.parser")
-        for option in soup.findAll("option"):
-            if option.text.lower().strip() == self._strasse.lower().strip():
-                args["calendar[streetID]"] = option.get("value")
-                break
-        if "calendar[streetID]" not in args:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "strasse",
-                self._strasse,
-                [option.text for option in soup.findAll("option")],
-            )
-
-        args["calendar[method]"] = "getNumbers"
-        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-        soup = BeautifulSoup(r.text, features="html.parser")
-        for option in soup.findAll("option"):
-            if option.text.lower().strip().replace(
-                " ", ""
-            ) == self._hnr.lower().strip().replace(" ", ""):
-                args["calendar[locationID]"] = option.get("value")
-                break
-        if "calendar[locationID]" not in args:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "hnr", self._hnr, [option.text for option in soup.findAll("option")]
-            )
-
-        args["calendar[method]"] = "getICSfile"
-        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-        r = s.get(r.text)
-
-        dates = self._ics.convert(r.text)
         entries = []
-        for d in dates:
-            bin_type = d[1].replace("wird abgeholt.", "").strip()
-            entries.append(Collection(d[0], bin_type, ICON_MAP.get(bin_type)))
+        waste_types = ["rest", "paper", "yellow", "brown", "mobile"]
+
+        for active_type in waste_types:
+            s = requests.Session()
+            args = {
+                "legacy_eID": "awigoCalendar",
+                "calendar[method]": "getCities",
+            }
+
+            for wt in waste_types:
+                args[f"calendar[{wt}]"] = 1 if wt == active_type else 0
+
+            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+
+            r.raise_for_status()
+
+            soup = BeautifulSoup(r.text, features="html.parser")
+            for option in soup.findAll("option"):
+                if compare_cities(self._ort, option.text):
+                    args["calendar[cityID]"] = option.get("value")
+                    break
+            if "calendar[cityID]" not in args:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "ort", self._ort, [option.text for option in soup.findAll("option")]
+                )
+
+            args["calendar[method]"] = "getStreets"
+
+            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+            r.raise_for_status()
+
+            soup = BeautifulSoup(r.text, features="html.parser")
+            for option in soup.findAll("option"):
+                if option.text.lower().strip() == self._strasse.lower().strip():
+                    args["calendar[streetID]"] = option.get("value")
+                    break
+            if "calendar[streetID]" not in args:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "strasse",
+                    self._strasse,
+                    [option.text for option in soup.findAll("option")]
+                )
+
+            args["calendar[method]"] = "getNumbers"
+            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+            soup = BeautifulSoup(r.text, features="html.parser")
+            for option in soup.findAll("option"):
+                if option.text.lower().strip().replace(
+                    " ", ""
+                ) == self._hnr.lower().strip().replace(" ", ""):
+                    args["calendar[locationID]"] = option.get("value")
+                    break
+            if "calendar[locationID]" not in args:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "hnr", self._hnr, [option.text for option in soup.findAll("option")]
+                )
+
+            args["calendar[method]"] = "getICSfile"
+            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+            r = s.get(r.text)
+            r.encoding = "utf-8"
+
+            dates = self._ics.convert(r.text)
+            for d in dates:
+                bin_type = d[1].replace("wird abgeholt.", "").strip()
+                entries.append(Collection(d[0], bin_type, ICON_MAP.get(bin_type)))
 
         return entries


### PR DESCRIPTION
As mentioned in my [comment](https://github.com/mampfes/hacs_waste_collection_schedule/issues/3447#issuecomment-2580445091) in #3447 AWIGO service is unreliable if you select all 5 types at once. It stops to work out of a sudden, starts at some time again, just to stop working again. I've explained it in detail in my additional [comment here](https://github.com/mampfes/hacs_waste_collection_schedule/pull/4044#issuecomment-2858090124) in #4044 . AWIGO did not respont to any communication, so we cannot expect a fix from them.

I have changed the call so that only one type of waste is retrieved per request. This means that a total of 5 individual requests now have to be made, but you always get results back.