### PR TITLE
fix: nsomester_gov_uk failing if Following collection date is not provided

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsomerset_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsomerset_gov_uk.py
@@ -70,6 +70,8 @@ class Source:
                     collection["Next collection date"],
                     collection.get("Following collection date"),
                 ]:
+                    if not date:
+                        continue
                     entries.append(
                         Collection(
                             date=datetime.strptime(date, "%A %d %B")


### PR DESCRIPTION
collection.get("Following collection date") may be None 

fixes second test case