### PR TITLE
fix: Blackpool, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
@@ -14,7 +14,7 @@ TEST_CASES = {
 }
 
 API_URL = "https://api.blackpool.gov.uk/api/bartec"
-REGEX_JOB_NAME = r"^Empty((?: [A-Za-z]+)+) \d+\w$"
+REGEX_JOB_NAME = r"^Empty(?: Bin)? ([A-Za-z ]+?) \d+\w$"
 NAME_MAP = {
     "Domestic Refuse": "Grey bin or Red sack",
     "Dry Recycling": "Blue bin",


### PR DESCRIPTION
This fixes #4108 

Appears the nameField on the api response changed for one of the waste types causing a mismatch with the MAP variables.

Modified regex to return strings that match the mapping variables, preventing the "AttributeError: 'NoneType' object has no attribute 'strip'" error.