### PR TITLE
Add missing form field for highpeak source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/highpeak_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/highpeak_gov_uk.py
@@ -73,6 +73,9 @@ class Source:
         soup = BeautifulSoup(r.text, "html.parser")
 
         form_data, next_url = self._extract_all_form_data(soup)
+
+        form_data["FINDBINDAYSHIGHPEAK_FORMACTION_NEXT"] = "FINDBINDAYSHIGHPEAK_POSTCODESELECT_PAGE1NEXT"
+        
         if next_url.startswith("/"):
             next_url = BASE_URL + next_url
 
@@ -81,6 +84,9 @@ class Source:
         soup = BeautifulSoup(r.text, "html.parser")
 
         form_data, next_url = self._extract_all_form_data(soup)
+
+        form_data["FINDBINDAYSHIGHPEAK_FORMACTION_NEXT"] = "FINDBINDAYSHIGHPEAK_ADDRESSSELECT_ADDRESSSELECTNEXTBTN"
+        
         if next_url.startswith("/"):
             next_url = BASE_URL + next_url
         r = s.post(next_url, data=form_data)


### PR DESCRIPTION
The form field "FINDBINDAYSHIGHPEAK_FORMACTION_NEXT" is required to progress to the next form page. Without this each http post is still on the post code entry page.