### PR TITLE
Update barrowbc_gov_uk.md

### DIFF
--- a/doc/ics/barrowbc_gov_uk.md
+++ b/doc/ics/barrowbc_gov_uk.md
@@ -5,8 +5,9 @@ Westmorland & Furness Council, Barrow area is supported by the generic [ICS](/do
 
 ## How to get the configuration arguments
 
-- Go to <https://ww.barrowbc.gov.uk/bins-recycling-and-street-cleaning/waste-collection-schedule> and select your location.  
+- Go to <https://www.barrowbc.gov.uk/bins-recycling-and-street-cleaning/waste-collection-schedule> and select your location.  
 - Right click -> copy the url of the `Add to iCalendar` link.
+- If the `Add to iCalendar` link is not shown, copy the webpage URL and change `/view/` to `/download/`
 - Replace the `url` in the example configuration with this link. (If you know your UPRN, you can just replace the last part of the url with it.)
 - if you want to shorten your entry names use the `regex` line from the second example (`Grey lidded bins for General waste` will show up as `Grey`)
 


### PR DESCRIPTION
The "Add to iCalendar" link seems to have been removed, but the ICS calendar URI still works. Added an instruction for how to manually modify the link

Fixed typo in link