### PR TITLE
Wigan Council: Fix parsing by changing dateWrapper-next to dateWrap-next

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wigan_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wigan_gov_uk.py
@@ -82,7 +82,7 @@ class Source:
         entries = []
         for bin in bin_collections:
             waste_type = bin.find("h2").text
-            waste_date = bin.find("div", {"class": "dateWrapper-next"}).get_text(
+            waste_date = bin.find("div", {"class": "dateWrap-next"}).get_text(
                 strip=True
             )
             waste_date = re.compile(REGEX_ORDINALS).sub("", waste_date.split("day")[1])


### PR DESCRIPTION
Wigan council appear to have updated some of their tags, causing the script to fail when trying to find the next collection date.

The fix involves a small change to adjust `dateWrapper-next` to `dateWrap-next`.