### PR TITLE
Fix: Wigan, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wigan_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wigan_gov_uk.py
@@ -82,7 +82,7 @@ class Source:
         entries = []
         for bin in bin_collections:
             waste_type = bin.find("h2").text
-            waste_date = bin.find("div", {"class": "dateWrapper-next"}).get_text(
+            waste_date = bin.find("div", {"class": "dateWrap-next"}).get_text(
                 strip=True
             )
             waste_date = re.compile(REGEX_ORDINALS).sub("", waste_date.split("day")[1])


### PR DESCRIPTION
Fixes #4246 

Website appears to have  changed a div class from `dateWrapper-next` to `dateWrap-next`

```bash
Testing source wigan_gov_uk ...
  found 4 entries for Test_001
    2025-06-18 : Black Bin [mdi:trash-can]
    2025-06-25 : Brown Bin [mdi:glass-fragile]
    2025-06-18 : Green Bin [mdi:leaf]
    2025-07-02 : Blue Bin [mdi:recycle]
  found 4 entries for Test_002
    2025-07-02 : Black Bin [mdi:trash-can]
    2025-06-18 : Brown Bin [mdi:glass-fragile]
    2025-06-18 : Green Bin [mdi:leaf]
    2025-06-25 : Blue Bin [mdi:recycle]
  found 4 entries for Test_003
    2025-06-17 : Black Bin [mdi:trash-can]
    2025-06-24 : Brown Bin [mdi:glass-fragile]
    2025-06-17 : Green Bin [mdi:leaf]
    2025-07-01 : Blue Bin [mdi:recycle]
```