### PR TITLE
Update: Gosnells, AUS

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gosnells_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gosnells_wa_gov_au.py
@@ -11,7 +11,7 @@ TEST_CASES = {
     "Test_001": {"address": "15 Mackay Crescent GOSNELLS 6110"},
     "Test_002": {"address": "7 Darkin Drive GOSNELLS 6110"},
     "Test_003": {"address": "35 Prince Street GOSNELLS 6110"},
-    "Test_004": {"address": "4A Turley Court LANGFORD 6147"},
+    "Test_004 (space character test)": {"address": "4A Turley Court LANGFORD 6147"},
 }
 HEADERS = {"user-agent": "Mozilla/5.0", "accept": "application/json"}
 ICON_MAP = {


### PR DESCRIPTION
Fixes issue with inconsistent use of the space character in website responses.

```bash
Testing source gosnells_wa_gov_au ...
  found 5 entries for Test_001
    2025-06-16 : Rubbish [mdi:trash-can]
    2025-06-16 : Recycling [mdi:recycle]
    2025-11-10 : Green [mdi:sprout]
    2026-05-18 : Green [mdi:sprout]
    2025-09-29 : Junk [mdi:television-classic]
  found 5 entries for Test_002
    2025-06-16 : Rubbish [mdi:trash-can]
    2025-06-16 : Recycling [mdi:recycle]
    2024-12-02 : Green [mdi:sprout]
    2025-06-09 : Green [mdi:sprout]
    2025-10-20 : Junk [mdi:television-classic]
  found 5 entries for Test_003
    2025-06-17 : Rubbish [mdi:trash-can]
    2025-06-24 : Recycling [mdi:recycle]
    2025-11-03 : Green [mdi:sprout]
    2026-05-11 : Green [mdi:sprout]
    2025-09-22 : Junk [mdi:television-classic]
  found 5 entries for Test_004 (space character test)
    2025-06-19 : Rubbish [mdi:trash-can]
    2025-06-26 : Recycling [mdi:recycle]
    2025-08-18 : Green [mdi:sprout]
    2026-02-23 : Green [mdi:sprout]
    2026-02-02 : Junk [mdi:television-classic]
```