### PR TITLE
Fix 403 error for Windsor and Maidenhead

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
@@ -53,7 +53,7 @@ class Source:
 
     def fetch(self):
         s = requests.Session()
-        r = s.get(API_URL, params={"uprn": self._uprn})
+        r = s.get(API_URL, params={"uprn": self._uprn} headers=HEADERS)
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, "html.parser")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rbwm_gov_uk.py
@@ -53,7 +53,7 @@ class Source:
 
     def fetch(self):
         s = requests.Session()
-        r = s.get(API_URL, params={"uprn": self._uprn} headers=HEADERS)
+        r = s.get(API_URL, params={"uprn": self._uprn}, headers=HEADERS)
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, "html.parser")


### PR DESCRIPTION
add headers to RBWM request to prevent 403 error.