### PR TITLE
Fix: Runnymede, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/runnymede_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/runnymede_gov_uk.py
@@ -18,7 +18,7 @@ TEST_CASES = {
 }
 
 API_URL = "https://www.runnymede.gov.uk/bin-collection-day"
-
+HEADERS = {"user-agent": "Mozilla/5.0"}
 
 ICON_MAP = {
     "Food caddy": "mdi:food",
@@ -35,7 +35,7 @@ class Source:
     def fetch(self):
         session = requests.Session()
         params = {"address": self._uprn}
-        r = session.get(API_URL, params=params)
+        r = session.get(API_URL, params=params, headers=HEADERS)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, features="html.parser")
         soup.prettify()


### PR DESCRIPTION
Fixes #4324
Adds user agent to headers

```bash
Testing source runnymede_gov_uk ...
  found 6 entries for Acacia Close/uprn as string
    2025-07-03 : Food caddy [mdi:food]
    2025-07-03 : Recycling [mdi:recycle]
    2025-07-10 : Food caddy [mdi:food]
    2025-07-10 : Refuse [mdi:trash-can]
    2025-07-17 : Recycling [mdi:recycle]
    2025-07-17 : Food caddy [mdi:food]
  found 6 entries for Acacia Close/uprn as number
    2025-07-03 : Food caddy [mdi:food]
    2025-07-03 : Recycling [mdi:recycle]
    2025-07-10 : Food caddy [mdi:food]
    2025-07-10 : Refuse [mdi:trash-can]
    2025-07-17 : Recycling [mdi:recycle]
    2025-07-17 : Food caddy [mdi:food]
  found 0 entries for Addlestone Library/uprn as string
  found 0 entries for Addlestone Library/uprn as number
```