### PR TITLE
Fix: Blaby, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blaby_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blaby_gov_uk.py
@@ -2,8 +2,16 @@ import re
 from datetime import datetime
 
 import requests
+import urllib3
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+# With verify=True the POST fails due to a SSLCertVerificationError.
+# Using verify=False works, but is not ideal. The following links may provide a better way of dealing with this:
+# https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
+# https://urllib3.readthedocs.io/en/1.26.x/user-guide.html#ssl
+# This line suppresses the InsecureRequestWarning when using verify=False
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 TITLE = "Blaby District Council"
 DESCRIPTION = "Source for blaby.gov.uk services for Blaby district, UK."
@@ -45,7 +53,10 @@ class Source:
         s = requests.Session()
         payload: dict = {"ref": self._uprn, "redirect": "collections"}
         r = s.get(
-            "https://my.blaby.gov.uk/set-location.php", params=payload, headers=HEADERS
+            "https://my.blaby.gov.uk/set-location.php",
+            verify=False,
+            params=payload,
+            headers=HEADERS,
         )
         r.raise_for_status()
 


### PR DESCRIPTION
Fixes #4382 

Use `verify=False` to negate the SSL verification error.

```bash
Testing source blaby_gov_uk ...
  found 4 entries for Test_001
    2025-07-11 : Refuse [mdi:trash-can]
    2025-07-25 : Refuse [mdi:trash-can]
    2025-07-18 : Recycling [mdi:recycle]
    2025-08-01 : Recycling [mdi:recycle]
  found 6 entries for Test_002
    2025-07-18 : Refuse [mdi:trash-can]
    2025-08-01 : Refuse [mdi:trash-can]
    2025-07-11 : Recycling [mdi:recycle]
    2025-07-25 : Recycling [mdi:recycle]
    2025-07-11 : Garden [mdi:leaf]
    2025-07-25 : Garden [mdi:leaf]
  found 4 entries for Test_003
    2025-07-09 : Refuse [mdi:trash-can]
    2025-07-23 : Refuse [mdi:trash-can]
    2025-07-16 : Recycling [mdi:recycle]
    2025-07-30 : Recycling [mdi:recycle]
```