### PR TITLE
Fix: Chesterfield, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesterfield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesterfield_gov_uk.py
@@ -53,10 +53,7 @@ class Source:
     def fetch(self):
 
         s = requests.Session()
-        r = s.get(
-            API_URLS["session"],
-            headers=HEADERS,
-        )
+        r = s.get(API_URLS["session"], headers=HEADERS, verify=False)
 
         # Capture fwuid value
         r = s.get(


### PR DESCRIPTION
Fixes #4396

First request needed verify=False added, other requests already were already using that setting.

```bash
Testing source chesterfield_gov_uk ...
  found 3 entries for Test_001
    2025-07-11 : Domestic Recycling [mdi:recycle]
    2025-07-11 : Domestic Paid Garden [mdi:leaf]
    2025-07-18 : Domestic Refuse [mdi:trash-can]
  found 2 entries for Test_002
    2025-07-23 : Domestic Recycling [mdi:recycle]
    2025-07-16 : Domestic Refuse [mdi:trash-can]
  found 3 entries for Test_003
    2025-07-21 : Domestic Refuse [mdi:trash-can]
    2025-07-14 : Domestic Recycling [mdi:recycle]
    2025-07-14 : Domestic Paid Garden [mdi:leaf]
  found 2 entries for Test_004
    2025-07-15 : Domestic Refuse [mdi:trash-can]
    2025-07-22 : Domestic Recycling [mdi:recycle]
```