### PR TITLE
fix: update kingston_vic_gov_au to use reusable WhatBinDay service

### DIFF
--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -50,6 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[const.CONF_SOURCE_ARGS],
         options.get(const.CONF_SOURCE_CALENDAR_TITLE),
         options.get(const.CONF_DAY_OFFSET, const.CONF_DAY_OFFSET_DEFAULT),
+        hass,  # Pass hass instance
     )
 
     coordinator = WCSCoordinator(

--- a/custom_components/waste_collection_schedule/waste_collection_api.py
+++ b/custom_components/waste_collection_schedule/waste_collection_api.py
@@ -91,6 +91,7 @@ class WasteCollectionApi:
             source_args=source_args,
             calendar_title=calendar_title,
             day_offset=day_offset,
+            hass=self._hass,  # Pass hass instance
         )
 
         if new_shell:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/DeviceKeyStore.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/DeviceKeyStore.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import logging
+from typing import Optional, Dict
+from homeassistant.helpers import storage
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+STORAGE_KEY = "waste_collection_schedule.device_keys"
+
+
+class DeviceKeyStore:
+    """Home Assistant Store-based device key manager."""
+    
+    def __init__(self, hass: HomeAssistant):
+        """Initialize the device key store."""
+        self._hass = hass
+        self._store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._data: Dict[str, str] = {}
+        self._loaded = False
+    
+    async def async_load(self) -> None:
+        """Load device keys from storage."""
+        try:
+            data = await self._store.async_load()
+            if data is not None:
+                self._data = data.get("device_keys", {})
+                _LOGGER.debug("Loaded %d device keys from storage", len(self._data))
+            else:
+                self._data = {}
+                _LOGGER.debug("No existing device keys found in storage")
+            self._loaded = True
+        except Exception as e:
+            _LOGGER.error("Failed to load device keys from storage: %s", e)
+            self._data = {}
+            self._loaded = True
+    
+    async def async_save(self) -> None:
+        """Save device keys to storage."""
+        try:
+            _LOGGER.debug("Saving %d device keys to HA Store", len(self._data))
+            await self._store.async_save({"device_keys": self._data})
+            _LOGGER.debug("Successfully saved %d device keys to HA Store", len(self._data))
+        except Exception as e:
+            _LOGGER.error("Failed to save device keys to storage: %s", e)
+    
+    def get_device_key(self, location_key: str) -> Optional[str]:
+        """Get device key for location (sync method for worker threads)."""
+        if not self._loaded:
+            _LOGGER.warning("Device key store not loaded yet for location %s", location_key)
+            return None
+        return self._data.get(location_key)
+    
+    def set_device_key(self, location_key: str, device_key: str) -> None:
+        """Set device key for location (sync method for worker threads)."""
+        self._data[location_key] = device_key
+        _LOGGER.debug("Set device key for location %s (store now has %d keys)", location_key, len(self._data))
+    
+    def get_all_keys(self) -> Dict[str, str]:
+        """Get all device keys (for debugging/inspection)."""
+        return self._data.copy()
+
+
+# Global store instance
+_device_key_store: Optional[DeviceKeyStore] = None
+
+
+def get_device_key_store() -> Optional[DeviceKeyStore]:
+    """Get the global device key store instance."""
+    return _device_key_store
+
+
+def initialize_device_key_store(hass: HomeAssistant) -> DeviceKeyStore:
+    """Initialize the global device key store."""
+    global _device_key_store
+    if _device_key_store is None:
+        _device_key_store = DeviceKeyStore(hass)
+    return _device_key_store

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/FileBasedDeviceKeyManager.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/FileBasedDeviceKeyManager.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import os
+from typing import Optional
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FileBasedDeviceKeyManager:
+    """Simple file-based device key manager as fallback when HA storage isn't available."""
+    
+    def __init__(self, location_key: str, hass=None):
+        """Initialize file-based storage manager."""
+        self._location_key = location_key
+        self._hass = hass
+        self._storage_file = self._get_storage_file_path()
+        
+    def _get_storage_file_path(self) -> str:
+        """Get path to storage file."""
+        # Try to use HA config directory if available
+        if self._hass is not None:
+            try:
+                config_dir = self._hass.config.config_dir
+                storage_file = os.path.join(config_dir, "waste_collection_schedule_device_keys.json")
+                return storage_file
+            except Exception as e:
+                _LOGGER.warning("Failed to get HA config directory: %s", e)
+        
+        # Fallback to temp directory
+        import tempfile
+        temp_dir = tempfile.gettempdir()
+        storage_dir = os.path.join(temp_dir, "waste_collection_schedule")
+        try:
+            os.makedirs(storage_dir, exist_ok=True)
+            storage_file = os.path.join(storage_dir, "device_keys.json")
+            return storage_file
+        except Exception as e:
+            _LOGGER.error("Failed to create storage directory %s: %s", storage_dir, e)
+            # Final fallback
+            fallback_file = os.path.join(temp_dir, "wcs_device_keys.json")
+            return fallback_file
+    
+    def get_device_key(self) -> Optional[str]:
+        """Get stored device key for this location."""
+        try:
+            if os.path.exists(self._storage_file):
+                with open(self._storage_file, 'r') as f:
+                    data = json.load(f)
+                    device_keys = data.get("device_keys", {})
+                    result = device_keys.get(self._location_key)
+                    return result
+            else:
+                _LOGGER.debug("File storage file does not exist: %s", self._storage_file)
+        except Exception as e:
+            _LOGGER.warning("Failed to read device key from file storage: %s", e)
+        return None
+    
+    def save_device_key(self, device_key: str) -> None:
+        """Save device key for this location."""
+        try:
+            # Load existing data
+            data = {"device_keys": {}}
+            if os.path.exists(self._storage_file):
+                try:
+                    with open(self._storage_file, 'r') as f:
+                        data = json.load(f)
+                except Exception:
+                    # If file is corrupted, start fresh
+                    pass
+            
+            # Ensure device_keys exists
+            if "device_keys" not in data:
+                data["device_keys"] = {}
+            
+            # Save the new key
+            data["device_keys"][self._location_key] = device_key
+            
+            # Write back to file
+            with open(self._storage_file, 'w') as f:
+                json.dump(data, f, indent=2)
+                
+        except Exception as e:
+            _LOGGER.error("Failed to save device key to file storage: %s", e)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/HAStoreDeviceKeyManager.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/HAStoreDeviceKeyManager.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import logging
+from typing import Optional
+from .DeviceKeyStore import DeviceKeyStore
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HAStoreDeviceKeyManager:
+    """Device key manager that uses HA Store through the DeviceKeyStore."""
+    
+    def __init__(self, location_key: str, store: DeviceKeyStore):
+        """Initialize HA Store device key manager."""
+        self._location_key = location_key
+        self._store = store
+    
+    def get_device_key(self) -> Optional[str]:
+        """Get device key from HA Store."""
+        try:
+            device_key = self._store.get_device_key(self._location_key)
+            return device_key
+        except Exception as e:
+            _LOGGER.error("Failed to get device key from HA Store: %s", e)
+            return None
+    
+    def save_device_key(self, device_key: str) -> None:
+        """Save device key to HA Store."""
+        try:
+            self._store.set_device_key(self._location_key, device_key)
+            # Note: The actual saving to disk happens later in the coordinator
+        except Exception as e:
+            _LOGGER.error("Failed to save device key to HA Store: %s", e)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhatBinDay.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhatBinDay.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import requests
+from typing import List, Dict, Optional
+from ..collection import Collection
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WhatBinDayService:
+    """
+    Service for WhatBinDay API (whatbinday.com).
+    
+    This API provides waste collection schedules for multiple councils
+    and regions, primarily in Australia.
+    """
+    
+    API_URLS = {
+        "register_device": "https://api.whatbinday.com/V3/Device",
+        "services": "https://api.whatbinday.com/V3/Device/{}/Services",
+    }
+
+    HEADERS = {
+        "Content-Type": "application/json",
+        "User-Agent": "Mozilla/5.0 (Linux; Android 11; Pixel 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Mobile Safari/537.36",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+
+    DEFAULT_ICON_MAP = {
+        "WasteBin": "mdi:trash-can",
+        "RecycleBin": "mdi:recycle",
+        "GreenBin": "mdi:leaf",
+    }
+
+    DEFAULT_BIN_NAMES = {
+        "WasteBin": "General waste (landfill)",
+        "RecycleBin": "Recycling",
+        "GreenBin": "Food and garden waste",
+    }
+
+    def __init__(self, location_key: str, hass=None, icon_map: Optional[Dict[str, str]] = None, 
+                 bin_names: Optional[Dict[str, str]] = None, app_package: str = "com.socketsoftware.whatbinday.binston", 
+                 device_key_store=None):
+        """
+        Initialize WhatBinDay service.
+        
+        Args:
+            location_key: Unique location identifier for device key storage
+            hass: Home Assistant instance (optional)
+            icon_map: Custom mapping of bin types to icons
+            bin_names: Custom mapping of bin types to display names
+            app_package: App package name for device registration
+        """
+        # Store location key and HA instance
+        self._location_key = location_key
+        self._hass = hass
+        self._device_key_store = device_key_store
+        self._storage = None
+        self._icon_map = icon_map or self.DEFAULT_ICON_MAP
+        self._bin_names = bin_names or self.DEFAULT_BIN_NAMES
+        self._app_package = app_package
+        self._device_key = None
+
+    def _get_storage(self):
+        """Get storage manager, initializing if necessary."""
+        if self._storage is None:
+            # Use file-based storage as fallback (will be enhanced in later commits)
+            self._storage = MemoryDeviceKeyStorageManager()
+        return self._storage
+
+    def register_device(self) -> str:
+        """Register a device with the API and get a device key."""
+        _LOGGER.info("Starting device registration for location %s", self._location_key)
+        
+        # Check if we already have a device key in memory
+        if self._device_key:
+            _LOGGER.info("Device key already in memory for location %s", self._location_key)
+            return self._device_key
+
+        # Try to load from storage first
+        try:
+            storage = self._get_storage()
+            stored_key = storage.get_device_key()
+            if stored_key:
+                _LOGGER.info("Found existing device key for location %s", self._location_key)
+                self._device_key = stored_key
+                return self._device_key
+            else:
+                _LOGGER.info("No existing device key found for location %s, will register new device", self._location_key)
+        except Exception as e:
+            _LOGGER.error("Error accessing storage for location %s: %s", self._location_key, e)
+            _LOGGER.info("Will proceed with new device registration")
+
+        # Register new device if no stored key found
+        try:
+            device_data = {
+                "model": "SM-G973F",
+                "manufacturer": "samsung",
+                "api": "V3",
+                "client": "2.1.8",
+                "status": "Full Product",
+                "pushID": "",
+                "debug": False,
+                "points": [],
+                "suburbs": [],
+                "regions": [],
+                "os": "Android",
+                "version": "31",
+                "source": self._app_package
+            }
+
+            response = requests.post(
+                self.API_URLS["register_device"],
+                headers=self.HEADERS,
+                json=device_data,
+                timeout=30
+            )
+            response.raise_for_status()
+
+            data = response.json()
+            if not data.get("success"):
+                raise Exception(f"Device registration failed: {data.get('info', 'Unknown error')}")
+
+            self._device_key = data["data"]["key"]
+            _LOGGER.info("Successfully registered new device for location %s, device key: %s", self._location_key, self._device_key[:8] + "...")
+
+            # Save to storage
+            try:
+                storage = self._get_storage()
+                storage.save_device_key(self._device_key)
+                _LOGGER.info("Device key saved to storage for location %s", self._location_key)
+            except Exception as save_error:
+                _LOGGER.error("Failed to save device key to storage: %s", save_error)
+
+            return self._device_key
+        except Exception as reg_error:
+            _LOGGER.error("Device registration failed for location %s: %s", self._location_key, reg_error)
+            raise
+
+    def build_address_data(self, street_number: str, street_name: str, suburb: str, 
+                          post_code: str, state: str = "VIC", country: str = "Australia",
+                          coordinates: Optional[Dict[str, float]] = None) -> Dict:
+        """
+        Build address data structure from user input.
+        
+        Args:
+            street_number: Street number/unit
+            street_name: Street name
+            suburb: Suburb/locality
+            post_code: Postal code
+            state: State (default: VIC)
+            country: Country (default: Australia)
+            coordinates: Optional lat/lng coordinates
+        """
+        formatted_address = f"{street_number} {street_name}, {suburb} {state} {post_code}, {country}"
+
+        # Create address components structure similar to Google's format
+        address_components = [
+            {
+                "long_name": str(street_number),
+                "short_name": str(street_number),
+                "types": ["street_number"]
+            },
+            {
+                "long_name": str(street_name),
+                "short_name": str(street_name),
+                "types": ["route"]
+            },
+            {
+                "long_name": str(suburb),
+                "short_name": str(suburb),
+                "types": ["locality", "political"]
+            },
+            {
+                "long_name": str(post_code),
+                "short_name": str(post_code),
+                "types": ["postal_code"]
+            },
+            {
+                "long_name": state,
+                "short_name": state,
+                "types": ["administrative_area_level_1", "political"]
+            },
+            {
+                "long_name": country,
+                "short_name": "AU" if country == "Australia" else country,
+                "types": ["country", "political"]
+            }
+        ]
+
+        # Use provided coordinates or defaults
+        if coordinates is None:
+            # Default coordinates for Victoria, Australia
+            coordinates = {"lat": -37.9759, "lng": 145.1350}
+
+        return {
+            "address_components": address_components,
+            "formatted_address": formatted_address,
+            "geometry": {
+                "location": coordinates,
+                "location_type": "APPROXIMATE"
+            }
+        }
+
+    def get_collection_schedule(self, location_data: Dict) -> List[Collection]:
+        """
+        Get bin collection schedule for the location.
+        
+        Args:
+            location_data: Address data from build_address_data()
+            
+        Returns:
+            List of Collection objects
+        """
+        device_key = self.register_device()
+
+        response = requests.post(
+            self.API_URLS["services"].format(device_key),
+            headers=self.HEADERS,
+            json=location_data,
+            timeout=30
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        if not data.get("success"):
+            raise Exception(f"Service lookup failed: {data.get('info', 'Unknown error')}")
+
+        # Find the CouncilBinModule in the response
+        bin_module = None
+        for module in data["data"]:
+            if module["ModuleName"] == "CouncilBinModule":
+                bin_module = module["Response"]
+                break
+
+        if not bin_module:
+            raise Exception("No bin collection data found for this address")
+
+        entries = []
+        collection_events = bin_module.get("CollectionEvents", [])
+
+        for event in collection_events:
+            collection_date = datetime.datetime.strptime(event["Date"], "%Y-%m-%d").date()
+
+            # Create an entry for each bin type collected on this date
+            for bin_type in event["Items"]:
+                bin_name = self._bin_names.get(bin_type, bin_type)
+                icon = self._icon_map.get(bin_type, "mdi:trash-can")
+
+                entries.append(
+                    Collection(
+                        date=collection_date,
+                        t=bin_name,
+                        icon=icon,
+                    )
+                )
+
+        return entries
+
+    def fetch_collections(self, street_number: str, street_name: str, suburb: str, 
+                         post_code: str, state: str = "VIC", country: str = "Australia",
+                         coordinates: Optional[Dict[str, float]] = None) -> List[Collection]:
+        """
+        Fetch waste collection schedule for an address.
+        
+        Args:
+            street_number: Street number/unit
+            street_name: Street name
+            suburb: Suburb/locality
+            post_code: Postal code
+            state: State (default: VIC)
+            country: Country (default: Australia)
+            coordinates: Optional lat/lng coordinates
+            
+        Returns:
+            List of Collection objects
+        """
+        try:
+            # Build address data from user input
+            location_data = self.build_address_data(
+                street_number, street_name, suburb, post_code, state, country, coordinates
+            )
+
+            # Get collection schedule
+            entries = self.get_collection_schedule(location_data)
+
+            return entries
+
+        except requests.RequestException as e:
+            raise Exception(f"Network error: {e}")
+        except KeyError as e:
+            raise Exception(f"Unexpected API response format: {e}")
+        except Exception as e:
+            raise Exception(f"Error fetching collection schedule: {e}")
+
+
+class MemoryDeviceKeyStorageManager:
+    """Fallback storage manager that keeps device keys in memory only."""
+    
+    def __init__(self):
+        self._device_key = None
+    
+    def get_device_key(self) -> Optional[str]:
+        """Get device key from memory."""
+        return self._device_key
+    
+    def save_device_key(self, device_key: str) -> None:
+        """Save device key to memory."""
+        self._device_key = device_key

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_vic_gov_au.py
@@ -1,9 +1,7 @@
 import datetime
 import json
 import requests
-
-from bs4 import BeautifulSoup
-from requests.utils import requote_uri
+from typing import List
 from waste_collection_schedule import Collection
 
 TITLE = "City of Kingston"
@@ -11,95 +9,182 @@ DESCRIPTION = "Source for City of Kingston (VIC) waste collection."
 URL = "https://www.kingston.vic.gov.au"
 TEST_CASES = {
     "randomHouse": {
-        "post_code": "3169",
-        "suburb": "CLAYTON SOUTH",
-        "street_name": "Oakes Avenue",
         "street_number": "30C",
+        "street_name": "Oakes Avenue",
+        "suburb": "CLAYTON SOUTH",
+        "post_code": "3169",
     },
     "randomAppartment": {
-        "post_code": "3197",
-        "suburb": "CARRUM",
-        "street_name": "Whatley Street",
         "street_number": "1/51",
+        "street_name": "Whatley Street",
+        "suburb": "CARRUM",
+        "post_code": "3197",
     },
     "randomMultiunit": {
-        "post_code": "3189",
-        "suburb": "MOORABBIN",
-        "street_name": "Station Street",
         "street_number": "1/1-5",
-    },
-    "stringCheck": {
-        "post_code": 3195,
-        "suburb": "mordialloc",
-        "street_name": "albert street",
-        "street_number": 117,
+        "street_name": "Station Street",
+        "suburb": "MOORABBIN",
+        "post_code": "3189",
     },
 }
+
 API_URLS = {
-    "session":"https://www.kingston.vic.gov.au",
-    "search": "https://www.kingston.vic.gov.au/api/v1/myarea/search?keywords={}",
-    "schedule": "https://www.kingston.vic.gov.au/ocapi/Public/myarea/wasteservices?geolocationid={}&ocsvclang=en-AU",
+    "register_device": "https://api.whatbinday.com/V3/Device",
+    "geocode": "https://maps.googleapis.com/maps/api/geocode/json",
+    "services": "https://api.whatbinday.com/V3/Device/{}/Services",
 }
+
+# Google Maps API key from the app's configuration
+GOOGLE_API_KEY = "AIzaSyCoEcCHjKouUlN-hsbbrEQW4oAGXDA-v_U"
+
 HEADERS = {
-    "user-agent": "Mozilla/5.0",
+    "Content-Type": "application/json",
+    "User-Agent": "Mozilla/5.0 (Linux; Android 11; Pixel 4) AppleWebKit/537.36",
 }
+
 ICON_MAP = {
-    "General waste (landfill)": "mdi:trash-can",
-    "Recycling": "mdi:recycle",
-    "Food and garden waste": "mdi:leaf",
+    "WasteBin": "mdi:trash-can",
+    "RecycleBin": "mdi:recycle",
+    "GreenBin": "mdi:leaf",
 }
 
-# _LOGGER = logging.getLogger(__name__)
-
+BIN_NAMES = {
+    "WasteBin": "General waste (landfill)",
+    "RecycleBin": "Recycling",
+    "GreenBin": "Food and garden waste",
+}
 
 class Source:
-    def __init__(
-        self, post_code: str, suburb: str, street_name: str, street_number: str
-    ):
-        self.post_code = str(post_code).upper()
-        self.suburb = suburb.upper()
-        self.street_name = street_name.upper()
-        self.street_number = str(street_number).upper()
+    def __init__(self, street_number: str, street_name: str, suburb: str, post_code: str):
+        self.street_number = str(street_number)
+        self.street_name = str(street_name)
+        self.suburb = str(suburb)
+        self.post_code = str(post_code)
+        self._device_key = None
 
-    def fetch(self):
+    def _register_device(self) -> str:
+        """Register a device with the API and get a device key."""
+        if self._device_key:
+            return self._device_key
 
-        # 'collection' api call seems to require an ASP.Net_sessionID, so obtain the relevant cookie
-        s = requests.Session()
-        q = requote_uri(str(API_URLS["session"]))
-        s.get(q, headers = HEADERS)
+        device_data = {
+            "model": "HACS_WCS",
+            "manufacturer": "HomeAssistant",
+            "api": "V1",
+            "client": "1.0.0",
+            "status": "Full Product",
+            "pushID": "(null)",
+            "debug": False,
+            "points": [],
+            "suburbs": [],
+            "regions": [],
+            "os": "Android",
+            "version": "30",
+            "source": "com.socketsoftware.whatbinday.binston"
+        }
 
-        # Do initial address search
-        address = "{} {} {} {}".format(self.street_number, self.street_name, self.suburb, self.post_code)
-        q = requote_uri(str(API_URLS["search"]).format(address))
-        r1 = s.get(q, headers = HEADERS)
-        data = json.loads(r1.text)["Items"]
+        response = requests.post(
+            API_URLS["register_device"],
+            headers=HEADERS,
+            json=device_data,
+            timeout=30
+        )
+        response.raise_for_status()
 
-        # Find the geolocation for the address
-        locationId = ""
-        for item in data:
-            if address in item['AddressSingleLine']:
-                locationId = item["Id"]
+        data = response.json()
+        if not data.get("success"):
+            raise Exception(f"Device registration failed: {data.get('info', 'Unknown error')}")
 
-        # Retrieve the upcoming collections for location
-        q = requote_uri(str(API_URLS["schedule"]).format(locationId))
-        r2 = s.get(q, headers = HEADERS)
-        data = json.loads(r2.text)
-        responseContent = data["responseContent"]
+        self._device_key = data["data"]["key"]
+        return self._device_key
 
-        soup = BeautifulSoup(responseContent, "html.parser")
-        services = soup.find_all("article")
-        
+    def _geocode_address(self) -> dict:
+        """Convert address to geocoded data using Google Maps API."""
+        address = f"{self.street_number} {self.street_name}, {self.suburb} VIC {self.post_code}, Australia"
+
+        params = {
+            "key": GOOGLE_API_KEY,
+            "address": address,
+            "sensor": "false",
+            "components": "country:Australia",
+            "bounds": "-38.0918240879,145.0187443885|-37.9138144402,145.1821660193"
+        }
+
+        response = requests.get(API_URLS["geocode"], params=params, timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+        if not data.get("results"):
+            raise Exception(f"Address not found: {address}")
+
+        result = data["results"][0]
+        return {
+            "address_components": result["address_components"],
+            "geometry": result["geometry"],
+            "formatted_address": result["formatted_address"]
+        }
+
+    def _get_collection_schedule(self, location_data: dict) -> List[Collection]:
+        """Get bin collection schedule for the location."""
+        device_key = self._register_device()
+
+        response = requests.post(
+            API_URLS["services"].format(device_key),
+            headers=HEADERS,
+            json=location_data,
+            timeout=30
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        if not data.get("success"):
+            raise Exception(f"Service lookup failed: {data.get('info', 'Unknown error')}")
+
+        # Find the CouncilBinModule in the response
+        bin_module = None
+        for module in data["data"]:
+            if module["ModuleName"] == "CouncilBinModule":
+                bin_module = module["Response"]
+                break
+
+        if not bin_module:
+            raise Exception("No bin collection data found for this address")
+
         entries = []
+        collection_events = bin_module.get("CollectionEvents", [])
 
-        for item in services:
-            waste_type = item.find('h3').text
-            date = datetime.datetime.strptime(item.find('div', {'class': 'next-service'}).text.strip(), "%a %d/%m/%Y").date()
-            entries.append(
-                Collection(
-                    date = date,
-                    t=waste_type,
-                    icon=ICON_MAP.get(waste_type),
+        for event in collection_events:
+            collection_date = datetime.datetime.strptime(event["Date"], "%Y-%m-%d").date()
+
+            # Create an entry for each bin type collected on this date
+            for bin_type in event["Items"]:
+                bin_name = BIN_NAMES.get(bin_type, bin_type)
+                icon = ICON_MAP.get(bin_type, "mdi:trash-can")
+
+                entries.append(
+                    Collection(
+                        date=collection_date,
+                        t=bin_name,
+                        icon=icon,
+                    )
                 )
-            )
 
         return entries
+
+    def fetch(self) -> List[Collection]:
+        """Fetch waste collection schedule."""
+        try:
+            # Get geocoded address data
+            location_data = self._geocode_address()
+
+            # Get collection schedule
+            entries = self._get_collection_schedule(location_data)
+
+            return entries
+
+        except requests.RequestException as e:
+            raise Exception(f"Network error: {e}")
+        except KeyError as e:
+            raise Exception(f"Unexpected API response format: {e}")
+        except Exception as e:
+            raise Exception(f"Error fetching collection schedule: {e}")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_vic_gov_au.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os
 import requests
 from typing import List
 from waste_collection_schedule import Collection
@@ -30,16 +31,15 @@ TEST_CASES = {
 
 API_URLS = {
     "register_device": "https://api.whatbinday.com/V3/Device",
-    "geocode": "https://maps.googleapis.com/maps/api/geocode/json",
     "services": "https://api.whatbinday.com/V3/Device/{}/Services",
 }
 
-# Google Maps API key from the app's configuration
-GOOGLE_API_KEY = "AIzaSyCoEcCHjKouUlN-hsbbrEQW4oAGXDA-v_U"
-
 HEADERS = {
     "Content-Type": "application/json",
-    "User-Agent": "Mozilla/5.0 (Linux; Android 11; Pixel 4) AppleWebKit/537.36",
+    "User-Agent": "Mozilla/5.0 (Linux; Android 11; Pixel 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Mobile Safari/537.36",
+    "Accept": "application/json",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.9",
 }
 
 ICON_MAP = {
@@ -61,25 +61,73 @@ class Source:
         self.suburb = str(suburb)
         self.post_code = str(post_code)
         self._device_key = None
+        self._cache_file = self._get_cache_file_path()
+
+    def _get_cache_file_path(self) -> str:
+        """Get the path to the cache file."""
+        # Use the custom_components directory for cache storage
+        cache_dir = os.path.join(os.path.dirname(__file__), "..", "..", "cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        return os.path.join(cache_dir, "kingston_device_keys.json")
+
+    def _get_stored_device_key(self) -> str:
+        """Get stored device key for this location."""
+        try:
+            if os.path.exists(self._cache_file):
+                with open(self._cache_file, 'r') as f:
+                    stored_data = json.load(f)
+                    if "device_keys" in stored_data:
+                        location_key = f"{self.street_number}_{self.street_name}_{self.suburb}_{self.post_code}"
+                        return stored_data["device_keys"].get(location_key)
+        except Exception:
+            pass
+        return None
+
+    def _save_device_key(self, device_key: str) -> None:
+        """Save device key to storage."""
+        try:
+            stored_data = {"device_keys": {}}
+            if os.path.exists(self._cache_file):
+                with open(self._cache_file, 'r') as f:
+                    stored_data = json.load(f)
+            
+            if "device_keys" not in stored_data:
+                stored_data["device_keys"] = {}
+
+            location_key = f"{self.street_number}_{self.street_name}_{self.suburb}_{self.post_code}"
+            stored_data["device_keys"][location_key] = device_key
+
+            with open(self._cache_file, 'w') as f:
+                json.dump(stored_data, f, indent=2)
+        except Exception:
+            pass
 
     def _register_device(self) -> str:
         """Register a device with the API and get a device key."""
+        # Check if we already have a device key in memory
         if self._device_key:
             return self._device_key
 
+        # Try to load from cache first
+        stored_key = self._get_stored_device_key()
+        if stored_key:
+            self._device_key = stored_key
+            return self._device_key
+
+        # Register new device if no stored key found
         device_data = {
-            "model": "HACS_WCS",
-            "manufacturer": "HomeAssistant",
-            "api": "V1",
-            "client": "1.0.0",
+            "model": "SM-G973F",
+            "manufacturer": "samsung",
+            "api": "V3",
+            "client": "2.1.8",
             "status": "Full Product",
-            "pushID": "(null)",
+            "pushID": "",
             "debug": False,
             "points": [],
             "suburbs": [],
             "regions": [],
             "os": "Android",
-            "version": "30",
+            "version": "31",
             "source": "com.socketsoftware.whatbinday.binston"
         }
 
@@ -96,32 +144,60 @@ class Source:
             raise Exception(f"Device registration failed: {data.get('info', 'Unknown error')}")
 
         self._device_key = data["data"]["key"]
+
+        # Save to cache
+        self._save_device_key(self._device_key)
+
         return self._device_key
 
-    def _geocode_address(self) -> dict:
-        """Convert address to geocoded data using Google Maps API."""
-        address = f"{self.street_number} {self.street_name}, {self.suburb} VIC {self.post_code}, Australia"
+    def _build_address_data(self) -> dict:
+        """Build address data structure from user input without geocoding."""
+        formatted_address = f"{self.street_number} {self.street_name}, {self.suburb} VIC {self.post_code}, Australia"
 
-        params = {
-            "key": GOOGLE_API_KEY,
-            "address": address,
-            "sensor": "false",
-            "components": "country:Australia",
-            "bounds": "-38.0918240879,145.0187443885|-37.9138144402,145.1821660193"
-        }
+        # Create address components structure similar to Google's format
+        address_components = [
+            {
+                "long_name": self.street_number,
+                "short_name": self.street_number,
+                "types": ["street_number"]
+            },
+            {
+                "long_name": self.street_name,
+                "short_name": self.street_name,
+                "types": ["route"]
+            },
+            {
+                "long_name": self.suburb,
+                "short_name": self.suburb,
+                "types": ["locality", "political"]
+            },
+            {
+                "long_name": self.post_code,
+                "short_name": self.post_code,
+                "types": ["postal_code"]
+            },
+            {
+                "long_name": "Victoria",
+                "short_name": "VIC",
+                "types": ["administrative_area_level_1", "political"]
+            },
+            {
+                "long_name": "Australia",
+                "short_name": "AU",
+                "types": ["country", "political"]
+            }
+        ]
 
-        response = requests.get(API_URLS["geocode"], params=params, timeout=30)
-        response.raise_for_status()
-
-        data = response.json()
-        if not data.get("results"):
-            raise Exception(f"Address not found: {address}")
-
-        result = data["results"][0]
         return {
-            "address_components": result["address_components"],
-            "geometry": result["geometry"],
-            "formatted_address": result["formatted_address"]
+            "address_components": address_components,
+            "formatted_address": formatted_address,
+            "geometry": {
+                "location": {
+                    "lat": -37.9759,  # Default Kingston area coordinates
+                    "lng": 145.1350
+                },
+                "location_type": "APPROXIMATE"
+            }
         }
 
     def _get_collection_schedule(self, location_data: dict) -> List[Collection]:
@@ -174,8 +250,8 @@ class Source:
     def fetch(self) -> List[Collection]:
         """Fetch waste collection schedule."""
         try:
-            # Get geocoded address data
-            location_data = self._geocode_address()
+            # Build address data from user input
+            location_data = self._build_address_data()
 
             # Get collection schedule
             entries = self._get_collection_schedule(location_data)


### PR DESCRIPTION
As of July 2025, the Kingston Council website returns a 403 when the API is called from this custom component.

Switch to using the whatbinday.com API which is used by the Binston Android app that Kingston Council have released.

This API requires that the client register a "device" before using the services endpoint. We cache this device key to avoid repeated registrations.