### PR TITLE
Fix: doc where to execute pytest

### DIFF
--- a/doc/contributing_ics.md
+++ b/doc/contributing_ics.md
@@ -124,4 +124,6 @@ To use it:
 
 ### Test before submitting using pytest
 
-To ensure that the source script is working as expected, it is recommended to install and run `pytest` in the `waste_collection_schedule` directory. This will run some additional tests making sure attributes are set correctly and all required files are present and update_docu_links run successfully. Pytest does not test the source script itself.
+To ensure that the source script is working as expected, it is recommended to install and run `pytest` in the `hacs_waste_collection_schedule` directory.
+This will run some additional tests making sure attributes are set correctly and all required files are present and update_docu_links run successfully.
+Pytest does not test the source script itself.


### PR DESCRIPTION
The actual fix is to execute pytest in `hacs_waste_collection_schedule`, not in `waste_collection_schedule`.

Other than that I changed the formatting of the paragraph. In markdown documents, you usually start each sentence on a new line. This is easier when reviewing changes. The rendered document looks the same.