### PR TITLE
Fix Broxbourne

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxbourne_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxbourne_gov_uk.py
@@ -40,6 +40,9 @@ class Source:
     def fetch(self):
         entries: list[Collection] = []
         session = requests.Session()
+        session.headers.update({
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        })
 
         token_response = session.get(API_URLS["get_session"])
         soup = BeautifulSoup(token_response.text, "html.parser")
@@ -58,9 +61,11 @@ class Source:
             "next": "Next",
         }
 
-        collection_response = session.post(API_URLS["collection"], data=form_data)
+        collection_response = session.post(
+            API_URLS["collection"], data=form_data)
 
-        collection_soup = BeautifulSoup(collection_response.text, "html.parser")
+        collection_soup = BeautifulSoup(
+            collection_response.text, "html.parser")
         tr = collection_soup.findAll("tr")
 
         # The council API returns no year for the collections


### PR DESCRIPTION
Session now requires a User-Agent header to be sent.

The first three logged failures are expected as the Broxbourne source sends no date where that service type is not available at that address.

> $ /workspaces/hacs_waste_collection_schedule/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s broxbourne_gov_uk -i -l
> Testing source broxbourne_gov_uk ...
> No date found for wastetype: Recycling. The date field in the table is empty or corrupted. Failed with error: time data '   2025' does not match format '%a %d %b %Y'
> No date found for wastetype: Food. The date field in the table is empty or corrupted. Failed with error: time data '   2025' does not match format '%a %d %b %Y'
> No date found for wastetype: Green Waste. The date field in the table is empty or corrupted. Failed with error: time data '   2025' does not match format '%a %d %b %Y'
>   found 1 entries for Old School Cottage (Domestic Waste Only)
>     2025-07-16 : Domestic [mdi:trash-can]
>   found 4 entries for 11 Park Road (All Services)
>     2025-07-17 : Recycling [mdi:recycle]
>     2025-07-17 : Domestic [mdi:trash-can]
>     2025-07-17 : Food [mdi:food-apple]
>     2025-07-24 : Green Waste [mdi:leaf]
>   found 4 entries for 11 Pulham Avenue (All Services)
>     2025-07-16 : Recycling [mdi:recycle]
>     2025-07-16 : Domestic [mdi:trash-can]
>     2025-07-16 : Food [mdi:food-apple]
>     2025-07-23 : Green Waste [mdi:leaf]`
> 
> 

 

> $ pytest
> =========================================================================================================== test session starts ============================================================================================================
> platform linux -- Python 3.10.12, pytest-8.4.1, pluggy-1.6.0
> rootdir: /workspaces/hacs_waste_collection_schedule
> configfile: pytest.ini
> collected 6 items                                                                                                                                                                                                                          
> 
> tests/test_source_components.py ......                                                                                                                                                                                               [100%]
> 
> ============================================================================================================ 6 passed in 3.32s =============================================================================================================

