### PR TITLE
Fix: Peterborough, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
@@ -1,11 +1,10 @@
-import datetime
+import logging
+from time import sleep
 
 import requests
+from bs4 import BeautifulSoup
+from dateutil import parser
 from waste_collection_schedule import Collection
-from waste_collection_schedule.exceptions import (
-    SourceArgumentNotFound,
-    SourceArgumentNotFoundWithSuggestions,
-)
 
 TITLE = "Peterborough City Council"
 DESCRIPTION = "Source for peterborough.gov.uk services for Peterborough"
@@ -15,97 +14,111 @@ TEST_CASES = {
     "houseName": {"post_code": "PE57AX", "name": "CASTOR HOUSE"},
     "houseUprn": {"uprn": "100090214774"},
 }
-
-API_URLS = {
-    "address_search": "https://www.peterborough.gov.uk/api/addresses/{postcode}",
-    "collection": "https://www.peterborough.gov.uk/api/jobs/{start}/{end}/{uprn}",
-}
-
+API_URL = "https://report.peterborough.gov.uk/waste"
 ICON_MAP = {
     "Empty Bin 240L Black": "mdi:trash-can",
     "Empty Bin 240L Green": "mdi:recycle",
     "Empty Bin 240L Brown": "mdi:leaf",
 }
+HEADERS = {"user-agent": "Mozilla/5.0"}
+BIN_MAP = {
+    "Black Bin": "Empty Bin 240L Black",
+    "Green Bin": "Empty Bin 240L Green",
+    "Brown Bin": "Empty Bin 240L Brown",
+}  # convert new bin names to old bin names for compatibility
 
-# _LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class Source:
     def __init__(self, post_code=None, number=None, name=None, uprn=None):
         self._post_code = post_code
-        self._number = number
-        self._name = name
+        self._number = number  # no longer required, but retained for compatibility
+        self._name = name  # no longer required, but retained for compatibility
         self._uprn = uprn
 
-    def fetch(self):
-        now = datetime.datetime.now().date()
-        if not self._uprn:
-            # look up the UPRN for the address
-            q = str(API_URLS["address_search"]).format(postcode=self._post_code)
-            r = requests.get(q)
-            r.raise_for_status()
-            addresses = r.json()["premises"]
-            if not addresses:
-                raise SourceArgumentNotFound("post_code", self._post_code)
-
-            if self._name:
-                uprns = [
-                    x["uprn"]
-                    for x in addresses
-                    if x["address"]["address1"].capitalize() == self._name.capitalize()
-                ]
-                if not uprns:
-                    raise SourceArgumentNotFoundWithSuggestions(
-                        "name",
-                        self._name,
-                        [
-                            x["address"]["address1"]
-                            for x in addresses
-                            if x["address"]["address1"]
-                        ],
-                    )
-                self._uprn = uprns[0]
-            elif self._number:
-                uprns = [
-                    x["uprn"]
-                    for x in addresses
-                    if x["address"]["address2"] == str(self._number)
-                ]
-                if not uprns:
-                    raise SourceArgumentNotFoundWithSuggestions(
-                        "number",
-                        self._number,
-                        [
-                            x["address"]["address2"]
-                            for x in addresses
-                            if x["address"]["address2"]
-                        ],
-                    )
-                self._uprn = uprns[0]
-
-            if not self._uprn:
-                raise Exception(
-                    f"Could not find address {self._post_code} {self._number}{self._name}"
-                )
-
-        q = str(API_URLS["collection"]).format(
-            start=now, end=(now + datetime.timedelta(14)), uprn=self._uprn
+    def get_uprn_from_postcode(self, s, pcode):
+        # returns the first uprn from a postcode search
+        # ensures old configs without a uprn arg still work
+        r = s.get(f"https://uprn.uk/postcode/{pcode}")
+        soup = BeautifulSoup(r.content, "html.parser")
+        cols = soup.find("div", {"class": "threecol"})
+        li = cols.find("li")
+        pcode_uprn = li.find("a", href=True).text
+        _LOGGER.warning(
+            f"Used postcode to find an approximate uprn ({pcode_uprn}). Update config with property uprn for more accurate results."
         )
-        r = requests.get(q)
+        return pcode_uprn
+
+    def get_postcode_from_uprn(self, s, u):
+        # returns the postcode from a uprn search
+        # ensures old configs without a postcode arg still work
+        r = s.get(f"https://uprn.uk/{u}")
+        soup = BeautifulSoup(r.content, "html.parser")
+        cols = soup.find_all("p", {"class": "flat nopad small"})
+        for item in cols:
+            if "Postcode:" in item.text:
+                pcode = item.find("a", href=True).text.strip().replace(" ", "")
+        return pcode
+
+    def fetch(self):
+
+        s = requests.Session()
+
+        # legacy configs may be missing some details for try and populate them
+        if self._uprn is None:
+            self._uprn = self.get_uprn_from_postcode(s, self._post_code)
+            self._post_code = str(self._post_code.replace(" ", ""))
+        if self._post_code is None:
+            self._post_code = self.get_postcode_from_uprn(s, self._uprn)
+
+        # visit page to get session cookies
+        r = s.get(API_URL, headers=HEADERS)
+
+        # get schedule
+        data = {"address": f"{self._post_code}:{self._uprn}"}
+        headers = HEADERS.update(
+            {
+                "content-type": "application/x-www-form-urlencoded",
+                "origin": "https://report.peterborough.gov.uk",
+                "referer": "https://report.peterborough.gov.uk/waste",
+            }
+        )
+        r = s.post(API_URL, headers=headers, data=data)
         r.raise_for_status()
 
-        collections = r.json()["jobs_FeatureScheduleDates"]
-        entries = []
+        # website script is sometimes returns a message when it's slow to respond
+        if "Loading your bin days..." in r.text:
+            print("Loading your bin days...")
+            r = s.get(f"{API_URL}/{self._post_code}:{self._uprn}", headers=HEADERS)
+            r.raise_for_status()
 
-        for collection in collections:
+        soup = BeautifulSoup(r.content, "html.parser")
+        wrappers = soup.find_all(
+            "div", {"class": "govuk-grid-row waste-service-wrapper"}
+        )
+        entries = []
+        for wrapper in wrappers:
+            waste_type = wrapper.find(
+                "h3", {"class": "govuk-heading-m waste-service-name"}
+            ).text
+            rows = wrapper.find_all("div", {"class": "govuk-summary-list__row"})
+            for row in rows:
+                if "Next collection" in row.text:
+                    waste_date = (
+                        row.find("dd", {"class": "govuk-summary-list__value"})
+                        .text.split(", ")[1]
+                        .strip()
+                    )
+                    # print(waste_type, waste_date)
+
             entries.append(
                 Collection(
-                    date=datetime.datetime.strptime(
-                        collection["nextDate"], "%Y-%m-%dT%H:%M:%S"
-                    ).date(),
-                    t=collection["jobDescription"],
-                    icon=ICON_MAP.get(collection["jobDescription"]),
+                    date=parser.parse(waste_date).date(),
+                    t=BIN_MAP.get(waste_type),
+                    icon=ICON_MAP.get(BIN_MAP.get(waste_type)),
                 )
             )
 
+        sleep(10)
         return entries

--- a/doc/source/peterborough_gov_uk.md
+++ b/doc/source/peterborough_gov_uk.md
@@ -1,6 +1,6 @@
 # Peterborough City Council
 
-Support for schedules provided by [Peterborough City Council](https://www.peterborough.gov.uk/residents/rubbish-and-recycling/bins).
+Support for schedules provided by [Peterborough City Council](https://www.peterborough.gov.uk/bins-waste-and-recycling/household-waste/bin-collection-days).
 
 ## Configuration via configuration.yaml
 
@@ -11,48 +11,58 @@ waste_collection_schedule:
       args:
         uprn: UNIQUE_PROPERTY_REFERENCE_NUMBER
         post_code: POST_CODE
-        name: HOUSE_NAME
-        number: HOUSE_NUMBER
+        name: HOUSE_NAME  # Legacy arg
+        number: HOUSE_NUMBER  # Legacy arg
 ```
 
 ### Configuration Variables
 
 **uprn**  
-*(string) (optional)*
+*(string) (required)*
 
-This is required if you do not supply any other options. (Using this removes the need to do an address look up web request)
-
-**name**  
-*(string) (optional)*
-
-This is required if you supply a Postcode and do not have a house number.
-
-**number**  
-*(string) (optional)*
-
-This is required if you supply a Postcode and have a house number.
+The "Unique Property Reference Number" for your address. 
 
 **post_code**  
-*(string) (optional)*
+*(string) (required)*
 
-This is required if you do not supply a UPRN. Single space between 1st and 2nd part of postcode is optional.
+The postcode for your property.
+
+**name**  
+*legacy arg (string) (optional)*
+
+The name of your property if you do not have a house number.
+No longer required.
+
+**number**  
+*legacy arg (string) (optional)*
+
+The house number of your property. No longer required.
+
 
 #### How to find your `UPRN`
 
 An easy way to discover your Unique Property Reference Number (UPRN) is by going to <https://www.findmyaddress.co.uk/> and entering in your address details.
 Otherwise you can inspect the web requests the Peterborough Council website makes when entering in your postcode and then selecting your address.
 
-## Example using UPRN
+#### 2025 Peterborough City Council Website Updates
+Peterborough changed their website api in July 2025 and queries now require both the UPRN and Postcode.
+For historic configs that supplied just the UPRN, the script will use the UPRN to approximate a postcode.
+For historic configs that supplied a postcode and name|number, the script will use the postcode to approximate a UPRN.
+For more accurate results, consider updating your config to use your specific UPRN and Postcode.
+
+
+## Example using preferred method (Postcode & UPRN)
 
 ```yaml
 waste_collection_schedule:
     sources:
     - name: peterborough_gov_uk
       args:
+        postcode: "PE5 7AX"
         uprn: 100090214774
 ```
 
-## Example using Address lookup
+## Example using legacy method (address config)
 
 ```yaml
 waste_collection_schedule:
@@ -62,3 +72,18 @@ waste_collection_schedule:
         post_code: PE57AX
         number: 1
 ```
+
+## Example using legacy method (UPRN config)
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: peterborough_gov_uk
+      args:
+        uprn: 100090214774
+```
+
+#### How to find your `UPRN`
+
+An easy way to discover your Unique Property Reference Number (UPRN) is by going to <https://www.findmyaddress.co.uk/> and entering in your address details.
+Otherwise you can inspect the website url when the Peterborough Council website displays your collection schedule. The url has the format `report.peterborough.gov.uk/waste/postcode:uprn`.


### PR DESCRIPTION
Fixes #4450 

Website API changed, as did the format of the schedule page.

Queries now need both a postcode and uprn, but the script tries to approximate these if old configs didn't provide one of them. LOGGER is used to indicate when an approximated uprn is being used.

The website can be slow to response and sometimes returns a "loading..." page , so the script tries to catch this and retry the query. If if fails 5 times it gives up.  LOGGER is used to indicate the retry attempts.


```bash
Testing source peterborough_gov_uk ...
Used postcode to find an approximate uprn (10008056041). Update config with property uprn for more accurate results.
Schedule retrieval attempt 0 failed. Retrying...
  found 3 entries for houseNumber
    2025-07-22 : Empty Bin 240L Green [mdi:recycle]
    2025-07-29 : Empty Bin 240L Black [mdi:trash-can]
    2025-07-29 : Empty Bin 240L Brown [mdi:leaf]
Used postcode to find an approximate uprn (10008056041). Update config with property uprn for more accurate results.
Schedule retrieval attempt 0 failed. Retrying...
Schedule retrieval attempt 1 failed. Retrying...
  found 3 entries for houseName
    2025-07-22 : Empty Bin 240L Green [mdi:recycle]
    2025-07-29 : Empty Bin 240L Black [mdi:trash-can]
    2025-07-29 : Empty Bin 240L Brown [mdi:leaf]
Schedule retrieval attempt 0 failed. Retrying...
  found 2 entries for houseUprn
    2025-07-22 : Empty Bin 240L Green [mdi:recycle]
    2025-07-29 : Empty Bin 240L Black [mdi:trash-can]
```