### PR TITLE
Fix: Ashford, UK

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashford_gov_uk.py
@@ -1,12 +1,8 @@
 import re
-import ssl
 from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup
-from requests.adapters import HTTPAdapter
-
-# from urllib3.poolmanager import PoolManager
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Ashford Borough Council"
@@ -30,16 +26,6 @@ ICON_MAP = {
 API_URL = "https://secure.ashford.gov.uk/waste/collectiondaylookup/"
 
 
-class TLSAdapter(HTTPAdapter):
-    def init_poolmanager(self, *args, **kwargs):
-        # Create SSL context that only allows TLSv1.2
-        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        context.minimum_version = ssl.TLSVersion.TLSv1_2
-        context.maximum_version = ssl.TLSVersion.TLSv1_2
-        kwargs["ssl_context"] = context
-        return super().init_poolmanager(*args, **kwargs)
-
-
 class Source:
     def __init__(self, postcode: str, uprn: str | int):
         self._uprn = str(uprn).strip()
@@ -47,8 +33,6 @@ class Source:
 
     def fetch(self):
         s = requests.Session()
-        s.mount("https://", TLSAdapter())
-
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashford_gov_uk.py
@@ -1,7 +1,10 @@
+import logging
 import re
 from datetime import datetime
 
+import certifi
 import requests
+import urllib3
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
@@ -25,6 +28,8 @@ ICON_MAP = {
 
 API_URL = "https://secure.ashford.gov.uk/waste/collectiondaylookup/"
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class Source:
     def __init__(self, postcode: str, uprn: str | int):
@@ -32,6 +37,11 @@ class Source:
         self._postcode = str(postcode).strip()
 
     def fetch(self):
+
+        _LOGGER.warning(
+            f"requests: {requests.__version__}, urllib3: {urllib3.__version__}, certifi: {certifi.__version__}"
+        )
+
         s = requests.Session()
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashford_gov_uk.py
@@ -10,7 +10,6 @@ from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 _LOGGER = logging.getLogger(__name__)
 
-
 TITLE = "Ashford Borough Council"
 DESCRIPTION = "Source for Ashford Borough Council."
 URL = "https://ashford.gov.uk"
@@ -19,26 +18,23 @@ TEST_CASES = {
     "100060780440": {"uprn": "100060780440", "postcode": "TN24 9JD"},
     "100062558476": {"uprn": "100062558476", "postcode": "TN233LX"},
 }
-
-
 ICON_MAP = {
     "household refuse": "mdi:trash-can",
     "food waste": "mdi:food",
     "garden waste": "mdi:leaf",
     "recycling": "mdi:recycle",
 }
-
-
 API_URL = "https://secure.ashford.gov.uk/waste/collectiondaylookup/"
 
 
 class LegacyTLSAdapter(HTTPAdapter):
-    # Required to work around poor server setting at ashford.gov.uk
-    # Modern python libraries reject such 'legacy' settings and return SSL errors.
+    # Modern python libraries reject Ashford's server settings and return SSL errors,
+    # Try and force requests to use downgraded settings
     def init_poolmanager(self, *args, **kwargs):
         ctx = ssl.create_default_context()
-        ctx.set_ciphers("AES256-SHA256")  # Explicitly allow this cipher
-        ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # Explicitly set the TLS version
+        ctx.set_ciphers("AES256-SHA256")  # Explicitly use this cipher
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # Explicitly use this TLS version
+        ctx.maximum_version = ssl.TLSVersion.TLSv1_2  # Explicitly use this TLS version
         kwargs["ssl_context"] = ctx
         return super().init_poolmanager(*args, **kwargs)
 
@@ -51,7 +47,7 @@ class Source:
     def fetch(self):
 
         _LOGGER.warning(
-            "Forcing requests to use TLSv1.2 & AES256-SHA256 to match ashford.gov.uk website"
+            "Forcing requests to use legacy TLSv1.2 & AES256-SHA256 to match ashford.gov.uk website"
         )
 
         # Use customised TLS/cipher settings


### PR DESCRIPTION
Fixes #4417

Forces request to use TLSv1.2 & AES256-SHA256 to match Ashford's server, otherwise
`SSL: UNEXPECTED_EOF_WHILE_READING` errors occur.

```bash
Testing source ashford_gov_uk ...
Forcing requests to use legacy TLSv1.2 & AES256-SHA256 to match ashford.gov.uk website
  found 3 entries for 100060796052
    2025-08-01 : Household Refuse (grey bin / black sacks) [mdi:trash-can]
    2025-07-25 : Recycling (green bin / clear sacks) [mdi:recycle]
    2025-07-25 : Food Waste (black container with orange lid) [mdi:food]
Forcing requests to use legacy TLSv1.2 & AES256-SHA256 to match ashford.gov.uk website
  found 3 entries for 100060780440
    2025-07-25 : Household Refuse (grey bin / black sacks) [mdi:trash-can]
    2025-08-01 : Recycling (green bin / clear sacks) [mdi:recycle]
    2025-07-25 : Food Waste (black container with orange lid) [mdi:food]
Forcing requests to use legacy TLSv1.2 & AES256-SHA256 to match ashford.gov.uk website
  found 3 entries for 100062558476
    2025-07-23 : Household Refuse (grey bin / black sacks) [mdi:trash-can]
    2025-07-30 : Recycling (green bin / clear sacks) [mdi:recycle]
    2025-07-23 : Food Waste (black container with orange lid) [mdi:food]
```