### PR TITLE
Fixed URL for royalgreenwich

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/royalgreenwich_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/royalgreenwich_gov_uk.py
@@ -96,7 +96,7 @@ class Source:
         s.headers.update(HEADERS)
 
         r = s.get(
-            "https://www.royalgreenwich.gov.uk/info/200171/recycling_and_rubbish/2436/black_top_bin_collections"
+            "https://www.royalgreenwich.gov.uk/recycling-and-rubbish/bins-and-collections/black-top-bin-collections"
         )
         r.raise_for_status()
 


### PR DESCRIPTION
https://www.royalgreenwich.gov.uk/info/200171/recycling_and_rubbish/2436/black_top_bin_collections returns 404 so fixing it to the correct one