### PR TITLE
Fix renodjurs_dk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/renodjurs_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/renodjurs_dk.py
@@ -82,14 +82,18 @@ class Source:
             if cells[4].get_text() is None or cells[4].get_text() == "":
                 continue
 
-            next_pickup = datetime.strptime(cells[4].get_text(), "%d-%m-%Y").date()
+            try:
+                next_pickup = datetime.strptime(cells[4].get_text(), "%d-%m-%Y").date()
+            except ValueError:
+                next_pickup = None
 
-            entries.append(
-                Collection(
-                    date=next_pickup,
-                    t=fraktion,
-                    icon=icon,
+            if next_pickup:
+                entries.append(
+                    Collection(
+                        date=next_pickup,
+                        t=fraktion,
+                        icon=icon,
+                    )
                 )
-            )
 
         return entries


### PR DESCRIPTION
Fixes #4495

This fixes a ValueError that occurs when the Reno Djurs integration encounters a non-date string like "Uge 33/34" in the pickup column. The datetime.strptime() call that parses the next pickup date (cells[4]) is now wrapped in a try/except block to handle ValueError. This prevents the integration from crashing when the text is not a valid date (e.g., week ranges or empty fields).

