### PR TITLE
Fix North Hertfordshire, UK after council API change

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/northherts_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/northherts_gov_uk.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import re
+
 import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
@@ -20,14 +22,56 @@ TEST_CASES = {
     },
 }
 ICON_MAP = {
-    "Refuse": "mdi:trash-can",
-    "Recycling": "mdi:recycle",
-    "Garden Waste": "mdi:leaf",
-    "Food Waste": "mdi:food-apple",
+    "Refuse Collection": "mdi:trash-can",
+    "Mixed Recycling Collection": "mdi:recycle",
+    "Garden Collection": "mdi:leaf",
+    "Food Collection": "mdi:food-apple",
+    "Paper/Card Collection": "mdi:package-variant",
+}
+#
+API_URLS = {
+    "BASE": "https://waste.nc.north-herts.gov.uk",
+    "CSRF": "/w/webpage/find-bin-collection-day-input-address",
+    # https://waste.nc.north-herts.gov.uk/
+    "KEYPREP": "/w/webpage/find-bin-collection-day-input-address",
+    "SCHEDULE": "/w/webpage/find-bin-collection-day-input-address?webpage_subpage_id=PAG0000778GBNLM1&webpage_token=81bf109be5477ba63904dc10c69c37000417bf78a9e0d2b21585ec15ef05088d",
+}
+HEADER_COMPONENTS = {
+    "BASE": {
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "Cache-Control": "max-age=0",
+        "Connection": "keep-alive",
+        "Origin": "https://waste.nc.north-herts.gov.uk",
+        "Host": "waste.nc.north-herts.gov.uk",
+        "sec-ch-ua": '"Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "Windows",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-User": "?1",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+    },
+    "GET": {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "Sec-Fetch-Mode": "none",
+    },
+    "POST": {
+        "Accept": "application/json, text/javascript, */*; q=0.01",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "Sec-Fetch-Mode": "cors",
+        "X-Requested-With": "XMLHttpRequest",
+    },
 }
 
-API_URL = "https://uhtn-wrp.whitespacews.com/"
-
+def _parse_custom_date(date_string):
+    # Remove ordinal suffixes (st, nd, rd, th) from the day number
+    cleaned_date = re.sub(r'(\d+)(st|nd|rd|th)', r'\1', date_string)
+    
+    try:
+        # Parse the cleaned date string
+        return datetime.strptime(cleaned_date, "%A %d %B %Y")
+    except ValueError as e:
+        raise ValueError(f"Could not parse date string '{date_string}': {str(e)}")
 
 class Source:
     def __init__(
@@ -43,70 +87,110 @@ class Source:
         self._address_postcode = address_postcode
 
     def fetch(self):
-        session = requests.Session()
+        s = requests.Session()
 
-        # get link from first page as has some kind of unique hash
-        r = session.get(
-            API_URL,
-        )
-        r.raise_for_status()
-        soup = BeautifulSoup(r.text, features="html.parser")
+        # Get CSRF token
+        headers = {**HEADER_COMPONENTS["BASE"], **HEADER_COMPONENTS["GET"]}
+        r0 = s.get(API_URLS["BASE"] + API_URLS["CSRF"], headers=headers)
 
-        alink = soup.find("a", text="Find my bin collection day")
+        soup = BeautifulSoup(r0.text, features="html.parser")
+        app_body = soup.find("div", {"class": "app-body"})
+        script = app_body.find("script", {"type": "text/javascript"}).string
+        p = re.compile("var CSRF = ('|\")(.*?)('|\");")
+        m = p.search(script)
+        csrf_token = m.groups()[1]
 
-        if alink is None:
-            raise Exception("Initial page did not load correctly")
-
-        # greplace 'seq' query string to skip next step
-        nextpageurl = alink["href"].replace("seq=1", "seq=2")
-
-        data = {
-            "address_name_number": self._address_name_numer,
-            "address_street": self._address_street,
-            "street_town": self._street_town,
-            "address_postcode": self._address_postcode,
+        # Get form tokens
+        form_data = {
+            "_dummy": "1",
+            "_session_storage": '{"_global":{}}',
+            "_update_page_content_request": "1",
+            "form_check_ajax": csrf_token,
+        }
+        headers = {
+            **HEADER_COMPONENTS["BASE"],
+            **HEADER_COMPONENTS["POST"],
         }
 
-        # get list of addresses
-        r = session.post(nextpageurl, data)
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, features="html.parser")
-
-        # get first address (if you don't enter enough argument values this won't find the right address)
-        alink = soup.find("div", id="property_list").find("a")
-
-        if alink is None:
-            raise Exception("Address not found")
-
-        nextpageurl = API_URL + alink["href"]
-
-        # get collection page
-        r = session.get(
-            nextpageurl,
+        r1 = s.post(
+            API_URLS["BASE"] + API_URLS["KEYPREP"],
+            headers=headers,
+            data=form_data,
         )
-        r.raise_for_status()
-        soup = BeautifulSoup(r.text, features="html.parser")
+        r1.raise_for_status()
 
-        if soup.find("span", id="waste-hint"):
-            raise Exception("No scheduled services at this address")
+        page_data = r1.json()["data"]
+        key = (
+            re.findall(r"data-unique_key=\"C_[a-f0-9]+\"", page_data)[-1]
+            .replace('data-unique_key="', "")
+            .replace('"', "")
+        )
+        soup = BeautifulSoup(page_data, features="html.parser")
+        submitted_widget_group_id = soup.findAll(
+            "input", {"name": "submitted_widget_group_id"}
+        )[-1].attrs["value"]
+        submission_token = soup.find("input", {"name": "submission_token"}).attrs[
+            "value"
+        ]
+        submitted_page_id = soup.find("input", {"name": "submitted_page_id"}).attrs[
+            "value"
+        ]
 
-        u1s = soup.find("section", id="scheduled-collections").find_all("u1")
+        # Fetch collection data
+        headers = {
+            **HEADER_COMPONENTS["BASE"],
+            **HEADER_COMPONENTS["POST"],
+        }
+        address_str = f"{self._address_name_numer} {self._address_street}"
+        form_data = {
+            "submitted_page_storage_key": "/w/webpage/find-bin-collection-day-input-address",
+            "submitted_page_id": submitted_page_id,
+            "submitted_widget_group_id": submitted_widget_group_id,
+            "submitted_widget_group_type": "search",
+            "submission_token": submission_token,
+            f"payload[{submitted_page_id}][{submitted_widget_group_id}][PCL0006978GBNLM1][search][{key}][PCF0023743GBNLM1]": address_str,
+            f"payload[{submitted_page_id}][{submitted_widget_group_id}][PCL0006978GBNLM1][search][{key}][PCF0023721GBNLM1]": "Find bin collection dates",
+            "submit_fragment_id": "PCF0023721GBNLM1",
+            "_session_storage": '{"_global":{"destination_stack":["w/webpage/find-bin-collection-day-input-address"]}}',
+            "_update_page_content_request": "1",
+            "form_check_ajax": csrf_token,
+            "form_check": csrf_token,
+        }
+        params = {
+            "webpage_subpage_id": submitted_page_id,
+            "webpage_token": "81bf109be5477ba63904dc10c69c37000417bf78a9e0d2b21585ec15ef05088d"
+        }
+        r2 = s.post(API_URLS["BASE"] + API_URLS["SCHEDULE"], headers=headers, data=form_data, params=params)
+        json_res = r2.json()
+        soup = BeautifulSoup(json_res["data"], features="html.parser")
+        schedule = soup.find_all("div", {"class": "page_fragment_collection form-group block"})
 
+        # Parse outputs
         entries = []
-
-        for u1 in u1s:
-            lis = u1.find_all("li", recursive=False)
-            entries.append(
-                Collection(
-                    date=datetime.strptime(
-                        lis[1].text.replace("\n", ""), "%d/%m/%Y"
-                    ).date(),
-                    t=lis[2].text.replace("\n", ""),
-                    icon=ICON_MAP.get(
-                        lis[2].text.replace("\n", "").replace(" Collection Service", "")
-                    ),
-                )
+        for pickup in schedule:
+            row_data = pickup.find_all(
+                "span", {"class": "value-as-text"}
             )
+            if row_data:
+                address = row_data[0].text.strip()
+                # Filter out mismatches (e.g. on duplicate street names)
+                if address_str.lower() not in address.lower():
+                    continue
+                if self._address_postcode is not None:
+                    # Postcodes can have spaces or without; UK format always splits at last 3 letters
+                    postcode_with_space = self._address_postcode if " " in self._address_postcode else self._address_postcode[:-3] + " " + self._address_postcode[-3:]
+                    postcode_without_space = self._address_postcode.replace(" ", "")
+                    if not (postcode_with_space.lower() in address.lower() or postcode_without_space.lower() in address.lower()):
+                        continue
+                if self._street_town and self._street_town.lower() not in address.lower():
+                    continue
+                collection_type = row_data[1].text.strip()
+                collection_date_str = row_data[2].text.strip()
+                entries.append(Collection(
+                    date=_parse_custom_date(collection_date_str).date(),
+                    t=collection_type.replace(" Collection", ""),  # No need for verbosity
+                    icon=ICON_MAP.get(collection_type),
+                ))
+                
 
         return entries


### PR DESCRIPTION
This pull request fixes issue #4145 

## Context
North Hertfordshire changed providers which broke the previous API integration.

The new portal is similar to `croydon_gov_uk.py` with a few minor adjustments.
I have kept the original parameters as to not to break existing configurations, although address search and matching works differently in this implementation.

## Test plan
```
$ python3 ./custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s northherts_gov_uk
Testing source northherts_gov_uk ...
  found 5 entries for Example
  found 5 entries for Example No Postcode Space
```

Ensured `pytest` still passes