### PR TITLE
Fix: AWN ApplicationName for iCal download

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
@@ -136,7 +136,7 @@ class Source:
         )
         r.raise_for_status()
 
-        args["ApplicationName"] = "com.athos.kd.neckarodenwald.AbfuhrTerminModel"
+        args["ApplicationName"] = "com.athos.kd.neckarodenwald.abfuhrtermine.AbfuhrTerminModel"
         args["SubmitAction"] = "filedownload_ICAL"
         r = session.post(
             SERVLET,


### PR DESCRIPTION
Some time this week the `awn_de` iCal download broke. It seems to be related to an upstream change of the `ApplicationName` parameter.