### PR TITLE
Add `opole` app to the ecoharmonogram service

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/EcoHarmonogramPL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/EcoHarmonogramPL.py
@@ -21,6 +21,7 @@ SUPPORTED_APPS_LITERAL = Literal[
     "slupsk",
     "trzebownisko",
     "zory",
+    "opole"
 ]
 
 SUPPORTED_APPS = get_args(SUPPORTED_APPS_LITERAL)

--- a/doc/source/ecoharmonogram_pl.md
+++ b/doc/source/ecoharmonogram_pl.md
@@ -19,6 +19,7 @@ Following towns are supported:
 |slupsk|Słupsk|
 |trzebownisko|Jasionka, Łąka, Łukawiec, Nowa Wieś, Stobierna, Tajęcina, Terliczka, Trzebownisko, Wólka Podleśna, Zaczernie|
 |zory|Żory|
+|opole|Opole|
 
 ## Configuration via configuration.yaml
 


### PR DESCRIPTION
This PR adds a new app to the `Ecoharmonogram` service that contains the city of `Opole`.

<img width="2688" height="1210" alt="ScreenShot 2025-08-03-13 32 46UTC@2x" src="https://github.com/user-attachments/assets/49727f77-5426-48eb-967a-a045428f8b8d" />

