### PR TITLE
Fix: unley sa gov au

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/unley_sa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/unley_sa_gov_au.py
@@ -10,23 +10,23 @@ TITLE = "Unley City Council (SA)"
 DESCRIPTION = "Source for Unley City Council rubbish collection."
 URL = "https://www.unley.sa.gov.au/"
 TEST_CASES = {
-    "Bible College of South Australia": {
+    "Test1": {
         "post_code": "5061",
         "suburb": "Malvern",
         "street_name": "Wattle Street",
-        "street_number": "176",
+        "street_number": "188",
     },
-    "291 on Unley": {
+    "Test2": {
         "post_code": 5061,
         "suburb": "Unley",
         "street_name": "Unley Road",
-        "street_number": "291",
+        "street_number": "192",
     },
-    "Consulate of Switzerland": {
+    "Test3": {
         "post_code": "5063",
         "suburb": "Parkside",
         "street_name": "Castle Street",
-        "street_number": 64,
+        "street_number": "63",
     },
 }
 
@@ -35,10 +35,28 @@ API_URLS = {
     "collection": "https://www.unley.sa.gov.au/ocapi/Public/myarea/wasteservices?geolocationid={}&ocsvclang=en-AU",
 }
 
-HEADERS = {"user-agent": "Mozilla/5.0"}
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate, br, zstd",
+    "DNT": "1",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Cache-Control": "max-age=0",
+}
 
 ICON_MAP = {
-    "General Waste": "trash-can",
+    "General Waste (Blue Bin)": "mdi:trash-can",
+    "Organic Waste (Green or Grey Bin)": "mdi:leaf",
+    "Recycling (Yellow Lid Bin)": "mdi:recycle",
+    "Residential Street Cleaning": "mdi:broom",
+    # Fallback patterns
+    "General Waste": "mdi:trash-can",
     "Recycling": "mdi:recycle",
     "Green Waste": "mdi:leaf",
 }
@@ -53,7 +71,7 @@ class Source:
         self.street_number = street_number
 
     def fetch(self):
-        locationId = 0
+        locationId = ""
 
         address = "{} {} {} SA {}".format(
             self.street_number, self.street_name, self.suburb, self.post_code
@@ -61,26 +79,34 @@ class Source:
 
         q = requote_uri(str(API_URLS["address_search"]).format(address))
 
-        # Retrieve suburbs
+        # Retrieve address search results
         r = requests.get(q, headers=HEADERS)
+        r.raise_for_status()
 
-        data = json.loads(r.text)
+        # Parse XML response (API returns XML, not JSON)
+        soup = BeautifulSoup(r.text, 'xml')
+        
+        # Look for PhysicalAddressSearchResult items in the XML response
+        address_results = soup.find_all('PhysicalAddressSearchResult')
+        
+        # Find the ID for our address
+        for result in address_results:
+            id_element = result.find('Id')
+            if id_element:
+                locationId = id_element.text.strip()
+                break
 
-        # Find the ID for our suburb
-        for item in data["Items"]:
-            locationId = item["Id"]
-            break
-
-        if locationId == 0:
+        if not locationId:
             return []
 
         # Retrieve the upcoming collections for our property
         q = requote_uri(str(API_URLS["collection"]).format(locationId))
 
         r = requests.get(q, headers=HEADERS)
+        r.raise_for_status()
 
+        # Parse JSON response and extract HTML content
         data = json.loads(r.text)
-
         responseContent = data["responseContent"]
 
         soup = BeautifulSoup(responseContent, "html.parser")
@@ -89,30 +115,27 @@ class Source:
         entries = []
 
         for item in services:
-            # test if <div> contains a valid date. If not, is is not a collection item.
             date_text = item.find("div", attrs={"class": "next-service"})
+            waste_type = item.find("h3")
             
-            # The date format currently used on https://www.unley.sa.gov.au/Bins-pets-parking/Waste-recycling/Rubbish-collection-dates
-            date_format = '%a %d/%m/%Y'
-
-            try:
-                # Strip carriage returns and newlines out of the HTML content
-                cleaned_date_text = date_text.text.replace('\r','').replace('\n','').strip()
-
-                # Parse the date
-                date = datetime.datetime.strptime(cleaned_date_text, date_format).date()
-
-            except ValueError:
+            if not date_text or not waste_type:
                 continue
+                
+            try:
+                # Parse the date (format: "Thu 7/8/2025")
+                cleaned_date_text = date_text.text.replace('\r','').replace('\n','').strip()
+                date = datetime.datetime.strptime(cleaned_date_text, '%a %d/%m/%Y').date()
+                
+                waste_type_text = waste_type.text.strip()
 
-            waste_type = item.find("h3").text.strip()
-
-            entries.append(
-                Collection(
-                    date=date,
-                    t=waste_type,
-                    icon=ICON_MAP.get(waste_type, "mdi:trash-can"),
+                entries.append(
+                    Collection(
+                        date=date,
+                        t=waste_type_text,
+                        icon=ICON_MAP.get(waste_type_text, "mdi:trash-can"),
+                    )
                 )
-            )
+            except (ValueError, AttributeError):
+                continue
 
         return entries


### PR DESCRIPTION
Fixes #4485

They changed the api somewhat but the request structure is almost the same.

None of the defined tests were working addresses in the new api, and that took some (a lot) of time to figure out :-)

I have defined 3 new tests.
Changed the request header to firefox on windows
Changed handling of the address search response (json->xml)
Changed handling of the waste type names i.e. General Waste -> General Waste (Blue Bin)

Testing source unley_sa_gov_au ...
found 4 entries for Test1
2025-08-07 : General Waste (Blue Bin) [mdi:trash-can]
2025-08-07 : Organic Waste (Green or Grey Bin) [mdi:leaf]
2025-08-14 : Recycling (Yellow Lid Bin) [mdi:recycle]
2025-08-18 : Residential Street Cleaning [mdi:broom]
found 4 entries for Test2
2025-08-13 : General Waste (Blue Bin) [mdi:trash-can]
2025-08-20 : Organic Waste (Green or Grey Bin) [mdi:leaf]
2025-08-13 : Recycling (Yellow Lid Bin) [mdi:recycle]
2025-08-18 : Residential Street Cleaning [mdi:broom]
found 4 entries for Test3
2025-08-07 : General Waste (Blue Bin) [mdi:trash-can]
2025-08-07 : Organic Waste (Green or Grey Bin) [mdi:leaf]
2025-08-14 : Recycling (Yellow Lid Bin) [mdi:recycle]
2025-08-25 : Residential Street Cleaning [mdi:broom]