### PR TITLE
Fix for Rushmoor

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushmoor_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushmoor_gov_uk.py
@@ -29,8 +29,7 @@ class Source:
         params = {"selectedAddress": self._uprn, "weeks": "16"}
         r = requests.get(API_URL, params=params)
         r.raise_for_status()
-        # Douple decode to get rid of the escaped quotes
-        data = json.loads(str(r.json()))
+        data = r.json()
 
         entries = []
         for collection_key in ("NextCollection", "PreviousCollection"):


### PR DESCRIPTION
I don't know what or when this happened, but since last week my integration stopped working.  Appears that the API is returning properly formatted json.  


I cloned locally, and same issue happened, after the change, tests pass:

```
Testing source rushmoor_gov_uk ...
  found 7 entries for GU14
    2025-08-21 : Refuse [mdi:trash-can]
    2025-08-14 : Recycling [mdi:recycle]
    2025-08-21 : GardenWaste [mdi:leaf]
    2025-08-14 : FoodWaste [mdi:food-apple]
    2025-08-07 : Refuse [mdi:trash-can]
    2025-08-07 : GardenWaste [mdi:leaf]
    2025-08-07 : FoodWaste [mdi:food-apple]
```

Was failing with:

```
fetch failed for source Rushmoor Borough Council: Traceback (most recent call last): File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py", line 158, 
in fetch entries: Iterable[Collection] = self._source.fetch() ~~~~~~~~~~~~~~~~~~^^ File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushmoor_gov_uk.py", line 33, 
in fetch data = json.loads(str(r.json())) File "/usr/local/lib/python3.13/json/__init__.py", line 346, 
in loads return _default_decoder.decode(s) ~~~~~~~~~~~~~~~~~~~~~~~^^^ File "/usr/local/lib/python3.13/json/decoder.py", line 345, 
in decode obj, end = self.raw_decode(s, idx=_w(s, 0).end()) ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.13/json/decoder.py", line 361, 
in raw_decode obj, end = self.scan_once(s, idx) ~~~~~~~~~~~~~~^^^^^^^^ json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

Fixes: #4594