### PR TITLE
New Sources: Yarra City Council (VIC, AUS) + Newcastle City Council (NSW, AUS)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_nsw_gov_au.py
@@ -1,0 +1,109 @@
+from datetime import date, timedelta
+from waste_collection_schedule import Collection
+
+TITLE = "City of Newcastle (NSW)"
+DESCRIPTION = "Newcastle (NSW) waste schedule – weekly rubbish; recycling and organics alternate on the collection day."
+URL = "https://newcastle.nsw.gov.au/living/waste-and-recycling/collection-services/bin-collection-days"
+TAGS = ["nsw", "newcastle", "australia"]
+
+ICON_MAP = {
+    "Rubbish": "mdi:trash-can",
+    "Recycling": "mdi:recycle",
+    "Organics": "mdi:leaf",
+}
+
+# weekday index: Mon=0, Tue=1, ... Sun=6
+WEEKDAY_NAME_TO_IDX = {
+    "monday": 0, "mon": 0,
+    "tuesday": 1, "tue": 1, "tues": 1,
+    "wednesday": 2, "wed": 2,
+    "thursday": 3, "thu": 3, "thurs": 3,
+    "friday": 4, "fri": 4,
+    "saturday": 5, "sat": 5,
+    "sunday": 6, "sun": 6,
+}
+
+class Source:
+    """
+    Args:
+      weekday: name or index of the collection weekday (default 'tuesday')
+      recycling_seed: ISO date (YYYY-MM-DD) of a known recycling day for your area
+                      (organics will be the alternating week)
+      start: optional ISO date for schedule start (default: Jan 1 of seed year)
+      end:   optional ISO date for schedule end   (default: Dec 31 of seed year)
+    Example (Cooks Hill, Area 1 – Tuesday):
+      - name: newcastle_nsw_gov_au
+        args:
+          weekday: tuesday
+          recycling_seed: 2025-01-07
+    """
+
+    def __init__(self, weekday="tuesday", recycling_seed=None, start=None, end=None):
+        if recycling_seed is None:
+            raise ValueError("recycling_seed (YYYY-MM-DD) is required")
+
+        # normalise weekday
+        if isinstance(weekday, int):
+            wd = weekday
+        else:
+            wd = WEEKDAY_NAME_TO_IDX.get(str(weekday).strip().lower())
+        if wd is None or wd < 0 or wd > 6:
+            raise ValueError("weekday must be 0–6 or a valid weekday name")
+        self.weekday = wd
+
+        # parse dates
+        def _parse(d):
+            y, m, dd = map(int, str(d).split("-"))
+            return date(y, m, dd)
+
+        self.seed = _parse(recycling_seed)
+
+        year = self.seed.year
+        self.start = _parse(start) if start else date(year, 1, 1)
+        self.end = _parse(end) if end else date(year, 12, 31)
+
+        # sanity: seed must be on the configured weekday
+        if self.seed.weekday() != self.weekday:
+            raise ValueError("recycling_seed must fall on the configured weekday")
+
+        # organics alternates with recycling (one week offset)
+        self.organics_seed = self.seed + timedelta(days=7)
+
+        # (Optional) add public-holiday shifts here if Council publishes them
+        self.holiday_shifts = {}  # e.g. {date(2025, 12, 30): date(2025, 12, 31)}
+
+    def _all_weekday_dates(self):
+        # first chosen weekday on/after start
+        d = self.start + timedelta((self.weekday - self.start.weekday()) % 7)
+        while d <= self.end:
+            yield d
+            d += timedelta(days=7)
+
+    def _fortnightly_from(self, seed):
+        d = seed
+        while d <= self.end:
+            if d >= self.start:
+                yield d
+            d += timedelta(days=14)
+
+    def _shift_if_holiday(self, d):
+        return self.holiday_shifts.get(d, d)
+
+    def fetch(self):
+        out = []
+
+        # Weekly: rubbish every configured weekday
+        for d in self._all_weekday_dates():
+            dd = self._shift_if_holiday(d)
+            out.append(Collection(dd, "Rubbish", icon=ICON_MAP["Rubbish"]))
+
+        # Fortnightly: recycling (seed), organics (seed + 7 days)
+        for d in self._fortnightly_from(self.seed):
+            dd = self._shift_if_holiday(d)
+            out.append(Collection(dd, "Recycling", icon=ICON_MAP["Recycling"]))
+
+        for d in self._fortnightly_from(self.organics_seed):
+            dd = self._shift_if_holiday(d)
+            out.append(Collection(dd, "Organics", icon=ICON_MAP["Organics"]))
+
+        return out

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
@@ -1,0 +1,71 @@
+from datetime import date, timedelta
+from waste_collection_schedule import Collection
+
+TITLE = "Yarra City Council (VIC)"
+DESCRIPTION = "Yarra bin schedule by zone (weekly rubbish + FOGO; alternating recycling/glass)"
+URL = "https://www.yarracity.vic.gov.au/residents/bins-waste-recycling-and-cleansing/recycling-and-rubbish/bin-collection"
+TAGS = ["vic", "yarra", "australia"]
+
+ICON_MAP = {
+    "Rubbish": "mdi:trash-can",
+    "FOGO": "mdi:leaf",
+    "Recycling": "mdi:recycle",
+    "Glass": "mdi:glass-fragile",
+}
+
+# Seeds for 2025–26, Zone 10
+ZONE_CFG = {
+    10: {
+        "weekday": 4,  # Monday=0 .. Sunday=6; Friday=4
+        "fy_start": date(2025, 7, 1),
+        "fy_end": date(2026, 6, 30),
+        "recycling_seed": date(2025, 7, 4),
+        "glass_seed": date(2025, 7, 11),
+        "holiday_shifts": {
+            date(2025, 12, 26): date(2025, 12, 27),
+            date(2026, 4, 3): date(2026, 4, 4),
+        },
+    }
+}
+
+
+class Source:
+    def __init__(self, zone: int = 10):
+        if zone not in ZONE_CFG:
+            raise ValueError("Unsupported Yarra zone (use 1–10)")
+        self.cfg = ZONE_CFG[zone]
+
+    def _weekly_dates(self, start, end):
+        d = start + timedelta((self.cfg["weekday"] - start.weekday()) % 7)
+        while d <= end:
+            yield d
+            d += timedelta(days=7)
+
+    def _fortnightly_dates(self, seed, end):
+        d = seed
+        while d <= end:
+            yield d
+            d += timedelta(days=14)
+
+    def fetch(self):
+        out = []
+
+        # Weekly: rubbish + FOGO
+        for d in self._weekly_dates(self.cfg["fy_start"], self.cfg["fy_end"]):
+            dd = self.cfg["holiday_shifts"].get(d, d)
+            out.append(Collection(dd, "Rubbish", icon=ICON_MAP["Rubbish"]))
+            out.append(Collection(dd, "FOGO", icon=ICON_MAP["FOGO"]))
+
+        # Fortnightly: recycling
+        for d in self._fortnightly_dates(self.cfg["recycling_seed"], self.cfg["fy_end"]):
+            if d >= self.cfg["fy_start"]:
+                dd = self.cfg["holiday_shifts"].get(d, d)
+                out.append(Collection(dd, "Recycling", icon=ICON_MAP["Recycling"]))
+
+        # Fortnightly: glass
+        for d in self._fortnightly_dates(self.cfg["glass_seed"], self.cfg["fy_end"]):
+            if d >= self.cfg["fy_start"]:
+                dd = self.cfg["holiday_shifts"].get(d, d)
+                out.append(Collection(dd, "Glass", icon=ICON_MAP["Glass"]))
+
+        return out

--- a/doc/source/newcastle_nsw_gov_au.md
+++ b/doc/source/newcastle_nsw_gov_au.md
@@ -1,0 +1,14 @@
+# City of Newcastle (NSW)
+
+Weekly rubbish (red) and alternating **recycling** / **organics** on the same weekday.
+
+## Configuration via YAML
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: newcastle_nsw_gov_au
+      args:
+        weekday: tuesday
+        recycling_seed: 2025-01-07
+```

--- a/doc/source/yarracity_vic_gov_au.md
+++ b/doc/source/yarracity_vic_gov_au.md
@@ -1,0 +1,16 @@
+# Yarra City Council (VIC)
+
+Supports zones 1–10.
+
+- Weekly: Rubbish + FOGO
+- Fortnightly: Recycling (from 2025-07-04), Glass (from 2025-07-11)
+- Holiday shifts: 26 Dec 2025 → 27 Dec, 3 Apr 2026 → 4 Apr
+
+## Configuration via YAML
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: yarracity_vic_gov_au
+      args:
+        zone: 10


### PR DESCRIPTION
Adds Yarra City Council (VIC, AUS).

- Weekly: Rubbish + FOGO
- Fortnightly: Recycling (from 2025-07-04), Glass (from 2025-07-11)
- Arg: `zone` (1–10)
- Holiday shifts: 26 Dec 2025 → 27 Dec, 3 Apr 2026 → 4 Apr

## Example config
```yaml
waste_collection_schedule:
  sources:
    - name: yarracity_vic_gov_au
      args:
        zone: 10
```

## References
- https://www.yarracity.vic.gov.au/residents/bins-waste-recycling-and-cleansing/recycling-and-rubbish/bin-collection
- Zone 10 collection calendar PDF