### PR TITLE
handle non-subscribed bin collection

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
@@ -125,12 +125,17 @@ class Source:
         li: list = soup.find_all("li")
         for item in li:
             details: list = item.find_all("strong")
-            entries.append(
-                Collection(
-                    date=self.append_year(details[2].text),
-                    t=str(details[0].text),
-                    icon=ICON_MAP.get(details[0].text),
+            try:
+                entries.append(
+                    Collection(
+                        date=self.append_year(details[2].text),
+                        t=str(details[0].text),
+                        icon=ICON_MAP.get(details[0].text),
+                    )
                 )
-            )
+            except (
+                IndexError
+            ):  # empty list is returned if property doesn't subscribe to that collection
+                continue
 
         return entries


### PR DESCRIPTION
Fixes #4684 

Now handles empty list return when property doesn't subscribe to one of the waste types.

```bash
Testing source north_norfolk_gov_uk ...
  found 2 entries for Test_001
    2025-09-11 : Grey bin [mdi:trash-can]
    2025-09-18 : Green bin [mdi:recycle]
  found 2 entries for Test_002
    2025-09-11 : Green bin [mdi:recycle]
    2025-09-18 : Grey bin [mdi:trash-can]
  found 3 entries for Test_003
    2025-09-11 : Grey bin [mdi:trash-can]
    2025-09-16 : Brown bin [mdi:leaf]
    2025-09-18 : Green bin [mdi:recycle]
````