### PR TITLE
fixed wrong source and icons for edlitz_at

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edlitz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edlitz_at.py
@@ -12,6 +12,7 @@ ICON_MAP = {
     "Biomüllabfuhr": "mdi:food",
     "Papier Tonne": "mdi:newspaper",
     "Grüne Tonne": "mdi:recycle",
+    "Gelber Sack": "mdi:recycle-variant",
     "Restmüll": "mdi:trash-can",
     "Restmüll mit Panoramastraße": "mdi:trash-can",
 }
@@ -23,7 +24,7 @@ class Source:
 
     def fetch(self):
         s = requests.Session()
-        r = s.get("https://www.edlitz.at/Buergerservice/Muellabfuhrtermine")
+        r = s.get("https://www.edlitz.at/system/web/kalender.aspx")
 
         soup = BeautifulSoup(r.text, "html.parser")
         td = soup.find_all("td", {"class": "td_kal"})


### PR DESCRIPTION
Fixes #4639 

```yaml
Testing source edlitz_at ...
  found 10 entries for TestSource
    2025-09-17 : Restmüll [mdi:trash-can]
    2025-09-24 : Biomüllabfuhr [mdi:food]
    2025-09-26 : Gelber Sack [mdi:recycle-variant]
    2025-10-08 : Biomüllabfuhr [mdi:food]
    2025-10-15 : Restmüll [mdi:trash-can]
    2025-10-22 : Biomüllabfuhr [mdi:food]
    2025-10-24 : Gelber Sack [mdi:recycle-variant]
    2025-11-05 : Biomüllabfuhr [mdi:food]
    2025-11-05 : Papier Tonne [mdi:newspaper]
    2025-11-12 : Restmüll [mdi:trash-can]
  found 10 entries for IgnoredArgument
    2025-09-17 : Restmüll [mdi:trash-can]
    2025-09-24 : Biomüllabfuhr [mdi:food]
    2025-09-26 : Gelber Sack [mdi:recycle-variant]
    2025-10-08 : Biomüllabfuhr [mdi:food]
    2025-10-15 : Restmüll [mdi:trash-can]
    2025-10-22 : Biomüllabfuhr [mdi:food]
    2025-10-24 : Gelber Sack [mdi:recycle-variant]
    2025-11-05 : Biomüllabfuhr [mdi:food]
    2025-11-05 : Papier Tonne [mdi:newspaper]
    2025-11-12 : Restmüll [mdi:trash-can]
```