### PR TITLE
Update zke_sb_de.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zke_sb_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zke_sb_de.py
@@ -5,7 +5,6 @@ import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.service.ICS import ICS
 
-
 # Source code based on ZKE Saarbrücken
 TITLE = "ZKE Saarbrücken"
 DESCRIPTION = "Source for Zentraler Kommunaler Entsorgungsbetrieb (ZKE) Saarbrücken."


### PR DESCRIPTION
Stabilize ZKE Saarbrücken source with minimal changes

Update custom_components/waste_collection_schedule/waste_collection_schedule/source/zke_sb_de.py

- Re-parse hidden form inputs after each server response to keep view state in sync.
- Remove unused/fragile "Zeitraum" parameter (not present in current form).
- Do not hardcode "ApplicationName" for ICS download; rely on server-provided value.

```
❯ ./test_sources.py -s zke_sb_de
Testing source zke_sb_de ...
  found 40 entries for Harthweg
  found 28 entries for Jahnweg
  found 42 entries for Netzbachtal
```