### PR TITLE
Update southglos_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southglos_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southglos_gov_uk.py
@@ -42,14 +42,16 @@ class Source:
 
         entries = []
         for item in pickups["value"]:
-            entries.append(
-                Collection(
-                    date=datetime.datetime.strptime(
-                        item["hso_nextcollection"].split("T")[0], "%Y-%m-%d"
-                    ).date(),
-                    t=WASTE_MAP[item["hso_servicename"]],
-                    icon=ICON_MAP.get(WASTE_MAP[item["hso_servicename"]]),
+            next_collection = item.get("hso_nextcollection")
+            if next_collection:
+                entries.append(
+                    Collection(
+                        date=datetime.datetime.strptime(
+                            item["hso_nextcollection"].split("T")[0], "%Y-%m-%d"
+                        ).date(),
+                        t=WASTE_MAP[item["hso_servicename"]],
+                        icon=ICON_MAP.get(WASTE_MAP[item["hso_servicename"]]),
+                    )
                 )
-            )
 
         return entries


### PR DESCRIPTION
Fixes #4762

After:
```
$ python test_sources.py -s southglos_gov_uk -l -t
Testing source southglos_gov_uk ...
  found 3 entries for Test_001
    2025-10-01 : RECYCLING
    2025-10-01 : BLACK BIN
    2025-10-01 : FOOD BIN
  found 3 entries for Test_002
    2025-10-01 : RECYCLING
    2025-10-01 : FOOD BIN
    2025-10-01 : BLACK BIN
```

Before:
```
$ python test_sources.py -s southglos_gov_uk -l -t
Testing source southglos_gov_uk ...
  Test_001 failed: 'NoneType' object has no attribute 'split'
    Traceback (most recent call last):
      File "/workspaces/hacs_waste_collection_schedule/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py", line 139, in test_fetch
        result = source.fetch()
                 ^^^^^^^^^^^^^^
      File "/workspaces/hacs_waste_collection_schedule/custom_components/waste_collection_schedule/waste_collection_schedule/source/southglos_gov_uk.py", line 50, in fetch
        item["hso_nextcollection"].split("T")[0], "%Y-%m-%d"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'split'
    
  found 3 entries for Test_002
    2025-10-01 : RECYCLING
    2025-10-01 : FOOD BIN
    2025-10-01 : BLACK BIN
```