### PR TITLE
Fixed faulty usage of dummy streets response from API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sammelkalender_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sammelkalender_ch.py
@@ -180,7 +180,14 @@ class Source:
 
     def _fetch_street(self) -> None:
         streets = self._get_streets()
-        if not streets:
+        
+        # switch to Sammelgebiete if API either returns no streets or one dummy street
+        if (
+            not streets
+            or len(streets) == 1
+            and streets[0].get("STRname") is None
+            and streets[0].get("SAGEid") is not None
+        ):
             self._fetch_sage()
             return
 


### PR DESCRIPTION
The ZKRI API returns a dummy street (show below) if the parameter `fuerStr=1` is set. Since the plugin always first searches for streets, and the dummy street includes a default `SAGEid` this default is always used and the SAGE (Sammelgebiet) can effectively not be chosen.

Dummy street returned by ZKRI API for the following parameters:
https://daten.zkri.ch/web/Sammelkalender/kunden_WANN_auswahl_form.php?optGem=33&fuerStr=1&Jahr=2025

```
[
  {
    "STRid": null,
    "STRname": null,
    "STRhausnr": null,
    "SAGESTRid": null,
    "SAGEid": 189
  }
]
```

This fixes issue #3696.