### PR TITLE
Fix Auckland council source.

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -74,14 +74,7 @@ class CollectionGroup(CollectionBase):
             x.set_picture(group[0].picture)
         else:
             x.set_icon(f"mdi:numeric-{len(group)}-box-multiple")
-        # Deduplicate types while preserving order
-        seen = set()
-        types = []
-        for it in group:
-            if it.type not in seen:
-                seen.add(it.type)
-                types.append(it.type)
-        x["types"] = types
+        x["types"] = list(it.type for it in group)
         return x
 
     @property


### PR DESCRIPTION
Tests passing with dates retrieved:

PS C:\Users\alfie\Downloads\hacs_waste_collection_schedule-master> Invoke-Expression "python custom_components\\waste_collection_schedule\\waste_collection_schedule\\test\\test_sources.py -s aucklandcouncil_govt_nz -l -i"
Testing source aucklandcouncil_govt_nz ...
  found 4 entries for 429 Sea View Road
    2025-10-20 : rubbish [None]
    2025-10-28 : recycle [None]
    2025-10-20 : rubbish [None]
    2025-10-28 : recycle [None]
  found 4 entries for 8 Dickson Road
    2025-10-23 : rubbish [None]
    2025-10-31 : recycle [None]
    2025-10-23 : rubbish [None]
    2025-10-31 : recycle [None]
  found 5 entries for with Food Scraps
    2025-10-20 : rubbish [None]
    2025-10-20 : food-waste [None]
    2025-10-28 : recycle [None]
    2025-10-20 : rubbish [None]
    2025-10-28 : recycle [None]
  found 5 entries for 3 Andrew Road
    2025-10-24 : rubbish [None]
    2025-10-24 : food-waste [None]
    2025-11-01 : recycle [None]
    2025-10-24 : rubbish [None]
    2025-11-01 : recycle [None]