### PR TITLE
Fix SSL certificate verification notificaiton for gardenbags_co_nz

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gardenbags_co_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gardenbags_co_nz.py
@@ -1,7 +1,11 @@
 import requests
+import urllib3
 from bs4 import BeautifulSoup
 from dateutil.parser import parse
 from waste_collection_schedule import Collection
+
+# This line suppresses the InsecureRequestWarning when using verify=False
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 TITLE = "GardenBags NZ"
 DESCRIPTION = "Source for GatdenBags NZ."


### PR DESCRIPTION
This PR fixes the InsecureRequestWarning that appears in Home Assistant logs when using the GardenBags NZ source. The fix follows the same pattern used by other sources in this integration (awg_de, basingstoke_gov_uk, etc.) that handle SSL certificate verification issues in Home Assistant environments.

`Testing source gardenbags_co_nz ...
  found 0 entries for Test 1`