### PR TITLE
Fix westoxon

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westoxon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westoxon_gov_uk.py
@@ -32,9 +32,10 @@ TEST_CASES = {
 
 
 ICON_MAP = {
+    "bin": "mdi:leaf",
     "refuse": "mdi:trash-can",
     "recycling": "mdi:recycle",
-    "food": "mdi:food",
+    "caddy": "mdi:food",
     "box": "mdi:recycle",
 }
 


### PR DESCRIPTION
Fixes: #2619

I reviewed the network log when looking for an address and noticed the flowDevName in one of the request headers had changed, updating it to 'WebFormAlloyWasteCollectionEnquiry' seems to fix the issue.

I also updated the icon map as I noticed the bin types didn't match for the garden bin and food caddy.

Here is the test run result:
<img width="709" height="223" alt="image" src="https://github.com/user-attachments/assets/933ca576-2188-4640-8102-749a4fe39dfb" />

