### PR TITLE
Recyclecoach: Adds steps to retrieve district_id, project_id, and zone_id

### DIFF
--- a/doc/source/recyclecoach_com.md
+++ b/doc/source/recyclecoach_com.md
@@ -1,7 +1,7 @@
 # Recycle Coach / recyclecoach.com
 
 Support for schedules provided by [Recycle Coach](https://recyclecoach.com/),
-serving several regions and municipalities in the USA
+serving several regions and municipalities in North America.
 
 ## Configuration via configuration.yaml
 
@@ -10,9 +10,9 @@ waste_collection_schedule:
     sources:
     - name: recyclecoach_com 
       args:
-        street: 123 road way
-        city: smithsville
-        state: ohio
+        street: 250 Main St
+        city: Port Dover
+        state: Ontario
 ```
 
 ### Configuration Variables
@@ -20,26 +20,63 @@ waste_collection_schedule:
 #### Basic Usage
 
 **street**<br>
-*(string) (required)* Street address, `123 road way` skip punctuation if
+*(string) (required)* Street address, `250 Main St` skip punctuation if
 abbreviating road type
 
 **city**<br>
 *(string) (required)* Name of your municipality
 
 **state**<br>
-*(string) (required)* Name of state, two latter abbreviation of fully spelled
-out correctly
+*(string) (required)* Name of state or providence (or two latter abbreviation)
 
 #### Alternative / Debugging Usage
 
-If for some reason the above does not get what you want and you want to dig in,
-   go ahead over to the [Recycle Coach Homepage][https://recyclecoach.com/) open
-   up your browser developer tools on network, and watch as you search for your
-   address.
+If the above does not get what you want or you don't want to use your address in
+requests, you can alternatively use your `district_id`, `project_id`, and
+`zone_id` to get your collection schedules.
 
-The XHR response you're triggering should have a json blob where you can find
-your district_id and project_id.  If you specify these, the script will skip the
-lookups and use those directly
+To find out your `district_id` and `project_id`, navigate to the following URL
+in your browser: 
+
+    https://api-city.recyclecoach.com/city/search?term=<city>, <state/providence>, <country>
+    
+Replace the placeholders. (For the United States, the country will be `USA`.)
+The spaces after the commas are **required**. As an example, we'll use the
+address: 250 Main St, Port Dover, Ontario, Canada.
+
+    https://api-city.recyclecoach.com/city/search?term=Port Dover, Ontario, CA
+    
+The result will be some JSON, which will contain keys for `disctrict_id` and
+`project_id`. In this exacmple,
+
+    ... ,"project_id":"3107","district_id":"OLYMP", ...
+
+If you can't get you location to work in that URL, you can also go to the
+[Recycle Coach Homepage](https://recyclecoach.com/) and open the dev tools in your browser. (In Firefox,
+three horizontal line button, More tools, Web Developer Tools. Then go to the
+Console tab.) Now, search for your city in the box on the homepage. In the
+Console, there should be a line with the JSON response (it'll probably be at
+the bottom). That JSON should have the `project_id` and `district_id`
+mentioned above.
+
+Now, to get the `zone_id`, use the following URL:
+
+    https://api-city.recyclecoach.com/zone-setup/address?sku=<project_id>&district=<district_id>&prompt=undefined&term=<specific address>
+
+Use the `project_id` and `district_id` from the last step. Replace
+`<specific address>` with your specific address.
+
+For example:
+
+    https://api-city.recyclecoach.com/zone-setup/address?sku=3107&district=OLYMP&prompt=undefined&term=250 Main St
+
+This will produce another JSON blob, which contains some potential matches.
+Each result will have a "zones" key. Pick the best match, probably the first on the list.
+
+    ... ,"zones":{"2447":"z11266","4085":"z16205","4086":"z16208","4087":"z16218"}, ...
+    
+The numbers prefixed with a "z" are the values we want. Just string them
+together. From the result above, the `zone_id` will be `zone-z11266-z16205-z16208-z16218`.
 
 **district_id**<br>
 *(string) (optional)* district_id provided by
@@ -53,14 +90,14 @@ lookups and use those directly
 *(string) (optional)*  string built from result set of
 `https://api-city.recyclecoach.com/zone-setup/address` endpoint
 
-
-As an example: Main St, Port Dover, Norfolk County, Ontario, Canada
+And finally, we can use the `district_id`, `project_id`, and `zone_id` in the
+config.
 ```yaml
 waste_collection_schedule:
     sources:
     - name: recyclecoach_com 
       args:
-        district_id: "OLYMP",
-        project_id: 3107,
+        district_id: "OLYMP"
+        project_id: 3107
         zone_id: "zone-z11266-z16205-z16208-z16218"
 ```


### PR DESCRIPTION
The goal was to add the steps one needed to take in order to determine the user's district_id, project_id, and zone_id.

The current directions do mention one way to get the district_id and project_id, but do not specifically explain how to get the zone_id.