### PR TITLE
Fix East Renfrewshire - Replace requests with cloudscraper for scraping

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/east_renfrewshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/east_renfrewshire_gov_uk.py
@@ -36,13 +36,17 @@ class Source:
         session = cloudscraper.create_scraper(
             browser={"browser": "chrome", "platform": "windows", "mobile": False}
         )
-        session.headers.update({
-            "User-Agent": ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                           "AppleWebKit/537.36 (KHTML, like Gecko) "
-                           "Chrome/129.0.0.0 Safari/537.36"),
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Accept-Language": "en-GB,en;q=0.9",
-        })
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/129.0.0.0 Safari/537.36"
+                ),
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language": "en-GB,en;q=0.9",
+            }
+        )
 
         address_page = self.__get_address_page(session, self._postcode)
         bin_collection_info_page = self.__get_bin_collection_info_page(


### PR DESCRIPTION
East Renfrewshire Council has implemented Cloudflare protection. Switching from requests to cloudscraper bypasses this. CLOSES #4904 