### PR TITLE
Fix: Updated Fife Council bin collection to use new endpoint

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fife_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fife_gov_uk.py
@@ -1,5 +1,6 @@
-import requests
 from datetime import datetime
+
+import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Fife Council"
@@ -87,9 +88,7 @@ class Source:
                 colour = collection.get("colour", "")
                 icon = ICON_MAP.get(colour)
 
-                entries.append(
-                    Collection(date=date, t=collection_type, icon=icon)
-                )
+                entries.append(Collection(date=date, t=collection_type, icon=icon))
             except (ValueError, KeyError):
                 # Skip invalid date entries but continue processing others
                 continue


### PR DESCRIPTION
Resolves https://github.com/mampfes/hacs_waste_collection_schedule/issues/4877

Fife Council recently changed the endpoint used for their bin calendar API.

The new form is viewable [here](https://fife.portal.uk.empro.verintcloudservices.com/site/fife/request/bin_calendar): https://fife.portal.uk.empro.verintcloudservices.com/site/fife/request/bin_calendar) and you will also notice that the previous working link (https://www.fife.gov.uk/services/forms/bin-calendar) redirects to the new `verintcloudservices` URL.

This PR changes the URL to use the new API endpoint.