### PR TITLE
Add second request with nc=1 to fetch full Newark & Sherwood bin data

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newark_sherwooddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newark_sherwooddc_gov_uk.py
@@ -28,10 +28,16 @@ class Source:
         self._uprn = uprn
 
     def fetch(self):
-        # get json file
+        entries = self.get_data({"pid": self._uprn})
+        try:
+            entries += self.get_data({"pid": self._uprn, "nc": "1"})
+        except Exception:
+            pass
+        return entries
+
+    def get_data(self, payload):
         r = requests.get(
-            "http://app.newark-sherwooddc.gov.uk/bincollection/calendar",
-            params={"pid": self._uprn},
+            "http://app.newark-sherwooddc.gov.uk/bincollection/calendar", params=payload
         )
 
         entries = []
@@ -81,58 +87,4 @@ class Source:
                     )
                 )
 
-#################### START OF EDIT credit to StreamingStar ######################
-        payload = {'pid': self._uprn, 'nc': '1'}
-
-        r = requests.get(
-            "http://app.newark-sherwooddc.gov.uk/bincollection/calendar",
-            params=payload
-        )
-
-        soup = BeautifulSoup(r.content, "html.parser")
-
-        # Collections are arranged by month, with each month as an individual table
-        # Split page by months
-        months = soup.find_all("table")
-
-        for month in months:
-            # Month and year are set in th
-            month_data = month.find("th").get_text(strip=True)
-            # Regex the month and year then convert month name to number
-            month_data_match = re.search(r"(\w*)\s*(\d{4})", month_data)
-            extracted_month_name = month_data_match.group(1)
-            month_number = list(calendar.month_name).index(extracted_month_name)
-            year = month_data_match.group(2)
-
-            # Each collection for the month is an individual table row with a classname beginning bin_
-            rows = month.find_all("tr", class_=re.compile("bin_"))
-            for collection_day in rows:
-                # Get type of bin collection
-                collection_type_match = re.search(
-                    r"bin_(\w*)", collection_day["class"][0]
-                )
-                collection_type = collection_type_match.group(1)
-
-                # Get date of collection
-                collection_day_match = re.search(
-                    r",\s*\w*\s*(\d{1,2})\w{2}",
-                    collection_day.find("td").get_text(strip=True),
-                )
-                collection_day = collection_day_match.group(1)
-
-                entries.append(
-                    Collection(
-                        date=datetime.date(
-                            int(year), int(month_number), int(collection_day)
-                        ),  # Collection date
-                        t=BINS.get(collection_type, {}).get(
-                            "name", collection_type
-                        ),  # Collection type
-                        icon=BINS.get(collection_type, {}).get(
-                            "icon"
-                        ),  # Collection icon
-                    )
-                )
-        
-#################### END OF EDIT ######################
         return entries


### PR DESCRIPTION
Newark & Sherwood District Council returns incomplete bin collection data unless the 'nc=1' parameter is added to the request.

This update performs a second fetch using:
  payload = {'pid': uprn, 'nc': '1'}

and parses both responses to capture all available months.

This ensures all bin types and dates are collected reliably.

Credit to StreamingStar #4881 for identifying the required request parameter.