### PR TITLE
Fix Stirling WA API authentication - update apikeylookup header

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
@@ -43,7 +43,7 @@ class Source:
             "configid": "7c833520-7b62-4228-8522-fb1a220b32e8",
             "form": "57753bab-f589-44d7-8934-098b6d5c572f",
             "fields": f"{self._lon},{self._lat}",
-            "apikeylookup": "Test Map Key",
+            "apikeylookup": "Bin Day",
             "X-Requested-With": "XMLHttpRequest",
             "Connection": "keep-alive",
         }


### PR DESCRIPTION
## Summary
Fixes the Stirling (Western Australia) bin collection source by correcting the API authentication header value.

## Changes Made
- Updated `apikeylookup` header in `stirling_wa_gov_au.py` from `"Test Map Key"` to `"Bin Day"`

## Files Updated
- ✅ `custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py` - Fixed API header
- ✅ `doc/source/stirling_wa_gov_au.md` - Already exists (no changes needed)
- ✅ `README.md` and `info.md` - Will be auto-updated by maintainers via update_docu_links.py

## Testing
Tested successfully with test coordinates:
- `-31.9034183, 115.8320855`
- `-31.8783052, 115.8157741`

The source now correctly authenticates with the Stirling API using the proper header value observed from browser network requests.

## Related Issue
Fixes #4894

(yes - Copilot Agent helped :) )
