### PR TITLE
Fix: Fylde Council - Bin type extraction logic

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fylde_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fylde_gov_uk.py
@@ -18,7 +18,7 @@ TEST_CASES = {
 API_URL = "https://collectiveview.bartec-systems.com/R152"
 API_METHOD = "GetData.ashx"
 
-REGEX_JOB_NAME = r"(?i)Empty Bin\s+(?P<bin_type>\S+(?:\s+\S+)?)"
+REGEX_BIN_TYPE = r"(?i)(?P<bin_type>(?:GREY|GREEN|BROWN|BLUE)\s+(?:BIN|BAG|BOX))"
 ICON_MAP = {
     "Grey Bin": "mdi:trash-can",
     "Green Bin": "mdi:leaf",
@@ -75,12 +75,13 @@ class Source:
         entries = []
         for job in jobs:
             # "Empty Bin GREY BIN 240L" -> "Grey Bin"
-            jobName = (
-                re.search(REGEX_JOB_NAME, job["title"])
-                .group("bin_type")
-                .strip()
-                .title()
-            )
+            jobName = re.search(REGEX_BIN_TYPE, job["title"])
+            if not jobName:
+                # Skip entries without a recognised bin type
+                continue
+
+            jobName = jobName.group("bin_type").strip().title()
+
             # Job 'start' string to epoch. "/Date(1580515199000)/" -> "1580515199000"
             date = job["start"][6:-2]
 


### PR DESCRIPTION
The previous regex pattern was rigid and assumed titles would always follow a specific format (e.g. `Empty Bin <BIN_TYPE>`), but the API can return varying formats, including
- `Empty Bin GREY BIN 240L`
- `Empty GREY BIN 240L`
- `GREY BIN 240L ( x2 )`

This causes an `AttributeError` when the regex fails to match certain titles, preventing any schedules from populating.

What has been changed
- Simplified regex to extract bin type from anywhere in the title
- Added `None` check before calling `.group()` to prevent crashes
- Skip entries that don't contain a recognised bin type
- More resilient to future API title format changes