### PR TITLE
Fix and update Renfrewshire Council Provider

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/renfrewshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/renfrewshire_gov_uk.py
@@ -1,9 +1,8 @@
-from urllib.parse import parse_qs, urlparse
-
-import requests, json
+import json
 from datetime import datetime
+
+import requests
 from bs4 import BeautifulSoup
-from dateutil import parser
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Renfrewshire Council"
@@ -24,6 +23,7 @@ ICON_MAP = {
     "Blue": "mdi:note",
 }
 
+
 class Source:
     def __init__(self, postcode, uprn):
         self._postcode = postcode
@@ -39,7 +39,9 @@ class Source:
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, features="html.parser")
-        collections_data = soup.find("script", {"type": "application/json", "id": "collections-data"})
+        collections_data = soup.find(
+            "script", {"type": "application/json", "id": "collections-data"}
+        )
 
         entries = []
 
@@ -51,16 +53,18 @@ class Source:
                 binData = json.loads(collections_data.string.strip())
             except json.JSONDecodeError as e:
                 raise Exception("JSON Decode Failed with: " + str(e)) from e
- 
+
             for date_str, bins in binData.items():
                 date = datetime.fromisoformat(date_str).date()
-                
+
                 for bin_name, details in bins.items():
                     if details is None:
                         continue  # skip empty bins
-                    
-                    collection_type = details["ShortName"]  # e.g. "Blue", "Brown", "Grey"
-                    
+
+                    collection_type = details[
+                        "ShortName"
+                    ]  # e.g. "Blue", "Brown", "Grey"
+
                     entries.append(
                         Collection(
                             date=date,


### PR DESCRIPTION
This provider has been broken for a while Renfrewhire Council has been updating their website and, unusually for a governmental agency, has actually made things better in the process.

You now only need to perform a GET to https://www.renfrewshire.gov.uk/bins-and-recycling/bin-collection/bin-collection-calendar/check-your-bin-collection-day/view/{uprn} to get your bin schedules, so no more faffing with forms!

Conveniently, the nice graphics on the page are dynamically generated from a JSON object embedded in the page, which makes scraping and parsing it a breeze!