### PR TITLE
Fixes concurrent years in gfa_lueneburg_de

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gfa_lueneburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gfa_lueneburg_de.py
@@ -5,6 +5,7 @@ from html.parser import HTMLParser
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.service.ICS import ICS
+from datetime import datetime
 
 TITLE = "GFA Lüneburg"
 DESCRIPTION = "Source for GFA Lüneburg."
@@ -87,6 +88,7 @@ class Source:
         parser.feed(r.text)
 
         args = parser.args
+        args["Zeitraum"] = f"Jahresübersicht {datetime.now().year}"
         args["Ort"] = self._city
         args["Strasse"] = self._street
         args["Hausnummer"] = str(self._hnr)
@@ -100,6 +102,7 @@ class Source:
         r.raise_for_status()
 
         args = parser.args
+        args["Zeitraum"] = f"Jahresübersicht {datetime.now().year}"
         args["Ort"] = self._city
         args["Strasse"] = self._street
         args["Hausnummer"] = str(self._hnr)
@@ -121,6 +124,7 @@ class Source:
         args["IsLastPage"] = "true"
         args["Method"] = "POST"
         args["PageName"] = "Terminliste"
+        del args["Zeitraum"]
         del args["Ort"]
         del args["Strasse"]
         del args["Hausnummer"]


### PR DESCRIPTION
Fixes https://github.com/mampfes/hacs_waste_collection_schedule/issues/5023

At the end of each year, GFA Lüneburg (https://gfa-lueneburg.de/service/abfuhrkalender.html
) runs two calendar instances in parallel, e.g., one for the current year and one for the upcoming year.
During this period, their website displays a radio group allowing users to select which year’s waste collection schedule should be returned. The default selection is always the upcoming year (e.g., 2026).

Because of this, the integration incorrectly retrieves only dates from the next year — resulting in the next scheduled pickup being shown as e.g. 35 days away instead of 2 days.

This fix adds the missing payload parameter Zeitraum, filling it dynamically with the current year.
The expected format is:
"Jahresübersicht {current_year}" (e.g., "Jahresübersicht 2025").

This ensures the correct year is always selected and the integration returns the proper upcoming pickup dates.