### PR TITLE
Fixes #5046

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_ca.py
@@ -389,6 +389,9 @@ class Source:
             start_hour, start_minute, end_hour, end_minute = self._parse_hours(
                 time_start, time_end
             )
+        else:
+            # Missing opening_hours start time, default to midnight
+            start_hour, start_minute = 0, 0
 
         # Week ranges
         week_pattern = r"week (\d+(?:-\d+(?:/\d+)?)?(?:,\d+(?:-\d+(?:/\d+)?)?)*)"


### PR DESCRIPTION
publidata_ca 2026 schedules started missing opening_hours start times. previously most start times were set to midnight.

the fix is when start time is missing, default to midnight.