### PR TITLE
Added glass collection to rushcliffe_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
@@ -116,8 +116,7 @@ class Source:
                 continue
             before_bin = line.split(" bin", 1)[0]
             before_bin = before_bin.replace("Your next ", "")
-            before_bin = before_bin.split("(", 1)[0].strip()
-            bin_type = before_bin.lower()
+            bin_type = before_bin.split("(", 1)[0].strip()
             date = re.search(r"\d{2}/\d{2}/\d{4}", line)
             if not date:
                 continue


### PR DESCRIPTION
Rushcliffe have now added a 4th bin (glass).

I've added an entry to ICON_MAP and adjusted the parsing code to only return "glass" rather than "glass (purple lid)", which is how the council currently refer to the bin on the website.