### PR TITLE
fix: Change API call from GET to POST method for Staedteservice

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/staedteservice_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/staedteservice_de.py
@@ -115,7 +115,8 @@ class Source:
         return dates
 
     def get_calendar_from_site(self, year: int) -> str:
-        r = self._session.get(
+        # the service has changed and will throw an 405 by using GET to call the endpoint
+        r = self._session.post(
             API_URL,
             params={
                 "orteId": self.city_code,


### PR DESCRIPTION
The Staedteservice changed the API spec to require the API to get called via POST on the endpoint ZeigeAbfallkalender.

Testresult via POST:
<img width="1113" height="653" alt="image" src="https://github.com/user-attachments/assets/072a81f1-3344-4475-b2dd-15cfb462c594" />

Testresult via GET:
<img width="1235" height="443" alt="image" src="https://github.com/user-attachments/assets/04bfcf0d-100c-488f-92fa-763367789526" />


The tickets #5124 and #5137 will be addressed by this PR.

---

Changed
* Changed the GET request for `ZeigeAbfallkalender` to POST.

Tested with HA `2025.12.4`