### PR TITLE
Fix: silea_it source get_calendar api result parsing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/silea_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/silea_it.py
@@ -90,9 +90,14 @@ class Source:
 
             # request and process calendar items for each available month
             for item in month_data:
-                collection_date = datetime.strptime(
-                    item["date"]["date"], "%Y-%m-%d %H:%M:%S.%f"
-                ).date()
+                try:
+                    collection_date = datetime.strptime(
+                        item["date"]["date"], "%Y-%m-%d %H:%M:%S.%f"
+                    ).date()
+                except ValueError:
+                    collection_date = datetime.strptime(
+                        item["format"], "%Y-%m-%d"
+                    ).date()
                 for service in item["services"]:
                     service_clean_name = service["service"].replace("  ", " ")
                     entries.append(


### PR DESCRIPTION
Fix for issue #5184 

Summary
This PR fixes error when parsing result for get_calendar action 

Problem
The format for the result of the get_calendar api recently changed from a dictionary to a list
Also the date changed from a simple string with format %Y-%m-%dT%H:%M:%S
```
 "date": "2025-12-01T05:30:00"
```
to an object like this
```
"date": {
      "date": "2025-12-30 05:30:00.000000",
      "timezone_type": 1,
      "timezone": "+01:00"
    },
```
with a change in date format to %Y-%m-%d %H:%M:%S.%f

Solution

Changed iteration from dict values into iteration in list entries
Changed the date parsing to use the date.date value with the correct format instead of the previous value

Testing

Tested with real inputs to retrieve the correct values from the apis

Breaking changes

I don't know since when, but now that it works again I noticed that, due to upstream changes the names of the waste collections changed, for example "indifferenziata" is now "INDIFFERENZIATO"
This is an example of the new attributes names
```
   CARTA E CARTONE
   INDIFFERENZIATO
   PLASTICA, LATTINE E TETRAPAK
   UMIDO
   VETRO
```
This reflected into needed changes to my previous automations