### PR TITLE
Fix for issue with Sammelkalender_CH after update

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -859,8 +859,9 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
     async def async_step_reconfigure(self, args_input: dict[str, Any] | None = None):
         await self._async_setup_sources()
 
-        config_entry = self.hass._get_reconfigure_entry()
-
+        config_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
         if config_entry is None:
             return self.async_abort(reason="reconfigure_failed")
 
@@ -868,6 +869,7 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
         schema, module = await self.__get_arg_schema(
             source, config_entry.data["args"], args_input, include_title=False
         )
+        title = module.TITLE
         errors: dict[str, str] = {}
         description_placeholders: dict[str, str] = {}
         # If all args are filled in
@@ -883,7 +885,11 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
                 data.update({CONF_SOURCE_NAME: source, CONF_SOURCE_ARGS: args_input})
                 return self.async_update_reload_and_abort(
                     config_entry,
-                    data_updates=data
+                    title=title,
+                    unique_id=config_entry.unique_id,
+                    data=data,
+                    options=options,
+                    reason="reconfigure_successful",
                 )
         return self.async_show_form(
             step_id=f"reconfigure_{source}",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sammelkalender_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sammelkalender_ch.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 import requests
+import logging
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,
@@ -97,6 +98,8 @@ PROVIDER_LITERALS = Literal["zeba", "zkri", "real_luzern", "zaku"]
 
 API_URL = ""
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class Source:
     def __init__(
@@ -157,21 +160,29 @@ class Source:
         sages = self._get_streets(sage=True)
         if not sages:
             return
+        # check: only one sage exists?
         if len(sages) == 1:
             self._address_id = sages[0]["SAGEid"]
             return
+        # check: street parameter defined?
+        if not self._street:
+            sage_names = list(
+                {s.get("STRname") or s.get("SAGEname") for s in sages}
+            )
+            # by default use first Sammelgebiet and log a Warning 
+            # (prevents breaking changes: existing users may have no street configured, because it was not mandatory previously)
+            self._address_id = sages[0]["SAGEid"]
+            _LOGGER.warning(
+                "No Sammelgebiet configured for this municipality. Using default Sammelgebiet '%s'. To configure, insert for the parameter 'street': %s",
+                sages[0]["SAGEname"], ", ".join(sage_names),
+            )
+            return
+        # otherwise find correct sage
         for sage in sages:
-            if not self._street:
-                street_names = list(
-                    {s.get("STRname") or s.get("SAGEname") for s in sages}
-                )
-                raise SourceArgumentRequiredWithSuggestions(
-                    "street", "Street required for this municipality", street_names
-                )
             if self._compare(self._street, [sage["SAGEabk"], sage["SAGEname"]]):
                 self._address_id = sage["SAGEid"]
-                break
-        if not self._address_id:
+                return
+        if self._address_id is None:
             raise SourceArgumentNotFoundWithSuggestions(
                 "street",
                 self._street,


### PR DESCRIPTION
These changes fix an issue which arose for some users after updating to integration version 2.11.0.

Issue:
Before version 2.11.0 the default Sammelgebiet was always used, since the API returned a single null Sammelgebiet. PR #4832 changed this. Unfortunately a new issue arose with this change. It is possible to not configure a Sammelgebiet at all (which some users did). In this case the integration now fails to fetch the waste collection dates.

Implemented Fix:
Instead of throwing an exception when the Sammelgebiet is missing (street parameter), a warning log entry is created which points out to the user that the street parameter should be configured. The first returned Sammelgebiet is then used to fetch the waste collection dates (similar behaviour as before PR #4832).

Improvements:
It would be cleaner to reconfigure all Configurations automatically to contain the default Sammelgebiet, which I do not know how to do. 