### PR TITLE
fix: redbridge council when no collections present for type

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/redbridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/redbridge_gov_uk.py
@@ -1,6 +1,7 @@
-from datetime import datetime
-import requests
 import re
+from datetime import datetime
+
+import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
@@ -10,7 +11,7 @@ URL = "https://redbridge.gov.uk"
 TEST_CASES = {
     "council office recycling only": {"uprn": 10034922090},
     "refuse and recycling only": {"uprn": 10013585215},
-    "a church vicarage, garden, recycling, refuse": {"uprn": 10034912354}
+    "a church vicarage, garden, recycling, refuse": {"uprn": 10034912354},
 }
 ICON_MAP = {
     "REFUSE": "mdi:trash-can",
@@ -18,14 +19,14 @@ ICON_MAP = {
     "GARDEN": "mdi:leaf",
 }
 
+
 class Source:
     def __init__(self, uprn):
         self._uprn = str(uprn)
 
     def fetch(self):
         r = requests.get(
-            "https://my.redbridge.gov.uk/RecycleRefuse",
-            params = {"uprn" : self._uprn}
+            "https://my.redbridge.gov.uk/RecycleRefuse", params={"uprn": self._uprn}
         )
         r.raise_for_status()
 
@@ -38,20 +39,28 @@ class Source:
         for service in services:
             waste_type = service.find("h3").text
 
-            month_raw = service.find("div", {"class" : re.compile(".*-collection-month")})
-            day_raw = service.find("div", {"class" : re.compile(".*-collection-day-numeric")})
+            month_raw = service.find(
+                "div", {"class": re.compile(".*-collection-month")}
+            )
+            day_raw = service.find(
+                "div", {"class": re.compile(".*-collection-day-numeric")}
+            )
 
             if not month_raw or not day_raw:
                 # no collection date found for this service
                 continue
 
             # sanitize and extract day, month and optional year (e.g., 'January 2026')
-            day_match = re.search(r'(\d{1,2})', day_raw.text.strip())
-            month_match = re.search(r'([A-Za-z]+)(?:\s+(\d{4}))?', month_raw.text.strip())
+            day_match = re.search(r"(\d{1,2})", day_raw.text.strip())
+            month_match = re.search(
+                r"([A-Za-z]+)(?:\s+(\d{4}))?", month_raw.text.strip()
+            )
 
             if not day_match or not month_match:
                 # not a valid date format
-                raise ValueError(f"Can't parse day/month from: day={day_raw.text!r}, month={month_raw.text!r}")
+                raise ValueError(
+                    f"Can't parse day/month from: day={day_raw.text!r}, month={month_raw.text!r}"
+                )
 
             day = day_match.group(1)
             month = month_match.group(1)
@@ -62,9 +71,13 @@ class Source:
                 year = int(year_from_month)
             else:
                 # if guessing the year, assume next year if month has already passed this year
-                year = datetime.now().year + 1 if datetime.strptime(month, "%B").month < datetime.now().month else datetime.now().year
+                year = (
+                    datetime.now().year + 1
+                    if datetime.strptime(month, "%B").month < datetime.now().month
+                    else datetime.now().year
+                )
 
-            date = datetime.strptime(f'{day} {month} {year}', "%d %B %Y")
+            date = datetime.strptime(f"{day} {month} {year}", "%d %B %Y")
 
             entries.append(
                 Collection(


### PR DESCRIPTION
This PR fixes redbridge council source when collections stop for a waste type. Have noticed missing data for a few weeks now.

Issues:
- Waste types are sometimes suspended e.g. garden waste over winter and hence extracting a date fails
- Similar to above, new waste types being introduced soon e.g. food waste causing parsing to break
- Year seems to have not previously been included but is now entered with the month text in format 'February 2026'

Improvements:
- Skip waste type if no dates available
- Try to use year included in month field and fallback to previous logic if not present

Future improvements:
Once available we should add the new waste types e.g. food

