### PR TITLE
fix: (publidata_fr) add missing 'bio' waste type mapping

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -110,6 +110,7 @@ ICON_MAP = {
     "dv": "mdi:leaf",
     "verre": "mdi:bottle-wine",
     "bio": "mdi:food-apple",
+    "sapin": "mdi:pine-tree",
 }
 
 LABEL_MAP = {
@@ -119,6 +120,7 @@ LABEL_MAP = {
     "dv": "Déchets verts",
     "verre": "Verres",
     "bio": "Biodéchets",
+    "sapin": "Sapin",
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {


### PR DESCRIPTION
## Description
This PR addresses an issue where the `publidata_fr` source returns a waste type `bio` (Biodéchets) that was missing from the internal `LABEL_MAP` and `ICON_MAP`. 
Previously, receiving this unmapped type caused the integration to fail with a `NoneType object has no attribute 'strip'` error, as the system attempted to process a `None` waste type.
## Changes
- Added `bio` mapped to `"Biodéchets"` in `LABEL_MAP`.
- Added `bio` mapped to `"mdi:food-apple"` in `ICON_MAP`.
