### PR TITLE
Fix: Blacktown, NSW

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blacktown_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blacktown_nsw_gov_au.py
@@ -47,9 +47,10 @@ API_URLS = {
 }
 
 HEADERS = {
-    "user-agent": "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
-    "accept": "application/json, text/javascript, */*; q=0.01",
-    "Referer": "https://www.blacktown.nsw.gov.au/My-Neighbourhood",
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+    "Accept": "text/plain, */*; q=0.01",
+    "Referer": "https://www.blacktown.nsw.gov.au/Services/Waste-services-and-collection/Bin-collection-and-new-service-delivery-days",
+    "X-Requested-With": "XMLHttpRequest",
 }
 
 


### PR DESCRIPTION
Fixes issues mentioned here: https://github.com/mampfes/hacs_waste_collection_schedule/issues/4434#issuecomment-3703420451

```bash
Testing source blacktown_nsw_gov_au ...
  found 2 entries for Plumpton Marketplace
    2026-01-05 : General Waste [trash-can]
    2026-01-12 : Recycling [mdi:recycle]
  found 2 entries for Rooty Hill Tennis & Squash Centre
    2026-01-05 : General Waste [trash-can]
    2026-01-12 : Recycling [mdi:recycle]
  found 2 entries for Workers Blacktown
    2026-01-07 : General Waste [trash-can]
    2026-01-07 : Recycling [mdi:recycle]
  found 2 entries for Hythe St
    2026-01-05 : General Waste [trash-can]
    2026-01-12 : Recycling [mdi:recycle]
  found 3 entries for Issue#4434
    2026-01-02 : General Waste [trash-can]
    2026-01-02 : Recycling [mdi:recycle]
    2026-01-02 : Food and Garden Waste [mdi:trash-can]
```