### PR TITLE
Update neath_port_talbot_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/neath_port_talbot_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/neath_port_talbot_gov_uk.py
@@ -97,7 +97,7 @@ class Source:
 
     Finally, the waste collection schedule is parsed from the resulting HTML page.
     """
-    _BASE_URL = f"{URL}bins-and-recycling/bin-day-finder/"
+    _BASE_URL = f"{URL}bins-and-recycling/equipment-and-collections/bin-day-finder/"
     _HEADERS = {
         "User-Agent": "Mozilla/5.0",
         "Referer": _BASE_URL,


### PR DESCRIPTION
Neath Port Talbot Council have changed the URL for waste collection information. This change modifies the Base URL to reflect this.

Changes:
- Modified _BASE_URL

Test output:

> Testing source neath_port_talbot_gov_uk ...
  found 5 entries for Test_001
    2026-01-15 : Plastic / Tins / Cans [mdi:bottle-soda]
    2026-01-15 : Cardboard, Cartons and Paper [mdi:package-variant]
    2026-01-15 : Glass [mdi:glass-fragile]
    2026-01-15 : Food Waste [mdi:leaf]
    2026-01-15 : Batteries [mdi:battery]
  found 5 entries for Test_002
    2026-01-15 : Plastic / Tins / Cans [mdi:bottle-soda]
    2026-01-15 : Cardboard, Cartons and Paper [mdi:package-variant]
    2026-01-15 : Glass [mdi:glass-fragile]
    2026-01-15 : Food Waste [mdi:leaf]
    2026-01-15 : Batteries [mdi:battery]
  found 5 entries for Test_003
    2026-01-15 : Plastic / Tins / Cans [mdi:bottle-soda]
    2026-01-15 : Cardboard, Cartons and Paper [mdi:package-variant]
    2026-01-15 : Glass [mdi:glass-fragile]
    2026-01-15 : Food Waste [mdi:leaf]
    2026-01-15 : Batteries [mdi:battery]

Also tested by modifying file on local HA installation.

Should fix https://github.com/mampfes/hacs_waste_collection_schedule/issues/5313