### PR TITLE
Update jumomind_de.py - Jumomind source fails on Python 3.13 due to Brotli decoding error (Content-Encoding: br) – workaround by forcing Accept-Encoding

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -281,6 +281,7 @@ class Source:
 
     def fetch(self):
         session = requests.Session()
+        session.headers.update({"Accept-Encoding": "identity"})
 
         city_id = self._city_id
         area_id = self._area_id


### PR DESCRIPTION
**What's Your Problem**
When using the waste_collection_schedule integration with the Jumomind source, the setup fails on Home Assistant versions running Python 3.13.

This issue currently affects **Ingolstadt** (and likely other Jumomind-based municipalities).

**Error**
During fetch, the integration raises the following exception:
requests.exceptions.ContentDecodingError: ('Received response with content-encoding: br, but failed to decode it.', brotli: decoder process called with data when 'can_accept_more_data()' is False) 

The error occurs while calling the Jumomind API (e.g. fetching streets or collection data).
The root cause is a Brotli (br) decoding failure in urllib3 / requests under Python 3.13.

**Root Cause**
The Jumomind API responds with Brotli-compressed content (Content-Encoding: br).
On Python 3.13, decoding this response fails and causes the integration to break.

**Workaround / Fix**
Force the requests session to disable compression by explicitly setting:
Accept-Encoding: identity 
Affected file
custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py 

**Required change**
Before
`session = requests.Session() `
After
```
session = requests.Session()
session.headers.update({"Accept-Encoding": "identity"}) 
```
⚠️ Important: use spaces only, no tabs (otherwise a TabError occurs).

Source (if relevant)
jumomind_de.py