### PR TITLE
Fix: Ryde, NSW - Update headers to bypass bot protection

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ryde_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ryde_nsw_gov_au.py
@@ -34,7 +34,12 @@ API_URLS = {
     "collection": "https://www.ryde.nsw.gov.au/ocapi/Public/myarea/wasteservices",
 }
 
-HEADERS = {"user-agent": "Mozilla/5.0"}
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+    "Accept": "text/plain, */*; q=0.01",
+    "Referer": "https://www.ryde.nsw.gov.au/Environment-and-Waste/Waste-and-Recycling",
+    "X-Requested-With": "XMLHttpRequest",
+}
 
 ICON_MAP = {
     "General Waste": "trash-can",


### PR DESCRIPTION
Updated HTTP headers to resolve 403 Forbidden errors from Akamai bot protection. This follows the same pattern used in PR #5230 for Blacktown NSW.

Changes:
- Updated User-Agent to modern Chrome version
- Set Accept header to text/plain with quality parameter
- Added Referer header pointing to the waste collection page
- Added X-Requested-With header for AJAX identification

All test cases now pass successfully.