### PR TITLE
Add multiple date collection for bins (rushcliffe.gov.uk)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
@@ -117,13 +117,14 @@ class Source:
             before_bin = line.split(" bin", 1)[0]
             before_bin = before_bin.replace("Your next ", "")
             bin_type = before_bin.split("(", 1)[0].strip()
-            date = re.search(r"\d{2}/\d{2}/\d{4}", line)
-            if not date:
+            dates = re.findall(r"\d{2}/\d{2}/\d{4}", line)
+            if not dates:
                 continue
-            date = date.group(0)
 
-            date = datetime.datetime.strptime(date, "%d/%m/%Y").date()
             icon = ICON_MAP.get(bin_type)  # Collection icon
-            entries.append(Collection(date=date, t=bin_type, icon=icon))
+
+            for d in dates:
+                date = datetime.datetime.strptime(d, "%d/%m/%Y").date()
+                entries.append(Collection(date=date, t=bin_type, icon=icon))
 
         return entries


### PR DESCRIPTION
Rushcliffe Borough Council now provides the next 2 dates each bin will be collected. This codes pulls both dates for the bins, rather than the first date in the list.