### PR TITLE
publidata_fr fix when response has null/None/unknown types

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -654,7 +654,11 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
 
             if len(resp) == 0:
                 errors["base"] = "fetch_empty"
-            self._fetched_types = list({x.type.strip() for x in resp})
+            # Skip entries with None type (e.g. publidata_fr when garbage_type not in LABEL_MAP)
+            # so setup does not crash and the type selector only shows valid types.
+            self._fetched_types = list(
+                {x.type.strip() for x in resp if x.type is not None}
+            )
         except SourceArgumentSuggestionsExceptionBase as e:
             if not hasattr(self, "_error_suggestions"):
                 self._error_suggestions = {}

--- a/custom_components/waste_collection_schedule/wcs_coordinator.py
+++ b/custom_components/waste_collection_schedule/wcs_coordinator.py
@@ -134,7 +134,10 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _fetch_now(self, *_):
         if self.shell:
             await self._hass.async_add_executor_job(self.shell.fetch)
-            
+            _LOGGER.debug(
+                "WCS coordinator fetch done: shell has %d entries",
+                len(self.shell._entries),
+            )
             # Save device keys to storage after fetch
             device_store = get_device_key_store()
             if device_store:


### PR DESCRIPTION
# Fix publidata_fr: empty calendar and setup crashes when API returns null/unknown types

## Summary

This PR fixes integration setup and calendar behaviour for the **publidata_fr** source when the Publidata API returns waste types that are `null`, missing from `LABEL_MAP`, or when response shape/date ranges differ from the original assumptions. Users could not complete setup (crash on `x.type.strip()`) or saw an empty calendar despite a successful fetch.

## Problem

1. **Setup crash**
   During config flow, `_fetched_types` was built with `{x.type.strip() for x in resp}`. If any collection had `type is None` (e.g. API returns a `garbage_type` not in `LABEL_MAP`), `.strip()` raised and setup failed.

2. **Empty calendar after “fixing” setup**  
   Even when filtering out `None` types in config flow:
   - **Source (publidata_fr)** could still create `Collection(..., None, ...)` for unknown `garbage_type`s, so `LABEL_MAP.get(waste_type)` was `None`.
   - **Source shell** did `e.type.strip()` on every fetch; if any entry had `type is None`, it raised, the exception was caught, and `_entries` was never set then the calendar stayed empty.
   - **Calendar** only shows events with `date >= today`. The API often returns schedules with `end_at` in the past; the rrule then only generated past dates, so all entries were filtered out and the calendar appeared empty.

3. **Other robustness issues**  
   - If the API returned no hit with `sectorization == "single"`, `_sanitize_response` produced no waste types -> 0 entries ->  empty calendar.  
   - If `schedules` was a dict instead of a list, iterating and using `schedule["schedule_type"]` could raise and abort the fetch.  
   - A single malformed schedule could make the whole fetch fail.

## Solution

### config_flow.py

- Build `_fetched_types` only from entries with a non-`None` type:  
  `{x.type.strip() for x in resp if x.type is not None}`  
  So setup no longer crashes and the type selector only shows valid types.

### source_shell.py

- **Consume fetch result to a list**  
  `entries = list(raw_entries) if raw_entries else []` so we never exhaust a generator when mutating then filtering.
- **Normalise type before use**  
  `e.set_type(str((e.type or "")).strip())` so we never call `.strip()` on `None` and type is always a string for filters/customize.
- **Debug logging**  
  Log entry count after filter/customize when debug logging is enabled.

### waste_collection_schedule/source/publidata_fr.py

- **Never pass `None` as collection type**  
  Use  
  `label = str(LABEL_MAP.get(waste_type) or waste_type or "Autre")`  
  so every collection has a string type (label, raw key, or `"Autre"`). Note: "Autre" means "Other" in French.
- **Handle `schedules` as list or dict**  
  If `schedules` is a dict, use `list(raw_schedules.values())` so we iterate over schedule dicts; otherwise use the list. Prevents crashes when the API returns a dict.
- **Resilient schedule parsing**  
  Wrap schedule handling in try/except; on `KeyError`, `ValueError`, `TypeError` log and skip that schedule so one bad entry does not empty the calendar.
- **Fallback when no “single” sectorization**  
  If no hit has `sectorization == "single"`, use the first hit and its schedules (with a key from `garbage_types` or `"collection"`) so the calendar still gets data.
- **Extend past `end_at` for future dates**  
  In `_parse_regular`, ensure the rrule `until` is at least “now + 365 days”. If the API’s `end_at` is in the past, use that minimum so we always generate future dates and the calendar can show upcoming collections.
- **Logging**  
  Add debug logs for fetch result (waste types count, entry count) and when the sectorization fallback or schedule skip is used.

### wcs_coordinator.py

- **Debug logging**  
  After the fetch, log how many entries the shell has (when debug logging is enabled).

## Testing

- Setup completes even when the API returns unknown/null waste types.
- Calendar shows upcoming waste collection events for publidata_fr.
- With debug logging enabled (`custom_components.waste_collection_schedule: debug`), logs show entry counts and any fallbacks/skips.

## Checklist

- [x] Code comments added where non-obvious.
- [x] No new linter issues.
- [x] Added a few `debug` logs if it can help future debugging.
- [x] Backward compatible: only adds fallbacks and guards; existing behaviour unchanged when API matches previous assumptions.

## Linked issues

This should fix #5127.
Hopefully not causing any regression.