### PR TITLE
Fix southkesteven_gov_uk after SKDC endpoint change

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southkesteven_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southkesteven_gov_uk.py
@@ -1,16 +1,21 @@
 import logging
-import re
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import bs4
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 URL = "https://southkesteven.gov.uk"
+FORM_URL = (
+    "https://selfservice.southkesteven.gov.uk/"
+    "renderform?k=2074C945A63DDC0D18F1EB74DA230AC3122958B1&t=213"
+)
+RENDER_URL = "https://selfservice.southkesteven.gov.uk/RenderForm"
+ADDRESS_LOOKUP_URL = "https://selfservice.southkesteven.gov.uk/core/addresslookup"
 TEST_CASES = {
-    "Long Bennington": {"address_id": 33399},
-    "Bourne": {"address_id": "7351"},
-    "Grantham": {"address_id": 18029},
+    "Bourne": {"address_id": "PE10 0RX"},
+    "Long Bennington": {"address_id": "NG23 5EQ"},
+    "Grantham": {"address_id": "NG31 6NP"},
 }
 _LOGGER = logging.getLogger(__name__)
 ICON_MAP = {
@@ -25,87 +30,81 @@ TITLE = "South Kesteven District Council"
 DESCRIPTION = "Source for southkesteven.gov.uk services for South Kesteven, UK."
 
 
-# Extract bin type form text like "What goes in the black bin"
-FUTURE_BIN_TYPE_REGEX = re.compile(r"What goes in the (\w+) bin")
-
-# Extract bin type form text like "This is a black bin day - [...]"
-NEXT_BIN_TYPE_REGEX = re.compile(r"This is a (\w+) bin day")
-
-
 class Source:
     def __init__(self, address_id):
-        self._address_id = address_id
+        self._address_id = str(address_id)
 
     def fetch(self):
-        r = requests.post(
-            "https://pre.southkesteven.gov.uk/BinSearch.aspx",
-            data={"address": self._address_id},
-        )
-        r.raise_for_status()
+        session = requests.Session()
+        form_resp = session.get(FORM_URL, timeout=30)
+        form_resp.raise_for_status()
+        form_soup = bs4.BeautifulSoup(form_resp.text, "html.parser")
 
-        collections = []
-        soup = bs4.BeautifulSoup(r.content, "html.parser")
+        token = form_soup.find("input", attrs={"name": "__RequestVerificationToken"})
+        form_guid = form_soup.find("input", attrs={"name": "FormGuid"})
+        object_template_id = form_soup.find("input", attrs={"name": "ObjectTemplateID"})
+        section_id = form_soup.find("input", attrs={"name": "CurrentSectionID"})
+        if not all([token, form_guid, object_template_id, section_id]):
+            raise ValueError("Unable to read South Kesteven form metadata")
 
-        date_translate = {
-            "Tomorrow": datetime.now().date() + timedelta(days=1),
-            "Today": datetime.now().date(),
+        payload = {
+            "__RequestVerificationToken": token["value"],
+            "FormGuid": form_guid["value"],
+            "ObjectTemplateID": object_template_id["value"],
+            "Trigger": "submit",
+            "CurrentSectionID": section_id["value"],
+            "FF5265": self._address_id,
+            "FF5265lbltxt": "Collection Address",
+            "FF5265searchnlpg": "False",
+            "FF5265manualaddressentry": "False",
+            "FF5265classification": "",
         }
+        data_resp = session.post(RENDER_URL, data=payload, timeout=30)
+        data_resp.raise_for_status()
+        data_soup = bs4.BeautifulSoup(data_resp.text, "html.parser")
 
-        # Find next collection
-        # find p looks like                     <p>Your next bin collection date is <span class="alert__heading alpha">Wed 19 June 2024</span></p>
-        next_collection_p = soup.find(
-            lambda tag: tag.name == "p"
-            and "Your next bin collection date is" in tag.text
-        )
-        # above does not work so try this
+        collections: list[Collection] = []
+        for row in data_soup.select("table.Alloy-table tr"):
+            cols = row.find_all("td", class_="Alloy-table-col")
+            if len(cols) < 2:
+                continue
+            raw_date = cols[0].get_text(strip=True)
+            raw_type = cols[1].get_text(strip=True)
+            try:
+                dt = datetime.strptime(raw_date, "%A %d %B, %Y").date()
+            except ValueError:
+                continue
+            icon = ICON_MAP.get(raw_type.lower())
+            if icon is None:
+                lower = raw_type.lower()
+                if "refuse" in lower:
+                    icon = ICON_MAP["black"]
+                elif "recycling" in lower or "paper" in lower:
+                    icon = ICON_MAP["gray"]
+                elif "green" in lower:
+                    icon = ICON_MAP["green"]
+                elif "purple" in lower:
+                    icon = ICON_MAP["purple"]
+            collections.append(Collection(dt, raw_type, icon))
 
-        if next_collection_p is None:
+        # If the new flow does not yield rows, try postcode lookup then resubmit.
+        if not collections and not self._address_id.startswith("U"):
+            lookup_resp = session.post(
+                ADDRESS_LOOKUP_URL,
+                data={"query": self._address_id, "searchNlpg": "False", "classification": ""},
+                timeout=30,
+            )
+            lookup_resp.raise_for_status()
+            data = lookup_resp.json()
+            if data:
+                # Prefer first returned address ID from SKDC lookup.
+                self._address_id = next(iter(data.keys()))
+                return self.fetch()
+        if not collections:
             _LOGGER.warning(
-                "No next collection text found, continuing to look for future collections"
+                "South Kesteven returned no collection rows for address_id=%s",
+                self._address_id,
             )
-        else:
-            date_str = next_collection_p.find("span").text
-            date = (
-                date_translate.get(date_str)
-                or datetime.strptime(date_str, "%a %d %B %Y").date()
-            )
-            bin_type = NEXT_BIN_TYPE_REGEX.search(
-                next_collection_p.find_next("p").text
-            ).group(1)
-            collections.append(Collection(date, bin_type, ICON_MAP.get(bin_type)))
-
-        # Find all Future collections
-        s = soup.find_all("h3", text="Future collections")
-
-        for collections_list in s:
-            collections_ul = collections_list.find_next_sibling("ul")
-            collection_futher_info_link = (
-                collections_ul.find_previous_sibling("ul").find("a")
-            )
-            if (collection_futher_info_link is None):
-                garden_check = (collections_ul.find_previous_sibling("ul").find("li").text)
-                if garden_check == "Leaves":
-                    bin_type = "green"
-            else:
-                bin_type = FUTURE_BIN_TYPE_REGEX.search(collection_futher_info_link.text).group(
-                    1
-                )
-
-            for collection in collections_list.find_next_sibling("ul").find_all("li"):
-                # like: "Thu 29 August 2024"
-                date_str = collection.text
-
-                try:
-                    date = (
-                        date_translate.get(date_str)
-                        or datetime.strptime(date_str, "%a %d %B %Y").date()
-                    )
-                except ValueError:
-                    _LOGGER.warning(
-                        f"Failed to parse date {date_str}, skipping this collection"
-                    )
-                    continue
-                collections.append(Collection(date, bin_type, ICON_MAP.get(bin_type)))
 
         # filter out duplicate entries
         collections = list(
@@ -114,5 +113,4 @@ class Source:
                 for collection in collections
             }.values()
         )
-
         return collections


### PR DESCRIPTION
## Fix `southkesteven_gov_uk` source after SKDC endpoint change

### Summary
This updates the South Kesteven source from the legacy `pre.southkesteven.gov.uk/BinSearch.aspx` workflow to the current self-service form workflow.

- Old endpoint now fails (`500` / broken behavior).
- New implementation uses SKDC selfservice flow and parses returned collection rows.

### What changed
- Replaced old POST-to-`BinSearch.aspx` scraping logic.
- New flow:
  1. GET form metadata from `selfservice.southkesteven.gov.uk/renderform?...t=213`
  2. POST selected address ID to `RenderForm`
  3. Parse collection rows from `table.Alloy-table`
- Added fallback:
  - If no rows and input is not a `U...` address ID, call `core/addresslookup` with the provided value (e.g. postcode), pick first address ID, retry fetch.
- Kept duplicate-event dedupe (`date`, `type`).
- Updated `TEST_CASES` to values compatible with the new flow (postcode input).

### Why this is safe
- Uses the current SKDC-hosted flow that is actively returning collection dates and bin types.
- No changes to unrelated sources.
- Parser is conservative: only rows with parseable date + type are used.

### Reproduction (before)
- Source `southkesteven_gov_uk` fails due to the old `BinSearch.aspx` endpoint no longer providing usable data.

### Validation (after)
- Address lookup endpoint returns structured data:
  - `POST https://selfservice.southkesteven.gov.uk/core/addresslookup`
- RenderForm flow returns collection table rows with concrete dates and bin types.
- Local compile check passes for updated source file.

### Notes
- Existing issue context:
  - https://github.com/mampfes/hacs_waste_collection_schedule/issues/4751
  - https://github.com/mampfes/hacs_waste_collection_schedule/pull/5029
