### PR TITLE
fix: cancel secondary pickup in holiday week for philadelphia source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
@@ -51,10 +51,27 @@ class Source:
         self._address: str = address.upper()
 
     def create_dates(self, days: list, start: date, end: date):
-        dts = list(rrule(freq=WEEKLY, byweekday=days, dtstart=start, until=end))
-        return dts
+        all_pickups = []
 
-    def check_holidays(self, hols: list[date], dt: date) -> date:
+        for index, day in enumerate(days):
+            occurrences = rrule(freq=WEEKLY, byweekday=day, dtstart=start, until=end)
+
+            for dt in occurrences:
+                all_pickups.append({"date": dt.date(), "weekly_pickup_num": index + 1})
+        return sorted(all_pickups, key=lambda x: x["date"])
+
+    def check_holidays(self, hols: list[date], dt: date, pickup_number: int) -> date:
+        if pickup_number > 1:
+            # Secondary pickups: if any observed holiday falls in the same Monday–Friday
+            # week as `dt`, cancel secondary pickup
+            week_monday = dt - timedelta(days=dt.weekday())  # Monday of this week
+            week_friday = week_monday + timedelta(days=4)
+            holiday_in_week = any(week_monday <= h <= week_friday for h in hols)
+            if holiday_in_week:
+                return None
+            return dt
+
+    def check_holidays(self, hols: list[date], dt: date, pickup_number: int) -> date:
         """
         Shift a collection date forward for holidays in the same week.
 
@@ -68,7 +85,7 @@ class Source:
         """
         # find all weekday holidays in the same Mon-Sun week as dt
         week_start = dt - timedelta(days=dt.weekday())  # Monday
-        week_end = week_start + timedelta(days=6)        # Sunday
+        week_end = week_start + timedelta(days=6)  # Sunday
         week_hols = sorted(h for h in hols if week_start <= h <= week_end)
 
         # shift by 1 for each holiday that falls on or before the collection day
@@ -77,7 +94,7 @@ class Source:
 
         # if the adjusted date itself is a holiday, shift once more
         if adjusted in hols and adjusted != dt:
-            adjusted = self.check_holidays(hols, adjusted)
+            adjusted = self.check_holidays(hols, adjusted, pickup_number)
 
         return adjusted
 
@@ -130,11 +147,16 @@ class Source:
         recycle = self.create_dates(recycle_days, start, end)
 
         # adjust for observed holidays
-        adjusted_trash = [self.check_holidays(holidays, d.date()) for d in trash]
-        adjusted_recycling = [self.check_holidays(holidays, d.date()) for d in recycle]
-
-        waste_schedule = list(set(adjusted_trash))
-        recycle_schedule = list(set(adjusted_recycling))
+        adjusted_trash = [
+            self.check_holidays(holidays, item["date"], item["weekly_pickup_num"])
+            for item in trash
+        ]
+        adjusted_recycling = [
+            self.check_holidays(holidays, item["date"], item["weekly_pickup_num"])
+            for item in recycle
+        ]
+        waste_schedule = list({d for d in adjusted_trash if d is not None})
+        recycle_schedule = list({d for d in adjusted_recycling if d is not None})
 
         entries = []
         for item in waste_schedule:


### PR DESCRIPTION
Some neighborhoods in Philadelphia have a secondary pickup and when there is a holiday in the week, the secondary pickup is [cancelled](https://www.phila.gov/services/trash-recycling-city-upkeep/find-your-trash-and-recycling-collection-day/#/):
<img width="871" height="202" alt="image" src="https://github.com/user-attachments/assets/b582c6fc-95a4-4f91-97d6-dcf1c538fc57" />


Previously the week of 2/16 (observed holiday for presidents day) for the test case would return:
```
2026-02-17 mdi:trash-can
2026-02-17 mdi:recycle
2026-02-20 mdi:trash-can
```
`2026-02-20` is incorrect and trash pickup is cancelled due to it being a holiday week.



Now this returns 
```
2026-02-17 mdi:trash-can
2026-02-17 mdi:recycle
```

I ran the following to test:
```
python3 <<'PY'
import sys, os
sys.path.insert(0, os.path.abspath('.'))
from custom_components.waste_collection_schedule.waste_collection_schedule.source import phila_gov
from datetime import date
s = phila_gov.Source("1830 Fitzwater Street")
items = s.fetch()
start = date(2026,2,16)
end = date(2026,2,22)
filtered = [i for i in items if start <= i.date <= end]
for i in sorted(filtered, key=lambda x: x.date):
    print(i.date.isoformat(), getattr(i,'icon',None))
print('Total:', len(filtered))
PY
```

