### PR TITLE
Avoid blocking platform import warning during entry setup

### DIFF
--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -82,7 +82,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(const.DOMAIN, {})[entry.entry_id] = coordinator
 
     # Pre-import platform modules in executor to avoid blocking import warnings
-    # when forwarding setups from the event loop.
+    # during async_forward_entry_setups, e.g.:
+    # "Detected blocking call to import_module ... waste_collection_schedule/calendar"
     for platform in PLATFORMS:
         await hass.async_add_executor_job(
             importlib.import_module, f"{__package__}.{platform}"


### PR DESCRIPTION
## Summary
Pre-import calendar and sensor platform modules in the executor before calling async_forward_entry_setups.

## Why
Home Assistant warns about a blocking import_module call from init_ui.py during startup:
- Detected blocking call to import_module ... custom_components/waste_collection_schedule/calendar

Preloading platform modules via hass.async_add_executor_job(importlib.import_module, ...) keeps import work off the event loop.

## Change
- Add importlib import
- In async_setup_entry, import each platform in PLATFORMS via executor
- Keep the existing async_forward_entry_setups flow unchanged
