### PR TITLE
fix: Ekosystem.wroc.pl unescape encoded & in the calendar url

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ekosystem_wroc_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ekosystem_wroc_pl.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import html
 import re
 from urllib.parse import urlparse, parse_qsl
 
@@ -67,7 +68,7 @@ class Source:
         match = self._calendar_url_pattern.search(message)
         if not match:
             raise Exception(f"Error: a message {message} does not contain a valid calendar url!")
-        calendar_url = match.group(1)
+        calendar_url = html.unescape(match.group(1))
         parsed_url = urlparse(calendar_url)
         params_list = parse_qsl(parsed_url.query)
         return {k: v for (k, v) in params_list}


### PR DESCRIPTION
After recent changes in the Ekosystem.wroc.pl API, the source system started returning URLs with HTML-encoded ampersands (&#038;) instead of &.

Example URL:
```
https://ekosystem.wroc.pl/download/?action=pdf&#038;kiedy_1=2026-03-09&#038;co_1=papier&#038;kiedy_2=2026-03-09&#038;co_2=tworzywa&#038;kiedy_3=2026-03-10&#038;co_3=zmieszane&#038;kiedy_4=2026-03-11&#038;co_4=BIO&#038;kiedy_5=2026-03-17&#038;co_5=zmieszane&#038;kiedy_6=2026-03-18&#038;co_6=BIO&#038;kiedy_7=2026-03-19&#038;co_7=szk%C5%82o&#038;kiedy_8=2026-03-23&#038;co_8=papier&#038;kiedy_9=2026-03-23&#038;co_9=tworzywa&#038;kiedy_10=2026-03-24&#038;co_10=zmieszane&#038;kiedy_11=2026-03-25&#038;co_11=BIO&#038;kiedy_12=2026-03-31&#038;co_12=zmieszane&#038;kiedy_13=2026-04-01&#038;co_13=BIO&#038;params=13" id="prin(...)
```

This caused the integration to fail with exceptions like:
```
2026-03-08 21:01:59.344 ERROR (SyncWorker_9) [custom_components.waste_collection_schedule.waste_collection_schedule.source_shell] fetch failed for source Wrocław:
Traceback (most recent call last):
  File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py", line 158, in fetch
    entries: Iterable[Collection] = self._source.fetch()
                                    ~~~~~~~~~~~~~~~~~~^^
  File "/config/custom_components/waste_collection_schedule/waste_collection_schedule/source/ekosystem_wroc_pl.py", line 48, in fetch
    raise Exception("Error: parameter number not present in the url!")
Exception: Error: parameter number not present in the url!
```

The fix decodes the HTML entities before parsing the URL, so parameters like kiedy_1, co_1, etc., are correctly extracted.

Calendars are now correctly imported into Home Assistant again.

Tests:
```
python test_sources.py -s ekosystem_wroc_pl
Testing source ekosystem_wroc_pl ...
  found 58 entries for Legnicka 160
  found 11 entries for Marcepanowa 7
```