### PR TITLE
fix: update Tauranga API URLs and improve form field discovery

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tauranga_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tauranga_govt_nz.py
@@ -69,7 +69,7 @@ class Source:
 
         return pickup_date_response
 
-    def generate_form_data(self, addr_1: str, addr_2: str) -> str:
+    def generate_form_data(self, addr_1: str, addr_2: str) -> Dict[str, str]:
         state_response = self._session.get(self.WASTE_URL)
         soup = BeautifulSoup(state_response.content, "html.parser")
         view_state = soup.find("input", attrs={"id": "__VIEWSTATE"})["value"]


### PR DESCRIPTION
This pull request updates the Tauranga City Council waste collection integration to improve its reliability and maintainability. The main changes involve updating URLs to reflect changes on the council's website and making the code more robust against future changes in the web form's structure.

**URL updates:**
* Updated both `API_URL` and `WASTE_URL` to the new `/services/rubbish-and-recycling/` path to reflect changes on the Tauranga City Council website. [[1]](diffhunk://#diff-7fa17055e5315fbcfb07695263342491796601e2d85d5d4d6cefed69330c7796L19-R19) [[2]](diffhunk://#diff-7fa17055e5315fbcfb07695263342491796601e2d85d5d4d6cefed69330c7796L35-R35)

**Form field handling improvements:**
* Modified the `generate_form_data` method to dynamically discover the form field names for address input and hidden value fields. This change ensures the integration continues to work even if the server changes the control/module IDs, making the code more robust to future updates on the council's website.