### PR TITLE
Revising source for Maribyrnong Council

### DIFF
--- a/doc/source/maribyrnong_vic_gov_au.md
+++ b/doc/source/maribyrnong_vic_gov_au.md
@@ -40,4 +40,4 @@ waste_collection_schedule:
 
 ## How to get the source arguments
 
-Visit the [Maribyrnong Council (VIC)](https://www.maribyrnong.vic.gov.au/Residents/Bins-and-recycling) page and search for your address.  The arguments should exactly match the results shown for Suburb and Street and the number portion of the Property.
+Visit https://maribyrnong.waste-info.com.au/api/v1/streets.json and search for your street name. The arguments should exactly match the results shown for the Suburb ("locality"), Street ("name") and the number portion of the Property.


### PR DESCRIPTION
Updated instructions for obtaining source arguments by using the API link in the Python file as the council website does not have an address searcher anymore. 