### PR TITLE
fix #5594 Stockton Borough Council

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stockton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stockton_gov_uk.py
@@ -53,7 +53,10 @@ class Source:
         soup = BeautifulSoup(r.text, features="html.parser")
 
         # Stockton migrated this form to a V2 name (and action URL includes pageSessionId)
-        form = soup.find("form", attrs={"id": "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_FORM"})
+        form = soup.find(
+            "form",
+            attrs={"id": "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_FORM"},
+        )
         if not form or not form.get("action"):
             raise ValueError("Could not find LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_FORM or action")
         form_url = form["action"]


### PR DESCRIPTION
fix #5594 Stockton Borough Council

Similar to fix previously for Gateshead Council.

**Details of changes**
Form ID and action update
Switched from the legacy form ID LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_FORM to the new LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_FORM.
Read and use the action attribute from this new form, which now includes pageSessionId and other parameters in the query string.

Hidden field name updates
Replaced all LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_* hidden input names with their V2 equivalents:
...V2_PAGESESSIONID
...V2_SESSIONID
...V2_NONCE
...V2_UPRN
...V2_CUSTODIAN
...V2_FORMACTION_NEXT / ...V2_FINDBUTTON

JavaScript payload variable update
Updated the regex and script lookup to target the new JS variable:
From: LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONFormData
To: LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2FormData
Added defensive checks so we fail with clear errors if the script block or payload cannot be found.

Imports / structure
Kept the existing HTML parsing of COLLECTIONDETAILS2 and date extraction logic intact, so the output format (list of Collection objects) is unchanged.