### PR TITLE
Fixed greenwich holidays parsing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/royalgreenwich_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/royalgreenwich_gov_uk.py
@@ -158,11 +158,11 @@ class Source:
             if len(row_dates) < 2:
                 continue
 
-            from_date = parser.parse(row_dates[0].text).date()
+            from_date = parser.parse(row_dates[0].text, fuzzy=True).date()
             to_date = (
                 from_date
-                if row_dates[1].text == "Collection as usual"
-                else parser.parse(row_dates[1].text).date()
+                if row_dates[1].text == "Collections as normal"
+                else parser.parse(row_dates[1].text, fuzzy=True).date()
             )
 
             result[from_date] = to_date


### PR DESCRIPTION
Changes based on https://www.royalgreenwich.gov.uk/recycling-and-rubbish/bins-and-collections/bank-holiday-collection-dates:
- `Collection as usual` was changed with `Collections as normal`
- Added `fuzzy=True` whilst parsing dates to avoid issues when parsing strings with dates like `Friday 3 April (Good Friday)` (currently it throws an error)