### PR TITLE
Fix Rushmoor Borough Council 403 by correcting User-Agent

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushmoor_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushmoor_gov_uk.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime
 
 import requests
@@ -11,7 +10,9 @@ TEST_CASES = {
     "GU14": {"uprn": "100060551749"},
 }
 
-HEADERS = {"user-agent": "Mozilla/5.0 (xxxx Windows NT 10.0; Win64; x64)"}
+HEADERS = {
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+}
 ICON_MAP = {
     "Refuse": "mdi:trash-can",
     "Recycling": "mdi:recycle",


### PR DESCRIPTION
## Summary
- Fixes malformed User-Agent header in `rushmoor_gov_uk.py` that contained `"xxxx"`, causing the server to reject requests with a 403 Forbidden error
- Replaced with a realistic Chrome browser User-Agent string consistent with other UK council sources in this repo
- Removed unused `import json`

Fixes #5617

## Test plan
- [ ] Verify the Rushmoor API returns 200 with the updated User-Agent
- [ ] Confirm waste collection data is parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)