### PR TITLE
Fix ccc_govt_nz missing collections from stale API dates

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
@@ -113,9 +113,22 @@ class Source:
             # The API can return stale dates. Advance past dates forward
             # by the collection interval until they are no longer in the past
             # (i.e., on or after today). Organic is collected weekly, all others fortnightly.
+            # After each advance, recheck overrides so holiday/special-date
+            # overrides are not missed for the corrected date.
             interval_weeks = 1 if bin["material"] == "Organic" else 2
-            while collection_date < today:
+            max_iterations = 52  # safety limit
+            iterations = 0
+            while collection_date < today and iterations < max_iterations:
                 collection_date += datetime.timedelta(weeks=interval_weeks)
+                iterations += 1
+                # Recheck overrides for the advanced date
+                date_str = collection_date.strftime("%Y-%m-%d")
+                for override in overrides:
+                    if override["OriginalDate"] == date_str:
+                        collection_date = datetime.datetime.strptime(
+                            override["NewDate"], "%Y-%m-%d"
+                        ).date()
+                        break
 
             entries.append(
                 Collection(


### PR DESCRIPTION
## Summary
- The CCC API returns `next_planned_date_app` values that can be in the past, causing Recycling and Organics collections to go missing
- Ports the same fix used on the CCC website itself: advance stale dates forward by the collection interval (weekly for Organic, fortnightly for others) until they are in the future
- Skips bins with `pick_up_group` of "Daily" or "Not Collected" as the CCC website does

Fixes #5605

## Test plan
- [ ] Verify all three collection types (Garbage, Recycle, Organic) are returned for test address "53 Hereford Street"
- [ ] Confirm returned dates are in the future
- [ ] Verify date override logic still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)