### PR TITLE
Fix Philadelphia holiday shift to affect rest of week

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
@@ -57,14 +57,18 @@ class Source:
         return dts
 
     def check_holidays(self, hols: list[date], dt: date) -> date:
-        # collections shifted by 1 day if they fall on a holiday
-        # if adjusted day is also a holiday, it shifts again
-        if dt in hols:
-            x = dt + timedelta(days=1)
-            x = self.check_holidays(hols, x)
-        else:
-            x = dt
-        return x
+        # In Philadelphia, when a holiday falls on a weekday, all collections
+        # on or after that day in the same week (Mon-Fri) are shifted by 1 day.
+        # Find the Monday of the collection week.
+        week_start = dt - timedelta(days=dt.weekday())
+        week_end = week_start + timedelta(days=4)  # Friday
+        # Count holidays in this week that fall on or before the collection day
+        shift = sum(1 for h in hols if week_start <= h <= min(dt, week_end))
+        adjusted = dt + timedelta(days=shift)
+        # If the adjusted date itself lands on a holiday, shift again
+        while adjusted in hols:
+            adjusted += timedelta(days=1)
+        return adjusted
 
     def fetch(self) -> list[Collection]:
         s = requests.Session()


### PR DESCRIPTION
## Summary
- Philadelphia's rule: when a holiday falls on a weekday, all collections **on or after** that day in the same week shift by one day
- The previous `check_holidays` only shifted collections falling exactly on a holiday date, so a Tuesday collection wasn't shifted when Monday was MLK Day
- New logic counts holidays in the same week on or before the collection day, shifting by that many days, plus handles the edge case where the adjusted date also lands on a holiday (e.g., Thanksgiving week with Thu+Fri holidays)

Fixes #5341

## Test plan
Verified with these scenarios:
- [x] MLK Day (Mon) → Tue shifts to Wed, Fri shifts to Sat
- [x] Thanksgiving (Thu+Fri) → Thu shifts to Sat, Fri shifts to Sun, Tue unaffected
- [x] Non-holiday weeks are unchanged
- [x] Collection on the holiday itself shifts to next day

🤖 Generated with [Claude Code](https://claude.com/claude-code)