### PR TITLE
Fixed timestamp for Calgary source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
@@ -72,7 +72,7 @@ class Source:
         entries = []
 
         for entry in schedule:
-            date_format = "%Y-%m-%dT%H:%M:%S.000Z"
+            date_format = "%Y-%m-%dT%H:%M:%S.%f"
 
             current_date = datetime.now()
             commodity = entry["commodity"]


### PR DESCRIPTION
Corrected the timestamp query match for the source which only has 3 decimal seconds digits for resulting time query.