### PR TITLE
Fix ekosystem_wroc_pl on Python 3.14

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ekosystem_wroc_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ekosystem_wroc_pl.py
@@ -2,9 +2,8 @@ import datetime
 import json
 import html
 import re
-from urllib.parse import urlparse, parse_qsl
-
-import requests
+from urllib.parse import parse_qsl, urlencode, urlparse
+from urllib.request import Request, urlopen
 from waste_collection_schedule import Collection
 
 TITLE = "Wrocław"
@@ -38,9 +37,20 @@ class Source:
             "<a href=\"(https://ekosystem\\.wroc\\.pl/download/\\?action=pdf[^\"]*)\"")
 
     def fetch(self):
-
-        r = requests.post(API_URL, data=dict(action="waste_disposal_form_get_schedule", id_numeru=self._location_id))
-        data = json.loads(r.text)
+        payload = urlencode(
+            {
+                "action": "waste_disposal_form_get_schedule",
+                "id_numeru": self._location_id,
+            }
+        ).encode()
+        request = Request(
+            API_URL,
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        with urlopen(request, timeout=30) as response:
+            data = json.loads(response.read().decode("utf-8"))
 
         calendar_data = self.extract_calendar_data(data)
         entries = []
@@ -53,7 +63,7 @@ class Source:
             type_str = calendar_data[WASTE_TYPE_PARAM_FORMAT.format(i)]
             entries.append(
                 Collection(
-                    date=datetime.datetime.strptime(date_str, "%Y-%m-%d").date(),
+                    date=datetime.date.fromisoformat(date_str),
                     t=type_str.capitalize(),
                     icon=ICON_MAP.get(type_str)
                 )


### PR DESCRIPTION
Fixes #5564.

## Summary

This updates `ekosystem_wroc_pl` to avoid two current failure modes:

1. The Wroclaw endpoint returns the PDF link in HTML, so the source must keep working with the unescaped query string.
2. On newer Home Assistant / Python runtimes, importing `requests` and using `datetime.strptime()` from this source can pull in the stdlib `calendar` module through an import path that collides with the integration's own `calendar.py`.

The second problem showed up for me on Home Assistant `2026.3.4` / Python `3.14.2` as:

`AttributeError: partially initialized module 'calendar' ... has no attribute 'timegm'`

## Changes

- replace the source's `requests.post(...)` call with stdlib `urllib.request`
- keep parsing the returned Wroclaw URL after HTML unescaping
- replace `datetime.strptime(..., "%Y-%m-%d")` with `date.fromisoformat(...)`

## Why this helps

Using stdlib `urllib` and `date.fromisoformat()` avoids the import chain that ends up resolving the custom component's `calendar.py` instead of the stdlib `calendar` module in this integration layout.

## Verification

- confirmed the patched source returns entries for the existing upstream test cases:
  - `Legnicka 160`
  - `Marcepanowa 7`
- confirmed the fix restores live entities on a real HA instance:
  - `calendar.wywoz_smieci` returned to `on`
  - `sensor.wywoz_smieci` returned upcoming dates again

I also ran the repository's source test harness with `test_sources.py -s ekosystem_wroc_pl`; the Wroclaw source itself passed, and the script only failed later on an unrelated missing local dependency for the separate `ics` source (`icalevents`).