### PR TITLE
fix special naming for special collection dates

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aha_region_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aha_region_de.py
@@ -151,7 +151,7 @@ class Source:
             raise Exception("got invalid ics file") from e
         entries = []
         for d in dates:
-            bin_type = d[1].replace("Abfuhr", "").strip()
-            entries.append(Collection(d[0], str(bin_type).replace(' *', ''), ICON_MAP.get(bin_type)))
+            bin_type = d[1].replace("Abfuhr", "").strip().replace(' *', '')
+            entries.append(Collection(d[0], bin_type, ICON_MAP.get(bin_type)))
 
         return entries


### PR DESCRIPTION
Most users configure their bin type (for aha_region_de) like 

type:
  - bin_type_x

but on special occasions the bin type gets an asterisk and ends up looking like: "bin_type_x *"

This small string replacement will fix this issue for a lot of users including multiple family members.

Yes the workaround would be adding multiple types for the same bin.
But this one seems like the easiest solution for a lot of complaints in German threads.