### PR TITLE
mijnblink: Move to Ximmio service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2007,7 +2007,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [Goes](/doc/ics/goes_nl.md) / goes.nl
 - [HVC Groep](/doc/source/hvcgroep_nl.md) / hvcgroep.nl
 - [Meerlanden](/doc/source/ximmio_nl.md) / meerlanden.nl
-- [Mijn Blink](/doc/source/hvcgroep_nl.md) / mijnblink.nl
+- [Mijn Blink](/doc/source/ximmio_nl.md) / mijnblink.nl
 - [PreZero](/doc/source/hvcgroep_nl.md) / prezero.nl
 - [Purmerend](/doc/source/hvcgroep_nl.md) / purmerend.nl
 - [RAD BV](/doc/source/ximmio_nl.md) / radbv.nl

--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -12957,11 +12957,11 @@
     },
     {
       "title": "Mijn Blink",
-      "module": "hvcgroep_nl",
+      "module": "ximmio_nl",
       "default_params": {
-        "service": "mijnblink"
+        "company": "mijnblink"
       },
-      "id": "hvcgroep_nl"
+      "id": "ximmio_nl"
     },
     {
       "title": "PreZero",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
@@ -46,11 +46,6 @@ TEST_CASES = {
         "house_number": "1",
         "service": "hvcgroep",
     },
-    "Mijnblink": {
-        "postal_code": "5741BV",
-        "house_number": "76",
-        "service": "mijnblink",
-    },
     "ZRD": {
         "postal_code": "4691DH", 
         "house_number": "4", 
@@ -159,16 +154,6 @@ SERVICE_MAP = [
             "kliko-grijs-rest": "mdi:trash-can",
             "kliko-groen-gft": "mdi:leaf",
             "kliko-grijs-oranje-pmd": "mdi:recycle",
-            "doos-karton-papier": "mdi:archive",
-        },
-    },
-    {
-        "title": "Mijn Blink",
-        "api_url": "https://mijnblink.nl",
-        "icons": {
-            "zak-grijs-rest": "mdi:trash-can",
-            "appel-gft": "mdi:leaf",
-            "blik-metaal-melkpak-drankpak-zak-oranje-plastic": "mdi:recycle",
             "doos-karton-papier": "mdi:archive",
         },
     },

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ximmio_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ximmio_nl.py
@@ -89,6 +89,12 @@ SERVICE_MAP = [
         "company": "meppel",
     },
     {
+        "title": "Mijn Blink",
+        "url": "https://mijnblink.nl/",
+        "uuid": "252d30d0-2e74-469c-8f1e-c0e2e434eb58",
+        "company": "mijnblink",
+    },
+    {
         "title": "RAD BV",
         "url": "https://www.radbv.nl",
         "uuid": "13a2cad9-36d0-4b01-b877-efcb421a864d",

--- a/doc/source/hvcgroep_nl.md
+++ b/doc/source/hvcgroep_nl.md
@@ -43,7 +43,6 @@ Use one of the following codes as service code:
 - hvcgroep
 - lingewaard
 - middelburgvlissingen
-- mijnblink
 - peelenmaas
 - prezero
 - purmerend

--- a/doc/source/ximmio_nl.md
+++ b/doc/source/ximmio_nl.md
@@ -30,6 +30,7 @@ Use one of the following codes as company code:
 - hellendoorn
 - meerlanden
 - meppel
+- mijnblink
 - rad
 - reinis
 - twentemilieu


### PR DESCRIPTION
MijnBlink has moved over to Ximmio as their service provider. The old API integration doesn't return data anymore.

The UUID was retrieved from the "Mijn Blink Afvalkalender" link on https://mijnblink.nl/wanneer. 