### PR TITLE
Refactor next_pickup extraction and date validation for Melton Vic

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_vic_gov_au.py
@@ -78,7 +78,15 @@ class Source:
         for article in soup.find_all("article"):
             waste_type = article.h3.string
             icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string.strip()
+            next_pickup = article.find(class_="next-service").getText().strip()
+            
+            if not re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
+                pattern = r"\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(0?[1-9]|[12][0-9]|3[01])/(0?[1-9]|1[0-2])/\d{4}\b"
+                date_match = re.search(pattern, next_pickup, re.IGNORECASE)
+        
+                if date_match:
+                    next_pickup = date_match.group(0) if date_match else None
+                
             if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
                 next_pickup_date = datetime.strptime(
                     next_pickup.split(sep=" ")[1], "%d/%m/%Y"


### PR DESCRIPTION
Updated next_pickup extraction to use getText() and added regex matching for date format.

Installed and running in my home assistant as well as tested via python online editor (using captured response) 

https://www.online-python.com/share/lHK7YoZzp1

May resolve issue #5488

When div contents did not contain just a date, the .string.strip function could fail