### PR TITLE
Add sensor discovery support and deprecate legacy sensor platform

### DIFF
--- a/custom_components/waste_collection_schedule/init_yaml.py
+++ b/custom_components/waste_collection_schedule/init_yaml.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.discovery import async_load_platform
 
@@ -29,6 +30,23 @@ CUSTOMIZE_CONFIG = vol.Schema(
         vol.Optional(const.CONF_PICTURE): cv.string,
         vol.Optional(const.CONF_USE_DEDICATED_CALENDAR): cv.boolean,
         vol.Optional(const.CONF_DEDICATED_CALENDAR_TITLE): cv.string,
+    }
+)
+
+SENSOR_CONFIG = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Optional(const.CONF_SOURCE_INDEX, default=0): vol.Any(
+            cv.positive_int, vol.All(cv.ensure_list, [cv.positive_int])
+        ),
+        vol.Optional(const.CONF_DETAILS_FORMAT, default="upcoming"): cv.string,
+        vol.Optional(const.CONF_COUNT): cv.positive_int,
+        vol.Optional(const.CONF_LEADTIME): cv.positive_int,
+        vol.Optional(const.CONF_COLLECTION_TYPES): cv.ensure_list,
+        vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(const.CONF_DATE_TEMPLATE): cv.template,
+        vol.Optional(const.CONF_ADD_DAYS_TO, default=False): cv.boolean,
+        vol.Optional(const.CONF_EVENT_INDEX, default=0): cv.positive_int,
     }
 )
 
@@ -65,6 +83,9 @@ CONFIG_SCHEMA = vol.Schema(
                     const.CONF_DAY_SWITCH_TIME,
                     default=const.CONF_DAY_SWITCH_TIME_DEFAULT,
                 ): cv.time,
+                vol.Optional(const.CONF_SENSORS, default=[]): vol.All(
+                    cv.ensure_list, [SENSOR_CONFIG]
+                ),
             }
         )
     },
@@ -120,6 +141,16 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
     # load calendar platform
     await async_load_platform(hass, "calendar", const.DOMAIN, {"api": api}, config)
+
+    # load sensor platform for each sensor defined in the config
+    for sensor_config in config[const.DOMAIN].get(const.CONF_SENSORS, []):
+        await async_load_platform(
+            hass,
+            "sensor",
+            const.DOMAIN,
+            {"api": api, "sensor_config": sensor_config},
+            config,
+        )
 
     # initial fetch of all data
     hass.add_job(api._fetch)

--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -118,36 +118,49 @@ async def async_setup_entry(hass, config: ConfigEntry, async_add_entities):
     async_add_entities(entities, update_before_add=True)
 
 
-# YAML setup
+# YAML setup (via discovery from waste_collection_schedule: sensors: or legacy sensor platform)
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    _LOGGER.warning(
-        "Configuration of waste_collection_schedule sensors via the sensor platform "
-        "is deprecated and will be removed in a future version. Please configure "
-        "sensors through the UI integration instead"
-    )
+    if discovery_info is not None:
+        # New method: sensor loaded via discovery from waste_collection_schedule: sensors:
+        api = discovery_info["api"]
+        sensor_config = discovery_info["sensor_config"]
+    else:
+        # Legacy method: sensor: platform: waste_collection_schedule
+        _LOGGER.warning(
+            "Configuration of waste_collection_schedule sensors via "
+            "'sensor: platform: waste_collection_schedule' is deprecated and will be "
+            "removed in a future version. Please move your sensor configuration into "
+            "the 'sensors:' key under 'waste_collection_schedule:' in your "
+            "configuration.yaml"
+        )
+        sensor_config = config
 
-    value_template = config.get(CONF_VALUE_TEMPLATE)
+        if DOMAIN not in hass.data:
+            raise Exception(
+                "Waste Collection Schedule integration not set up, please check you configured a source in your configuration.yaml"
+            )
+
+        api = hass.data[DOMAIN].get("YAML_CONFIG")
+
+        if api is None:
+            raise Exception(
+                "Waste Collection Schedule YAML configuration not found, please check you have configured sources under waste_collection_schedule: in your configuration.yaml"
+            )
+
+    value_template = sensor_config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
+        if not isinstance(value_template, Template):
+            value_template = cv.template(value_template)
         value_template.hass = hass
 
-    date_template = config.get(CONF_DATE_TEMPLATE)
+    date_template = sensor_config.get(CONF_DATE_TEMPLATE)
     if date_template is not None:
+        if not isinstance(date_template, Template):
+            date_template = cv.template(date_template)
         date_template.hass = hass
 
-    if DOMAIN not in hass.data:
-        raise Exception(
-            "Waste Collection Schedule integration not set up, please check you configured a source in your configuration.yaml"
-        )
-
-    api = hass.data[DOMAIN].get("YAML_CONFIG")
-
-    if api is None:
-        raise Exception(
-            "Waste Collection Schedule YAML configuration not found, please check you have configured sources under waste_collection_schedule: in your configuration.yaml"
-        )
-
     # create aggregator for all sources
-    source_index = config[CONF_SOURCE_INDEX]
+    source_index = sensor_config.get(CONF_SOURCE_INDEX, 0)
     if not isinstance(source_index, list):
         source_index = [source_index]
 
@@ -162,6 +175,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     aggregator = CollectionAggregator(shells)
 
+    details_format = sensor_config.get(CONF_DETAILS_FORMAT, "upcoming")
+    if isinstance(details_format, str):
+        details_format = DetailsFormat(details_format)
+
     entities = []
 
     entities.append(
@@ -169,16 +186,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             hass=hass,
             api=api,
             coordinator=None,
-            name=config[CONF_NAME],
+            name=sensor_config[CONF_NAME],
             aggregator=aggregator,
-            details_format=config[CONF_DETAILS_FORMAT],
-            count=config.get(CONF_COUNT),
-            leadtime=config.get(CONF_LEADTIME),
-            collection_types=config.get(CONF_COLLECTION_TYPES),
+            details_format=details_format,
+            count=sensor_config.get(CONF_COUNT),
+            leadtime=sensor_config.get(CONF_LEADTIME),
+            collection_types=sensor_config.get(CONF_COLLECTION_TYPES),
             value_template=value_template,
             date_template=date_template,
-            add_days_to=config.get(CONF_ADD_DAYS_TO),
-            event_index=config.get(CONF_EVENT_INDEX),
+            add_days_to=sensor_config.get(CONF_ADD_DAYS_TO, False),
+            event_index=sensor_config.get(CONF_EVENT_INDEX, 0),
         )
     )
 


### PR DESCRIPTION
## Summary
This PR refactors the waste collection schedule sensor setup to support a new discovery-based configuration method while maintaining backward compatibility with the legacy sensor platform approach. It introduces a new `sensors:` configuration key under `waste_collection_schedule:` and deprecates the old `sensor: platform: waste_collection_schedule` method.

## Key Changes

- **New Discovery-Based Setup**: Added support for loading sensors via discovery from `waste_collection_schedule: sensors:` configuration, allowing sensors to be defined directly within the integration's config block
- **Legacy Platform Deprecation**: The old `sensor: platform: waste_collection_schedule` method now logs a deprecation warning and will be removed in a future version
- **Configuration Validation**: Added `SENSOR_CONFIG` schema in `init_yaml.py` to validate sensor configurations with proper defaults for optional fields
- **Template Handling**: Improved template validation to ensure `value_template` and `date_template` are properly converted to Template objects if provided as strings
- **Default Values**: Added explicit default values for optional sensor parameters (`source_index`, `details_format`, `add_days_to`, `event_index`) to handle both discovery and legacy setup paths
- **Platform Loading**: Modified `async_setup()` in `init_yaml.py` to iterate through configured sensors and load the sensor platform for each one via discovery

## Implementation Details

- The `async_setup_platform()` function now checks for `discovery_info` to determine whether it's being called via the new discovery method or the legacy platform method
- When using the legacy method, the function retrieves the API from `hass.data[DOMAIN]["YAML_CONFIG"]` with appropriate error handling
- Template objects are now validated and converted at setup time rather than relying on config validation alone
- The `details_format` parameter is converted to a `DetailsFormat` enum if provided as a string
- All sensor configuration parameters now use `.get()` with sensible defaults to support both setup paths

Fixes #318
