### PR TITLE
Add EVA Abfallentsorgung test cases for Hohenpeissenberg and Peissenberg

### DIFF
--- a/doc/ics/eva_abfallentsorgung_de.md
+++ b/doc/ics/eva_abfallentsorgung_de.md
@@ -46,3 +46,23 @@ waste_collection_schedule:
       args:
         url: https://www.eva-abfallentsorgung.de/genics?ort=Eglfing&strasse=10465&strassenname=Eglfing&erinnerung=0&alarm=0&r=1&b=1&g=1&p=1&s=1&z=1
 ```
+### Hohenpeissenberg
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ics
+      args:
+        url: https://www.eva-abfallentsorgung.de/genics?ort=Hohenpeissenberg&strasse=11166&strassenname=Hohenpeissenberg&erinnerung=0&alarm=0&r=1&b=1&g=1&p=1&s=0&z=0
+        year_field: year
+```
+### Peissenberg
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ics
+      args:
+        url: https://www.eva-abfallentsorgung.de/genics?ort=Peissenberg&strasse=10997&strassenname=Peissenberg&erinnerung=0&alarm=0&r=1&b=1&g=1&p=1&s=0&z=0
+        year_field: year
+```

--- a/doc/ics/yaml/eva_abfallentsorgung_de.yaml
+++ b/doc/ics/yaml/eva_abfallentsorgung_de.yaml
@@ -34,3 +34,9 @@ test_cases:
     split_at: ' & '
   Eglfing:
     url: https://www.eva-abfallentsorgung.de/genics?ort=Eglfing&strasse=10465&strassenname=Eglfing&erinnerung=0&alarm=0&r=1&b=1&g=1&p=1&s=1&z=1
+  Hohenpeissenberg:
+    url: https://www.eva-abfallentsorgung.de/genics?ort=Hohenpeissenberg&strasse=11166&strassenname=Hohenpeissenberg&erinnerung=0&alarm=0&r=1&b=1&g=1&p=1&s=0&z=0
+    year_field: year
+  Peissenberg:
+    url: https://www.eva-abfallentsorgung.de/genics?ort=Peissenberg&strasse=10997&strassenname=Peissenberg&erinnerung=0&alarm=0&r=1&b=1&g=1&p=1&s=0&z=0
+    year_field: year


### PR DESCRIPTION
## Summary
- Adds test cases for Hohenpeissenberg and Peissenberg to existing EVA Abfallentsorgung ICS config
- These locations use the same eva-abfallentsorgung.de platform

Closes #4725
Closes #3204

🤖 Generated with [Claude Code](https://claude.ai/claude-code)