### PR TITLE
Fix Bisamberg calendar example in umweltverbaende_at docs

### DIFF
--- a/doc/source/umweltverbaende_at.md
+++ b/doc/source/umweltverbaende_at.md
@@ -165,7 +165,7 @@ waste_collection_schedule:
       args:
         district: "korneuburg" # Korneuburg
         municipal: "Bisamberg" # Municipal
-        calendar: "Zone B" # Rayon
+        calendar: "Bisamberg B" # Rayon
         calendar_title_separator: ","
         calendar_splitter: ":"
 ```


### PR DESCRIPTION
## Summary
- Update the Korneuburg/Bisamberg example: `"Zone B"` → `"Bisamberg B"`
- The provider changed their calendar naming convention

Reported in https://github.com/mampfes/hacs_waste_collection_schedule/discussions/5754