### PR TITLE
Fix reconfigure wiping existing sensor and customization options

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -940,12 +940,15 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
             if len(errors) == 0:
                 data = {**config_entry.data}
                 data.update({CONF_SOURCE_NAME: source, CONF_SOURCE_ARGS: args_input})
+                # Preserve existing options (sensors, customizations, etc.)
+                # and only update the fields returned by validation
+                merged_options = {**config_entry.options, **options}
                 return self.async_update_reload_and_abort(
                     config_entry,
                     title=title,
                     unique_id=config_entry.unique_id,
                     data=data,
-                    options=options,
+                    options=merged_options,
                     reason="reconfigure_successful",
                 )
         return self.async_show_form(


### PR DESCRIPTION
## Summary
- When reconfiguring a source via the UI, the existing `options` (sensors, customizations, calendar title) were replaced with only the options returned by validation — typically just `calendar_title` or an empty dict.
- This fix merges the new options on top of existing ones (`{**config_entry.options, **options}`), preserving user-configured sensors and customizations through reconfigure.

## Details
`async_step_reconfigure` calls `__validate_args_user_input` which returns a sparse `options` dict containing at most `CONF_SOURCE_CALENDAR_TITLE`. This was passed directly to `async_update_reload_and_abort`, replacing all existing options including `CONF_SENSORS` and `CONF_CUSTOMIZE`.

The fix spreads existing options first, then overlays the new values — the standard merge pattern.

## Test plan
- [ ] Configure a source with custom sensors and waste type customizations (icons, aliases)
- [ ] Reconfigure the source (e.g. change an address parameter)
- [ ] Verify sensors and customizations are preserved after reconfigure

🤖 Generated with [Claude Code](https://claude.com/claude-code)