### PR TITLE
Fix ICS recurrence exceptions showing None as waste type

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -49,6 +49,19 @@ class ICS:
             start=start_date, end=end_date, string_content=ics_data.encode()
         )
 
+        # Inherit summary for recurrence exceptions that lack one.
+        # Some ICS generators omit SUMMARY on replacement VEVENTs
+        # (those with RECURRENCE-ID), expecting clients to inherit
+        # from the parent recurring event.
+        uid_summaries: dict = {}
+        for e in events:
+            if e.summary and e.recurring:
+                uid_summaries[e.uid] = e.summary
+        for e in events:
+            if not e.summary and hasattr(e, "recurrence_id") and e.recurrence_id:
+                if e.uid in uid_summaries:
+                    e.summary = uid_summaries[e.uid]
+
         entries: List[Tuple[datetime.date, str]] = []
 
         for e in events:


### PR DESCRIPTION
## Summary
- Inherit SUMMARY from parent recurring event for recurrence exceptions that lack one
- Fixes moved collection dates (e.g. due to holidays) showing "None" instead of the waste type

## Root Cause
Some ICS generators (e.g. Mayer Recycling AT) create replacement VEVENTs with RECURRENCE-ID that only include the changed DTSTART, omitting the SUMMARY property. The `icalevents` library doesn't inherit SUMMARY from the parent, so `event.summary` is `None`, which the Jinja template renders as the literal string "None".

## Fix
After parsing events, build a UID → summary mapping from recurring events, then backfill missing summaries on recurrence exceptions before rendering.

Fixes #5777