### PR TITLE
Fix Valorlux docs: parameter is commune, not city

### DIFF
--- a/doc/source/valorlux_lu.md
+++ b/doc/source/valorlux_lu.md
@@ -9,16 +9,16 @@ waste_collection_schedule:
   sources:
     - name: valorlux_lu
       args:
-        city: CITY
+        commune: COMMUNE
         zone: ZONE
 ```
 
 ### Arguments
 
-**city**  
+**commune**  
 *(string) (required)*
 
-The name of your city or municipality. This will be a dropdown list in the UI.
+The name of your commune (municipality). This will be a dropdown list in the UI.
 
 **zone**  
 *(string) (optional)*


### PR DESCRIPTION
## Summary
- Fix documentation: parameter name is `commune`, not `city`
- Users following the docs got `unexpected keyword argument 'city'` errors

Ref #5782