### PR TITLE
Update AWP Pfaffenhofen URL in docs

### DIFF
--- a/doc/ics/awp_landkreis_pfaffenhofen.md
+++ b/doc/ics/awp_landkreis_pfaffenhofen.md
@@ -5,7 +5,7 @@ Abfallwirtschaftsbetrieb des Landkreises Pfaffenhofen a.d.Ilm (AWP) is supported
 
 ## How to get the configuration arguments
 
-- Go to <https://www.awp-paf.de/Abfuhrtermine/Abfallkalender.aspx> and select your town.
+- Go to <https://www.awp-paf.de/termine/abfuhrtermine/> and select your town.
 - Enter your street and house number.
 - Click on `ical-Kalenderabo` and `URL in die Zwischenablage kopieren` to get a webcal link.
 - Use this link as the `url` parameter.

--- a/doc/ics/yaml/awp_landkreis_pfaffenhofen.yaml
+++ b/doc/ics/yaml/awp_landkreis_pfaffenhofen.yaml
@@ -4,7 +4,7 @@ url: https://www.awp-paf.de
 country: de
 howto:
   en: |
-    - Go to <https://www.awp-paf.de/Abfuhrtermine/Abfallkalender.aspx> and select your town.
+    - Go to <https://www.awp-paf.de/termine/abfuhrtermine/> and select your town.
     - Enter your street and house number.
     - Click on `ical-Kalenderabo` and `URL in die Zwischenablage kopieren` to get a webcal link.
     - Use this link as the `url` parameter.


### PR DESCRIPTION
## Summary
- Update the AWP Pfaffenhofen calendar URL from the old `Abfuhrtermine/Abfallkalender.aspx` to `termine/abfuhrtermine/`
- Fixed in both the YAML source and generated MD

Supersedes #5764