### PR TITLE
ximmio/mijnblink: Use correct Service URL

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ximmio_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ximmio_nl.py
@@ -29,6 +29,7 @@ TEST_CASES = {
 SERVICE_URLS = {
     "avalex": "https://wasteprod2api.ximmio.com",
     "meerlanden": "https://wasteprod2api.ximmio.com",
+    "mijnblink": "https://wasteprod2api.ximmio.com",
     "rad": "https://wasteprod2api.ximmio.com",
     "westland": "https://wasteprod2api.ximmio.com",
 }


### PR DESCRIPTION
mijnblink's API is located on the wasteprod2api domain rather than the default