### PR TITLE
Fix frwa_com_au: broken nonce extraction after website redesign

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frwa_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frwa_com_au.py
@@ -1,4 +1,4 @@
-import json
+import re
 from datetime import datetime
 
 import requests
@@ -45,7 +45,10 @@ ICON_MAP = {
     "Recycling": "mdi:recycle",
     "Green Waste": "mdi:leaf",
 }
-HEADERS = {"user-agent": "Mozilla/5.0"}
+HEADERS = {
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Referer": "https://fleurieuregionalwasteauthority.com.au/collection-calendar-downloads",
+}
 EXTRA_INFO = [
     {"title": "Kangaroo Island Council", "url": "https://www.kangarooisland.sa.gov.au"},
     {
@@ -89,11 +92,10 @@ class Source:
 
         # get security token
         r = s.get(API_URLS["HOME"], headers=HEADERS)
-        soup: BeautifulSoup = BeautifulSoup(r.content, "html.parser")
-        script_text = soup.find("script", {"id": "autocomplete-search-js-extra"}).string
-        json_text = script_text.split("=", 1)[1].rsplit(";", 1)[0].strip()
-        data = json.loads(json_text)
-        token = data["ajax_nonce"]
+        match = re.search(r'"ajax_nonce"\s*:\s*"([^"]+)"', r.text)
+        if not match:
+            raise Exception("Unable to find ajax_nonce on FRWA website")
+        token = match.group(1)
 
         # get unique ID from street search
         params = {


### PR DESCRIPTION
## Summary
- Fix broken `ajax_nonce` extraction after FRWA website redesign removed the `<script id="autocomplete-search-js-extra">` tag
- Use regex to find the nonce in inline script instead of BeautifulSoup tag lookup
- Update `HEADERS` with full user-agent and `Referer` to avoid Mod_Security rejections

Fixes #5775

## Test plan
- [x] Verified against live FRWA site — nonce extracted, street search works, collection dates returned for all test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)