### PR TITLE
Add optional public_type parameter to Publidata source

### DIFF
--- a/custom_components/waste_collection_schedule/translations/de.json
+++ b/custom_components/waste_collection_schedule/translations/de.json
@@ -4359,13 +4359,15 @@
           "calendar_title": "Kalender Titel",
           "address": "Adresse",
           "insee_code": "INSEE-Code",
-          "instance_id": "Instanz-ID"
+          "instance_id": "Instanz-ID",
+          "public_type": "Wohnungstyp"
         },
         "data_description": {
           "calendar_title": "Ein lesbarerer oder benutzerfreundlicherer Name für den Müllkalender. Wenn nichts angegeben wird, wird der Name der Quelle verwendet.",
           "address": "Ihre vollständige Adresse",
           "insee_code": "Der 5-stellige INSEE-Code Ihrer Gemeinde",
-          "instance_id": "Eine Kennung Ihres Abfallsammeldienstes. Zum Beispiel ist die von GPSEO 1292 und kann durch Inspektion der Netzwerkaufrufe auf {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002} gefunden werden"
+          "instance_id": "Eine Kennung Ihres Abfallsammeldienstes. Zum Beispiel ist die von GPSEO 1292 und kann durch Inspektion der Netzwerkaufrufe auf {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002} gefunden werden",
+          "public_type": "Wohnungstyp-Filter (optional). Verwenden Sie 'individual_housing' für Häuser oder 'collective_housing' für Wohnungen, wenn Ihr Gebiet unterschiedliche Abholpläne je Wohnungstyp hat."
         }
       },
       "reconfigure_publidata_fr": {
@@ -4375,12 +4377,14 @@
           "calendar_title": "Kalender Titel",
           "address": "Adresse",
           "insee_code": "INSEE-Code",
-          "instance_id": "Instanz-ID"
+          "instance_id": "Instanz-ID",
+          "public_type": "Wohnungstyp"
         },
         "data_description": {
           "address": "Ihre vollständige Adresse",
           "insee_code": "Der 5-stellige INSEE-Code Ihrer Gemeinde",
-          "instance_id": "Eine Kennung Ihres Abfallsammeldienstes. Zum Beispiel ist die von GPSEO 1292 und kann durch Inspektion der Netzwerkaufrufe auf {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002} gefunden werden"
+          "instance_id": "Eine Kennung Ihres Abfallsammeldienstes. Zum Beispiel ist die von GPSEO 1292 und kann durch Inspektion der Netzwerkaufrufe auf {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002} gefunden werden",
+          "public_type": "Wohnungstyp-Filter (optional). Verwenden Sie 'individual_housing' für Häuser oder 'collective_housing' für Wohnungen, wenn Ihr Gebiet unterschiedliche Abholpläne je Wohnungstyp hat."
         }
       },
       "args_cc-montesquieu_fr": {

--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -4439,13 +4439,15 @@
           "calendar_title": "Calendar Title",
           "address": "Address",
           "insee_code": "INSEE Code",
-          "instance_id": "Instance ID"
+          "instance_id": "Instance ID",
+          "public_type": "Housing Type"
         },
         "data_description": {
           "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used.",
           "address": "Your full address",
           "insee_code": "The 5-digit INSEE code of your commune",
-          "instance_id": "An identifier of your waste collection service. For example GPSEO's is 1292 and found by inspecting the network calls on {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}"
+          "instance_id": "An identifier of your waste collection service. For example GPSEO's is 1292 and found by inspecting the network calls on {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}",
+          "public_type": "Housing type filter (optional). Use 'individual_housing' for houses or 'collective_housing' for apartments if your area has different schedules per housing type."
         }
       },
       "reconfigure_publidata_fr": {
@@ -4455,12 +4457,14 @@
           "calendar_title": "Calendar Title",
           "address": "Address",
           "insee_code": "INSEE Code",
-          "instance_id": "Instance ID"
+          "instance_id": "Instance ID",
+          "public_type": "Housing Type"
         },
         "data_description": {
           "address": "Your full address",
           "insee_code": "The 5-digit INSEE code of your commune",
-          "instance_id": "An identifier of your waste collection service. For example GPSEO's is 1292 and found by inspecting the network calls on {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}"
+          "instance_id": "An identifier of your waste collection service. For example GPSEO's is 1292 and found by inspecting the network calls on {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}",
+          "public_type": "Housing type filter (optional). Use 'individual_housing' for houses or 'collective_housing' for apartments if your area has different schedules per housing type."
         }
       },
       "args_cc-montesquieu_fr": {

--- a/custom_components/waste_collection_schedule/translations/fr.json
+++ b/custom_components/waste_collection_schedule/translations/fr.json
@@ -4316,7 +4316,8 @@
           "calendar_title": "Titre du Calendrier",
           "address": "Adresse",
           "insee_code": "Insee Code",
-          "instance_id": "Instance Id"
+          "instance_id": "Instance Id",
+          "public_type": "Public Type"
         },
         "data_description": {
           "calendar_title": "Un nom plus lisible ou convivial pour le calendrier des déchets. Si aucun n'est fourni, le nom renvoyé par la source sera utilisé."
@@ -4329,7 +4330,8 @@
           "calendar_title": "Titre du Calendrier",
           "address": "Adresse",
           "insee_code": "Insee Code",
-          "instance_id": "Instance Id"
+          "instance_id": "Instance Id",
+          "public_type": "Public Type"
         },
         "data_description": {}
       },

--- a/custom_components/waste_collection_schedule/translations/it.json
+++ b/custom_components/waste_collection_schedule/translations/it.json
@@ -4315,13 +4315,15 @@
           "calendar_title": "Nome Calendario",
           "address": "Indirizzo",
           "insee_code": "Codice INSEE",
-          "instance_id": "ID Istanza"
+          "instance_id": "ID Istanza",
+          "public_type": "Tipo Abitazione"
         },
         "data_description": {
           "calendar_title": "Puoi cambiare il nome del calendario della raccolta dei rifiuti, altrimenti di default verra' utilizzato il nome del tuo fornitore di servizi.",
           "address": "Il tuo indirizzo completo",
           "insee_code": "Il codice INSEE a 5 cifre del tuo comune",
-          "instance_id": "Un identificatore del tuo servizio di raccolta rifiuti. Ad esempio, quello di GPSEO è 1292 e si trova ispezionando le chiamate di rete su {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}"
+          "instance_id": "Un identificatore del tuo servizio di raccolta rifiuti. Ad esempio, quello di GPSEO è 1292 e si trova ispezionando le chiamate di rete su {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}",
+          "public_type": "Filtro tipo abitazione (opzionale). Usare 'individual_housing' per case o 'collective_housing' per appartamenti se la zona ha calendari diversi per tipo di abitazione."
         }
       },
       "reconfigure_publidata_fr": {
@@ -4331,12 +4333,14 @@
           "calendar_title": "Nome Calendario",
           "address": "Indirizzo",
           "insee_code": "Codice INSEE",
-          "instance_id": "ID Istanza"
+          "instance_id": "ID Istanza",
+          "public_type": "Tipo Abitazione"
         },
         "data_description": {
           "address": "Il tuo indirizzo completo",
           "insee_code": "Il codice INSEE a 5 cifre del tuo comune",
-          "instance_id": "Un identificatore del tuo servizio di raccolta rifiuti. Ad esempio, quello di GPSEO è 1292 e si trova ispezionando le chiamate di rete su {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}"
+          "instance_id": "Un identificatore del tuo servizio di raccolta rifiuti. Ad esempio, quello di GPSEO è 1292 e si trova ispezionando le chiamate di rete su {url_infos_dechets_gpseo_fr_4e79ytzv7m_list__addressid_78005_0073_00002}",
+          "public_type": "Filtro tipo abitazione (opzionale). Usare 'individual_housing' per case o 'collective_housing' per appartamenti se la zona ha calendari diversi per tipo di abitazione."
         }
       },
       "args_cc-montesquieu_fr": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -145,16 +145,19 @@ PARAM_DESCRIPTIONS = {
         "address": "Your full address",
         "insee_code": "The 5-digit INSEE code of your commune",
         "instance_id": "An identifier of your waste collection service. For example GPSEO's is 1292 and found by inspecting the network calls on https://infos-dechets.gpseo.fr/4E79YtZv7M/list/?addressId=78005_0073_00002",
+        "public_type": "Housing type filter (optional). Use 'individual_housing' for houses or 'collective_housing' for apartments if your area has different schedules per housing type.",
     },
     "de": {
         "address": "Ihre vollständige Adresse",
         "insee_code": "Der 5-stellige INSEE-Code Ihrer Gemeinde",
         "instance_id": "Eine Kennung Ihres Abfallsammeldienstes. Zum Beispiel ist die von GPSEO 1292 und kann durch Inspektion der Netzwerkaufrufe auf https://infos-dechets.gpseo.fr/4E79YtZv7M/list/?addressId=78005_0073_00002 gefunden werden",
+        "public_type": "Wohnungstyp-Filter (optional). Verwenden Sie 'individual_housing' für Häuser oder 'collective_housing' für Wohnungen, wenn Ihr Gebiet unterschiedliche Abholpläne je Wohnungstyp hat.",
     },
     "it": {
         "address": "Il tuo indirizzo completo",
         "insee_code": "Il codice INSEE a 5 cifre del tuo comune",
         "instance_id": "Un identificatore del tuo servizio di raccolta rifiuti. Ad esempio, quello di GPSEO è 1292 e si trova ispezionando le chiamate di rete su https://infos-dechets.gpseo.fr/4E79YtZv7M/list/?addressId=78005_0073_00002",
+        "public_type": "Filtro tipo abitazione (opzionale). Usare 'individual_housing' per case o 'collective_housing' per appartamenti se la zona ha calendari diversi per tipo di abitazione.",
     },
 }
 
@@ -163,16 +166,19 @@ PARAM_TRANSLATIONS = {
         "address": "Address",
         "insee_code": "INSEE Code",
         "instance_id": "Instance ID",
+        "public_type": "Housing Type",
     },
     "de": {
         "address": "Adresse",
         "insee_code": "INSEE-Code",
         "instance_id": "Instanz-ID",
+        "public_type": "Wohnungstyp",
     },
     "it": {
         "address": "Indirizzo",
         "insee_code": "Codice INSEE",
         "instance_id": "ID Istanza",
+        "public_type": "Tipo Abitazione",
     },
 }
 
@@ -282,10 +288,11 @@ _LOGGER = logging.getLogger(__name__)
 class Source:
     geocoder_url = "https://api.publidata.io/v2/geocoder"
 
-    def __init__(self, address, insee_code, instance_id):
+    def __init__(self, address, insee_code, instance_id, public_type: str | None = None):
         self.address = address
         self.insee_code = insee_code
         self.instance_id = instance_id
+        self._public_type = public_type
 
     def _get_address_params(self, address, insee_code):
         params = {
@@ -321,6 +328,9 @@ class Source:
             "instances[]": self.instance_id,
             **self.address_params,
         }
+        if self._public_type:
+            params["publics[]"] = "resident"
+            params["public_types[]"] = self._public_type
 
         response = requests.get(api_url, params=params)
 


### PR DESCRIPTION
## Summary
- Add optional `public_type` parameter to `publidata_fr` source
- Allows filtering by housing type: `individual_housing` (houses) or `collective_housing` (apartments)
- Some Publidata areas return different or missing waste types without this filter

Fixes #5679

## Test plan
- [x] Verified parameter is correctly passed to the API as `publics[]=resident&public_types[]=<value>`
- [x] Existing behaviour unchanged when parameter is not set (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)