### PR TITLE
Fix Torridge: handle parenthetical annotations in date strings

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/torridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/torridge_gov_uk.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime, timedelta
 from time import time_ns
 
@@ -110,7 +111,10 @@ class Source:
 
                 date_part = parts[1].split(" then ")[0].strip()  # e.g., "Wed 26 Feb"
 
-                # Handle "No collection" messages
+                # Strip parenthetical annotations e.g. "(Adjusted for Easter)"
+                date_part = re.sub(r"\(.*?\)", "", date_part).strip()
+
+                # Handle "No collection" or "No live" messages
                 if date_part.split()[0].lower() == "no":
                     continue  # Skip entries where collection isn't available
 
@@ -119,11 +123,11 @@ class Source:
                     collection_date = today + timedelta(days=RELATIVE_DATES[date_part])
                 else:
                     # Extract the date
-                    date_parts = date_part.split(" ")
+                    date_parts = date_part.split()
                     if len(date_parts) < 3:
                         raise ValueError("Unexpected date format")
 
-                    _, bin_day_num, bin_month = date_parts
+                    _, bin_day_num, bin_month = date_parts[:3]
                     if bin_month not in MONTHS:
                         raise ValueError(f"Unknown month: {bin_month}")
 


### PR DESCRIPTION
## Summary
- Strip parenthetical annotations (e.g. `(Adjusted for Easter)`) from date strings before parsing
- Use `date_parts[:3]` instead of exact unpacking to be resilient to extra parts
- API now returns formats like `Thu 9 Apr(Adjusted for Easter) then every Wed`

Fixes #5657

## Test plan
- [x] Verified against live API — all 3 bin types parse correctly
- [x] Handles: normal dates, parenthetical annotations, "No live" messages, "Today"/"Tomorrow"

🤖 Generated with [Claude Code](https://claude.com/claude-code)