### PR TITLE
Fix Blackpool: regex fails on 'Paper & Card' job names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
@@ -14,15 +14,18 @@ TEST_CASES = {
 }
 
 API_URL = "https://api.blackpool.gov.uk/api/bartec"
-REGEX_JOB_NAME = r"^Empty(?: Bin)? ([A-Za-z ]+?)( \d+\w)?$"
+REGEX_JOB_NAME = r"^Empty(?: Bin)? ([A-Za-z &]+?)( \d+\w)?$"
 NAME_MAP = {
     "Domestic Refuse": "Grey bin or Red sack",
     "Dry Recycling": "Blue bin",
+    "Paper & Card": "Paper & Card",
 }
 ICON_MAP = {
     "Domestic Refuse": "mdi:trash-can",
     "Dry Recycling": "mdi:recycle",
     "Brown Sack": "mdi:newspaper",
+    "Paper & Card": "mdi:newspaper",
+    "Green Waste": "mdi:leaf",
 }
 
 


### PR DESCRIPTION
## Summary
- Fix regex `[A-Za-z ]` → `[A-Za-z &]` to match job names containing `&` (e.g. "Paper & Card")
- Add NAME_MAP and ICON_MAP entries for Paper & Card and Green Waste
- The existing API is still working fine — no rebuild needed

Fixes #5667

## Test plan
- [x] Verified all 3 test case UPRNs against live API
- [x] All job names now parse correctly: Domestic Refuse, Dry Recycling, Paper & Card, Green Waste

🤖 Generated with [Claude Code](https://claude.com/claude-code)