### PR TITLE
Improve ICS source GUI defaults and howto text

### DIFF
--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -7050,7 +7050,25 @@
     {
       "title": "Ginsheim-Gustavsburg",
       "module": "ics",
-      "default_params": {},
+      "default_params": {
+        "method": "POST",
+        "params": {
+          "dateFrom": "2026-01-01",
+          "dateTo": "2026-12-31",
+          "category": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9"
+          ]
+        },
+        "url": "https://abfallkalender.gigu.de/export"
+      },
       "id": "ics_gigu_de"
     },
     {
@@ -8282,6 +8300,7 @@
           "papier": "1",
           "papiertonne": "1"
         },
+        "split_at": "\\+",
         "url": "https://mobil.abfallwirtschaft-heidenheim.de/icalendar/download.php",
         "year_field": "jahr"
       },

--- a/doc/ics/abfall_hdh_de.md
+++ b/doc/ics/abfall_hdh_de.md
@@ -5,9 +5,10 @@ Landkreis Heidenheim is supported by the generic [ICS](/doc/source/ics.md) sourc
 
 ## How to get the configuration arguments
 
-- Go to <https://www.abfall-hdh.de/internet/inhalt/inhalt.php?seite=98> and select your location.  
-- Replace the `gemeinde`, `ortsteil` and `strasse` in the example configuration with the names you selected (leave `strasse` as is if you do not selected one on the website).
-- You may also want to set the `bio`, `garten`, `gs`, `rest`, `papier` and `papiertonne` parameters to `"0"` if you do not want to see the corresponding waste types in the calendar.
+- Go to <https://www.abfall-hdh.de/internet/inhalt/inhalt.php?seite=98> and select your location.
+- Most fields are pre-filled. In the **Params** field, add your `gemeinde`, `ortsteil` and `strasse` to the existing JSON, e.g.: `{"gemeinde": "Dischingen", "ortsteil": "Hofen", "strasse": "", "bio": "1", ...}`
+- Set `split_at` to `\+` if events contain combined waste types.
+- Set waste type toggles (`bio`, `garten`, `gs`, `rest`, `papier`, `papiertonne`) to `"0"` to hide unwanted types.
 
 ## Examples
 

--- a/doc/ics/entsorgung_regional_de.md
+++ b/doc/ics/entsorgung_regional_de.md
@@ -5,10 +5,10 @@ Abfallwirtschaft Enzkreis is supported by the generic [ICS](/doc/source/ics.md) 
 
 ## How to get the configuration arguments
 
-- Go to <https://www.abfallwirtschaft-enzkreis.de/entsorgung/leerungstermine/terminservice-ics-datei.html> and select your location.  
-- Select all waste types (or at least the ones you want to be reminded of).
-- Use this link as the `url` parameter. 
-- Do not forget the method and params parameter.
+- Go to <https://www.abfallwirtschaft-enzkreis.de/entsorgung/leerungstermine/terminservice-ics-datei.html>.
+- Select your municipality, district, and waste types, then click "ICS Datei herunterladen".
+- Copy the download URL from your browser. Use it as the `url` parameter.
+- The `method` (POST) and `params` are pre-filled.
 
 ## Examples
 

--- a/doc/ics/yaml/abfall_hdh_de.yaml
+++ b/doc/ics/yaml/abfall_hdh_de.yaml
@@ -3,13 +3,20 @@ title: Landkreis Heidenheim
 url: https://abfall-hdh.de
 howto:
   en: |
-    - Go to <https://www.abfall-hdh.de/internet/inhalt/inhalt.php?seite=98> and select your location.  
-    - Replace the `gemeinde`, `ortsteil` and `strasse` in the example configuration with the names you selected (leave `strasse` as is if you do not selected one on the website).
-    - You may also want to set the `bio`, `garten`, `gs`, `rest`, `papier` and `papiertonne` parameters to `"0"` if you do not want to see the corresponding waste types in the calendar.
+    - Go to <https://www.abfall-hdh.de/internet/inhalt/inhalt.php?seite=98> and select your location.
+    - Most fields are pre-filled. In the **Params** field, add your `gemeinde`, `ortsteil` and `strasse` to the existing JSON, e.g.: `{"gemeinde": "Dischingen", "ortsteil": "Hofen", "strasse": "", "bio": "1", ...}`
+    - Set `split_at` to `\+` if events contain combined waste types.
+    - Set waste type toggles (`bio`, `garten`, `gs`, `rest`, `papier`, `papiertonne`) to `"0"` to hide unwanted types.
+  de: |
+    - Gehen Sie auf <https://www.abfall-hdh.de/internet/inhalt/inhalt.php?seite=98> und wählen Sie Ihren Standort.
+    - Die meisten Felder sind vorausgefüllt. Fügen Sie im Feld **Parameter** Ihre `gemeinde`, `ortsteil` und `strasse` zum vorhandenen JSON hinzu, z.B.: `{"gemeinde": "Dischingen", "ortsteil": "Hofen", "strasse": "", "bio": "1", ...}`
+    - Setzen Sie `split_at` auf `\+`, wenn Termine kombinierte Abfallarten enthalten.
+    - Setzen Sie Abfallart-Schalter (`bio`, `garten`, `gs`, `rest`, `papier`, `papiertonne`) auf `"0"`, um ungewünschte Typen auszublenden.
 default_params:
   url: https://mobil.abfallwirtschaft-heidenheim.de/icalendar/download.php
   method: POST
   year_field: jahr
+  split_at: \+
   params:
     tag: '0'
     uhrzeit: ''

--- a/doc/ics/yaml/entsorgung_regional_de.yaml
+++ b/doc/ics/yaml/entsorgung_regional_de.yaml
@@ -3,11 +3,15 @@ title: Abfallwirtschaft Enzkreis
 url: https://www.abfallwirtschaft-enzkreis.de/
 howto:
   en: |
-    - Go to <https://www.abfallwirtschaft-enzkreis.de/entsorgung/leerungstermine/terminservice-ics-datei.html> and select your location.  
-    - Select all waste types (or at least the ones you want to be reminded of).
-    - Use this link as the `url` parameter. 
-    - Do not forget the method and params parameter.
-
+    - Go to <https://www.abfallwirtschaft-enzkreis.de/entsorgung/leerungstermine/terminservice-ics-datei.html>.
+    - Select your municipality, district, and waste types, then click "ICS Datei herunterladen".
+    - Copy the download URL from your browser. Use it as the `url` parameter.
+    - The `method` (POST) and `params` are pre-filled.
+  de: |
+    - Gehen Sie auf <https://www.abfallwirtschaft-enzkreis.de/entsorgung/leerungstermine/terminservice-ics-datei.html>.
+    - Wählen Sie Ihre Gemeinde, Ortsteil und Abfallarten, dann klicken Sie auf "ICS Datei herunterladen".
+    - Kopieren Sie die Download-URL aus Ihrem Browser und verwenden Sie sie als `url`-Parameter.
+    - Die `method` (POST) und `params` sind vorausgefüllt.
 default_params:
   method: POST
   params:

--- a/doc/ics/yaml/gigu_de.yaml
+++ b/doc/ics/yaml/gigu_de.yaml
@@ -13,6 +13,22 @@ howto:
     - Setze `district` auf deine Stadtteilnummer (`1` für Ginsheim, `2` für Gustavsburg).
     - Die `category`-Liste wählt die Abfallarten aus (1-9 für alle Abfallarten). Passe die Liste nach Bedarf an.
     - Setze `dateFrom` und `dateTo` auf den gewünschten Zeitraum (Format: `YYYY-MM-DD`).
+default_params:
+  url: https://abfallkalender.gigu.de/export
+  method: POST
+  params:
+    dateFrom: "2026-01-01"
+    dateTo: "2026-12-31"
+    category:
+      - "1"
+      - "2"
+      - "3"
+      - "4"
+      - "5"
+      - "6"
+      - "7"
+      - "8"
+      - "9"
 test_cases:
   Gustavsburg all categories:
     url: https://abfallkalender.gigu.de/export


### PR DESCRIPTION
## Summary
Improves the GUI experience for ICS sources with complex POST configurations:

- **Landkreis Heidenheim**: add `split_at` to default_params, rewrite howto with explicit GUI instructions (EN + DE)
- **Abfallwirtschaft Enzkreis**: rewrite vague howto with clearer step-by-step GUI instructions (EN + DE)
- **Ginsheim-Gustavsburg**: add `default_params` (was missing entirely) so URL, method, and all params are pre-filled in GUI

Only 4 ICS sources use POST method. The 4th (Abfallwirtschaft Sonneberg) already has good defaults and documentation.

Addresses #5803

## Test plan
- [x] Verified doc update script generates correct sources.json entries with new default_params
- [x] All 3 YAML files produce valid generated markdown docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)