### PR TITLE
Fix Müllmax: auto-detect and match house number selection

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
@@ -2,6 +2,8 @@ from html.parser import HTMLParser
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import \
+    SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.service.ICS import ICS
 from waste_collection_schedule.service.MuellmaxDe import SERVICE_MAP
 
@@ -39,6 +41,11 @@ TEST_CASES = {
         "mm_frm_str_sel": "Freiligrathstraße",
         "mm_frm_hnr_sel": "44791;Innenstadt;55;",
     },
+    "ASH Schäferstraße 49 (plain number)": {
+        "service": "Ash",
+        "mm_frm_str_sel": "Schäferstraße",
+        "mm_frm_hnr_sel": "49",
+    },
 }
 
 HEADERS = {
@@ -73,6 +80,32 @@ class InputCheckboxParser(HTMLParser):
                 self._value[d["name"]] = d.get("value")
 
 
+# Parser for HTML select options
+class SelectOptionParser(HTMLParser):
+    def __init__(self, select_name):
+        super().__init__()
+        self._select_name = select_name
+        self._in_select = False
+        self._options = []
+
+    @property
+    def options(self):
+        return self._options
+
+    def handle_starttag(self, tag, attrs):
+        d = dict(attrs)
+        if tag == "select" and d.get("name") == self._select_name:
+            self._in_select = True
+        if tag == "option" and self._in_select:
+            value = d.get("value", "")
+            if value:
+                self._options.append(value)
+
+    def handle_endtag(self, tag):
+        if tag == "select":
+            self._in_select = False
+
+
 # Parser for HTML input (hidden) text
 class InputTextParser(HTMLParser):
     def __init__(self, **identifiers):
@@ -95,7 +128,11 @@ class InputTextParser(HTMLParser):
 
 class Source:
     def __init__(
-        self, service, mm_frm_ort_sel=None, mm_frm_str_sel=None, mm_frm_hnr_sel=None
+        self,
+        service,
+        mm_frm_ort_sel=None,
+        mm_frm_str_sel=None,
+        mm_frm_hnr_sel=None,
     ):
         self._service = service
         self._mm_frm_ort_sel = mm_frm_ort_sel
@@ -106,7 +143,11 @@ class Source:
     def fetch(self):
         mm_ses = InputTextParser(name="mm_ses")
 
-        url = f"https://www.muellmax.de/abfallkalender/{self._service.lower()}/res/{self._service}Start.php"
+        url = (
+            f"https://www.muellmax.de/abfallkalender/"
+            f"{self._service.lower()}/res/"
+            f"{self._service}Start.php"
+        )
         session = requests.Session()
         r = session.get(url, headers=HEADERS)
         mm_ses.feed(r.text)
@@ -148,19 +189,51 @@ class Source:
             r = session.post(url, data=args, headers=HEADERS)
             mm_ses.feed(r.text)
 
-        if self._mm_frm_hnr_sel is not None:
-            # select house number
+        # auto-detect if house number selection is required
+        if "mm_frm_hnr_sel" in r.text:
+            hnr_value = self._mm_frm_hnr_sel
+            if hnr_value is None:
+                op = SelectOptionParser("mm_frm_hnr_sel")
+                op.feed(r.text)
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "mm_frm_hnr_sel", "", op.options
+                )
+
+            # if user provided a plain number, match against dropdown options
+            if ";" not in str(hnr_value):
+                op = SelectOptionParser("mm_frm_hnr_sel")
+                op.feed(r.text)
+                matches = [
+                    o
+                    for o in op.options
+                    if o.split(";")[2] == str(hnr_value)
+                ]
+                if len(matches) == 1:
+                    hnr_value = matches[0]
+                elif len(matches) == 0:
+                    raise SourceArgumentNotFoundWithSuggestions(
+                        "mm_frm_hnr_sel", str(hnr_value), op.options
+                    )
+                else:
+                    raise SourceArgumentNotFoundWithSuggestions(
+                        "mm_frm_hnr_sel", str(hnr_value), matches
+                    )
+
             args = {
                 "mm_ses": mm_ses.value,
                 "xxx": 1,
-                "mm_frm_hnr_sel": self._mm_frm_hnr_sel,
+                "mm_frm_hnr_sel": hnr_value,
                 "mm_aus_hnr_sel_submit": "weiter",
             }
             r = session.post(url, data=args, headers=HEADERS)
             mm_ses.feed(r.text)
 
         # select to get ical
-        args = {"mm_ses": mm_ses.value, "xxx": 1, "mm_ica_auswahl": "iCalendar-Datei"}
+        args = {
+            "mm_ses": mm_ses.value,
+            "xxx": 1,
+            "mm_ica_auswahl": "iCalendar-Datei",
+        }
         r = session.post(url, data=args, headers=HEADERS)
         mm_ses.feed(r.text)
 
@@ -181,7 +254,8 @@ class Source:
             dates = self._ics.convert(r.text)
         except ValueError as e:
             raise ValueError(
-                "Got invalid response from the server, please recheck your arguments"
+                "Got invalid response from the server, "
+                "please recheck your arguments"
             ) from e
 
         entries = []


### PR DESCRIPTION
## Summary
- Fixes #5653 — Müllmax source returning "invalid response" for multiple cities (Hamm, Bochum, Hanau)
- The multi-step form requires house number selection after street selection, but the source treated `mm_frm_hnr_sel` as optional. Skipping it caused the server to return HTML instead of iCal data
- Now auto-detects when house number selection is required and accepts plain house numbers (e.g. `"49"`) in addition to full dropdown values (e.g. `"59071;Werries;49;"`)
- Raises helpful error with available options if no match found or if house number is required but not provided

## Test plan
- [x] Tested end-to-end: ASH (Hamm) Schäferstraße with plain number `49` — returns valid iCal
- [x] Tested end-to-end: USB (Bochum) Freiligrathstraße with full value `44791;Innenstadt;55;` — backwards compatible
- [x] Tested missing house number — raises error with available options
- [ ] Verify in Home Assistant UI that config flow works with plain house number

🤖 Generated with [Claude Code](https://claude.com/claude-code)