### PR TITLE
Fix AbfallNavi for services with dead per-service subdomains

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -170,12 +170,35 @@ DEFAULT_TIMEOUT = 20
 
 
 class AbfallnaviDe:
+    # Services where the per-service subdomain DNS is dead;
+    # use the shared domain directly to avoid DNS timeout.
+    SHARED_DOMAIN_SERVICES = {
+        "unna",
+        "frankenthal",
+        "awvlippe",
+        "kranenburg",
+    }
+
     def __init__(self, service_domain):
         self._service_domain = service_domain
-        self._service_url = f"https://{service_domain}-abfallapp.regioit.de/abfall-app-{service_domain}/rest"
-        self._service_url_fallback = (
-            f"https://abfallapp.regioit.de/abfall-app-{service_domain}/rest"
-        )
+        if service_domain in self.SHARED_DOMAIN_SERVICES:
+            self._service_url = (
+                "https://abfallapp.regioit.de/" f"abfall-app-{service_domain}/rest"
+            )
+            self._service_url_fallback = (
+                f"https://{service_domain}"
+                f"-abfallapp.regioit.de/"
+                f"abfall-app-{service_domain}/rest"
+            )
+        else:
+            self._service_url = (
+                f"https://{service_domain}"
+                f"-abfallapp.regioit.de/"
+                f"abfall-app-{service_domain}/rest"
+            )
+            self._service_url_fallback = (
+                "https://abfallapp.regioit.de/" f"abfall-app-{service_domain}/rest"
+            )
         self._session = requests.Session()
 
     def _fetch(self, path, params=None):


### PR DESCRIPTION
## Summary
- Fixes #5761 — AbfallNavi config flow hangs for Unna (and 3 other services)
- Four services (`unna`, `frankenthal`, `awvlippe`, `kranenburg`) have dead DNS on their per-service subdomain. The existing fallback works but DNS timeout can hang the config flow on some platforms
- Uses the shared domain (`abfallapp.regioit.de`) as primary for these four services, keeping the per-service subdomain as fallback
- All other services unchanged

## Test plan
- [x] Verified all 28 services against both URL patterns to identify which are affected
- [x] Tested full API flow for Unna/Werne (cities, streets, waste types, dates) on shared URL
- [x] Confirmed 4 SHARED_ONLY services, 18 PERSVC_ONLY, 6 dead on both (pre-existing)
- [ ] User confirmation that config flow completes for Unna

🤖 Generated with [Claude Code](https://claude.com/claude-code)