### PR TITLE
Rewrite Wirral Council source for new website

### DIFF
--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -3839,7 +3839,9 @@
   },
   "wirral_gov_uk": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/wirral_gov_uk.md",
-    "howto": {},
+    "howto": {
+      "en": "Go to https://www.wirral.gov.uk/bincal_dev/ and enter your postcode. Right-click on your address in the dropdown and select 'Inspect' to find the 12-digit option value. Use that as the address_value parameter."
+    },
     "urls": {}
   },
   "wokingham_gov_uk": {

--- a/custom_components/waste_collection_schedule/translations/de.json
+++ b/custom_components/waste_collection_schedule/translations/de.json
@@ -21701,8 +21701,8 @@
         "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
         "data": {
           "calendar_title": "Kalender Titel",
-          "street": "Straße",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "PLZ"
         },
         "data_description": {
           "calendar_title": "Ein lesbarerer oder benutzerfreundlicherer Name für den Müllkalender. Wenn nichts angegeben wird, wird der Name der Quelle verwendet."
@@ -21713,8 +21713,8 @@
         "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
         "data": {
           "calendar_title": "Kalender Titel",
-          "street": "Straße",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "PLZ"
         },
         "data_description": {}
       },

--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -22029,11 +22029,13 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
-          "street": "Street",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "Postcode"
         },
         "data_description": {
-          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used."
+          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used.",
+          "address_value": "The 12-digit address value from the dropdown on the Wirral bin calendar page.",
+          "postcode": "Your postcode, e.g. CH49 4NP."
         }
       },
       "reconfigure_wirral_gov_uk": {
@@ -22041,10 +22043,13 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
-          "street": "Street",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "Postcode"
         },
-        "data_description": {}
+        "data_description": {
+          "address_value": "The 12-digit address value from the dropdown on the Wirral bin calendar page.",
+          "postcode": "Your postcode, e.g. CH49 4NP."
+        }
       },
       "args_wokingham_gov_uk": {
         "title": "Configure Source",

--- a/custom_components/waste_collection_schedule/translations/fr.json
+++ b/custom_components/waste_collection_schedule/translations/fr.json
@@ -21595,8 +21595,8 @@
         "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
         "data": {
           "calendar_title": "Titre du Calendrier",
-          "street": "Street",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "Code Postal"
         },
         "data_description": {
           "calendar_title": "Un nom plus lisible ou convivial pour le calendrier des déchets. Si aucun n'est fourni, le nom renvoyé par la source sera utilisé."
@@ -21607,8 +21607,8 @@
         "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
         "data": {
           "calendar_title": "Titre du Calendrier",
-          "street": "Street",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "Code Postal"
         },
         "data_description": {}
       },

--- a/custom_components/waste_collection_schedule/translations/it.json
+++ b/custom_components/waste_collection_schedule/translations/it.json
@@ -21607,8 +21607,8 @@
         "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Maggiori informazioni: {docs_url}.",
         "data": {
           "calendar_title": "Nome Calendario",
-          "street": "Strada",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "Codice Postale CAP"
         },
         "data_description": {
           "calendar_title": "Puoi cambiare il nome del calendario della raccolta dei rifiuti, altrimenti di default verra' utilizzato il nome del tuo fornitore di servizi."
@@ -21619,8 +21619,8 @@
         "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Per maggiori informazioni: {docs_url}.",
         "data": {
           "calendar_title": "Nome Calendario",
-          "street": "Strada",
-          "suburb": "Suburb"
+          "address_value": "Address Value",
+          "postcode": "Codice Postale CAP"
         },
         "data_description": {}
       },

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wirral_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wirral_gov_uk.py
@@ -9,52 +9,111 @@ TITLE = "Wirral Council"
 DESCRIPTION = "Source for wirral.gov.uk services for Wirral Council, UK."
 URL = "https://wirral.gov.uk"
 TEST_CASES = {
-    "Test_001": {"street": "Vernon Avenue", "suburb": "Poulton"},
-    "Test_002": {"street": "Vernon Avenue", "suburb": "Seacombe"},
-    "Test_003": {"street": "Claremont Road", "suburb": "West Kirby"},
-    "Test_004": {"street": "Beckenham Road", "suburb": "New Brighton"},
+    "Elm Avenue, Upton": {
+        "postcode": "CH49 4NP",
+        "address_value": "000042037487",
+    },
 }
 ICON_MAP = {
-    "NON RECYCLEABLE (GREEN BIN)": "mdi:trash-can",
-    "PAPER AND PACKAGING (GREY BIN)": "mdi:newspaper",
-    "GARDEN WASTE (BROWN BIN)": "mdi:leaf",
+    "Green bin": "mdi:trash-can",
+    "Grey bin": "mdi:recycle",
+    "Brown bin": "mdi:leaf",
 }
-WASTES = {
-    "Non recycleable (green bin)",
-    "Garden waste (brown bin)",
-    "Paper and packaging (grey bin)",
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Go to https://www.wirral.gov.uk/bincal_dev/ and enter "
+        "your postcode. Right-click on your address in the dropdown "
+        "and select 'Inspect' to find the 12-digit option value. "
+        "Use that as the address_value parameter."
+    ),
 }
-DATE_REGEX = "^([0-9]{1,2} [A-Za-z]+ [0-9]{4})"
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "postcode": "Your postcode, e.g. CH49 4NP.",
+        "address_value": (
+            "The 12-digit address value from the dropdown "
+            "on the Wirral bin calendar page."
+        ),
+    }
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "postcode": "Postcode",
+        "address_value": "Address Value",
+    }
+}
+
+BIN_URL = "https://www.wirral.gov.uk/bincal_dev/"
+DATE_REGEX = r"(\w+ \d{1,2} \w+ \d{4})"
 
 
 class Source:
-    def __init__(self, street, suburb):
-        self._street = street
-        self._suburb = suburb
+    def __init__(self, postcode: str, address_value: str):
+        self._postcode = postcode.strip()
+        self._address_value = address_value.strip()
 
-    def fetch(self):
-        s = requests.Session()
-        # Loop through waste types
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        # Step 1: GET initial page
+        r = session.get(BIN_URL)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        # Collect form data
+        data = self._extract_inputs(soup)
+        data["ctl00$MainContent$Postcode"] = self._postcode
+        data["ctl00$MainContent$LookupPostcode"] = "Look Up"
+
+        # Step 2: POST postcode
+        r = session.post(BIN_URL, data=data)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        # Step 3: Select address and find rounds
+        data = self._extract_inputs(soup)
+        data.pop("ctl00$MainContent$LookupPostcode", None)
+        data["ctl00$MainContent$addressDropDown"] = self._address_value
+        data["ctl00$MainContent$FindRounds"] = "Find collection rounds"
+
+        r = session.post(BIN_URL, data=data)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        # Parse bin rows
         entries = []
-        for waste in WASTES:
-            r = s.get(
-                f"https://ww3.wirral.gov.uk//recycling/detailContentDru7.asp?s={self._street}&t={self._suburb}&c={waste}"
+        for row in soup.select("div.binRow"):
+            h2 = row.find("h2")
+            strong = row.find("strong")
+            if not h2 or not strong:
+                continue
+
+            bin_type = h2.get_text(strip=True)
+            date_text = strong.get_text(strip=True).rstrip(".")
+            match = re.search(DATE_REGEX, date_text)
+            if not match:
+                continue
+
+            entries.append(
+                Collection(
+                    date=datetime.strptime(
+                        match.group(1), "%A %d %B %Y"
+                    ).date(),
+                    t=bin_type,
+                    icon=ICON_MAP.get(bin_type),
+                )
             )
-            # extract dates
-            soup = BeautifulSoup(r.text, "html.parser")
-            dates = soup.findAll("li")
-            if len(dates) != 0:
-                for item in dates:
-                    match = re.match(DATE_REGEX, item.text)
-                    if match:
-                        entries.append(
-                            Collection(
-                                date=datetime.strptime(
-                                    match.group(1), "%d %B %Y"
-                                ).date(),
-                                t=waste,
-                                icon=ICON_MAP.get(waste.upper()),
-                            )
-                        )
 
         return entries
+
+    @staticmethod
+    def _extract_inputs(soup: BeautifulSoup) -> dict:
+        data = {}
+        for inp in soup.find_all("input"):
+            name = inp.get("name")
+            if name:
+                data[name] = inp.get("value", "")
+        return data

--- a/doc/source/wirral_gov_uk.md
+++ b/doc/source/wirral_gov_uk.md
@@ -9,19 +9,21 @@ waste_collection_schedule:
   sources:
     - name: wirral_gov_uk
       args:
-        street: STREET
-        suburb: SUBURB
+        postcode: POSTCODE
+        address_value: ADDRESS_VALUE
 ```
 
 ### Configuration Variables
 
-**street**  
+**postcode**  
 *(string) (required)*
 
-**suburb**  
+Your postcode, e.g. `CH49 4NP`.
+
+**address_value**  
 *(string) (required)*
 
-Both the street and suburb are should be supplied in the arguments, as they appear on the web site when viewing your schedule.
+The 12-digit address value from the dropdown on the Wirral bin calendar page. To find this, go to https://www.wirral.gov.uk/bincal_dev/, enter your postcode, right-click your address in the dropdown and select "Inspect" to find the `<option value="...">` value.
 
 ## Examples
 
@@ -30,6 +32,6 @@ waste_collection_schedule:
   sources:
     - name: wirral_gov_uk
       args:
-        street: "Beckenham Road"
-        suburb: "New Brighton"
+        postcode: "CH49 4NP"
+        address_value: "000042037487"
 ```


### PR DESCRIPTION
## Summary
- Fixes #4972 — Wirral Council migrated to new website, old endpoint dead since late 2025
- Rewrites source for new ASP.NET form at `wirral.gov.uk/bincal_dev/`
- Two-step form: POST postcode → address dropdown → POST address → bin dates
- Parameters changed from `street`/`suburb` to `postcode`/`address_value`
- Credit to @SolutechUK for documenting the new form flow in the issue

## Test plan
- [x] Tested full form flow: postcode lookup → address selection → bin date parsing
- [x] Verified date parsing for "Grey bin" and "Green bin" collection types
- [x] Ran formatters (black, isort, flake8) — clean
- [x] Ran `update_docu_links.py`
- [ ] Verify in Home Assistant config flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)