### PR TITLE
Fix Blackpool source crash on unrecognised job names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
@@ -58,13 +58,16 @@ class Source:
         entries = []
         for job in r1.json()["jobsField"]:
             # "Empty Domestic Refuse 240L" -> "Domestic Refuse"
-            jobName = (
-                re.search(REGEX_JOB_NAME, job["jobField"]["nameField"]).group(1).strip()
-            )
+            name_field = job["jobField"]["nameField"]
+            match = re.search(REGEX_JOB_NAME, name_field)
+            if not match:
+                continue
+            jobName = match.group(1).strip()
             entries.append(
                 Collection(
                     date=datetime.strptime(
-                        job["jobField"]["scheduledStartField"], "%Y-%m-%dT%H:%M:%S"
+                        job["jobField"]["scheduledStartField"],
+                        "%Y-%m-%dT%H:%M:%S",
                     ).date(),
                     t=NAME_MAP.get(jobName, jobName),
                     icon=ICON_MAP.get(jobName),


### PR DESCRIPTION
## Summary
- Fixes #5667 — AttributeError when `re.search()` returns None for unexpected job name format
- Adds None guard on regex match; skips unrecognised job names instead of crashing
- Bartec API still works — tested all 3 existing test cases successfully
- Asked reporter for their UPRN to investigate which job name format causes the mismatch

## Test plan
- [x] Verified Bartec API returns valid data for all existing test cases
- [x] All job names match regex: "Empty Domestic Refuse 240L", "Empty Bin Paper & Card 240L", etc.
- [x] Ran black + flake8 — clean
- [ ] Awaiting reporter's UPRN to confirm fix resolves their specific case

🤖 Generated with [Claude Code](https://claude.com/claude-code)