### PR TITLE
Fix publidata_fr instance_id type handling in config flow

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -288,10 +288,16 @@ _LOGGER = logging.getLogger(__name__)
 class Source:
     geocoder_url = "https://api.publidata.io/v2/geocoder"
 
-    def __init__(self, address, insee_code, instance_id, public_type: str | None = None):
+    def __init__(
+        self,
+        address: str,
+        insee_code: str,
+        instance_id: int | str,
+        public_type: str | None = None,
+    ):
         self.address = address
         self.insee_code = insee_code
-        self.instance_id = instance_id
+        self.instance_id = int(instance_id)
         self._public_type = public_type
 
     def _get_address_params(self, address, insee_code):


### PR DESCRIPTION
## Summary
- Fixes #5723 — config flow rejects pre-populated instance_id when selecting a publidata service (e.g. CASGBS)
- The `EXTRA_INFO` default_params provide `instance_id` as an int, but the config flow form expected a string since the `__init__` parameter had no type annotation
- Adds `int | str` annotation and coerces to `int` in `__init__`, so both typed and pre-populated values work

## Test plan
- [x] Verified the config flow uses `inspect.signature` to derive form field types
- [x] `int | str` maps to `SUPPORTED_ARG_TYPES` correctly
- [x] Ran black + flake8 — clean (only pre-existing F401)
- [ ] Verify in HA config flow that CASGBS pre-populated value is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)