### PR TITLE
fix(calendar): compare dates instead of datetimes so today's all-day events are not dropped

### DIFF
--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -104,7 +104,7 @@ class WasteCollectionCalendar(CalendarEntity):
         ):
             event = self._convert(collection)
 
-            if start_date <= event.start_datetime_local <= end_date:
+            if start_date.date() <= event.start_datetime_local.date() <= end_date.date():
                 events.append(event)
 
         return events


### PR DESCRIPTION
## Summary

`WasteCollectionCalendar.async_get_events()` compares the request's wall-clock `start_date` against `event.start_datetime_local`. For all-day collection events, `start_datetime_local` is always `00:00:00` local time, so the moment the request happens after midnight (which is any normal frontend call), today's events fail the inclusive range check and are silently dropped.

This is especially visible when **two collection types fall on the same day** (e.g. `Hausmüll` + `Papiermüll`): only one of them may still appear via the state cache, the other one becomes invisible to any consumer of `async_get_events()`, such as the `custom:trash-card` frontend.

Fixes #5852.

## Fix

Compare **dates only**, since these are all-day events:

```diff
-            if start_date <= event.start_datetime_local <= end_date:
+            if start_date.date() <= event.start_datetime_local.date() <= end_date.date():
                 events.append(event)
```

- No behavioural change for future days.
- No API change, no new dependencies.
- Preserves the inclusive boundary semantics.
- Single-line fix.

## Testing

Reproduced with a local ICS source containing `Hausmüll` and `Papiermüll` on the same date (`2026-04-07`).

**Before patch** (request after midnight local time):
```
GET /api/calendars/calendar.abfall_app?start=2026-04-07T05:30:00.000Z&end=2026-04-09T05:30:00.000Z
=> []
```

**After patch**:
```json
[
  { "summary": "Hausmüll",   "start": { "date": "2026-04-07" }, ... },
  { "summary": "Papiermüll", "start": { "date": "2026-04-07" }, ... }
]
```

The `trash-card` frontend then correctly displays both collections.