### PR TITLE
Fix SSL verification error for Newham source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
@@ -22,7 +22,10 @@ class Source:
 
     def fetch(self):
         s = requests.Session()
-        r = s.get(f"https://bincollection.newham.gov.uk/Details/Index/{self._property}")
+        r = s.get(
+            f"https://bincollection.newham.gov.uk/Details/Index/{self._property}",
+            verify=False,
+        )
 
         # Make a BS4 object
         soup = BeautifulSoup(r.text, features="html.parser")


### PR DESCRIPTION
## Summary
- Disable SSL verification for the `newham_gov_uk` source, as `bincollection.newham.gov.uk` has a broken certificate chain causing `CERTIFICATE_VERIFY_FAILED` errors
- Consistent with how ~15 other sources already handle broken SSL certs (e.g. awg_de, basingstoke, karlsruhe, etc.)

Fixes #5581

## Test plan
- [ ] Verify Newham source fetches successfully without SSL errors
- [ ] Confirm no regression for other sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)