### PR TITLE
Switch Sutton Council source to curl_cffi

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
@@ -1,6 +1,6 @@
 from time import sleep
 
-import requests
+from curl_cffi import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.service.ICS import ICS
 
@@ -28,15 +28,7 @@ class Source:
         self._ics = ICS()
 
     def fetch(self):
-        s = requests.Session()
-        s.headers.update(
-            {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-GB,en;q=0.5",
-                "Referer": "https://sutton.gov.uk",
-            }
-        )
+        s = requests.Session(impersonate="chrome")
 
         api_url = API_URL.format(id=self._id)
         ical_url = ICAL_URL.format(id=self._id)


### PR DESCRIPTION
## Summary
- Switch `sutton_gov_uk` source from `requests` to `curl_cffi` with browser impersonation to bypass Sutton Council's bot protection returning 503 errors
- Removes manual User-Agent headers in favour of curl_cffi's built-in browser impersonation

Fixes #5485

## Test plan
- [ ] Verify Sutton Council source fetches successfully without 503 errors
- [ ] Confirm ICS calendar data is parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)