### PR TITLE
Fall back to Alle Hausnummern in AppAbfallplusDe

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -842,6 +842,13 @@ class AppAbfallplusDe:
                 if hnr["f_id_strasse"] is not None:
                     self._f_id_strasse = hnr["f_id_strasse"]
                 return
+        # fall back to "Alle Hausnummern" if the specific house number is not found
+        for hnr in hnrs:
+            if compare(hnr["name"], "Alle Hausnummern", remove_space=True):
+                self._hnr = hnr["id"]
+                if hnr["f_id_strasse"] is not None:
+                    self._f_id_strasse = hnr["f_id_strasse"]
+                return
         raise SourceArgumentNotFoundWithSuggestions(
             "hnr", self._hnr_search, [hnr["name"] for hnr in hnrs]
         )


### PR DESCRIPTION
## Summary
- When a specific house number is not found in the AppAbfallplusDe service, fall back to "Alle Hausnummern" if available
- Some providers (e.g. ZAKB) have switched from individual house numbers to a single "Alle Hausnummern" entry, breaking existing user configurations

Fixes #5460

## Test plan
- [ ] Verify sources with individual house numbers still work (exact match takes priority)
- [ ] Verify sources that only have "Alle Hausnummern" work with any house number configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)