### PR TITLE
Rewrite Victoria Park source for FOGO schedule

### DIFF
--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -459,7 +459,9 @@
   },
   "victoriapark_wa_gov_au": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/victoriapark_wa_gov_au.md",
-    "howto": {},
+    "howto": {
+      "en": "Visit the <a href='https://www.victoriapark.wa.gov.au/residents/waste-and-recycling/bins-and-collections.aspx'>Bins and Collections</a> page to find your collection group (1 or 2) and day."
+    },
     "urls": {}
   },
   "townsville_qld_gov_au": {

--- a/custom_components/waste_collection_schedule/translations/de.json
+++ b/custom_components/waste_collection_schedule/translations/de.json
@@ -1948,8 +1948,8 @@
         "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
         "data": {
           "calendar_title": "Kalender Titel",
-          "address": "Addresse",
-          "predict": "Predict"
+          "day": "Day",
+          "group": "Group"
         },
         "data_description": {
           "calendar_title": "Ein lesbarerer oder benutzerfreundlicherer Name für den Müllkalender. Wenn nichts angegeben wird, wird der Name der Quelle verwendet."
@@ -1960,8 +1960,8 @@
         "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
         "data": {
           "calendar_title": "Kalender Titel",
-          "address": "Addresse",
-          "predict": "Predict"
+          "day": "Day",
+          "group": "Group"
         },
         "data_description": {}
       },

--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -1997,11 +1997,13 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
-          "address": "Address",
-          "predict": "Predict"
+          "day": "Collection Day",
+          "group": "Collection Group"
         },
         "data_description": {
-          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used."
+          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used.",
+          "day": "Collection day (Monday to Friday)",
+          "group": "Collection group (1 or 2) — check the calendar on the council website"
         }
       },
       "reconfigure_victoriapark_wa_gov_au": {
@@ -2009,10 +2011,13 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
-          "address": "Address",
-          "predict": "Predict"
+          "day": "Collection Day",
+          "group": "Collection Group"
         },
-        "data_description": {}
+        "data_description": {
+          "day": "Collection day (Monday to Friday)",
+          "group": "Collection group (1 or 2) — check the calendar on the council website"
+        }
       },
       "args_townsville_qld_gov_au": {
         "title": "Configure Source",

--- a/custom_components/waste_collection_schedule/translations/fr.json
+++ b/custom_components/waste_collection_schedule/translations/fr.json
@@ -1948,8 +1948,8 @@
         "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
         "data": {
           "calendar_title": "Titre du Calendrier",
-          "address": "Adresse",
-          "predict": "Predict"
+          "day": "Day",
+          "group": "Group"
         },
         "data_description": {
           "calendar_title": "Un nom plus lisible ou convivial pour le calendrier des déchets. Si aucun n'est fourni, le nom renvoyé par la source sera utilisé."
@@ -1960,8 +1960,8 @@
         "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
         "data": {
           "calendar_title": "Titre du Calendrier",
-          "address": "Adresse",
-          "predict": "Predict"
+          "day": "Day",
+          "group": "Group"
         },
         "data_description": {}
       },

--- a/custom_components/waste_collection_schedule/translations/it.json
+++ b/custom_components/waste_collection_schedule/translations/it.json
@@ -1948,8 +1948,8 @@
         "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Maggiori informazioni: {docs_url}.",
         "data": {
           "calendar_title": "Nome Calendario",
-          "address": "Indirizzo",
-          "predict": "Predict"
+          "day": "Day",
+          "group": "Group"
         },
         "data_description": {
           "calendar_title": "Puoi cambiare il nome del calendario della raccolta dei rifiuti, altrimenti di default verra' utilizzato il nome del tuo fornitore di servizi."
@@ -1960,8 +1960,8 @@
         "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Per maggiori informazioni: {docs_url}.",
         "data": {
           "calendar_title": "Nome Calendario",
-          "address": "Indirizzo",
-          "predict": "Predict"
+          "day": "Day",
+          "group": "Group"
         },
         "data_description": {}
       },

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/victoriapark_wa_gov_au.py
@@ -1,178 +1,115 @@
-import re
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 
-import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
 
 TITLE = "Town of Victoria Park"
 DESCRIPTION = "Source for www.victoriapark.wa.gov.au Waste Collection Services"
 URL = "https://www.victoriapark.wa.gov.au"
 TEST_CASES = {
-    "Monday": {"address": "51 Cookham Road, Lathlain"},  # Monday
-    "Town of Vic Park (Tues)": {
-        "address": "99 Shepperton Road, VICTORIA PARK",
-        "predict": True,
-    },  # Tuesday
-    "Wednesday": {"address": "156 Oats St, Carlisle"},  # Wednesday
-    "Park Centre (Thurs)": {
-        "address": "789 Albany hwy, EAST VICTORIA PARK"
-    },  # Thursday
-    "Aqualife (Thurs)": {"address": "42 Somerset St, East Victoria Park"},  # Thursday
-    "Friday": {
-        "address": "90 Canterbury Terrace, East Victoria Park",
-        "predict": True,
-    },  # Friday
+    "Group 1 Monday": {"group": 1, "day": "Monday"},
+    "Group 2 Friday": {"group": 2, "day": "Friday"},
+    "Group 1 Wednesday": {"group": 1, "day": "Wednesday"},
 }
+
+COUNTRY = "au"
 
 ICON_MAP = {
-    "Rubbish": "mdi:trash-can",
+    "FOGO": "mdi:leaf",
+    "General Waste": "mdi:trash-can",
     "Recycling": "mdi:recycle",
-    "Bulk Waste": "mdi:microwave",
-    "Green Waste": "mdi:tree",
-    "Go Bin": "mdi:leaf",
 }
 
+# Reference date: Monday 30 June 2025 is a YELLOW week for Group 1 (FOGO + Recycling)
+# and a RED week for Group 2 (FOGO + General Waste).
+# Weeks alternate every 7 days from this reference.
+REFERENCE_MONDAY = date(2025, 6, 30)
 
-def clean_months(start_date, date_str):
-    date_cleaned = start_date + re.sub(r"^\d+", "", date_str)
-    date_cleaned = re.sub(r"Janu?a?r?y?", "Jan", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Febr?u?a?r?y?", "Feb", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Marc?h?", "Mar", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Apri?l?", "Apr", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"June?", "Jun", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"July?", "Jul", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Augu?s?t?", "Aug", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Sept?e?m?b?e?r?", "Sep", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Octo?b?e?r?", "Oct", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Nov?e?m?b?e?r?", "Nov", date_cleaned, flags=re.IGNORECASE)
-    date_cleaned = re.sub(r"Dec?e?m?b?e?r?", "Dec", date_cleaned, flags=re.IGNORECASE)
-    # deal with dates that span months like "31 Aug Sep 2024"
-    date_elements: list = date_cleaned.split(" ")
-    date_cleaned = f"{date_elements[0]} {date_elements[1]} {date_elements[-1]}"
-    return date_cleaned
+VALID_DAYS = {
+    "Monday": 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Visit the <a href='https://www.victoriapark.wa.gov.au/residents/waste-and-recycling/bins-and-collections.aspx'>Bins and Collections</a> page to find your collection group (1 or 2) and day.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "group": "Collection group (1 or 2) — check the calendar on the council website",
+        "day": "Collection day (Monday to Friday)",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "group": "Collection Group",
+        "day": "Collection Day",
+    },
+}
 
 
 class Source:
-    def __init__(self, address, predict=False):
-        address = address.strip()
-        address = re.sub(" +", " ", address)
-        address = re.sub("hwy", "highway", address, flags=re.IGNORECASE)
-        address = re.sub(
-            r"western australia (\d{4})", "WA \\1", address, flags=re.IGNORECASE
-        )
-        address = re.sub(r" wa (\d{4})", "  WA  \\1", address, flags=re.IGNORECASE)
-        self._address = address
-        if not isinstance(predict, bool):
-            raise Exception("'predict' must be a boolean value")
-        self._predict = predict
+    def __init__(self, group: int, day: str):
+        if group not in (1, 2):
+            raise SourceArgumentNotFoundWithSuggestions("group", str(group), ["1", "2"])
+        day_title = day.strip().title()
+        if day_title not in VALID_DAYS:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "day", day, list(VALID_DAYS.keys())
+            )
+        self._group = group
+        self._day_offset = VALID_DAYS[day_title]
 
-    def collect_dates(self, start_date, weeks):
-        dates = []
-        dates.append(start_date)
-        for _ in range(1, 4 // weeks):
-            start_date = start_date + timedelta(days=(weeks * 7))
-            dates.append(start_date)
-        return dates
-
-    def fetch(self):
+    def fetch(self) -> list[Collection]:
+        today = date.today()
         entries = []
-        # initiate a session
-        url = "https://maps.vicpark.wa.gov.au/IntraMaps22B/ApplicationEngine/Integration/api/search"
 
-        payload = {}
-        params = {
-            "configId": "00000000-0000-0000-0000-000000000000",
-            "form": "4a7d4da6-26b5-40ce-a0b3-814f5e82c0f3",
-            "fields": self._address,
-        }
-        headers = {"Authorization": "apikey 8b1fdca5-5d16-4724-99cd-df3a32c650a0"}
+        # Find the next occurrence of the collection day on or after today minus 1 week
+        start = today - timedelta(days=7)
+        # Align to the collection day
+        days_until = (self._day_offset - start.weekday()) % 7
+        collection_date = start + timedelta(days=days_until)
 
-        r = requests.get(url, headers=headers, data=payload, params=params)
-        r.raise_for_status()
+        # Generate collections for ~52 weeks
+        while collection_date < today + timedelta(days=365):
+            # Determine if this is a yellow or red week for Group 1
+            weeks_since_ref = (collection_date - REFERENCE_MONDAY).days // 7
+            is_yellow_group1 = weeks_since_ref % 2 == 0
 
-        j = r.json()
+            if self._group == 1:
+                is_yellow = is_yellow_group1
+            else:
+                is_yellow = not is_yellow_group1
 
-        if len(j) == 0:
-            raise Exception("address not found")
-
-        # Just picking first date
-        j = j[0]
-
-        # search for the address
-        url = "https://maps.vicpark.wa.gov.au/IntraMaps22B/ApplicationEngine/Integration/api/search"
-
-        fields_dict = {item["name"]: item["value"] for item in j}
-
-        params = {
-            "configId": "00000000-0000-0000-0000-000000000000",
-            "form": "f3f264a3-94f5-499a-a697-0fac668cd027",
-            "fields": fields_dict.get("mapkey") + "," + fields_dict.get("dbkey"),
-        }
-
-        r = requests.get(url, headers=headers, data=payload, params=params)
-        r.raise_for_status()
-
-        fields_json = r.json()[0]
-
-        data_dict = {item["name"]: item for item in fields_json}
-
-        day_rubbish = data_dict.get("General_Bin")["value"].split(" - ")[0]
-        date_recycling = data_dict.get("Recycling_Bin")["value"][:11]
-        date_go = data_dict.get("GO_Bin")["value"][:11]
-        raw_green_waste = data_dict.get("Green_Waste")["value"]
-        raw_bulk_waste = data_dict.get("Bulk_Waste")["value"]
-        # 15-16 Jul 2023, 9-10 Dec 2023
-        # Months are inconsistent and a range
-        green_waste_bits = re.split(r"\s*[\-,()]\s*", raw_green_waste)
-        date_green_waste = clean_months(green_waste_bits[0], green_waste_bits[1])
-        date_green_waste2 = clean_months(green_waste_bits[2], green_waste_bits[3])
-
-        bulk_waste_bits = re.split(r"\s*[\-,()]\s*", raw_bulk_waste)
-        date_bulk_waste = clean_months(bulk_waste_bits[0], bulk_waste_bits[1])
-        date_bulk_waste2 = clean_months(bulk_waste_bits[2], bulk_waste_bits[3])
-
-        date_rubbish = datetime.today()
-        while date_rubbish.strftime("%A").lower() != day_rubbish.lower():
-            date_rubbish = date_rubbish + timedelta(days=1)
-
-        if self._predict:
-            rub_dates = self.collect_dates(date_rubbish.date(), 1)
-            rec_dates = self.collect_dates(
-                datetime.strptime(date_recycling, "%d %b %Y").date(), 2
+            # FOGO goes out every week
+            entries.append(
+                Collection(date=collection_date, t="FOGO", icon=ICON_MAP["FOGO"])
             )
-            go_dates = self.collect_dates(
-                datetime.strptime(date_go, "%d %b %Y").date(), 2
-            )
-            grn_dates = [
-                datetime.strptime(date_green_waste, "%d %b %Y").date(),
-                datetime.strptime(date_green_waste2, "%d %b %Y").date(),
-            ]
-            blk_dates = [
-                datetime.strptime(date_bulk_waste, "%d %b %Y").date(),
-                datetime.strptime(date_bulk_waste2, "%d %b %Y").date(),
-            ]
-        else:
-            rub_dates = [date_rubbish.date()]
-            rec_dates = [datetime.strptime(date_recycling, "%d %b %Y").date()]
-            go_dates = [datetime.strptime(date_go, "%d %b %Y").date()]
-            grn_dates = [datetime.strptime(date_green_waste, "%d %b %Y").date()]
-            blk_dates = [datetime.strptime(date_bulk_waste, "%d %b %Y").date()]
 
-        collections = []
-        collections.append({"type": "Rubbish", "dates": rub_dates})
-        collections.append({"type": "Recycling", "dates": rec_dates})
-        collections.append({"type": "Go Bin", "dates": go_dates})
-        collections.append({"type": "Green Waste", "dates": grn_dates})
-        collections.append({"type": "Bulk Waste", "dates": blk_dates})
-
-        for collection in collections:
-            for date in collection["dates"]:
+            # Yellow week = Recycling, Red week = General Waste
+            if is_yellow:
                 entries.append(
                     Collection(
-                        date=date,
-                        t=collection["type"],
-                        icon=ICON_MAP.get(collection["type"]),
+                        date=collection_date,
+                        t="Recycling",
+                        icon=ICON_MAP["Recycling"],
                     )
                 )
+            else:
+                entries.append(
+                    Collection(
+                        date=collection_date,
+                        t="General Waste",
+                        icon=ICON_MAP["General Waste"],
+                    )
+                )
+
+            collection_date += timedelta(days=7)
 
         return entries

--- a/doc/source/victoriapark_wa_gov_au.md
+++ b/doc/source/victoriapark_wa_gov_au.md
@@ -1,6 +1,6 @@
-# Town of Victoria Park Council
+# Town of Victoria Park
 
-Support for schedules provided by [Town of Victoria Park Bins and collections](https://www.victoriapark.wa.gov.au/residents/waste-and-recycling/bins-and-collections.aspx).
+Support for schedules provided by [Town of Victoria Park Bins and Collections](https://www.victoriapark.wa.gov.au/residents/waste-and-recycling/bins-and-collections.aspx).
 
 ## Configuration via configuration.yaml
 
@@ -9,13 +9,17 @@ waste_collection_schedule:
   sources:
     - name: victoriapark_wa_gov_au
       args:
-        address: ADDRESS
+        group: GROUP
+        day: DAY
 ```
 
 ### Configuration Variables
 
-**address**  
-*(string) (required)*
+**group**  
+*(int) (required)* Collection group: `1` or `2`
+
+**day**  
+*(string) (required)* Collection day: `Monday`, `Tuesday`, `Wednesday`, `Thursday`, or `Friday`
 
 ## Example
 
@@ -24,17 +28,16 @@ waste_collection_schedule:
   sources:
     - name: victoriapark_wa_gov_au
       args:
-        address: 99 Shepperton Road East Victoria Park 6101
+        group: 1
+        day: Monday
 ```
 
 ## How to get the source arguments
 
-Visit the [Town of Victoria Park Bins and collections](https://www.victoriapark.wa.gov.au/residents/waste-and-recycling/bins-and-collections.aspx) page and search for your address. The arguments should exactly match the results of the property.
+Visit the [Bins and Collections](https://www.victoriapark.wa.gov.au/residents/waste-and-recycling/bins-and-collections.aspx) page to find your collection group (1 or 2) and collection day from the calendar images.
 
-Currently exporting out:
+Collection types:
 
-- Rubbish
-- Recycling
-- Go Bin
-- Green Waste
-- Bulk Waste
+- **FOGO** (Food Organics/Garden Organics) — collected weekly
+- **Recycling** — collected fortnightly (yellow weeks)
+- **General Waste** — collected fortnightly (red weeks)


### PR DESCRIPTION
## Summary
- Victoria Park has removed their IntraMaps API and switched to a static FOGO calendar
- Rewrite the source to calculate the alternating fortnightly schedule based on user-provided **group** (1 or 2) and **collection day** (Mon–Fri)
- FOGO is collected weekly; Recycling and General Waste alternate fortnightly
- No API dependency — schedule is calculated algorithmically from a known reference week
- **Breaking change**: `address` and `predict` params replaced with `group` and `day`

Fixes #5418

## How it works
The council publishes static calendar images showing two groups with alternating yellow (Recycling) and red (General Waste) weeks. Using a reference date (Mon 30 June 2025 = Yellow week for Group 1), we calculate which type applies to each week.

## Test plan
- [x] Verified schedule logic matches both Group 1 and Group 2 calendar images
- [ ] User testing with real group/day configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)