### PR TITLE
Fix regex in Landkreis Amberg-Sulzbach ICS doc

### DIFF
--- a/doc/ics/landkreis_as_de.md
+++ b/doc/ics/landkreis_as_de.md
@@ -29,7 +29,7 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        regex: (.*?)\s+\|.*
+        regex: (.*?)\s*\|.*
         url: https://landkreis-as.de/abfallwirtschaft/abfuhrtermine_kalender_freudenberg.ics
 ```
 ### Ensdorf (regex also strip `! vorgefahren !`)
@@ -39,6 +39,6 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        regex: (.*?)\s+(\||\!).*
+        regex: (.*?)\s*(\||\!).*
         url: https://landkreis-as.de/abfallwirtschaft/abfuhrtermine_kalender_ensdorf.ics
 ```

--- a/doc/ics/yaml/landkreis_as_de.yaml
+++ b/doc/ics/yaml/landkreis_as_de.yaml
@@ -13,7 +13,7 @@ test_cases:
     url: https://landkreis-as.de/abfallwirtschaft/abfuhrtermine_kalender_sulzbach-rosenberg8.ics
   Freudenberg (regex strip after `|`):
     url: https://landkreis-as.de/abfallwirtschaft/abfuhrtermine_kalender_freudenberg.ics
-    regex: (.*?)\s+\|.*
+    regex: (.*?)\s*\|.*
   Ensdorf (regex also strip `! vorgefahren !`):
     url: https://landkreis-as.de/abfallwirtschaft/abfuhrtermine_kalender_ensdorf.ics
-    regex: (.*?)\s+(\||\!).*
+    regex: (.*?)\s*(\||\!).*


### PR DESCRIPTION
## Summary
- Fix regex examples in `doc/ics/landkreis_as_de.md`: change `\s+` to `\s*` before `|` and `!` delimiters
- The ICS file has inconsistent spacing — e.g. `Altpapier|` (no space) vs `Restmüll |` (with space)

Fixes #5419

## Test plan
- [x] Verified regex matches both `Altpapier|` and `Restmüll |` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)