### PR TITLE
Update affaldonline_dk.py with FFV

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
@@ -64,6 +64,12 @@ AFFALDONLINE_MUNICIPALITIES = {
         "parser": "pdf",
         "values": "Nørre Klit|5||||6720|Fanø|2582|1747246|0",
     },
+    "ffv": {
+        "title": "Faaborg Forsynings Virksomhed",
+        "url": "https://www.ffv.dk/",
+        "parser": "pdf",
+        "values": "Marsk Billesvej|18||||5672|Broby|36193544|576846|0",
+    },
     "fredericia": {
         "title": "Fredericia Kommune Affald & Genbrug",
         "url": "https://affaldgenbrug-fredericia.dk/",


### PR DESCRIPTION
Added Faaborg-Midtfyn kommune - FFV as an option to generate schedule from generated PDF, same as other Affaldonline municiplaities. Done in accordance to [Source Request]: Faaborg-Midtfyn kommune - FFV #2955. I hvae not tested this as I am not sure how.