### PR TITLE
Add Food Caddy support to Blackpool source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackpool_gov_uk.py
@@ -14,11 +14,12 @@ TEST_CASES = {
 }
 
 API_URL = "https://api.blackpool.gov.uk/api/bartec"
-REGEX_JOB_NAME = r"^Empty(?: Bin)? ([A-Za-z &]+?)( \d+\w)?$"
+REGEX_JOB_NAME = r"^Empty(?: Bin)?(?: \d+\w+)? ([A-Za-z &]+?)( \d+\w)?$"
 NAME_MAP = {
     "Domestic Refuse": "Grey bin or Red sack",
     "Dry Recycling": "Blue bin",
     "Paper & Card": "Paper & Card",
+    "Food Caddy": "Food Caddy",
 }
 ICON_MAP = {
     "Domestic Refuse": "mdi:trash-can",
@@ -26,6 +27,7 @@ ICON_MAP = {
     "Brown Sack": "mdi:newspaper",
     "Paper & Card": "mdi:newspaper",
     "Green Waste": "mdi:leaf",
+    "Food Caddy": "mdi:food-apple",
 }
 
 


### PR DESCRIPTION
## Summary
- Update regex to handle the new food caddy job name format `Empty Bin 23ltr Food Caddy` where the size appears between "Bin" and the type name (other bins have size at the end)
- Add Food Caddy to NAME_MAP and ICON_MAP

Fixes #5667

## Test plan
- [x] Regex matches all existing job names: `Empty Domestic Refuse 240L`, `Empty Bin Dry Recycling 240L`, `Empty Bin Paper & Card 240L`, `Empty Bin Green Waste 240L`
- [x] Regex matches new format: `Empty Bin 23ltr Food Caddy`
- [x] API returns valid data for all test UPRNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)