### PR TITLE
docs: Fix lon parameter name typo in mitchellshire_vic_gov_au docs

### DIFF
--- a/doc/source/mitchellshire_vic_gov_au.md
+++ b/doc/source/mitchellshire_vic_gov_au.md
@@ -20,7 +20,7 @@ waste_collection_schedule:
 
 Your latitude.
 
-**lng**<br>
+**lon**<br>
 *(float) (required)*
 
 Your longitude. 


### PR DESCRIPTION
Fixes a typo in the mitchellshire_vic_gov_au documentation where `lng` 
was used instead of `lon` for the longitude parameter name, sorry.