### PR TITLE
Fix ecoharmonogram_pl crash when street has mixed sides and no matcher set

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -188,6 +188,12 @@ TEST_CASES = {
         "additional_sides_matcher": "Заміська забудова",
         "language": "uk",
     },
+    "Sławków (mixed sides: empty + non-empty, no matcher)": {
+        "town": "Sławków",
+        "street": "Jagiellońska",
+        "house_number": "32",
+        "additional_sides_matcher": "", # Available sides are "Zabudowa wysoka" and "" (empty string)
+    },
 }
 
 
@@ -374,13 +380,7 @@ class Source:
         for street in streets["streets"]:
             if street["sides"] == "":
                 to_return.append(street)
-            elif self.additional_sides_matcher_input == "":
-                raise SourceArgumentRequiredWithSuggestions(
-                    "additional_sides_matcher",
-                    self.additional_sides_matcher_input,
-                    {x["sides"] for x in streets["streets"]},
-                )
-            elif (
+            elif self.additional_sides_matcher_input != "" and (
                 street["sides"].lower().casefold()
                 == self.additional_sides_matcher_input.lower().casefold()
             ):
@@ -393,7 +393,7 @@ class Source:
                 {x["sides"] for x in streets["streets"]},
             )
 
-        return streets
+        return {**streets, "streets": to_return}
 
     @staticmethod
     def _extract_number(value: str) -> int | None:


### PR DESCRIPTION
## Summary

- When the API returns streets with both `sides=""` (universal) and non-empty `sides` values, the source incorrectly raised `SourceArgumentRequiredWithSuggestions` mid-loop, even though a valid universal street was already collected.
- The raise is now deferred until after the loop and only fires when truly no street could be matched.
- Also fixes the return value to use the filtered list instead of the original unfiltered dict.
- Adds a `TEST_CASES` entry reproducing the bug: a street where the API returns a mix of empty and non-empty `sides` values with no `additional_sides_matcher` configured.

## Testing

- Verified the new test case crashes on the old code with the exact error I got in HA.
- Ran `test_sources.py -s ecoharmonogram_pl` — all existing cases passed, new case returned entries successfully.

_Debugging and fix assisted by Claude Code._