### PR TITLE
Refactor Bayside and Waipa sources to use IntraMaps service

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayside_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayside_vic_gov_au.py
@@ -1,10 +1,14 @@
-import json
-import logging
 import re
 from datetime import datetime, timedelta
 
-import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.IntraMaps import (
+    IntraMapsSearchError,
+    MapsClient,
+    MapsClientConfig,
+    extract_panel_fields,
+)
 
 TITLE = "Bayside Council (Victoria)"
 DESCRIPTION = "Source for Bayside Council rubbish collection."
@@ -13,17 +17,28 @@ TEST_CASES = {
     "76 Royal Avenue Sandringham": {"street_address": "76 Royal Avenue Sandringham"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
-# IntraMaps API configuration
-CONFIG_ID = "7a287c70-ea2d-4abd-943c-8bf55cf09fe5"
-PROJECT_ID = "1c8f869f-fa4a-4c39-b7bb-94641ee61597"
-FORM_ID = "a2f4b83c-a8ec-4ad8-83e4-f04f5d936077"
-
 ICON_MAP = {
     "Recycling": "mdi:recycle",
     "Food & Green Waste": "mdi:leaf",
     "Domestic Waste": "mdi:trash-can",
+}
+
+INTRAMAPS_CONFIG = MapsClientConfig(
+    base_url="https://gis.bayside.vic.gov.au",
+    instance="IntraMaps910",
+    config_id="7a287c70-ea2d-4abd-943c-8bf55cf09fe5",
+    project="1c8f869f-fa4a-4c39-b7bb-94641ee61597",
+    module_id="5c590b56-e989-48a3-9bb8-207d4a388373",
+)
+
+WEEKDAYS = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
 }
 
 
@@ -32,139 +47,19 @@ class Source:
         self._street_address = street_address
 
     def fetch(self):
-        session = requests.Session()
+        try:
+            with MapsClient(INTRAMAPS_CONFIG) as client:
+                result = client.select_address(self._street_address)
+        except IntraMapsSearchError as e:
+            raise SourceArgumentNotFound("street_address", self._street_address) from e
 
-        headers = {
-            "Content-Type": "application/json",
-            "X-Requested-With": "XMLHttpRequest",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-        }
+        fields = extract_panel_fields(result["response"])
 
-        # Step 1: Initialize IntraMaps session
-        projects_url = (
-            "https://gis.bayside.vic.gov.au/IntraMaps910/ApplicationEngine/Projects/"
-        )
-        params = {
-            "configId": CONFIG_ID,
-            "appType": "MapBuilder",
-            "project": PROJECT_ID,
-            "datasetCode": "",
-        }
-
-        response = session.post(projects_url, headers=headers, json={}, params=params)
-        response.raise_for_status()
-
-        if "X-IntraMaps-Session" not in response.headers:
-            raise Exception("Failed to initialize IntraMaps session")
-
-        sessionid = response.headers["X-IntraMaps-Session"]
-        _LOGGER.debug("IntraMaps session ID: %s", sessionid)
-
-        # Step 2: Load the Waste module
-        modules_url = (
-            "https://gis.bayside.vic.gov.au/IntraMaps910/ApplicationEngine/Modules/"
-        )
-        module_payload = json.dumps(
-            {
-                "module": "Waste",
-                "includeWktInSelection": True,
-                "includeBasemaps": False,
-            }
-        )
-        params_module = {"IntraMapsSession": sessionid}
-
-        response = session.post(
-            modules_url, headers=headers, data=module_payload, params=params_module
-        )
-        response.raise_for_status()
-
-        # Step 3: Search for the address
-        search_url = (
-            "https://gis.bayside.vic.gov.au/IntraMaps910/ApplicationEngine/Search/"
-        )
-        search_payload = json.dumps({"fields": [self._street_address]})
-        search_params = {
-            "infoPanelWidth": "350",
-            "mode": "Refresh",
-            "form": FORM_ID,
-            "resubmit": "false",
-            "IntraMapsSession": sessionid,
-        }
-
-        response = session.post(
-            search_url, headers=headers, data=search_payload, params=search_params
-        )
-        response.raise_for_status()
-
-        search_result = response.json()
-
-        if not search_result.get("fullText") or len(search_result["fullText"]) == 0:
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. "
-                f"Try a simpler format like '76 Royal Avenue Sandringham' (without unit number or postcode)"
-            )
-
-        # Use the first match
-        first_result = search_result["fullText"][0]
-        map_key = first_result["mapKey"]
-        db_key = first_result["dbKey"]
-        selection_layer = first_result["selectionLayer"]
-
-        _LOGGER.debug("Found address: %s", first_result.get("displayValue", "Unknown"))
-
-        # Step 4: Get detailed waste collection information
-        refine_url = "https://gis.bayside.vic.gov.au/IntraMaps910/ApplicationEngine/Search/Refine/Set"
-        refine_payload = json.dumps(
-            {
-                "selectionLayer": selection_layer,
-                "mapKey": map_key,
-                "dbKey": db_key,
-                "infoPanelWidth": 350,
-                "mode": "Refresh",
-                "zoomType": "current",
-            }
-        )
-        refine_params = {"IntraMapsSession": sessionid}
-
-        response = session.post(
-            refine_url, headers=headers, data=refine_payload, params=refine_params
-        )
-        response.raise_for_status()
-
-        refine_result = response.json()
-
-        # Step 5: Parse waste collection data
         entries = []
-
-        if "infoPanels" in refine_result:
-            for panel_data in refine_result["infoPanels"].values():
-                if not isinstance(panel_data, dict):
-                    continue
-
-                if panel_data.get("caption") == "Waste Collection Details":
-                    if "feature" in panel_data and "fields" in panel_data["feature"]:
-                        fields = panel_data["feature"]["fields"]
-
-                        for field in fields:
-                            field_name = field.get("name", "")
-                            field_value_obj = field.get("value", {})
-
-                            if isinstance(field_value_obj, dict):
-                                field_value = field_value_obj.get("value", "")
-                            else:
-                                field_value = str(field_value_obj)
-
-                            # Parse collection dates
-                            if field_name in [
-                                "Recycling",
-                                "Domestic Waste",
-                                "Food & Green Waste",
-                            ]:
-                                entries.extend(
-                                    self._parse_collection_field(
-                                        field_name, field_value
-                                    )
-                                )
+        for waste_type in ["Recycling", "Domestic Waste", "Food & Green Waste"]:
+            value = fields.get(waste_type, "")
+            if value:
+                entries.extend(self._parse_collection_field(waste_type, value))
 
         return entries
 
@@ -172,70 +67,47 @@ class Source:
         """Parse collection field text.
 
         Handles formats like:
-        - "Fortnightly on Wednesday, Next: 11 Feb 2026"
-        - "Weekly on Wednesdays"
+        - "Fortnightly on Thursday, Next: 16 Apr 2026"
+        - "Weekly on Thursdays"
         """
         entries = []
         icon = ICON_MAP.get(waste_type, "mdi:trash-can-outline")
 
-        # Extract the next collection date if present
         date_match = re.search(r"Next:\s*(\d{1,2}\s+\w+\s+\d{4})", value_text)
         if date_match:
-            date_str = date_match.group(1)
             try:
-                next_date = datetime.strptime(date_str, "%d %b %Y").date()
-
-                # Determine if it's weekly or fortnightly
+                next_date = datetime.strptime(date_match.group(1), "%d %b %Y").date()
                 is_fortnightly = "fortnightly" in value_text.lower()
                 interval = 14 if is_fortnightly else 7
 
-                # Generate next 4 collection dates
-                for i in range(4):
-                    collection_date = next_date + timedelta(days=i * interval)
+                for i in range(13):
                     entries.append(
-                        Collection(date=collection_date, t=waste_type, icon=icon)
+                        Collection(
+                            date=next_date + timedelta(days=i * interval),
+                            t=waste_type,
+                            icon=icon,
+                        )
                     )
+            except ValueError:
+                pass
 
-            except ValueError as e:
-                _LOGGER.warning("Failed to parse date '%s': %s", date_str, e)
-
-        # Handle "Weekly on [Day]" without explicit next date
         elif "weekly" in value_text.lower():
-            # Extract the day of week
             day_match = re.search(r"on\s+(\w+day)", value_text, re.IGNORECASE)
             if day_match:
-                day_name = (
-                    day_match.group(1).lower().rstrip("s")
-                )  # Remove trailing 's' from "Wednesdays"
-
-                # Map day names to weekday numbers (0=Monday, 6=Sunday)
-                weekdays = {
-                    "monday": 0,
-                    "tuesday": 1,
-                    "wednesday": 2,
-                    "thursday": 3,
-                    "friday": 4,
-                    "saturday": 5,
-                    "sunday": 6,
-                }
-
-                if day_name in weekdays:
-                    target_weekday = weekdays[day_name]
+                day_name = day_match.group(1).lower().rstrip("s")
+                weekday = WEEKDAYS.get(day_name)
+                if weekday is not None:
                     today = datetime.now().date()
-                    current_weekday = today.weekday()
-
-                    # Calculate days until next occurrence
-                    days_ahead = target_weekday - current_weekday
-                    if days_ahead <= 0:  # Target day already happened this week
-                        days_ahead += 7
-
+                    days_ahead = (weekday - today.weekday()) % 7
                     next_date = today + timedelta(days=days_ahead)
 
-                    # Generate next 4 weekly collection dates
-                    for i in range(4):
-                        collection_date = next_date + timedelta(days=i * 7)
+                    for i in range(26):
                         entries.append(
-                            Collection(date=collection_date, t=waste_type, icon=icon)
+                            Collection(
+                                date=next_date + timedelta(weeks=i),
+                                t=waste_type,
+                                icon=icon,
+                            )
                         )
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/waipa_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/waipa_nz.py
@@ -1,8 +1,14 @@
-import json
+import re
 from datetime import datetime
 
-import requests
 from waste_collection_schedule import Collection
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.IntraMaps import (
+    IntraMapsSearchError,
+    MapsClient,
+    MapsClientConfig,
+    extract_panel_fields,
+)
 
 TITLE = "Waipa District Council"
 DESCRIPTION = (
@@ -19,159 +25,54 @@ ICON_MAP = {
     "Glass": "mdi:glass-fragile",
 }
 
+INTRAMAPS_CONFIG = MapsClientConfig(
+    base_url="https://waipadc.spatial.t1cloud.com",
+    instance="spatial/IntraMaps",
+    config_id="6aa41407-1db8-44e1-8487-0b9a08965283",
+    project="b5bc138e-edce-4b01-b159-ec44539ab455",
+    module_id="5373c4e1-c975-4c8f-b51a-0ac976f5313c",
+    default_selection_layer="e7163a17-2f10-42b1-8dbf-8c53adf089a8",
+)
+
+# Match field names containing "Recycling" or "Glass" (they have verbose names)
+RECYCLING_PATTERN = re.compile(r"Mixed Recycling", re.IGNORECASE)
+GLASS_PATTERN = re.compile(r"Glass Recycling", re.IGNORECASE)
+
+# Extract dates in format "DD-Mon-YYYY"
+DATE_PATTERN = re.compile(r"\b(\d{1,2}-[A-Za-z]{3}-\d{4})\b")
+
 
 class Source:
     def __init__(self, address):
         self._address = address
 
-    def _parse_collection_dates(self, dates_text, collection_type):
-        """
-        Parse collection dates from the API response text.
-
-        Expected format: "Will be collected on DD-MMM-YYYY, and then will be collected in two weeks on DD-MMM-YYYY"
-
-        Args:
-            dates_text: The text containing collection dates
-            collection_type: The type of collection (e.g., "Recycling", "Glass")
-
-        Returns:
-            List of Collection objects
-        """
-        parts = dates_text.split(" on ")
-        if len(parts) < 3:
-            raise Exception(f"Unexpected {collection_type} date format: {dates_text}")
-
-        first_date = parts[1].split(",")[0]  # Extract "DD-MMM-YYYY"
-        second_date = parts[2]  # Extract "DD-MMM-YYYY"
-
-        icon = ICON_MAP.get(collection_type)
-
-        return [
-            Collection(
-                datetime.strptime(first_date, "%d-%b-%Y").date(),
-                collection_type,
-                icon=icon,
-            ),
-            Collection(
-                datetime.strptime(second_date, "%d-%b-%Y").date(),
-                collection_type,
-                icon=icon,
-            ),
-        ]
-
     def fetch(self):
-        entries = []
-
-        # Initiate a session
-        url = "https://waipadc.spatial.t1cloud.com/spatial/IntraMaps/ApplicationEngine/Projects/"
-
-        payload = {}
-        params = {
-            "configId": "6aa41407-1db8-44e1-8487-0b9a08965283",
-            "appType": "MapBuilder",
-            "project": "b5bc138e-edce-4b01-b159-ec44539ab455",
-            "datasetCode": "",
-        }
-        headers = {
-            "Content-Type": "application/json",
-            "X-Requested-With": "XMLHttpRequest",
-        }
-
-        response = requests.request(
-            "POST", url, headers=headers, data=payload, params=params
-        )
-
-        if "X-IntraMaps-Session" not in response.headers:
-            raise Exception(
-                "Failed to initiate session: X-IntraMaps-Session header not found"
-            )
-
-        sessionid = response.headers["X-IntraMaps-Session"]
-
-        # Load the Map Project (further requests don't appear to work if this request is not made)
-        url = "https://waipadc.spatial.t1cloud.com/spatial/IntraMaps/ApplicationEngine/Modules/"
-
-        payload = json.dumps(
-            {
-                "module": "5373c4e1-c975-4c8f-b51a-0ac976f5313c",
-                "includeWktInSelection": True,
-                "includeBasemaps": False,
-            }
-        )
-
-        params = {"IntraMapsSession": sessionid}
-
-        response = requests.request(
-            "POST", url, headers=headers, data=payload, params=params
-        )
-
-        # Search for the address
-        url = "https://waipadc.spatial.t1cloud.com/spatial/IntraMaps/ApplicationEngine/Search/"
-
-        payload = json.dumps({"fields": [self._address]})
-
-        params = {
-            "infoPanelWidth": "0",
-            "mode": "Refresh",
-            "form": "e6677a33-9d47-407a-b199-5c7967a4be07",
-            "resubmit": "false",
-            "IntraMapsSession": sessionid,
-        }
-
-        response = requests.request(
-            "POST", url, headers=headers, data=payload, params=params
-        )
-
-        # This request may return multiple addresses. Use the first one.
-        search_results = response.json()
-
-        if not search_results.get("fullText") or len(search_results["fullText"]) == 0:
-            raise Exception(f"No addresses found for '{self._address}'")
-
-        address_map_key = search_results["fullText"][0]["mapKey"]
-
-        # Lookup the specific property data
-        url = "https://waipadc.spatial.t1cloud.com/spatial/IntraMaps/ApplicationEngine/Search/Refine/Set"
-
-        payload = json.dumps(
-            {
-                "selectionLayer": "e7163a17-2f10-42b1-8dbf-8c53adf089a8",
-                "mapKey": address_map_key,
-                "infoPanelWidth": 350,
-                "mode": "Refresh",
-                "dbKey": address_map_key,
-                "zoomType": "current",
-            }
-        )
-
-        params = {"IntraMapsSession": sessionid}
-
-        response = requests.request(
-            "POST", url, headers=headers, data=payload, params=params
-        )
-        property_data = response.json()
-
-        # Validate the response structure
         try:
-            fields = property_data["infoPanels"]["info1"]["feature"]["fields"]
-        except (KeyError, TypeError) as e:
-            raise Exception(f"Unexpected API response structure: {e}")
+            with MapsClient(INTRAMAPS_CONFIG) as client:
+                result = client.select_address(self._address)
+        except IntraMapsSearchError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
 
-        if len(fields) < 4:
-            raise Exception(
-                f"Expected at least 4 fields in API response, got {len(fields)}"
-            )
+        fields = extract_panel_fields(result["response"])
 
-        # General recycling (yellow bin) - field [2]
-        general_recycling_dates_text = fields[2]["value"]["value"]
-        entries.extend(
-            self._parse_collection_dates(general_recycling_dates_text, "Recycling")
-        )
+        entries = []
+        for field_name, field_value in fields.items():
+            if RECYCLING_PATTERN.search(field_name):
+                entries.extend(self._parse_dates(field_value, "Recycling"))
+            elif GLASS_PATTERN.search(field_name):
+                entries.extend(self._parse_dates(field_value, "Glass"))
 
-        # Glass recycling (blue bin) - field [3]
-        glass_recycling_dates_text = fields[3]["value"]["value"]
-        entries.extend(
-            self._parse_collection_dates(glass_recycling_dates_text, "Glass")
-        )
+        return entries
 
+    @staticmethod
+    def _parse_dates(text: str, collection_type: str) -> list[Collection]:
+        icon = ICON_MAP.get(collection_type)
+        dates = DATE_PATTERN.findall(text)
+        entries = []
+        for date_str in dates:
+            try:
+                d = datetime.strptime(date_str, "%d-%b-%Y").date()
+                entries.append(Collection(date=d, t=collection_type, icon=icon))
+            except ValueError:
+                continue
         return entries


### PR DESCRIPTION
## Summary
- Migrate `bayside_vic_gov_au` from manual IntraMaps HTTP calls to the shared `IntraMaps` service (self-hosted at `gis.bayside.vic.gov.au/IntraMaps910`)
- Migrate `waipa_nz` from manual IntraMaps HTTP calls to the shared `IntraMaps` service (SaaS at `waipadc.spatial.t1cloud.com`)
- Both now use `MapsClient` + `extract_panel_fields()`, eliminating duplicated session management and API plumbing
- Bayside: also improved from 4 entries per type to 13/26 (fortnightly/weekly) for better calendar coverage
- Net reduction of ~227 lines

Six sources now share the IntraMaps service: Swan, Rockingham, Kalamunda, Fraser Coast, Bayside, and Waipa.

## Test plan
- [x] `test_sources.py -s bayside_vic_gov_au` — 52 entries (13 Recycling + 26 Food & Green + 13 Domestic)
- [x] `test_sources.py -s waipa_nz` — both test cases pass (4 entries each: 2 Recycling + 2 Glass)
- [x] `pytest tests/test_source_components.py` — 6/6 pass
- [x] `update_docu_links.py` — no changes (existing sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)