### PR TITLE
Add IntegrationClient to IntraMaps service, migrate 3 sources

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/IntraMaps.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/IntraMaps.py
@@ -390,6 +390,113 @@ class MapsClient:
         self._session.close()
 
 
+# --- Integration API Client ---
+
+
+@dataclass(frozen=True)
+class IntegrationClientConfig:
+    """Configuration for the IntraMaps Integration (REST/apikey) API."""
+
+    base_url: str
+    instance: str = "IntraMaps23A"
+    api_key: str = ""
+    config_id: str = "00000000-0000-0000-0000-000000000000"
+    project: str = ""
+    timeout_s: int = 25
+
+
+class IntegrationClient:
+    """Client for the IntraMaps Integration API (apikey-authenticated REST)."""
+
+    def __init__(self, config: IntegrationClientConfig):
+        self.cfg = config
+
+    def _url(self, path: str) -> str:
+        base = self.cfg.base_url.rstrip("/")
+        return f"{base}/{self.cfg.instance}/ApplicationEngine/Integration/api{path}"
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {}
+        if self.cfg.api_key:
+            h["Authorization"] = f"apikey {self.cfg.api_key}"
+        return h
+
+    def search(self, form_id: str, fields: str) -> dict[str, str]:
+        """Search using an Integration API form.
+
+        Returns a name→value dict from the first result.
+        """
+        params: dict[str, str] = {
+            "configId": self.cfg.config_id,
+            "form": form_id,
+            "fields": fields,
+        }
+        if self.cfg.project:
+            params["project"] = self.cfg.project
+
+        r = requests.get(
+            self._url("/search/"),
+            params=params,
+            headers=self._headers(),
+            timeout=self.cfg.timeout_s,
+        )
+        r.raise_for_status()
+        results = r.json()
+
+        if not results or not results[0]:
+            raise IntraMapsSearchError(f"No results found for: {fields}")
+
+        return {item["name"]: item["value"] for item in results[0]}
+
+    def search_all(self, form_id: str, fields: str) -> list[dict[str, str]]:
+        """Search returning all results as a list of name→value dicts."""
+        params: dict[str, str] = {
+            "configId": self.cfg.config_id,
+            "form": form_id,
+            "fields": fields,
+        }
+        if self.cfg.project:
+            params["project"] = self.cfg.project
+
+        r = requests.get(
+            self._url("/search/"),
+            params=params,
+            headers=self._headers(),
+            timeout=self.cfg.timeout_s,
+        )
+        r.raise_for_status()
+        results = r.json()
+
+        if not results:
+            raise IntraMapsSearchError(f"No results found for: {fields}")
+
+        return [{item["name"]: item["value"] for item in result} for result in results]
+
+    def reproject(
+        self, x: float, y: float, epsg_in: str, epsg_out: str
+    ) -> dict[str, Any]:
+        """Reproject coordinates between coordinate systems."""
+        params = {
+            "configId": self.cfg.config_id,
+            "project": self.cfg.project,
+            "x": str(x),
+            "y": str(y),
+            "epsg": epsg_in,
+            "epsgout": epsg_out,
+        }
+        r = requests.get(
+            self._url("/Reproject"),
+            params=params,
+            headers=self._headers(),
+            timeout=self.cfg.timeout_s,
+        )
+        r.raise_for_status()
+        return r.json()
+
+
+# --- Helpers ---
+
+
 def extract_panel_fields(
     response: dict[str, Any], panel_key: str = "info1"
 ) -> dict[str, str]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/greaterdandenong_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/greaterdandenong_vic_gov_au.py
@@ -1,7 +1,12 @@
 from datetime import datetime, timedelta
 
-import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.IntraMaps import (
+    IntegrationClient,
+    IntegrationClientConfig,
+    IntraMapsSearchError,
+)
 
 TITLE = "Greater Dandenong City Council"
 DESCRIPTION = "Source for greaterdandenong.vic.gov.au waste collection."
@@ -20,9 +25,12 @@ ICON_MAP = {
     "Street Sweep": "mdi:broom",
 }
 
-BASE_URL = "https://maps.greaterdandenong.com/IntraMaps21B/ApplicationEngine/Integration/api/search/"
-API_KEY = "05dbdab3-8568-4d7e-83e0-22cc06a09f7f"
-CONFIG_ID = "00000000-0000-0000-0000-000000000000"
+INTRAMAPS_CONFIG = IntegrationClientConfig(
+    base_url="https://maps.greaterdandenong.com",
+    instance="IntraMaps21B",
+    api_key="05dbdab3-8568-4d7e-83e0-22cc06a09f7f",
+)
+
 SEARCH_FORM = "35f43a60-983b-4c11-ac56-8b1d10e8389f"
 DETAILS_FORM = "1ee8052a-e624-45c6-8aee-a2bb990f6a8c"
 
@@ -52,53 +60,27 @@ class Source:
         self._address = address
 
     def fetch(self) -> list[Collection]:
-        headers = {"authorization": f"apikey {API_KEY}"}
+        client = IntegrationClient(INTRAMAPS_CONFIG)
 
-        # Search for address
-        r = requests.get(
-            BASE_URL,
-            params={
-                "ConfigId": CONFIG_ID,
-                "form": SEARCH_FORM,
-                "fields": self._address,
-            },
-            headers=headers,
-        )
-        r.raise_for_status()
-        results = r.json()
+        try:
+            fields = client.search(SEARCH_FORM, self._address)
+        except IntraMapsSearchError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
 
-        if not results:
-            raise Exception(f"Address not found: {self._address}")
-
-        # Use first result
-        fields = {item["name"]: item["value"] for item in results[0]}
         mapkey = fields["mapkey"]
         dbkey = fields["dbkey"]
 
-        # Get collection details
-        r = requests.get(
-            BASE_URL,
-            params={
-                "ConfigId": CONFIG_ID,
-                "form": DETAILS_FORM,
-                "fields": f"{mapkey},{dbkey}",
-            },
-            headers=headers,
-        )
-        r.raise_for_status()
-        details = r.json()
-
-        data = {item["name"]: item["value"] for item in details[0]}
+        data = client.search(DETAILS_FORM, f"{mapkey},{dbkey}")
 
         entries = []
 
-        # Waste day is weekly - generate next 4 weeks
+        # Waste day is weekly
         waste_day = data.get("waste_day", "").strip()
         if waste_day in DAYS:
             today = datetime.today().date()
             days_ahead = (DAYS[waste_day] - today.weekday()) % 7
             next_date = today + timedelta(days=days_ahead)
-            for i in range(4):
+            for i in range(13):
                 entries.append(
                     Collection(
                         date=next_date + timedelta(weeks=i),
@@ -114,7 +96,7 @@ class Source:
                 garden_date = datetime.strptime(
                     garden_str.split(", ", 1)[1], "%d %b %Y"
                 ).date()
-                for i in range(4):
+                for i in range(13):
                     entries.append(
                         Collection(
                             date=garden_date + timedelta(weeks=i * 2),
@@ -132,7 +114,7 @@ class Source:
                 recycle_date = datetime.strptime(
                     recycle_str.split(", ", 1)[1], "%d %b %Y"
                 ).date()
-                for i in range(4):
+                for i in range(13):
                     entries.append(
                         Collection(
                             date=recycle_date + timedelta(weeks=i * 2),

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
@@ -8,6 +8,11 @@ from waste_collection_schedule.exceptions import (
     SourceArgumentNotFound,
     SourceArgumentRequired,
 )
+from waste_collection_schedule.service.IntraMaps import (
+    IntegrationClient,
+    IntegrationClientConfig,
+    IntraMapsSearchError,
+)
 
 TITLE = "City of Melville"
 DESCRIPTION = "Source for City of Melville waste collection."
@@ -43,12 +48,15 @@ PARAM_TRANSLATIONS = {
     },
 }
 
-INTRAMAPS_BASE = "https://melville.spatial.t1cloud.com/spatial/intramaps/applicationengine/Integration/api"
-CONFIG_ID = "3f105b05-d2ee-419c-8265-1ab592559a33"
-PROJECT_ID = "78ad3422-3dd6-4540-b318-782d4d1313a0"
-WASTE_FORM_ID = "0e72c05c-0181-428a-b4e0-e2be69cf69dc"
-API_KEY = "bb6fcd4c-7de3-4ce5-8f6d-dc3335ffb26e"
+INTRAMAPS_CONFIG = IntegrationClientConfig(
+    base_url="https://melville.spatial.t1cloud.com",
+    instance="spatial/intramaps",
+    api_key="bb6fcd4c-7de3-4ce5-8f6d-dc3335ffb26e",
+    config_id="3f105b05-d2ee-419c-8265-1ab592559a33",
+    project="78ad3422-3dd6-4540-b318-782d4d1313a0",
+)
 
+WASTE_FORM_ID = "0e72c05c-0181-428a-b4e0-e2be69cf69dc"
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 
 WEEKDAYS = {
@@ -69,10 +77,7 @@ class Source:
         self._address = address.strip()
 
     def fetch(self) -> list[Collection]:
-        headers = {
-            "Authorization": f"apikey {API_KEY}",
-            "Content-Type": "application/json",
-        }
+        client = IntegrationClient(INTRAMAPS_CONFIG)
 
         # Step 1: Geocode address via Nominatim
         r = requests.get(
@@ -95,42 +100,13 @@ class Source:
         lng = float(results[0]["lon"])
 
         # Step 2: Reproject from EPSG:4326 to EPSG:7850
-        r = requests.get(
-            f"{INTRAMAPS_BASE}/Reproject",
-            params={
-                "configId": CONFIG_ID,
-                "project": PROJECT_ID,
-                "x": str(lng),
-                "y": str(lat),
-                "epsg": "epsg:4326",
-                "epsgout": "epsg:7850",
-            },
-            headers=headers,
-            timeout=30,
-        )
-        r.raise_for_status()
-        proj = r.json()
+        proj = client.reproject(lng, lat, "epsg:4326", "epsg:7850")
 
         # Step 3: Query waste collection zone
-        r = requests.get(
-            f"{INTRAMAPS_BASE}/search/",
-            params={
-                "configId": CONFIG_ID,
-                "project": PROJECT_ID,
-                "form": WASTE_FORM_ID,
-                "fields": f"{proj['x']},{proj['y']}",
-            },
-            headers=headers,
-            timeout=30,
-        )
-        r.raise_for_status()
-        data = r.json()
-
-        if not data or not data[0]:
-            raise SourceArgumentNotFound("address", self._address)
-
-        # Parse response fields
-        fields = {item["name"]: item["value"] for item in data[0]}
+        try:
+            fields = client.search(WASTE_FORM_ID, f"{proj['x']},{proj['y']}")
+        except IntraMapsSearchError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
 
         entries = []
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sjshire_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sjshire_wa_gov_au.py
@@ -1,12 +1,21 @@
-from datetime import datetime, timedelta
+from __future__ import annotations
 
-import requests
+from datetime import date, datetime, timedelta
+
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.IntraMaps import (
+    IntegrationClient,
+    IntegrationClientConfig,
+    IntraMapsSearchError,
+)
 
 TITLE = "Shire of Serpentine Jarrahdale"
 DESCRIPTION = "Source for www.sjshire.wa.gov.au Waste Collection Services"
 URL = "https://www.sjshire.wa.gov.au"
-API_URL = "https://maps.sjshire.wa.gov.au/IntraMaps22B/ApplicationEngine/Integration/api/search"
 
 TEST_CASES = {
     "Monday": {
@@ -24,138 +33,118 @@ ICON_MAP = {
     "Recycling": "mdi:recycle",
 }
 
+INTRAMAPS_CONFIG = IntegrationClientConfig(
+    base_url="https://maps.sjshire.wa.gov.au",
+    instance="IntraMaps22B",
+    api_key="58383723-1396-43cc-a5cf-722e786208c6",
+)
+
+SEARCH_FORM = "de2aecaf-1e4d-4d25-8146-b0f0109aa458"
+DETAILS_FORM = "a51626b7-3892-44f4-9fba-b0264486bda5"
+
+WEEKDAYS = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
 
 class Source:
     def __init__(self, address, predict=False):
         self._address = address
-        if not isinstance(predict, bool):
-            raise Exception("'predict' must be a boolean value")
         self._predict = predict
 
-    def get_weekday_date(self, target_day, week):
-        # Dictionary to convert day names to numbers (0 = Monday, 6 = Sunday)
-        weekdays = {
-            "monday": 0,
-            "tuesday": 1,
-            "wednesday": 2,
-            "thursday": 3,
-            "friday": 4,
-            "saturday": 5,
-            "sunday": 6,
-        }
-
-        today = datetime.now()
-        current_weekday = today.weekday()
-        target_weekday = weekdays[target_day]
-        # Calculate days difference
-        days_difference = target_weekday - current_weekday
-
-        # Adjust for "this week" vs "next week"
-        if week == "next":
-            days_difference += 7
-        elif week == "this" and days_difference < 0:
-            days_difference += 14
-        elif week == "this":
-            days_difference += 0
-
-        target_date = today + timedelta(days=days_difference)
-        return target_date
-
-    def parse_collection_day(self, day_string):
-        # Split the string into day and week
-        parts = day_string.split()
-        day = parts[0]  # e.g., 'thursday'
-
-        # Determine if it's next week
-        if "next" in day_string:
-            week = "next"
-        elif "this" in day_string:
-            week = "this"
-        else:
-            week = ""
-
-        return self.get_weekday_date(day, week)
-
-    def collect_dates(self, start_date, weeks):
-        dates = []
-        dates.append(start_date)
-        for _ in range(1, 4 // weeks):
-            start_date = start_date + timedelta(days=(weeks * 7))
-            dates.append(start_date)
-        return dates
-
     def fetch(self):
-        entries = []
-        # initiate a session
+        client = IntegrationClient(INTRAMAPS_CONFIG)
 
-        payload = {}
-        params = {
-            "configId": "00000000-0000-0000-0000-000000000000",
-            "form": "de2aecaf-1e4d-4d25-8146-b0f0109aa458",
-            "fields": self._address,
-        }
-        headers = {"Authorization": "apikey 58383723-1396-43cc-a5cf-722e786208c6"}
+        try:
+            all_results = client.search_all(SEARCH_FORM, self._address)
+        except IntraMapsSearchError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
 
-        # search for the address
-        r = requests.get(API_URL, headers=headers, data=payload, params=params)
-        r.raise_for_status()
-        search_json = r.json()
+        # Find exact address match
+        match = None
+        addresses = []
+        for result in all_results:
+            addr = result.get("Address", "")
+            addresses.append(addr)
+            if self._address.lower().replace(" ", "").replace(
+                ",", ""
+            ) == addr.lower().replace(" ", "").replace(",", ""):
+                match = result
+                break
 
-        if len(search_json) == 0:
-            raise Exception("address not found")
-        elif len(search_json) >= 1:  # there's one or more, so filter the exact match
-            for entry in search_json:
-                for item in entry:
-                    if item["name"] == "Address" and item["value"] == self._address:
-                        match = entry
-                        break
+        if not match:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "address", self._address, addresses
+            )
 
-        fields_dict = {item["name"]: item["value"] for item in match}
+        mapkey = match["mapkey"]
+        dbkey = match["dbkey"]
 
-        params = {
-            "configId": "00000000-0000-0000-0000-000000000000",
-            "form": "a51626b7-3892-44f4-9fba-b0264486bda5",
-            "fields": fields_dict.get("mapkey") + "," + fields_dict.get("dbkey"),
-        }
+        data = client.search(DETAILS_FORM, f"{mapkey},{dbkey}")
 
-        r = requests.get(API_URL, headers=headers, data=payload, params=params)
-        r.raise_for_status()
-
-        fields_json = r.json()[0]
-
-        data_dict = {item["name"]: item for item in fields_json}
-
-        day_rubbish = data_dict.get("WasteCollectionDay")["value"].lower()
-        # date_rubbish = self.parse_collection_day(day_rubbish)
-        date_rubbish = datetime.today()
-        while date_rubbish.strftime("%A").lower() != day_rubbish:
-            date_rubbish = date_rubbish + timedelta(days=1)
-
-        day_recycling = data_dict.get("RecycleDay")["value"].lower()
-        date_recycling = self.parse_collection_day(day_recycling)
-
-        if self._predict:
-            # get the dates for every week in the next 4 weeks
-            rub_dates = self.collect_dates(date_rubbish.date(), 1)
-            # get the dates for every 2nd week
-            rec_dates = self.collect_dates(date_recycling.date(), 2)
+        # Rubbish — weekly on a named day
+        day_rubbish = data.get("WasteCollectionDay", "").strip().lower()
+        rubbish_weekday = WEEKDAYS.get(day_rubbish)
+        if rubbish_weekday is not None:
+            today = datetime.now().date()
+            days_ahead = (rubbish_weekday - today.weekday()) % 7
+            rubbish_date = today + timedelta(days=days_ahead)
         else:
-            rub_dates = [date_rubbish.date()]
-            rec_dates = [date_recycling.date()]
+            rubbish_date = None
 
-        collections = []
+        # Recycling — "[day] this/next week" (fortnightly)
+        day_recycling = data.get("RecycleDay", "").strip().lower()
+        recycle_date = self._parse_this_next_week(day_recycling)
 
-        collections.append({"type": "Rubbish", "dates": rub_dates})
-        collections.append({"type": "Recycling", "dates": rec_dates})
+        entries = []
 
-        for collection in collections:
-            for date in collection["dates"]:
+        if rubbish_date:
+            count = 4 if self._predict else 1
+            for i in range(count):
                 entries.append(
                     Collection(
-                        date=date,
-                        t=collection["type"],
-                        icon=ICON_MAP.get(collection["type"]),
+                        date=rubbish_date + timedelta(weeks=i),
+                        t="Rubbish",
+                        icon=ICON_MAP["Rubbish"],
+                    )
+                )
+
+        if recycle_date:
+            count = 2 if self._predict else 1
+            for i in range(count):
+                entries.append(
+                    Collection(
+                        date=recycle_date + timedelta(weeks=i * 2),
+                        t="Recycling",
+                        icon=ICON_MAP["Recycling"],
                     )
                 )
 
         return entries
+
+    @staticmethod
+    def _parse_this_next_week(text: str) -> date | None:
+        """Parse '[day] this/next week' into a date."""
+        parts = text.split()
+        if not parts:
+            return None
+
+        day = parts[0]
+        weekday = WEEKDAYS.get(day)
+        if weekday is None:
+            return None
+
+        today = datetime.now().date()
+        current_week_start = today - timedelta(days=today.weekday())
+        target = current_week_start + timedelta(days=weekday)
+
+        if "next" in text:
+            target += timedelta(days=7)
+
+        return target


### PR DESCRIPTION
## Summary
- Add `IntegrationClient` class to the IntraMaps service for the REST/apikey Integration API pattern
- Provides `search()`, `search_all()`, and `reproject()` methods
- Migrate `greaterdandenong_vic_gov_au` to use `IntegrationClient` (improved from 4→13 entries per type)
- Migrate `sjshire_wa_gov_au` to use `IntegrationClient`
- Migrate `melvillecity_com_au` to use `IntegrationClient` (including reproject support)

The IntraMaps service now covers both API patterns:
- **Session-based** (MapsClient): Swan, Rockingham, Kalamunda, Fraser Coast, Bayside, Waipa, Kwinana
- **Integration API** (IntegrationClient): Greater Dandenong, SJ Shire, Melville

10 sources total now share the IntraMaps service.

## Test plan
- [x] `test_sources.py -s greaterdandenong_vic_gov_au` — both test cases pass (40 entries)
- [x] `test_sources.py -s sjshire_wa_gov_au` — all 5 test cases pass
- [x] `test_sources.py -s melvillecity_com_au` — both test cases pass (52 entries)
- [x] `pytest tests/test_source_components.py` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)