### PR TITLE
Update armadale_wa_gov_au to use new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [Alexandrina Council](/doc/source/app_my_local_services_au.md) / alexandrina.sa.gov.au
 - [Alexandrina Council](/doc/source/frwa_com_au.md) / alexandrina.sa.gov.au
 - [App Backend of My Local Services](/doc/source/app_my_local_services_au.md) / localcouncils.sa.gov.au
-- [Armadale (Western Australia)](/doc/source/armadale_wa_gov_au.md) / armadale.wa.gov.au
+- [Armadale (Western Australia)](/doc/source/armadale_wa_gov_au.md) / my.armadale.wa.gov.au
 - [Australian Capital Territory (ACT)](/doc/source/act_gov_au.md) / cityservices.act.gov.au/recycling-and-waste
 - [Ballina Shire Council](/doc/source/ballina_nsw_gov_au.md) / ballina.nsw.gov.au/Residents/Waste-and-Recycling/Bin-Collection-Day
 - [Banyule City Council](/doc/source/banyule_vic_gov_au.md) / banyule.vic.gov.au

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/armadale_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/armadale_wa_gov_au.py
@@ -1,12 +1,12 @@
 import datetime
 
 import requests
-from bs4 import BeautifulSoup, NavigableString
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 
 TITLE = "Armadale (Western Australia)"
 DESCRIPTION = "Source for Armadale (Western Australia)."
-URL = "https://www.armadale.wa.gov.au"
+URL = "https://my.armadale.wa.gov.au"
 TEST_CASES = {
     "23 Sexty St, ARMADALE": {"address": "23 Sexty St, ARMADALE"},
     "270 Skeet Rd, HARRISDALE": {"address": "270 Skeet Rd, HARRISDALE"},
@@ -22,9 +22,7 @@ WEEKDAYS = {
     "Sunday": 6,
 }
 
-
-# this is the current ajax server used by the tool on their website
-API_URL = "https://app-corporate-prod-001.azurewebsites.net/system/ajax"
+API_URL = "https://api.my.armadale.wa.gov.au/bins"
 
 
 def easter(year):
@@ -53,53 +51,20 @@ class Source:
         self._address: str = address
 
     def fetch(self):
-        s = requests.Session()
-
-        args: dict[str, str] = {
-            "address": self._address,
-            "form_id": "waste_collection_form",
-        }
-
-        r = s.get("https://info.armadale.wa.gov.au/find-my-waste-collection-day")
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, "html.parser")
-        form_build_id = soup.find("input", {"type": "hidden", "name": "form_build_id"})
-        if (
-            not form_build_id
-            or isinstance(form_build_id, NavigableString)
-            or not form_build_id.attrs["value"]
-        ):
-            raise Exception("Could not find form_build_id")
-
-        form_build_id = form_build_id["value"]
-        if not isinstance(form_build_id, str):
-            raise Exception("Could not find form_build_id")
-        args["form_build_id"] = form_build_id
-
-        # get json
-        r = s.post(API_URL, data=args)
+        r = requests.get(API_URL, params={"address": self._address})
         r.raise_for_status()
 
         data = r.json()
+        if not data:
+            raise SourceArgumentNotFoundWithSuggestions("address", self._address, [])
 
-        if len(data) < 2:
-            raise Exception("wrong data returned")
-
-        data = data[1]["data"]
-
-        soup = BeautifulSoup(data, "html.parser")
-
-        trs = soup.find_all("tr")
-        if not trs or len(trs) < 3:
-            raise Exception("Could not parse data correctly")
-
-        bin_day = trs[1].find("td").text.strip()
-        if not bin_day or bin_day not in WEEKDAYS:
-            raise Exception("Could not parse data correctly")
+        result = data[0]
+        bin_day = result["bin_day"]
+        if bin_day not in WEEKDAYS:
+            raise Exception(f"Unknown bin day: {bin_day}")
         bin_day = WEEKDAYS[bin_day]
 
-        recycling: bool = trs[2].find("td").text.strip().lower().startswith("this week")
+        recycling: bool = result["recycle_area"].lower().startswith("this week")
 
         current_day = datetime.datetime.now().date()
 

--- a/doc/source/armadale_wa_gov_au.md
+++ b/doc/source/armadale_wa_gov_au.md
@@ -1,6 +1,6 @@
 # Armadale (Western Australia)
 
-Support for schedules provided by [Armadale (Western Australia)](https://www.armadale.wa.gov.au), serving Armadale (Western Australia), Australia.
+Support for schedules provided by [Armadale (Western Australia)](https://my.armadale.wa.gov.au), serving Armadale (Western Australia), Australia.
 
 ## Configuration via configuration.yaml
 
@@ -31,4 +31,4 @@ waste_collection_schedule:
 
 ## How to get the source argument
 
-Find the parameter of your address using [https://www.armadale.wa.gov.au/my-waste-collection](https://www.armadale.wa.gov.au/my-waste-collection) and write them exactly like on the web page.
+Find the parameter of your address using [https://my.armadale.wa.gov.au/service/waste-and-recycling/find-your-bin-collection-day/](https://my.armadale.wa.gov.au/service/waste-and-recycling/find-your-bin-collection-day/) and write them exactly like on the web page.


### PR DESCRIPTION
## Summary
- City of Armadale migrated their website from `info.armadale.wa.gov.au` to `my.armadale.wa.gov.au`
- Replaced the HTML scraping / AJAX POST approach with the new JSON API (`GET https://api.my.armadale.wa.gov.au/bins?address=...`)
- The new API returns `bin_day` and `recycle_area` directly as JSON — no form token extraction or HTML parsing needed
- Holiday shift logic (Easter, Christmas, New Year's) unchanged
- Removed `bs4` dependency for this source

Fixes #5929

## Test plan
- [x] Both existing TEST_CASES pass against the live API
- [x] `update_docu_links.py` run, README updated
- [ ] Verify with reporter (@darkling111) that their address works

🤖 Generated with [Claude Code](https://claude.com/claude-code)