### PR TITLE
Migrate Reinis from Ximmio to Opzet (hvcgroep_nl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2103,7 +2103,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [RAD BV](/doc/source/ximmio_nl.md) / radbv.nl
 - [Rd4](/doc/source/rd4_nl.md) / rd4.nl
 - [Reinigingsdienst Midden Nederland](/doc/source/burgerportaal_nl.md) / rmn.nl
-- [Reinis](/doc/source/ximmio_nl.md) / reinis.nl
+- [Reinis](/doc/source/hvcgroep_nl.md) / reinis.nl
 - [Spaarnelanden](/doc/source/hvcgroep_nl.md) / spaarnelanden.nl
 - [Twente Milieu](/doc/source/ximmio_nl.md) / twentemilieu.nl
 - [Waardlanden](/doc/source/ximmio_nl.md) / waardlanden.nl

--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -13595,11 +13595,11 @@
     },
     {
       "title": "Reinis",
-      "module": "ximmio_nl",
+      "module": "hvcgroep_nl",
       "default_params": {
-        "company": "reinis"
+        "service": "reinis"
       },
-      "id": "ximmio_nl"
+      "id": "hvcgroep_nl"
     },
     {
       "title": "Spaarnelanden",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
@@ -46,6 +46,7 @@ TEST_CASES = {
         "house_number": "1",
         "service": "hvcgroep",
     },
+    "Reinis": {"postal_code": "3201AA", "house_number": "1", "service": "reinis"},
     "ZRD": {"postal_code": "4691DH", "house_number": "4", "service": "zrd"},
 }
 
@@ -242,6 +243,16 @@ SERVICE_MAP = [
             "plastic_blik_drank": "mdi:recycle",
             "papier": "mdi:archive",
             "rest": "mdi:trash-can",
+        },
+    },
+    {
+        "title": "Reinis",
+        "api_url": "https://reinis.nl",
+        "icons": {
+            "appel-gft": "mdi:leaf",
+            "plastic-pak-blik": "mdi:recycle",
+            "doos-karton-papier": "mdi:archive",
+            "kliko-grijs-zak-grijs-rest": "mdi:trash-can",
         },
     },
     {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ximmio_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ximmio_nl.py
@@ -102,12 +102,6 @@ SERVICE_MAP = [
         "company": "rad",
     },
     {
-        "title": "Reinis",
-        "url": "https://www.reinis.nl/",
-        "uuid": "9dc25c8a-175a-4a41-b7a1-83f237a80b77",
-        "company": "reinis",
-    },
-    {
         "title": "Twente Milieu",
         "url": "https://www.twentemilieu.nl/",
         "uuid": "8d97bb56-5afd-4cbc-a651-b4f7314264b4",


### PR DESCRIPTION
## Summary
- Reinis has switched from the Ximmio platform to the Opzet platform, breaking the existing `ximmio_nl` source (API returns `null` for Reinis company code)
- Reinis now uses the identical Opzet REST API as `hvcgroep_nl` and `afvalstoffendienst_nl`, hosted at `https://reinis.nl`
- Moved Reinis into `hvcgroep_nl` SERVICE_MAP and removed from `ximmio_nl` SERVICE_MAP
- Reinis serves Nissewaard and Voorne aan Zee municipalities (postcodes around 3200)
- **Breaking change for existing users**: `service` parameter changes from `"reinis"` (via ximmio_nl) to `"reinis"` (via hvcgroep_nl), and input parameters change from `company`/`post_code`/`house_number` to `postal_code`/`house_number`/`service`

Fixes #4885

## Test plan
- [x] Reinis test case returns 65 entries via hvcgroep_nl
- [x] `update_docu_links.py` run
- [ ] Verify with reporters (@iantmn, @DrDirtyDevil) that their addresses work

🤖 Generated with [Claude Code](https://claude.com/claude-code)