### PR TITLE
Warn when jumomind_de street spans multiple collection zones

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -59,6 +59,12 @@ TEST_CASES = {
         "city": "Linden",
         "street": "Am Buschkopf",
     },
+    "KSR Recklinghausen Ottostr. 53": {
+        "service_id": "ksr",
+        "city": "Recklinghausen",
+        "street": "Ottostr.",
+        "house_number": "53",
+    },
 }
 
 
@@ -335,13 +341,24 @@ class Source:
                         street_found = True
                         area_id = street["area_id"]
                         if "houseNumbers" in street:
-                            for house_number in street["houseNumbers"]:
-                                if (
-                                    house_number[0].lower().strip().lstrip("0")
-                                    == self._house_number
-                                ):
-                                    area_id = house_number[1]
-                                    break
+                            if self._house_number is not None:
+                                for house_number in street["houseNumbers"]:
+                                    if (
+                                        house_number[0].lower().strip().lstrip("0")
+                                        == self._house_number
+                                    ):
+                                        area_id = house_number[1]
+                                        break
+                            else:
+                                distinct_area_ids = {
+                                    hn[1] for hn in street["houseNumbers"]
+                                }
+                                if len(distinct_area_ids) > 1:
+                                    LOGGER.warning(
+                                        "Street '%s' spans multiple collection zones. "
+                                        "Please provide a house_number for accurate results",
+                                        street["name"],
+                                    )
                         break
                 if not street_found:
                     streets_suggestions = {s.get("name") for s in streets}


### PR DESCRIPTION
## Summary
- Log a warning when a street has house numbers in multiple collection zones and no `house_number` was provided, so users know to add it for accurate results
- Add KSR Recklinghausen test case covering house-number-specific zone resolution

## Context
Some streets (e.g. Ottostr. in Recklinghausen) are split across different collection zones by house number. Without a `house_number`, the source uses the street's default `area_id`, which returns wrong dates for users in the non-default zone.

Fixes #5917

## Test plan
- [x] All existing `jumomind_de` test cases pass
- [x] New KSR Recklinghausen test case returns correct zone B dates
- [x] `test_source_components.py` passes
- [x] No behavior change for existing configs — warning is informational only

🤖 Generated with [Claude Code](https://claude.com/claude-code)