### PR TITLE
Update EGLZ URLs from abfall-eglz.de to eglz-abfall.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,7 +916,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [Abfallwirtschaft Alb-Donau-Kreis](/doc/source/buergerportal_de.md) / aw-adk.de
 - [Abfallwirtschaft Dithmarschen (AWD)](/doc/ics/awd_online_de.md) / awd-online.de
 - [Abfallwirtschaft Enzkreis](/doc/ics/entsorgung_regional_de.md) / abfallwirtschaft-enzkreis.de
-- [Abfallwirtschaft Freiburg](/doc/ics/abfallwirtschaft_freiburg_de.md) / abfall-eglz.de
+- [Abfallwirtschaft Freiburg](/doc/ics/abfallwirtschaft_freiburg_de.md) / abfallwirtschaft-freiburg.de
 - [Abfallwirtschaft Germersheim](/doc/source/abfallwirtschaft_germersheim_de.md) / abfallwirtschaft-germersheim.de
 - [Abfallwirtschaft Isar-Inn](/doc/source/awido_de.md) / awv-isar-inn.de
 - [Abfallwirtschaft Kreis Plön](/doc/ics/kreis_ploen_de.md) / kreis-ploen.de
@@ -1120,7 +1120,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [Entsorgungsbetrieb Märkisch-Oderland](/doc/ics/entsorgungsbetrieb_mol_de.md) / entsorgungsbetrieb-mol.de
 - [Entsorgungsbetrieb Stadt Mainz](/doc/source/muellmax_de.md) / eb-mainz.de
 - [Entsorgungsbetriebe Essen](/doc/source/abfall_io.md) / ebe-essen.de
-- [Entsorgungsgesellschaft Görlitz-Löbau-Zittau](/doc/ics/abfall_eglz_de.md) / abfall-eglz.de
+- [Entsorgungsgesellschaft Görlitz-Löbau-Zittau](/doc/ics/abfall_eglz_de.md) / eglz-abfall.de
 - [Entsorgungstermine Jena](/doc/ics/entsorgungstermine_jena_de.md) / entsorgungstermine.jena.de
 - [Entsorgungsverband Völklingen (EVV)](/doc/source/evv_voelklingen_de.md) / evv-voelklingen.de
 - [Eppstein](/doc/ics/mein_abfallkalender_online.md) / eppstein.de

--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -1824,8 +1824,8 @@
   "ics_abfall_eglz_de": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/ics/abfall_eglz_de.md",
     "howto": {
-      "de": "- Gehen Sie zu <https://www.abfall-eglz.de/abfallkalender.html> und wählen Sie Ihre Gemeinde aus.\n- Klicken Sie mit der rechten Maustaste auf `Entsorgungstermine als iCalendar herunterladen` und kopieren Sie den Link.\n- Ersetzen Sie die `url` in der Beispielkonfiguration durch diesen Link.\n",
-      "en": "- Go to <https://www.abfall-eglz.de/abfallkalender.html> and select your municipality.  \n- Right-click on `Entsorgungstermine als iCalendar herunterladen` and copy link address.\n- Use this link as the `url` parameter.\n"
+      "de": "- Gehen Sie zu <https://www.eglz-abfall.de/service/abfallkalender> und wählen Sie Ihre Gemeinde aus.\n- Klicken Sie mit der rechten Maustaste auf `Entsorgungstermine als iCalendar herunterladen` und kopieren Sie den Link.\n- Ersetzen Sie die `url` in der Beispielkonfiguration durch diesen Link.\n",
+      "en": "- Go to <https://www.eglz-abfall.de/service/abfallkalender> and select your municipality.\n- Right-click on `Entsorgungstermine als iCalendar herunterladen` and copy link address.\n- Use this link as the `url` parameter.\n"
     },
     "urls": {}
   },

--- a/doc/contributing_ics.md
+++ b/doc/contributing_ics.md
@@ -39,19 +39,19 @@ Example:
 
 ```yaml
 title: Entsorgungsgesellschaft Görlitz-Löbau-Zittau
-url: https://www.abfall-eglz.de
+url: https://www.eglz-abfall.de
 howto: 
   en: |
-      - Go to <https://www.abfall-eglz.de/abfallkalender.html> and select your municipality.  
+      - Go to <https://www.eglz-abfall.de/service/abfallkalender> and select your municipality.
       - Right-click on `Entsorgungstermine als iCalendar herunterladen` and copy link address.
       - Replace the `url` in the example configuration with this link.
    de: |
-      - Gehen Sie zu <https://www.abfall-eglz.de/abfallkalender.html> und wählen Sie Ihre Gemeinde aus.
+      - Gehen Sie zu <https://www.eglz-abfall.de/service/abfallkalender> und wählen Sie Ihre Gemeinde aus.
       - Klicken Sie mit der rechten Maustaste auf `Entsorgungstermine als iCalendar herunterladen` und kopieren Sie den Link.
       - Ersetzen Sie die `url` in der Beispielkonfiguration durch diesen Link.
 test_cases:
    Oppach:
-       url: "https://www.abfall-eglz.de/abfallkalender.html?ort=Oppach&ortsteil=Ort+Oppach&strasse=&ics=1"
+       url: "https://www.eglz-abfall.de/service/abfallkalender?Ort=Oppach&format=icalc"
        split_at: " & "
 ```
 

--- a/doc/ics/abfall_eglz_de.md
+++ b/doc/ics/abfall_eglz_de.md
@@ -5,7 +5,7 @@ Entsorgungsgesellschaft Görlitz-Löbau-Zittau is supported by the generic [ICS]
 
 ## How to get the configuration arguments
 
-- Go to <https://www.abfall-eglz.de/abfallkalender.html> and select your municipality.  
+- Go to <https://www.eglz-abfall.de/service/abfallkalender> and select your municipality.
 - Right-click on `Entsorgungstermine als iCalendar herunterladen` and copy link address.
 - Use this link as the `url` parameter.
 
@@ -18,5 +18,5 @@ waste_collection_schedule:
   sources:
     - name: ics
       args:
-        url: https://www.abfall-eglz.de/abfallkalender.html?ort=Oppach&ortsteil=Ort+Oppach&strasse=&ics=1
+        url: https://www.eglz-abfall.de/service/abfallkalender?Ort=Oppach&format=icalc
 ```

--- a/doc/ics/yaml/abfall_eglz_de.yaml
+++ b/doc/ics/yaml/abfall_eglz_de.yaml
@@ -1,16 +1,16 @@
 ---
 title: Entsorgungsgesellschaft Görlitz-Löbau-Zittau
-url: https://www.abfall-eglz.de
+url: https://www.eglz-abfall.de
 howto:
   en: |
-    - Go to <https://www.abfall-eglz.de/abfallkalender.html> and select your municipality.  
+    - Go to <https://www.eglz-abfall.de/service/abfallkalender> and select your municipality.
     - Right-click on `Entsorgungstermine als iCalendar herunterladen` and copy link address.
     - Use this link as the `url` parameter.
   de: |
-    - Gehen Sie zu <https://www.abfall-eglz.de/abfallkalender.html> und wählen Sie Ihre Gemeinde aus.
+    - Gehen Sie zu <https://www.eglz-abfall.de/service/abfallkalender> und wählen Sie Ihre Gemeinde aus.
     - Klicken Sie mit der rechten Maustaste auf `Entsorgungstermine als iCalendar herunterladen` und kopieren Sie den Link.
     - Ersetzen Sie die `url` in der Beispielkonfiguration durch diesen Link.
 
 test_cases:
   Oppach:
-    url: https://www.abfall-eglz.de/abfallkalender.html?ort=Oppach&ortsteil=Ort+Oppach&strasse=&ics=1
+    url: https://www.eglz-abfall.de/service/abfallkalender?Ort=Oppach&format=icalc

--- a/doc/ics/yaml/abfallwirtschaft_freiburg_de.yaml
+++ b/doc/ics/yaml/abfallwirtschaft_freiburg_de.yaml
@@ -1,6 +1,6 @@
 ---
 title: Abfallwirtschaft Freiburg
-url: https://www.abfall-eglz.de
+url: https://www.abfallwirtschaft-freiburg.de
 howto:
   en: |
     - Go to <https://www.abfallwirtschaft-freiburg.de/de/private_haushalte/abfuhrtermine.php> and select your location.

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -203,7 +203,7 @@ This source has been successfully tested with the following service providers:
 - [abfallverband-rheingau](/doc/ics/mein_abfallkalender_online.md) / abfallverband-rheingau.de
 - [Abfallwirtschaft Dithmarschen (AWD)](/doc/ics/awd_online_de.md) / awd-online.de
 - [Abfallwirtschaft Enzkreis](/doc/ics/entsorgung_regional_de.md) / abfallwirtschaft-enzkreis.de
-- [Abfallwirtschaft Freiburg](/doc/ics/abfallwirtschaft_freiburg_de.md) / abfall-eglz.de
+- [Abfallwirtschaft Freiburg](/doc/ics/abfallwirtschaft_freiburg_de.md) / abfallwirtschaft-freiburg.de
 - [Abfallwirtschaft Kreis Plön](/doc/ics/kreis_ploen_de.md) / kreis-ploen.de
 - [Abfallwirtschaft Landkreis Böblingen](/doc/ics/abfall_io_ics.md) / awb-bb.de
 - [Abfallwirtschaft Landkreis Göppingen](/doc/ics/abfall_io_ics.md) / awb-gp.de
@@ -253,7 +253,7 @@ This source has been successfully tested with the following service providers:
 - [ELW - Entsorgungsbetriebe der Landeshauptstadt Wiesbaden](/doc/ics/elw_de.md) / elw.de
 - [ENNI Energie & Umwelt Niederrhein (Moers)](/doc/ics/abfallkalender_enni_de.md) / abfallkalender.enni.de
 - [Entsorgungsbetrieb Märkisch-Oderland](/doc/ics/entsorgungsbetrieb_mol_de.md) / entsorgungsbetrieb-mol.de
-- [Entsorgungsgesellschaft Görlitz-Löbau-Zittau](/doc/ics/abfall_eglz_de.md) / abfall-eglz.de
+- [Entsorgungsgesellschaft Görlitz-Löbau-Zittau](/doc/ics/abfall_eglz_de.md) / eglz-abfall.de
 - [Entsorgungstermine Jena](/doc/ics/entsorgungstermine_jena_de.md) / entsorgungstermine.jena.de
 - [Eppstein](/doc/ics/mein_abfallkalender_online.md) / eppstein.de
 - [Erftstadt (inoffical)](/doc/ics/abfallkalender_erftstadt_de.md) / abfallkalender-erftstadt.de


### PR DESCRIPTION
## Summary
- Provider changed domain from `abfall-eglz.de` to `eglz-abfall.de` (old domain 301-redirects but ICS download path changed, breaking calendar fetches)
- Update YAML config, docs, and test case with new URL format
- Fix `abfallwirtschaft_freiburg_de.yaml` which incorrectly had the EGLZ URL instead of `abfallwirtschaft-freiburg.de`

Fixes #5963

## Test plan
- [ ] Verified new ICS URL returns valid calendar data (`test_sources.py -s ics -y abfall_eglz_de.yaml`)
- [ ] Freiburg entry in `doc/source/ics.md` now shows correct URL
- [ ] `pytest tests/test_source_components.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)