### PR TITLE
Add address geocoding support to Stirling source

### DIFF
--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -522,7 +522,9 @@
   },
   "stirling_wa_gov_au": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/stirling_wa_gov_au.md",
-    "howto": {},
+    "howto": {
+      "en": "Enter your street address including suburb (e.g. '100 Cedric Street, Stirling, WA, Australia'), or provide latitude and longitude coordinates."
+    },
     "urls": {}
   },
   "stonnington_vic_gov_au": {

--- a/custom_components/waste_collection_schedule/translations/de.json
+++ b/custom_components/waste_collection_schedule/translations/de.json
@@ -2118,6 +2118,7 @@
         "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
         "data": {
           "calendar_title": "Kalender Titel",
+          "address": "Addresse",
           "lat": "Breitengrad",
           "lon": "Längengrad"
         },
@@ -2130,6 +2131,7 @@
         "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
         "data": {
           "calendar_title": "Kalender Titel",
+          "address": "Addresse",
           "lat": "Breitengrad",
           "lon": "Längengrad"
         },

--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -2205,11 +2205,15 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
+          "address": "Street Address",
           "lat": "Latitude",
           "lon": "Longitude"
         },
         "data_description": {
-          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used."
+          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used.",
+          "address": "Street address with suburb (e.g. '100 Cedric Street, Stirling, WA, Australia')",
+          "lat": "Latitude (optional if address is provided)",
+          "lon": "Longitude (optional if address is provided)"
         }
       },
       "reconfigure_stirling_wa_gov_au": {
@@ -2217,10 +2221,15 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
+          "address": "Street Address",
           "lat": "Latitude",
           "lon": "Longitude"
         },
-        "data_description": {}
+        "data_description": {
+          "address": "Street address with suburb (e.g. '100 Cedric Street, Stirling, WA, Australia')",
+          "lat": "Latitude (optional if address is provided)",
+          "lon": "Longitude (optional if address is provided)"
+        }
       },
       "args_stonnington_vic_gov_au": {
         "title": "Configure Source",

--- a/custom_components/waste_collection_schedule/translations/fr.json
+++ b/custom_components/waste_collection_schedule/translations/fr.json
@@ -2118,6 +2118,7 @@
         "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
         "data": {
           "calendar_title": "Titre du Calendrier",
+          "address": "Adresse",
           "lat": "Latitude",
           "lon": "Longitude"
         },
@@ -2130,6 +2131,7 @@
         "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
         "data": {
           "calendar_title": "Titre du Calendrier",
+          "address": "Adresse",
           "lat": "Latitude",
           "lon": "Longitude"
         },

--- a/custom_components/waste_collection_schedule/translations/it.json
+++ b/custom_components/waste_collection_schedule/translations/it.json
@@ -2118,6 +2118,7 @@
         "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Maggiori informazioni: {docs_url}.",
         "data": {
           "calendar_title": "Nome Calendario",
+          "address": "Indirizzo",
           "lat": "Lat",
           "lon": "Lon"
         },
@@ -2130,6 +2131,7 @@
         "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Per maggiori informazioni: {docs_url}.",
         "data": {
           "calendar_title": "Nome Calendario",
+          "address": "Indirizzo",
           "lat": "Lat",
           "lon": "Lon"
         },

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
@@ -3,6 +3,8 @@ import logging
 import requests
 from dateutil import parser
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import ArcGisGeocodeError, geocode
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -10,8 +12,31 @@ TITLE = "Stirling"
 DESCRIPTION = "Source for Stirling."
 URL = "https://www.stirling.wa.gov.au"
 TEST_CASES = {
-    "-31.9034183 115.8320855": {"lat": -31.9034183, "lon": 115.8320855},
-    "-31.878331, 115.815553": {"lat": "-31.8783052", "lon": "115.8157741"},
+    "by_address": {"address": "100 Cedric Street, Stirling, WA, Australia"},
+    "by_coords": {"lat": -31.9034183, "lon": 115.8320855},
+    "by_coords_str": {"lat": "-31.8783052", "lon": "115.8157741"},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter your street address including suburb "
+    "(e.g. '100 Cedric Street, Stirling, WA, Australia'), "
+    "or provide latitude and longitude coordinates.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Street address with suburb (e.g. '100 Cedric Street, Stirling, WA, Australia')",
+        "lat": "Latitude (optional if address is provided)",
+        "lon": "Longitude (optional if address is provided)",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+        "lat": "Latitude",
+        "lon": "Longitude",
+    },
 }
 
 ICON_MAP = {
@@ -26,21 +51,41 @@ REFERER_PATH = "/waste-and-environment/waste-and-recycling/bin-collections"
 
 
 class Source:
-    def __init__(self, lat: float, lon: float):
-        if isinstance(lat, str):
-            lat = float(lat)
-        if isinstance(lon, str):
-            lon = float(lon)
+    def __init__(
+        self,
+        address: str | None = None,
+        lat: float | None = None,
+        lon: float | None = None,
+    ):
+        self._address = address
+        self._lat = float(lat) if lat is not None else None
+        self._lon = float(lon) if lon is not None else None
 
-        self._lat: float = lat
-        self._lon: float = lon
+        if not self._address and (self._lat is None or self._lon is None):
+            raise ValueError(
+                "Either 'address' or both 'lat' and 'lon' must be provided"
+            )
+
+    def _resolve_coordinates(self) -> tuple[float, float]:
+        """Return (lat, lon), geocoding from address if needed."""
+        if self._lat is not None and self._lon is not None:
+            return self._lat, self._lon
+
+        try:
+            location = geocode(self._address)
+        except ArcGisGeocodeError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        return location["y"], location["x"]
 
     def fetch(self) -> list[Collection]:
+        lat, lon = self._resolve_coordinates()
+
         headers = {
             "Accept": "application/json, text/javascript, */*; q=0.01",
             "configid": "7c833520-7b62-4228-8522-fb1a220b32e8",
             "form": "57753bab-f589-44d7-8934-098b6d5c572f",
-            "fields": f"{self._lon},{self._lat}",
+            "fields": f"{lon},{lat}",
             "apikeylookup": "Bin Day",
             "Origin": URL,
             "Referer": f"{URL}{REFERER_PATH}",

--- a/doc/source/stirling_wa_gov_au.md
+++ b/doc/source/stirling_wa_gov_au.md
@@ -9,20 +9,37 @@ waste_collection_schedule:
     sources:
     - name: stirling_wa_gov_au
       args:
-        lat: LATITUDE
-        lon: LONGITUDE
+        address: ADDRESS
         
 ```
 
 ### Configuration Variables
 
+**address**  
+*(String) (optional)*
+
 **lat**  
-*(Float) (required)*
+*(Float) (optional)*
 
 **lon**  
-*(Float) (required)*
+*(Float) (optional)*
 
-## Example
+Either `address` or both `lat` and `lon` must be provided.
+
+## Examples
+
+### Using address (recommended)
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: stirling_wa_gov_au
+      args:
+        address: "100 Cedric Street, Stirling, WA, Australia"
+        
+```
+
+### Using coordinates
 
 ```yaml
 waste_collection_schedule:
@@ -36,11 +53,15 @@ waste_collection_schedule:
 
 ## How to get the source argument
 
-### Using your address coordinates
+### Using your address (recommended)
 
-1. Find the coordinates of your address using any map service like Google Maps. (the coordinates should be in decimal format with 7 decimal places)
-2. Write the coordinates in the configuration file.
+Enter your full street address including suburb and state (e.g. `100 Cedric Street, Stirling, WA, Australia`). The address will be geocoded automatically.
 
-### Inspecting network requests of the Stirling website
+### Using coordinates
 
-Visit <https://www.stirling.wa.gov.au/waste-and-environment/waste-and-recycling/residential-bin-collections> and open the developer tools of your browser. Go to the network tab and filter. search for your address in the websites search bar and click on you address. In your network tab look for a GET request to https://www.stirling.wa.gov.au/aapi/map. Click on that request and look for the Request Headers. The `fields` value of the Request Headers is latitude and longitude **in inverse order!!!** (longitude,latitude). Write the coordinates in the configuration file.
+If address lookup does not work for your location, you can provide coordinates instead:
+
+1. Visit <https://www.stirling.wa.gov.au/waste-and-environment/waste-and-recycling/bin-collections> and search for your address.
+2. Open your browser's developer tools (Network tab) and look for the request to `/bincollectioncheck/getresult`.
+3. The `fields` header contains the coordinates as `longitude,latitude`. Note the **inverse order**.
+4. Enter the latitude and longitude values in the configuration file.


### PR DESCRIPTION
## Summary
- Add optional `address` parameter to `stirling_wa_gov_au` source that geocodes via ArcGIS World GeocodeServer
- Existing `lat`/`lon` parameters continue to work (fully backwards compatible)
- Users can now enter a street address (e.g. `100 Cedric Street, Stirling, WA, Australia`) instead of needing to find precise coordinates
- Updated docs, translations, and metadata via `update_docu_links.py`

## Motivation
The Stirling API performs a tight property-boundary spatial lookup, so coordinates need to be very precise. Generic map coordinates (even from Google Maps) can be ~10m off and return empty results. The website itself solves this with a Google Places geocode step. This PR adds ArcGIS geocoding (already used by other sources in the project) as a free, keyless alternative.

## Test plan
- [x] Tested address geocoding returns valid collection dates
- [x] Tested existing lat/lon configs still work (float and string)
- [x] All 3 test cases pass via `test_sources.py`
- [x] `pytest tests/test_source_components.py` passes (6/6)
- [x] Linted with black + isort
- [x] Ran `update_docu_links.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)