### PR TITLE
Enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,28 @@
-*       text=auto
-*.py    text
-*.md    text
-*.yaml  text
+# Normalize all text files to LF in the repo and on checkout.
+# This prevents CRLF warnings on Windows and ensures consistent
+# line endings across all platforms (Windows, macOS, Linux).
+*       text=auto eol=lf
+
+# Explicitly mark common text file types
+*.py    text eol=lf
+*.md    text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.json  text eol=lf
+*.xml   text eol=lf
+*.html  text eol=lf
+*.css   text eol=lf
+*.js    text eol=lf
+*.txt   text eol=lf
+*.cfg   text eol=lf
+*.ini   text eol=lf
+*.toml  text eol=lf
+*.sh    text eol=lf
+
+# Binary files — do not modify
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.zip   binary


### PR DESCRIPTION
## Summary
- Add `eol=lf` to all text file rules in `.gitattributes` to enforce LF line endings on checkout across all platforms
- Add explicit rules for common file types (`.json`, `.yml`, `.xml`, `.html`, `.sh`, etc.)
- Add binary rules for image/archive files to prevent accidental mangling

## Motivation
Windows contributors get persistent `LF will be replaced by CRLF` warnings because the existing `.gitattributes` uses `text=auto` without specifying `eol`. With `eol=lf`, git normalizes to LF in the repo **and** on checkout, regardless of the user's `core.autocrlf` setting. This is the standard approach for cross-platform Python projects.

## Test plan
- [x] `git add --renormalize .` confirms no existing files need conversion
- [x] No functional changes — only line ending policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)