### PR TITLE
Document abfall parameter for c-trace Restabfall filtering

### DIFF
--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -6370,7 +6370,7 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
-          "abfall": "Abfall",
+          "abfall": "Waste type IDs",
           "gemeinde": "Municipality",
           "hausnummer": "House number",
           "ort": "District",
@@ -6379,7 +6379,8 @@
           "strasse": "Street"
         },
         "data_description": {
-          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used."
+          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used.",
+          "abfall": "Pipe-separated waste type IDs to fetch (e.g. '0|1|2|5'). Leave empty to fetch all types. Visit your provider's calendar page to see which IDs correspond to which waste types."
         }
       },
       "reconfigure_c_trace_de": {
@@ -6387,7 +6388,7 @@
         "description": "Configure your service provider. {howto}More details: {docs_url}.",
         "data": {
           "calendar_title": "Calendar Title",
-          "abfall": "Abfall",
+          "abfall": "Waste type IDs",
           "gemeinde": "Municipality",
           "hausnummer": "House number",
           "ort": "District",
@@ -6395,7 +6396,9 @@
           "service": "Operator",
           "strasse": "Street"
         },
-        "data_description": {}
+        "data_description": {
+          "abfall": "Pipe-separated waste type IDs to fetch (e.g. '0|1|2|5'). Leave empty to fetch all types. Visit your provider's calendar page to see which IDs correspond to which waste types."
+        }
       },
       "args_ics_abfallwirtschaft_sonneberg_de": {
         "title": "Configure Source",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
@@ -65,6 +65,13 @@ TEST_CASES = {
         "hausnummer": "2d/e",
         "service": "aurich-abfallkalender",
     },
+    "MainTauber 4-weekly": {
+        "ort": "Tauberbischofsheim",
+        "strasse": "Hauptstraße",
+        "hausnummer": 1,
+        "service": "maintauberkreis-abfallkalender",
+        "abfall": "0|1|2|5",
+    },
 }
 
 DEFAULT_SUBDOMAIN = "web"
@@ -159,6 +166,14 @@ SERVICE_MAP = {
 BASE_URL = "https://{subdomain}.c-trace.de"
 
 
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "abfall": "Pipe-separated waste type IDs to fetch (e.g. '0|1|2|5'). "
+        "Leave empty to fetch all types. Visit your provider's calendar page "
+        "to see which IDs correspond to which waste types.",
+    },
+}
+
 PARAM_TRANSLATIONS = {
     "en": {
         "strasse": "Street",
@@ -167,6 +182,7 @@ PARAM_TRANSLATIONS = {
         "ort": "District",
         "ortsteil": "Subdistrict",
         "service": "Operator",
+        "abfall": "Waste type IDs",
     }
 }
 

--- a/doc/source/c_trace_de.md
+++ b/doc/source/c_trace_de.md
@@ -44,7 +44,7 @@ Needed only for some municipalities but not all (can be left empty if unneeded)
 
 **abfall**
 *(string) (optional)*
-Needed only to filter waste types (if empty you get all waste types). Separator between waste types is '|'.
+Pipe-separated waste type IDs to filter which types are returned (e.g. `0|1|2|5`). If empty, all waste types are fetched. This is important for providers like Main-Tauber-Kreis where multiple Restabfall frequencies exist (weekly, 14-day, 4-weekly) but all appear as "Restabfall" in the calendar. Use the `abfall` parameter to select only your frequency. Visit your provider's calendar page to see the checkbox list of waste types — the IDs correspond to their order (0 for the first, 1 for the second, etc.).
 
 ## Example
 
@@ -92,6 +92,22 @@ waste_collection_schedule:
       gemeinde: Aurich
       ort: Kirchdorf
 ```
+
+### Main-Tauber-Kreis with 4-weekly Restabfall
+
+```yaml
+waste_collection_schedule:
+  sources:
+  - name: c_trace_de
+    args:
+      ort: Tauberbischofsheim
+      strasse: Hauptstraße
+      hausnummer: 1
+      service: maintauberkreis-abfallkalender
+      abfall: "0|1|2|5"
+```
+
+The waste type IDs for Main-Tauber-Kreis are: 0=Bioabfall, 1=Gelbe Tonne, 2=Papierabfall, 3=Restabfall wöchentlich, 4=Restabfall 14-täglich, 5=Restabfall 4-wöchentlich. Use only the ID for your Restabfall frequency.
 
 ## How to get the source arguments
 


### PR DESCRIPTION
## Summary
- Add `PARAM_DESCRIPTIONS` for the `abfall` parameter so it appears in the config UI
- Add `PARAM_TRANSLATIONS` entry for `abfall`
- Update doc with detailed explanation of how to use `abfall` to filter Restabfall frequencies
- Add Main-Tauber-Kreis example with waste type ID mapping (0=Bioabfall, 1=Gelbe Tonne, 2=Papierabfall, 3=Restabfall wöchentlich, 4=Restabfall 14-täglich, 5=Restabfall 4-wöchentlich)
- Add test case for Main-Tauber-Kreis with 4-weekly Restabfall

## Motivation
Main-Tauber-Kreis offers 3 Restabfall frequencies (weekly, 14-day, 4-weekly) but the ICS calendar labels them all identically as "Restabfall". Without using the `abfall` parameter to select only the correct frequency, users get all variants merged into one. The parameter existed but was undocumented in the UI.

Fixes #5974

## Test plan
- [x] New MainTauber test case passes (59 entries with filtered types)
- [x] All existing test cases still pass (except `roth` which has a pre-existing 500 server error)
- [x] `pytest tests/test_source_components.py` passes (6/6)
- [x] Linted with black + isort
- [x] Ran `update_docu_links.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)