### PR TITLE
Fix Newham date parsing after website format change

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
@@ -1,7 +1,6 @@
-from datetime import datetime
-
 import requests
 from bs4 import BeautifulSoup
+from dateutil import parser as dateparser
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "London Borough of Newham"
@@ -59,7 +58,7 @@ class Source:
                 .find_next("mark")
                 .next_sibling.strip()
             )
-            next_collection = datetime.strptime(date_string, "%d/%m/%Y").date()
+            next_collection = dateparser.parse(date_string).date()
 
             entries.append(
                 Collection(


### PR DESCRIPTION
## Summary
- Replace `datetime.strptime(date_string, "%d/%m/%Y")` with `dateutil.parser.parse(date_string)` in the Newham source
- The Newham website changed its date format from `DD/MM/YYYY` to `M/D/YYYY` (US-style, no zero-padding), breaking the parser

## Motivation
Users reported the source stopped working (#5581). The SSL issue was previously fixed with `verify=False`, but the date format change was the remaining problem. Using `dateutil.parser` handles both formats robustly.

Fixes #5581

## Test plan
- [x] All 3 test cases pass (Test_001, Test_002, Test_003)
- [x] `pytest tests/test_source_components.py` passes (6/6)
- [x] Linted with black + isort

🤖 Generated with [Claude Code](https://claude.com/claude-code)