### PR TITLE
Improve issue templates with auto-labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,82 +1,70 @@
-name: Bug Report
-description: Report a bug with a source, sensor or the integration in general
+name: Integration Bug
+description: Report a bug with the core integration (not a specific source or sensor configuration)
 title: "[Bug]: "
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this Bug Report!
-  - type: dropdown
-    id: error
-    attributes:
-      label: "I Have A Problem With:"
-      options:
-        - A specific source
-        - Sensor configuration
-        - The integration in general
-      multiple: true
-    validations:
-      required: true
+        Report a bug with the integration itself — config flow crashes, calendar not displaying, integration failing to load, etc.
+
+        **Please use the correct template for your issue:**
+        - **Source stopped working?** → [Source Defect](https://github.com/mampfes/hacs_waste_collection_schedule/issues/new?template=SOURCE-DEFECT.yml)
+        - **Sensor showing "unknown" or wrong values?** → [Configuration Issue](https://github.com/mampfes/hacs_waste_collection_schedule/issues/new?template=CONFIGURATION-ISSUE.yml)
+        - **Want a new source added?** → [Source Request](https://github.com/mampfes/hacs_waste_collection_schedule/issues/new?template=SOURCE-REQUEST.yml)
   - type: textarea
     id: description
     attributes:
-      label: What's Your Problem
-      description: Describe your problem as detailed as possible
+      label: Describe the bug
+      description: What happened? What did you expect to happen?
     validations:
       required: true
-  - type: input
-    id: source
+  - type: textarea
+    id: steps
     attributes:
-      label: Source (if relevant)
-      description: Which source are you using?
-      placeholder: ex. broxtowe_gov_uk
+      label: Steps to reproduce
+      description: How can we reproduce this bug?
     validations:
-      required: false
+      required: true
   - type: textarea
     id: logs
     attributes:
       label: Logs
-      description: Please provide relevant logs from Home Assistant if no relevant logs are available please write "no relevant logs" (please remove sensitive information or use example addresses)
+      description: Relevant logs from Home Assistant (Settings → System → Logs). Remove sensitive information.
       render: Shell
     validations:
-      required: false
+      required: true
   - type: textarea
     id: configuration
     attributes:
       label: Relevant Configuration
-      description: Please provide your configuration (source/sensor) if relevant (please remove sensitive information or use example addresses)
+      description: Your configuration if relevant. Use example addresses, not your own.
       render: YAML
     validations:
       required: false
-  - type: checkboxes
-    id: checklist-source
+  - type: input
+    id: version
     attributes:
-      label: Checklist Source Error
-      description: Have you tried the following?
+      label: Integration Version
+      description: Which version of the integration are you running?
+      placeholder: ex. 2.19.0 or master
+    validations:
+      required: true
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant Version
+      placeholder: ex. 2025.4.0
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
       options:
-        - label: Use the example parameters for your source (often available in the documentation) (don't forget to restart Home Assistant after changing the configuration)
-          required: false
-        - label: Checked that the website of your service provider is still working
-          required: false
-        - label: Tested my attributes on the service provider website (if possible)
-          required: false
-        - label: I have tested with the latest version of the integration (master) (for HACS in the 3 dot menu of the integration click on "Redownload" and choose master as version)
+        - label: I have tested with the latest version (master branch)
           required: true
-  - type: checkboxes
-    id: checklist-sensor
-    attributes:
-      label: Checklist Sensor Error
-      description: Have you tried the following?
-      options:
-        - label: Checked in the Home Assistant Calendar tab if the event names match the types names (if types argument is used) 
-          required: false
-  - type: checkboxes
-    id: checklist-general
-    attributes:
-      label: Required
-      description: "Please make sure you agree with these statements:"
-      options:
-        - label: I have searched past (closed AND opened) issues to see if this bug has already been reported, and it hasn't been.
+        - label: This is not a source-specific problem (it affects the integration itself)
           required: true
-        - label: I understand that people give their precious time for free, and thus I've done my very best to make this problem as easy as possible to investigate.
+        - label: I have searched past issues (open and closed) for this problem
           required: true

--- a/.github/ISSUE_TEMPLATE/CONFIGURATION-ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/CONFIGURATION-ISSUE.yml
@@ -1,0 +1,71 @@
+name: Configuration Issue
+description: Sensors showing "unknown", incorrect values, or setup problems
+title: "[Config]: "
+labels: ["configuration issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Having trouble with sensor setup, types not matching, or values showing as "unknown"?
+
+        **Before filing this issue, please check:**
+        1. Open the **Calendar** tab in Home Assistant — do your collection events appear there?
+        2. If yes, the source is working. The issue is in your sensor configuration.
+        3. Make sure your sensor `type` values match the calendar event names **exactly** (case-sensitive).
+
+        **If the calendar is empty or the source itself is erroring, please use the [Source Defect](https://github.com/mampfes/hacs_waste_collection_schedule/issues/new?template=SOURCE-DEFECT.yml) template instead.**
+  - type: dropdown
+    id: problem-type
+    attributes:
+      label: What's the problem?
+      options:
+        - Sensor shows "unknown"
+        - Sensor shows wrong date or value
+        - Cannot set up the integration
+        - Collection types not appearing
+        - Other configuration problem
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+      description: What did you expect to happen vs what actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Full Configuration
+      description: Your complete waste_collection_schedule configuration (source AND sensor). Use example addresses, not your own.
+      render: YAML
+    validations:
+      required: true
+  - type: textarea
+    id: calendar-check
+    attributes:
+      label: Calendar Tab Check
+      description: "Do events appear in the Home Assistant Calendar tab? If yes, what are the exact event names shown?"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs (if any)
+      description: Paste relevant logs from Home Assistant (Settings → System → Logs). Remove any sensitive information.
+      render: Shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have checked the Calendar tab to see if events appear
+          required: true
+        - label: I have verified that my sensor `type` values match the calendar event names exactly
+          required: true
+        - label: I have restarted Home Assistant after making configuration changes
+          required: true
+        - label: I have searched past issues (open and closed) for this problem
+          required: true

--- a/.github/ISSUE_TEMPLATE/SOURCE-DEFECT.yml
+++ b/.github/ISSUE_TEMPLATE/SOURCE-DEFECT.yml
@@ -1,0 +1,55 @@
+name: Source Defect
+description: A previously working source has stopped working or returns incorrect data
+title: "[Source Defect]: "
+labels: ["source defect"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A source that was previously working is now broken, returning errors, or showing incorrect data.
+
+        **If you need help with sensor setup or configuration, please use the [Configuration Issue](https://github.com/mampfes/hacs_waste_collection_schedule/issues/new?template=CONFIGURATION-ISSUE.yml) template instead.**
+  - type: input
+    id: source
+    attributes:
+      label: Source Name
+      description: The source module name (as shown in your configuration)
+      placeholder: ex. newham_gov_uk
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What's happening?
+      description: Describe the problem. When did it last work? What changed?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Logs
+      description: Paste relevant logs from Home Assistant (Settings → System → Logs). Remove any sensitive information (addresses, API keys).
+      render: Shell
+    validations:
+      required: true
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Source Configuration
+      description: Your source configuration from configuration.yaml or the UI. Use example addresses, not your own.
+      render: YAML
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have tested with the latest version (master branch) via HACS → 3-dot menu → Redownload → select `master`
+          required: true
+        - label: The service provider's website is still working
+          required: true
+        - label: I have tested with the example parameters from the documentation
+          required: false
+        - label: I have searched past issues (open and closed) for this problem
+          required: true

--- a/.github/ISSUE_TEMPLATE/SOURCE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/SOURCE-REQUEST.yml
@@ -6,51 +6,83 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this source request!
+        Thanks for requesting a new source!
+
+        **Before submitting**, please check if your provider is already supported:
+        - Search the [source list](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/README.md) for your municipality name
+        - Check if your provider uses a platform we already support (Recollect, ArcGIS, ICS feeds, Abfall+ app, etc.)
   - type: input
     id: region
     attributes:
       label: Municipality / Region
-      description: Which municipality or region should be supported in the future?
+      description: Which municipality or region should be supported?
       placeholder: ex. Berlin, Germany
     validations:
       required: true
   - type: input
     id: collection-url
     attributes:
-      label: Collection Calendar Webpage 
-      description: Where are information about bin collections listed (preferred ULR)
+      label: Collection Calendar Webpage
+      description: URL where collection schedules can be looked up
       placeholder: https://example.com
     validations:
-      required: false
-  - type: textarea
+      required: true
+  - type: input
     id: example-address
     attributes:
       label: Example Address
-      description: (preferred) An address or other needed parameter for getting your collection info (not your own)
-      placeholder: ex. Gundelfinger Str. 4, 10318 Berlin
+      description: A working example address for testing (not your own). Include any parameters needed (postcode, UPRN, etc.)
+      placeholder: ex. 10 Downing Street, London SW1A 2AA
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: format
     attributes:
-      label: Collection Data Format
-      description: In which format does your service provider provides collection dates.
+      label: Data Format
+      description: How does the provider make collection dates available?
       options:
-        - As ICS/ICAL file
-        - As html on a webpage
-        - Dedicated IOS/Android APP
-        - As PDF Download
-        - As documented API
-        - Something different (add to additional information) 
-      multiple: true
+        - ICS / iCal calendar file
+        - HTML webpage (dates visible on the page)
+        - JSON / REST API
+        - Mobile app only (iOS/Android)
+        - PDF download only
+        - Other (describe in additional information)
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Known Platform (if any)
+      description: Does the provider use a platform we may already support? Check the URL or page footer for clues.
+      options:
+        - Not sure / Unknown
+        - Recollect (recollect.net)
+        - ArcGIS (arcgis.com)
+        - Abfall+ / k4systems app
+        - AbfallIO (abfall.io)
+        - IntraMaps (intramaps.com)
+        - OCAPI (opencityamerica.com)
+        - Publidata (publidata.ca)
+        - C-Trace (c-trace.de)
+        - FCC Environment
+        - Junker App (junkerapp.it)
+        - Other known platform (describe in additional information)
+      multiple: false
     validations:
       required: true
   - type: textarea
     id: additional-information
     attributes:
       label: Additional Information
-      description: (optional) additional information that might be helpful to implement a source for the municipality / region
-      placeholder: Additional information
+      description: Any additional context — how the lookup works, whether an account is needed, API details you've found, etc.
     validations:
       required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched the [source list](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/README.md) and my provider is not already supported
+          required: true
+        - label: I have provided a working example address (not my own) for testing
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Question/Help wanted
-    about: Ask the community a question
+  - name: Question / Help
+    about: Ask the community a question or get help with setup
     url: https://github.com/mampfes/hacs_waste_collection_schedule/discussions/categories/q-a

--- a/.github/workflows/issue-labeler.yaml
+++ b/.github/workflows/issue-labeler.yaml
@@ -1,0 +1,66 @@
+---
+name: Auto-label Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label from issue template fields
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const labels = [];
+
+            // Data format mapping (from Source Request template)
+            const dataFormats = {
+              'ICS / iCal calendar file': 'data: ICS',
+              'HTML webpage (dates visible on the page)': 'data: HTML',
+              'JSON / REST API': 'data: JSON/API',
+              'Mobile app only (iOS/Android)': 'data: app',
+              'PDF download only': 'data: PDF',
+            };
+
+            // Platform mapping (from Source Request template)
+            const platforms = {
+              'Recollect (recollect.net)': 'platform: Recollect',
+              'ArcGIS (arcgis.com)': 'platform: ArcGIS',
+              'Abfall+ / k4systems app': 'platform: AbfallPlus',
+              'AbfallIO (abfall.io)': 'platform: AbfallIO',
+              'IntraMaps (intramaps.com)': 'platform: IntraMaps',
+              'OCAPI (opencityamerica.com)': 'platform: OCAPI',
+              'Publidata (publidata.ca)': 'platform: Publidata',
+              'C-Trace (c-trace.de)': 'platform: C-Trace',
+              'Junker App (junkerapp.it)': 'platform: Junker',
+            };
+
+            for (const [text, label] of Object.entries(dataFormats)) {
+              if (body.includes(text)) {
+                labels.push(label);
+              }
+            }
+
+            for (const [text, label] of Object.entries(platforms)) {
+              if (body.includes(text)) {
+                labels.push(label);
+              }
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels,
+              });
+              console.log(`Added labels: ${labels.join(', ')}`);
+            } else {
+              console.log('No matching labels found in issue body');
+            }


### PR DESCRIPTION
## Summary
- **Split bug report** into 3 focused templates: Source Defect, Configuration Issue, Integration Bug
- **Improve Source Request** with data format and known platform dropdowns
- **Add auto-labeler** GitHub Action that applies `data:` and `platform:` labels based on dropdown selections
- **Disable blank issues** to guide users to the correct template

## Motivation
The single bug report template was used for source defects, config issues, and integration bugs interchangeably, making triage difficult. Source requests didn't capture data format or platform info, requiring manual investigation.

## Templates

| Template | Auto-labels | Key required fields |
|---|---|---|
| Source Defect | `source defect` | Source name, error logs, configuration |
| Configuration Issue | `configuration issue` | Calendar tab check, full config |
| Integration Bug | `bug` | HA version, integration version, repro steps |
| Source Request | `source request` + auto data/platform labels | URL, example address, format, platform |

## Labels (already created on the repo)
- Data: `data: ICS`, `data: HTML`, `data: JSON/API`, `data: PDF`, `data: app`
- Platform: `platform: Recollect`, `platform: ArcGIS`, `platform: AbfallPlus`, `platform: AbfallIO`, `platform: IntraMaps`, `platform: C-Trace`, `platform: Junker`

## Test plan
- [x] All template YAML files are valid
- [x] Labels created on repo
- [x] Auto-labeler workflow uses `actions/github-script@v7` — no external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)