### PR TITLE
Fix Northern Beaches fortnightly alternation using ISO week number

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/northernbeaches_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/northernbeaches_nsw_gov_au.py
@@ -145,12 +145,15 @@ class Source:
         # Northern Beaches pattern:
         #   - General Waste: weekly
         #   - Recycling & Garden Organics: fortnightly, alternating weeks
-        # A zones: even weeks = Recycling, odd weeks = Garden Organics
-        # B zones: even weeks = Garden Organics, odd weeks = Recycling
+        # Use ISO week number as a stable anchor for the alternation:
+        #   B zones: even ISO weeks = Recycling, odd = Garden Organics
+        #   A zones: even ISO weeks = Garden Organics, odd = Recycling
         entries: list[Collection] = []
 
         for week in range(26):
             d = next_date + timedelta(weeks=week)
+            iso_week = d.isocalendar()[1]
+            even_week = iso_week % 2 == 0
 
             entries.append(
                 Collection(
@@ -160,7 +163,7 @@ class Source:
                 )
             )
 
-            recycling_week = week % 2 == (1 if is_b_zone else 0)
+            recycling_week = even_week if is_b_zone else not even_week
 
             if recycling_week:
                 entries.append(


### PR DESCRIPTION
## Summary
- Use ISO week number instead of week offset from `next_date` to determine Recycling vs Garden Organics alternation
- B zones: even ISO weeks = Recycling, odd = Garden Organics
- A zones: opposite

## Motivation
The previous logic used `week % 2` relative to the next collection date returned by the API. Since the API doesn't indicate which bin type is being collected, the alternation had no stable anchor and drifted out of sync. ISO week number provides a consistent, date-independent anchor.

Verified against user report in #4026: Thu-B on 2026-04-16 (ISO week 16, even) correctly shows Recycling.

Fixes #5993

## Test plan
- [x] All 3 test cases pass (Manly=WedB, Brookvale=WedA, Dee Why=FriB)
- [x] A and B zones correctly show opposite alternation
- [x] `pytest tests/test_source_components.py` passes (6/6)
- [x] Linted with black + isort

🤖 Generated with [Claude Code](https://claude.com/claude-code)