### PR TITLE
Fix North Norfolk source after website journey flow change

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
@@ -67,15 +67,30 @@ class Source:
 
         s = requests.Session()
 
-        # visit homepage to get token for later queries
+        # Step 1: Launch the BinDaysJourney to start a session
         r = s.get(
-            "https://forms.north-norfolk.gov.uk/xforms/Address/Show/CollectionAddress",
+            "https://forms.north-norfolk.gov.uk/xforms/Launch/New/BinDaysJourney",
             headers=HEADERS,
         )
         soup: BeautifulSoup = BeautifulSoup(r.content, "html.parser")
         token: str = soup.find("input", {"name": "__RequestVerificationToken"}).get(
             "value"
         )
+
+        # Step 2: Confirm the landing page to proceed to address search
+        r = s.post(
+            r.url,
+            headers=HEADERS,
+            data={
+                "__RequestVerificationToken": token,
+                "Confirm": "true",
+                "BusinessName": "",
+                "IsDirty": "False",
+                "Journey": "BinDaysJourney",
+            },
+        )
+        soup = BeautifulSoup(r.content, "html.parser")
+        token = soup.find("input", {"name": "__RequestVerificationToken"}).get("value")
 
         payload: dict = {
             "__RequestVerificationToken": token,


### PR DESCRIPTION
## Summary
- Add BinDaysJourney launch and confirmation steps before the address lookup
- The North Norfolk forms site now requires starting a journey session before the address search page is accessible

## Motivation
The website changed its flow — previously you could hit the address search page directly, now it requires launching a "BinDaysJourney" first. Without this, the page returns "Session timed out" and no verification token, causing `AttributeError: 'NoneType' object has no attribute 'get'`.

Fixes #5401

## Test plan
- [x] All 3 test cases pass (Test_001: 2 entries, Test_002: 2 entries, Test_003: 3 entries)
- [x] `pytest tests/test_source_components.py` passes (6/6)
- [x] Linted with black + isort

🤖 Generated with [Claude Code](https://claude.com/claude-code)