### PR TITLE
Fix hvcgroep house_letter-only matching, add Hoorn test case

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
@@ -48,6 +48,7 @@ TEST_CASES = {
     },
     "Reinis": {"postal_code": "3201AA", "house_number": "1", "service": "reinis"},
     "ZRD": {"postal_code": "4691DH", "house_number": "4", "service": "zrd"},
+    "Hoorn": {"postal_code": "1628XA", "house_number": "1", "service": "hvcgroep"},
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -308,7 +309,7 @@ class Source:
             raise Exception("no data found for this address")
 
         bag_id = data[0]["bagid"]
-        if len(data) > 1 and self.house_letter and self.suffix:
+        if len(data) > 1 and (self.house_letter or self.suffix):
             _LOGGER.info(f"Checking {self.house_letter} {self.suffix}")
             for address in data:
                 if (


### PR DESCRIPTION
## Summary
- Fix address disambiguation to match on house_letter OR suffix (was AND)
- Add Hoorn test case (64 entries via `hvcgroep` service)

## Motivation
PR #5971 fixed the `house_letter` assignment bug, but a second issue remained: the disambiguation logic on line 311 required **both** `house_letter` AND `suffix` to be truthy. Addresses with only a house_letter (e.g. "14a") but no suffix would skip disambiguation and use the first result, which could be wrong.

Changed `and` to `or` so either parameter triggers the matching logic.

Also adds Hoorn as a test case since it was requested in #5376 and is supported via HVC Groep.

Closes #5376

## Test plan
- [x] All 11 test cases pass (including new Hoorn)
- [x] Existing Cranendonck test (has house_letter "b") still passes
- [x] `pytest tests/test_source_components.py` passes (6/6)
- [x] Linted with black + isort
- [x] Ran `update_docu_links.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)