### PR TITLE
Replace requests with curl_cffi for HTTP requests

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/teignbridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/teignbridge_gov_uk.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-import requests
+from curl_cffi import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/teignbridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/teignbridge_gov_uk.py
@@ -44,7 +44,7 @@ class Source:
 
     def fetch(self) -> list[Collection]:
         # Fetch collection schedule
-        r = requests.get(BIN_URL, params={"uprn": self._uprn})
+        r = requests.get(BIN_URL, params={"uprn": self._uprn}, impersonate="chrome124")
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, "html.parser")


### PR DESCRIPTION
Teignbridge server uses TLS fingerprinting which blocks Python's default TLS client hello, so curl_cffi is required