### PR TITLE
Remove duplicates dates

### DIFF
--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -5119,7 +5119,7 @@
   "wakefield_gov_uk": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/wakefield_gov_uk.md",
     "howto": {
-      "en": "Enter your UPRN (available from [FindMyAddress.co.uk](https://www.findmyaddress.co.uk/)).Alternatively: you can also see it in the URL/location bar of your browser when you search the Wakefield site manually, look for 'uprn=' in the url and take the numbers immediately after. "
+      "en": "Enter your UPRN (available from [FindMyAddress.co.uk](https://www.findmyaddress.co.uk/)).Alternatively: you can also see it in the URL/location bar of your browser when you search the Wakefield site manually, look for 'uprn=' in the url and take the numbers immediately after."
     },
     "urls": {}
   },

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
@@ -22,8 +22,8 @@ TYPES = {
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {  # Optional dictionary to describe how to get the arguments, will be shown in the GUI configuration form above the input fields, does not need to be translated in all languages
-    "en": "Enter your UPRN (available from [FindMyAddress.co.uk](https://www.findmyaddress.co.uk/)). "
-          "Alternatively: you can also see it in the URL/location bar of your browser when you search the Wakefield site manually, look for 'uprn=' in the url and take the numbers immediately after."
+    "en": "Enter your UPRN (available from [FindMyAddress.co.uk](https://www.findmyaddress.co.uk/))."
+    "Alternatively: you can also see it in the URL/location bar of your browser when you search the Wakefield site manually, look for 'uprn=' in the url and take the numbers immediately after."
 }
 
 PARAM_DESCRIPTIONS = {  # Optional dict to describe the arguments, will be shown in the GUI configuration below the respective input field
@@ -40,7 +40,7 @@ class Source:
     def fetch(self) -> List[Collection]:
         entries = []
         with requests.Session() as sess:
-            url = "https://www.wakefield.gov.uk/where-i-live/"
+            url = "https://www.wakefield.gov.uk/where-i-live/" # the a parameter is needed for page to load but contents doesn't matter
             request = sess.get(url, params={"uprn": self._uprn, "a": "Your Address"})
             soup = BeautifulSoup(request.content, "html.parser")
             collection_sections = soup.select(".tablet\\:l-col-fb-4.u-mt-10")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
@@ -21,12 +21,12 @@ TYPES = {
     "Garden": {"icon": "mdi:leaf", "alias": "Garden"},
 }
 
-HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {  # Optional dictionary to describe how to get the arguments, will be shown in the GUI configuration form above the input fields, does not need to be translated in all languages
     "en": "Enter your UPRN (available from [FindMyAddress.co.uk](https://www.findmyaddress.co.uk/)). "
           "Alternatively: you can also see it in the URL/location bar of your browser when you search the Wakefield site manually, look for 'uprn=' in the url and take the numbers immediately after."
 }
 
-PARAM_DESCRIPTIONS = {
+PARAM_DESCRIPTIONS = {  # Optional dict to describe the arguments, will be shown in the GUI configuration below the respective input field
     "en": {
         "uprn": "Unique Property Reference Number (UPRN)",
     }
@@ -41,38 +41,26 @@ class Source:
         entries = []
         with requests.Session() as sess:
             url = "https://www.wakefield.gov.uk/where-i-live/"
-            # Removed the extra curly braces around self._uprn which would create a set string
             request = sess.get(url, params={"uprn": self._uprn, "a": "Your Address"})
             soup = BeautifulSoup(request.content, "html.parser")
-            
             collection_sections = soup.select(".tablet\\:l-col-fb-4.u-mt-10")
-            
             for section in collection_sections:
-                # Use a set to automatically filter out duplicate dates for THIS bin type
                 collection_dates = set()
                 bin_type_raw = section.find("strong").text.split(" ")[0]
                 bin_type = TYPES.get(bin_type_raw)
-                
                 if not bin_type:
                     continue
-
-                # 1. Grab dates from the 'u-mb-2' divs (usually Prev/Next)
                 date_elements = section.select(".u-mb-2")
-                # 2. Grab dates from 'li' elements (future dates)
                 date_elements.extend(section.find_all("li"))
-
                 for element in date_elements:
                     if ", " not in element.text:
                         continue
                     try:
-                        # Parsing date from format "Monday, 14 April 2026"
                         date_str = element.text.split(", ")[1].strip()
                         clean_date = datetime.strptime(date_str, "%d %B %Y").date()
                         collection_dates.add(clean_date)
                     except (ValueError, IndexError):
                         continue
-
-                # Add the unique dates for this category to the final entries
                 for collection_date in collection_dates:
                     entries.append(
                         Collection(
@@ -80,6 +68,5 @@ class Source:
                             t=bin_type["alias"],
                             icon=bin_type["icon"],
                         )
-                    )
-                    
+                    )       
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
@@ -21,12 +21,12 @@ TYPES = {
     "Garden": {"icon": "mdi:leaf", "alias": "Garden"},
 }
 
-HOW_TO_GET_ARGUMENTS_DESCRIPTION = {  # Optional dictionary to describe how to get the arguments, will be shown in the GUI configuration form above the input fields, does not need to be translated in all languages
-    "en": "Enter your UPRN (available from [FindMyAddress.co.uk](https://www.findmyaddress.co.uk/))."
-    "Alternatively: you can also see it in the URL/location bar of your browser when you search the Wakefield site manually, look for 'uprn=' in the url and take the numbers immediately after. "
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter your UPRN (available from [FindMyAddress.co.uk](https://www.findmyaddress.co.uk/)). "
+          "Alternatively: you can also see it in the URL/location bar of your browser when you search the Wakefield site manually, look for 'uprn=' in the url and take the numbers immediately after."
 }
 
-PARAM_DESCRIPTIONS = {  # Optional dict to describe the arguments, will be shown in the GUI configuration below the respective input field
+PARAM_DESCRIPTIONS = {
     "en": {
         "uprn": "Unique Property Reference Number (UPRN)",
     }
@@ -40,42 +40,46 @@ class Source:
     def fetch(self) -> List[Collection]:
         entries = []
         with requests.Session() as sess:
-            url = "https://www.wakefield.gov.uk/where-i-live/"  # the a parameter is needed for page to load but contents doesn't matter
-            request = sess.get(url, params={"uprn": {self._uprn}, "a": "Your Address"})
+            url = "https://www.wakefield.gov.uk/where-i-live/"
+            # Removed the extra curly braces around self._uprn which would create a set string
+            request = sess.get(url, params={"uprn": self._uprn, "a": "Your Address"})
             soup = BeautifulSoup(request.content, "html.parser")
+            
             collection_sections = soup.select(".tablet\\:l-col-fb-4.u-mt-10")
+            
             for section in collection_sections:
+                # Use a set to automatically filter out duplicate dates for THIS bin type
                 collection_dates = set()
-                bin_type = section.find("strong").text.split(" ")[0]
-                prev_and_next_collection = section.select(".u-mb-2")
-                for collection in prev_and_next_collection:
-                    if ", " not in collection.text:
+                bin_type_raw = section.find("strong").text.split(" ")[0]
+                bin_type = TYPES.get(bin_type_raw)
+                
+                if not bin_type:
+                    continue
+
+                # 1. Grab dates from the 'u-mb-2' divs (usually Prev/Next)
+                date_elements = section.select(".u-mb-2")
+                # 2. Grab dates from 'li' elements (future dates)
+                date_elements.extend(section.find_all("li"))
+
+                for element in date_elements:
+                    if ", " not in element.text:
                         continue
                     try:
-                        collection_dates.add(
-                            datetime.strptime(
-                                collection.text.split(", ")[1].strip(), "%d %B %Y"
-                            ).date()
-                        )
-                    except ValueError:
-                        pass
+                        # Parsing date from format "Monday, 14 April 2026"
+                        date_str = element.text.split(", ")[1].strip()
+                        clean_date = datetime.strptime(date_str, "%d %B %Y").date()
+                        collection_dates.add(clean_date)
+                    except (ValueError, IndexError):
+                        continue
+
+                # Add the unique dates for this category to the final entries
                 for collection_date in collection_dates:
                     entries.append(
                         Collection(
                             date=collection_date,
-                            t=TYPES[bin_type]["alias"],
-                            icon=TYPES[bin_type]["icon"],
+                            t=bin_type["alias"],
+                            icon=bin_type["icon"],
                         )
                     )
-                list_elements = section.find_all("li")
-                for element in list_elements:
-                    entries.append(
-                        Collection(
-                            date=datetime.strptime(
-                                element.text.split(", ")[1].strip(), "%d %B %Y"
-                            ).date(),
-                            t=TYPES[bin_type]["alias"],
-                            icon=TYPES[bin_type]["icon"],
-                        )
-                    )
+                    
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wakefield_gov_uk.py
@@ -40,7 +40,7 @@ class Source:
     def fetch(self) -> List[Collection]:
         entries = []
         with requests.Session() as sess:
-            url = "https://www.wakefield.gov.uk/where-i-live/" # the a parameter is needed for page to load but contents doesn't matter
+            url = "https://www.wakefield.gov.uk/where-i-live/"  # the a parameter is needed for page to load but contents doesn't matter
             request = sess.get(url, params={"uprn": self._uprn, "a": "Your Address"})
             soup = BeautifulSoup(request.content, "html.parser")
             collection_sections = soup.select(".tablet\\:l-col-fb-4.u-mt-10")
@@ -68,5 +68,5 @@ class Source:
                             t=bin_type["alias"],
                             icon=bin_type["icon"],
                         )
-                    )       
+                    )
         return entries


### PR DESCRIPTION
The dates for some bin collections are duplicated on the source website, meaning some dates collections appear twice in the calendar. Made changes to remove the duplicate dates.