### PR TITLE
Fix CRLF line endings in update_docu_links.py on Windows

### DIFF
--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -562,7 +562,7 @@ def write_ics_md_file(filename: Path, data: IcsSourceData) -> None:
         md += multiline_indent(yaml.dump(tc).rstrip("\n"), 8) + "\n"
         md += "```\n"
         # md += "\n"
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="\n") as f:
         f.write(md)
 
 
@@ -648,12 +648,13 @@ def update_sources_json(countries: dict[str, list[SourceInfo]]) -> None:
         "custom_components/waste_collection_schedule/sources.json",
         "w",
         encoding="utf-8",
+        newline="\n",
     ) as f:
         f.write(json.dumps(output, indent=2))
 
     # Save metadata separately (for runtime use)
     metadata_file = "custom_components/waste_collection_schedule/source_metadata.json"
-    with open(metadata_file, "w", encoding="utf-8") as f:
+    with open(metadata_file, "w", encoding="utf-8", newline="\n") as f:
         json.dump(source_metadata_by_module, f, indent=2, ensure_ascii=False)
 
 
@@ -838,6 +839,7 @@ def update_json(
             tranlation_file,
             "w",
             encoding="utf-8",
+            newline="\n",
         ) as f:
             json.dump(translations, f, indent=2, ensure_ascii=False)
 
@@ -1012,7 +1014,7 @@ def _patch_file(filename, section_id, str):
     md = md[:start_pos] + str + md[end_pos:]
 
     # write entire file
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="\n") as f:
         f.write(md)
 
 


### PR DESCRIPTION
## Summary
- Add `newline="\n"` to all write-mode `open()` calls in `update_docu_links.py`
- On Windows, Python text-mode I/O translates `\n` to `\r\n` by default, causing git CRLF warnings when the script regenerates derived files (sources.json, translations, doc markdown, source_metadata.json)
- The repo's `.gitattributes` enforces LF everywhere, so this just makes the script match that expectation on all platforms

## Test plan
- [x] Ran `update_docu_links.py` on Windows — zero CRLF warnings from git
- [x] `pytest tests/test_source_components.py` — all 6 tests pass
- [x] Only the script file itself is modified; no generated files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)