### PR TITLE
Fix irenambiente_it fortnightly schedules not applied

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/irenambiente_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/irenambiente_it.py
@@ -39,6 +39,11 @@ TEST_CASES = {
         "street": "ARGINE COPERMIO OVEST",
         "house_number": 74,
     },
+    "San Secondo Parmense BORGO DELLA ROVACCHIA 12": {
+        "city": "San Secondo Parmense",
+        "street": "BORGO DELLA ROVACCHIA",
+        "house_number": 12,
+    },
     "Torino Corso Quintino Sella 11 Scala A": {
         "city": "Torino",
         "street": "Corso Quintino Sella",
@@ -117,6 +122,8 @@ class Holiday(TypedDict):
 class CollectionItem(TypedDict):
     Materiale: str
     ICalRRule: str
+    IdFrequenza: str
+    FlagFreq: str
     FestivitaCalendario: list[Holiday]
     NonVisibile: bool
 
@@ -233,6 +240,24 @@ class Source:
         r.raise_for_status()
         return r.json()
 
+    @staticmethod
+    def _fortnightly_dtstart(flag_freq: str, year: int) -> datetime:
+        """Compute DTSTART for fortnightly (2S) schedules.
+
+        The Iren annual calendar numbers weeks starting from the first
+        Monday of the year.  'Dispari' (odd) = weeks 1, 3, 5 …;
+        'Pari' (even) = weeks 2, 4, 6 ….
+
+        FlagFreq 'N' → dispari (start on first Monday).
+        FlagFreq 'P' → pari (start on second Monday).
+        """
+        # Find first Monday of the year
+        jan1 = datetime(year, 1, 1)
+        first_monday = jan1 + timedelta(days=(7 - jan1.weekday()) % 7)
+        if flag_freq == "P":
+            first_monday += timedelta(weeks=1)
+        return first_monday
+
     def _get_collections(self) -> list[Collection]:
         if not self._address_id:
             raise ValueError("address id not set")
@@ -264,6 +289,19 @@ class Source:
                         "%Y%m%dT%H%M%SZ",
                     )
                 rulestr = DTSTART_REGEX.sub("", rulestr).strip(";")
+
+            # Fix fortnightly schedules: the API returns FREQ=WEEKLY but
+            # IdFrequenza="2S" indicates every 2 weeks.  Inject INTERVAL=2
+            # and compute the correct DTSTART for odd/even week alignment.
+            if (
+                item.get("IdFrequenza") == "2S"
+                and "INTERVAL" not in rulestr
+                and rulestr.startswith("RRULE:")
+            ):
+                rulestr = rulestr.replace("FREQ=WEEKLY", "FREQ=WEEKLY;INTERVAL=2")
+                start_datetime = self._fortnightly_dtstart(
+                    item.get("FlagFreq", "N"), datetime.now().year
+                )
 
             try:
                 if start_datetime:


### PR DESCRIPTION
## Summary
- The Iren API returns `IdFrequenza="2S"` (fortnightly) and `FlagFreq` for odd/even week alignment, but the `ICalRRule` only contains `FREQ=WEEKLY` — missing `INTERVAL=2`
- The source only read `ICalRRule`, so fortnightly collections (e.g. Carta at San Secondo Parmense) appeared every week instead of every other week
- Now detects `IdFrequenza="2S"` and injects `INTERVAL=2` with a DTSTART aligned to the correct odd/even week based on `FlagFreq` and the annual calendar numbering (week 1 = first Monday of the year)
- Added test case for San Secondo Parmense which has fortnightly Carta

Fixes #5883

## Test plan
- [x] All 7 test cases return valid data (including new San Secondo case)
- [x] San Secondo Carta now shows fortnightly on odd annual weeks (Apr 13, Apr 27, May 11...) instead of every Monday
- [x] Existing Colorno skip-date logic unaffected
- [x] `pytest tests/test_source_components.py` — 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)