### PR TITLE
Fix avfallsor_no source to use Avfall Sør collection JSON API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsor_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsor_no.py
@@ -1,8 +1,7 @@
 import datetime
-import logging
+import re
 
 import requests
-from bs4 import BeautifulSoup, Tag
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 
@@ -10,7 +9,6 @@ TITLE = "Avfall Sør, Kristiansand"
 DESCRIPTION = "Source for Avfall Sør, Kristiansand."
 URL = "https://avfallsor.no/"
 TEST_CASES = {"Auglandslia 1, Kristiansand": {"address": "Auglandslia 1, Kristiansand"}}
-_LOGGER = logging.getLogger(__name__)
 
 ICON_MAP = {
     "Restavfall": "mdi:trash-can",
@@ -18,54 +16,16 @@ ICON_MAP = {
     "Papp og papir": "mdi:package-variant",
     "Plastemballasje": "mdi:recycle",
     "Glass- og metallemballasje": "mdi:bottle-soda",
+    "residual": "mdi:trash-can",
+    "bio": "mdi:leaf",
+    "paper": "mdi:package-variant",
+    "plastic": "mdi:recycle",
+    "glass": "mdi:bottle-soda",
+    "metal": "mdi:bottle-soda",
 }
 
 
 API_URL = "https://avfallsor.no/wp-json/addresses/v1/address"
-
-
-NO_WEEKDAYS = ["mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag", "søndag"]
-NO_MONTHS = [
-    "januar",
-    "februar",
-    "mars",
-    "april",
-    "mai",
-    "juni",
-    "juli",
-    "august",
-    "september",
-    "oktober",
-    "november",
-    "desember",
-]
-
-
-def parse_date(date_str: str) -> datetime.date:
-    date_str = date_str.lower()
-    for weekday in NO_WEEKDAYS:
-        date_str = date_str.replace(weekday, "")
-
-    month_number = None
-    for i, month in enumerate(NO_MONTHS):
-        if month in date_str:
-            month_number = i + 1
-            date_str = date_str.replace(month, "")
-            break
-    if month_number is None:
-        raise ValueError("Could not find month in date string %s" % date_str)
-
-    date_str = date_str.replace(".", "").strip()
-    try:
-        day = int(date_str)
-    except ValueError:
-        raise ValueError("Day is not an integer: %s" % date_str)
-
-    date_ = datetime.date(datetime.datetime.now().year, month_number, day)
-    if datetime.date.today() > date_:
-        return date_.replace(year=datetime.datetime.now().year + 1)
-
-    return date_
 
 
 class Source:
@@ -73,7 +33,7 @@ class Source:
         self._address: str = address
 
     def fetch(self) -> list[Collection]:
-        args = {"address": self._address.split(",")[0].strip()}
+        args = {"lookup_term": self._address.split(",")[0].strip()}
 
         r = requests.get(API_URL, params=args)
         r.raise_for_status()
@@ -103,33 +63,35 @@ class Source:
                 self._address,
                 [match["label"] for match in matches],
             )
-        r = requests.get(href)
-        r.raise_for_status()
 
-        soup = BeautifulSoup(r.text, "html.parser")
-        pickup_div = (
-            soup.select_one("div.pickup-days-large")
-            or soup.select_one("div.pickup-days-small")
-            or soup.select_one("div.pickup-days")
-        )
-        if not pickup_div:
-            raise ValueError("Could not find pickup days")
+        # Extract propertyId from href
+        match = re.search(r'/([0-9a-f-]{36})/?$', href)
+        if not match:
+            raise ValueError(f"Could not extract propertyId from href: {href}")
+        property_id = match.group(1)
+
+        api_url = f"https://avfallsor.no/wp-json/pickup-calendar/v1/collections/property-id/{property_id}"
+        r = requests.get(api_url)
+        r.raise_for_status()
+        data = r.json()
 
         entries = []
-        for h3 in soup.select("h3"):
-            date_ = parse_date(h3.text)
-            div = h3.find_next_sibling("div")
-
-            if not div or not isinstance(div, Tag):
-                _LOGGER.warning("Could not find div for %s", h3.text)
+        today = datetime.date.today()
+        for collection in data.get("collections", []):
+            date_str = collection.get("dateIndex")
+            if not date_str:
                 continue
-
-            for text_div in div.select("div.info-boxes-box-info"):
-                for span in text_div.select("span"):
-                    span.decompose()
-                bin_type = text_div.text.strip()
-
-                icon = ICON_MAP.get(bin_type)  # Collection icon
-                entries.append(Collection(date=date_, t=bin_type, icon=icon))
+            try:
+                date = datetime.date.fromisoformat(date_str)
+            except ValueError:
+                continue
+            if date < today:
+                continue
+            waste_types = []
+            for item in collection.get("items", []):
+                waste_types.extend(item.get("wasteIcons", []))
+            for waste_type in waste_types:
+                icon = ICON_MAP.get(waste_type)
+                entries.append(Collection(date=date, t=waste_type, icon=icon))
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsor_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsor_no.py
@@ -10,18 +10,29 @@ DESCRIPTION = "Source for Avfall Sør, Kristiansand."
 URL = "https://avfallsor.no/"
 TEST_CASES = {"Auglandslia 1, Kristiansand": {"address": "Auglandslia 1, Kristiansand"}}
 
+# Maps fraksjonId to English waste type names
+# fraksjonId is the stable provider identifier
+FRAKSJON_ID_MAP = {
+    "9011": "Residual",  # Restavfall
+    "1111": "Bio",  # Bioavfall
+    "2499": {
+        # This fraksjonId maps to multiple waste types depending on fraksjon field
+        "Papp og papir": "Paper",
+        "Plastemballasje": "Plastic",
+    },
+    "1322": {
+        # This fraksjonId contains multiple waste types
+        "Glass- og metallemballasje": ["Glass", "Metal"],
+    },
+}
+
 ICON_MAP = {
-    "Restavfall": "mdi:trash-can",
-    "Bioavfall": "mdi:leaf",
-    "Papp og papir": "mdi:package-variant",
-    "Plastemballasje": "mdi:recycle",
-    "Glass- og metallemballasje": "mdi:bottle-soda",
-    "residual": "mdi:trash-can",
-    "bio": "mdi:leaf",
-    "paper": "mdi:package-variant",
-    "plastic": "mdi:recycle",
-    "glass": "mdi:bottle-soda",
-    "metal": "mdi:bottle-soda",
+    "Residual": "mdi:trash-can",
+    "Bio": "mdi:leaf",
+    "Paper": "mdi:package-variant",
+    "Plastic": "mdi:recycle",
+    "Glass": "mdi:bottle-soda",
+    "Metal": "mdi:bottle-soda",
 }
 
 
@@ -87,11 +98,29 @@ class Source:
                 continue
             if date < today:
                 continue
-            waste_types = []
             for item in collection.get("items", []):
-                waste_types.extend(item.get("wasteIcons", []))
-            for waste_type in waste_types:
-                icon = ICON_MAP.get(waste_type)
-                entries.append(Collection(date=date, t=waste_type, icon=icon))
+                fraksjon_id = item.get("fraksjonId")
+                fraksjon = item.get("fraksjon")
+                
+                # Look up English waste type name using fraksjonId
+                mapping = FRAKSJON_ID_MAP.get(fraksjon_id)
+                
+                # Handle nested mappings for fraksjonIds with multiple waste types
+                if isinstance(mapping, dict):
+                    # Lookup by both fraksjonId and fraksjon name
+                    waste_type_value = mapping.get(fraksjon)
+                    if isinstance(waste_type_value, list):
+                        waste_types = waste_type_value
+                    else:
+                        waste_types = [waste_type_value] if waste_type_value else []
+                else:
+                    # Single waste type for this fraksjonId
+                    waste_types = [mapping] if mapping else []
+                
+                # Create collection entries for each waste type
+                for waste_type in waste_types:
+                    if waste_type:
+                        icon = ICON_MAP.get(waste_type)
+                        entries.append(Collection(date=date, t=waste_type, icon=icon))
 
         return entries


### PR DESCRIPTION
## PR Description

### Summary
This PR updates avfallsor_no.py to use Avfall Sør’s JSON pickup calendar API instead of scraping HTML from the address page.

### What changed
- Replaced HTML scraping logic with direct API use
- Looked up the address via `https://avfallsor.no/wp-json/addresses/v1/address?lookup_term=...`
- Extracted `propertyId` from the returned `href`
- Fetched collection data from `https://avfallsor.no/wp-json/pickup-calendar/v1/collections/property-id/{property_id}`
- Converted JSON collection items into `Collection` objects
- Removed obsolete BeautifulSoup/date parsing code

### Why
The Avfall Sør site renders pickup details dynamically, making HTML scraping fragile and unreliable. Using the official JSON endpoint is much more robust and matches the working approach used by the referenced external project.

### Credit
This implementation was inspired by the workaround used in the `oal/avfallsor-mqtt-py` project, which also uses the same Avfall Sør JSON API flow.

### Testing
- Verified locally that the branch builds and the source produces collection entries
- Branch pushed to `Wuerger/hacs_waste_collection_schedule` as `fix/avfallsor_no-api-source`