### PR TITLE
ccc_govt_nz Fix overrides and increase loop limit

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
@@ -125,14 +125,15 @@ class Source:
             while collection_date < today and iterations < max_iterations:
                 collection_date += datetime.timedelta(weeks=interval_weeks)
                 iterations += 1
-                # Recheck overrides for the advanced date
-                date_str = collection_date.strftime("%Y-%m-%d")
-                for override in overrides:
-                    if override["OriginalDate"] == date_str:
-                        collection_date = datetime.datetime.strptime(
-                            override["NewDate"], "%Y-%m-%d"
-                        ).date()
-                        break
+
+            # Recheck overrides for the advanced date
+            date_str = collection_date.strftime("%Y-%m-%d")
+            for override in overrides:
+                if override["OriginalDate"] == date_str:
+                    collection_date = datetime.datetime.strptime(
+                        override["NewDate"], "%Y-%m-%d"
+                    ).date()
+                    break
 
             entries.append(
                 Collection(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
@@ -88,16 +88,6 @@ class Source:
         )
         overrides = overridesResponse.json()
 
-        _LOGGER.debug("Processing overrides...")
-        for bin in bins:
-            for override in overrides:
-                if override["OriginalDate"] == bin["next_planned_date_app"]:
-                    _LOGGER.debug(
-                        "Processing overrides for %s", override["OriginalDate"]
-                    )
-                    bin["next_planned_date_app"] = override["NewDate"]
-        _LOGGER.debug("Overrides processing complete")
-
         _LOGGER.debug("Processing bins...")
         today = datetime.date.today()
         for bin in bins:
@@ -117,8 +107,6 @@ class Source:
             # The API can return stale dates. Advance past dates forward
             # by the collection interval until they are no longer in the past
             # (i.e., on or after today). Organic is collected weekly, all others fortnightly.
-            # After each advance, recheck overrides so holiday/special-date
-            # overrides are not missed for the corrected date.
             interval_weeks = 1 if bin["material"] == "Organic" else 2
             max_iterations = 208  # safety limit
             iterations = 0
@@ -126,13 +114,17 @@ class Source:
                 collection_date += datetime.timedelta(weeks=interval_weeks)
                 iterations += 1
 
-            # Recheck overrides for the advanced date
+            # After the final advanced date is computed, apply any matching
+            # holiday/special-date override for that date.
             date_str = collection_date.strftime("%Y-%m-%d")
             for override in overrides:
                 if override["OriginalDate"] == date_str:
                     collection_date = datetime.datetime.strptime(
                         override["NewDate"], "%Y-%m-%d"
                     ).date()
+                    _LOGGER.debug(
+                        "Processing overrides for %s", override["OriginalDate"]
+                    )
                     break
 
             entries.append(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ccc_govt_nz.py
@@ -120,7 +120,7 @@ class Source:
             # After each advance, recheck overrides so holiday/special-date
             # overrides are not missed for the corrected date.
             interval_weeks = 1 if bin["material"] == "Organic" else 2
-            max_iterations = 52  # safety limit
+            max_iterations = 208  # safety limit
             iterations = 0
             while collection_date < today and iterations < max_iterations:
                 collection_date += datetime.timedelta(weeks=interval_weeks)


### PR DESCRIPTION
Only apply override dates to the **Final** date calculated. Previously overrides were applied every loop leading to compound errors if there were override dates between next_planned_date_app and today.
Also increased loop limit to 4 years, as some dates are already 6 months out of date, quite possibly the previous limit of 1 year was not enough.