### PR TITLE
fix(ICS): handle truncated DTSTART/DTEND with missing time after 'T'

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -44,6 +44,14 @@ class ICS:
             ics_data,
         )
 
+        # Fix truncated DTSTART/DTEND values where the time portion is missing
+        # after the 'T' separator (e.g. "DTSTART;TZID=Europe/Berlin:20260505T").
+        ics_data = re.sub(
+            r"(DT(?:START|END)[^:]*:\d{8})T(\r?\n)",
+            r"\g<1>T000000\g<2>",
+            ics_data,
+        )
+
         # parse ics data
         events: List[Any] = icalevents.events(
             start=start_date, end=end_date, string_content=ics_data.encode()


### PR DESCRIPTION
## Summary

Some providers (e.g. azv-hof.de) emit malformed iCal events where `DTSTART` includes a `TZID` but the time portion is absent:

```
DTSTART;TZID=Europe/Berlin:20260505T
```

The `icalevents` parser raises `BrokenCalendarProperty` on these, aborting the entire fetch for that source. This causes the config flow to show `'NoneType' object has no attribute 'dt'` to the user.

The fix pre-processes the raw ICS data to complete truncated `DTSTART`/`DTEND` values to midnight (`T000000`) before parsing, following the same pattern as the existing `EXDATE` workaround.

Fixes #6033.

## Test plan

- Tested manually against the azv-hof.de ICS URL for Leupoldsgrün — previously failed with `BrokenCalendarProperty`, now returns 59 entries correctly
- Existing ICS test cases unaffected (regex only matches lines ending with `\d{8}T` at end of line)