### PR TITLE
Fix kiedysmieci_info: incomplete v5 municipality list blocks valid locations

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiedysmieci_info.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiedysmieci_info.py
@@ -1,7 +1,8 @@
 import datetime
 import json
 import ssl
-import urllib
+import urllib.parse
+import urllib.request
 
 from waste_collection_schedule import Collection
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -22,6 +23,12 @@ TEST_CASES = {
         "district": "dębicki",
         "municipality": "Dębica",
         "street": "Kędzierz",
+    },
+    "Parkowa, lubelskie, zamojski, Szczebrzeszyn": {
+        "voivodeship": "lubelskie",
+        "district": "zamojski",
+        "municipality": "Szczebrzeszyn",
+        "street": "Parkowa",
     },
 }
 
@@ -62,25 +69,24 @@ class Source:
                 suggestions=voivodeships_list,
             )
 
-        districts_list = self.get_districts_list()
+        # The v5 municipality list is incomplete; validate district/municipality via
+        # the streets endpoint instead (returns 404 for unknown locations).
+        streets_list = self.get_streets_list()
 
-        if district.lower() not in [c.lower() for c in districts_list]:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "district",
-                district,
-                suggestions=districts_list,
-            )
-
-        municipalities_list = self.get_municipalities_list()
-
-        if municipality.lower() not in [m.lower() for m in municipalities_list]:
+        if streets_list is None:
+            districts_list = self.get_districts_list()
+            if district.lower() not in [c.lower() for c in districts_list]:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "district",
+                    district,
+                    suggestions=districts_list,
+                )
+            municipalities_list = self.get_municipalities_list()
             raise SourceArgumentNotFoundWithSuggestions(
                 "municipality",
                 municipality,
                 suggestions=municipalities_list,
             )
-
-        streets_list = self.get_streets_list()
 
         if street.lower() not in [s.lower() for s in streets_list]:
             raise SourceArgumentNotFoundWithSuggestions(


### PR DESCRIPTION
## Summary

- The `dostepne_gminy/v5` endpoint only covers a subset of municipalities, causing valid locations (e.g. zamojski district in lubelskie) to be rejected with a misleading "district not found" error
- Replaced the v5-based district/municipality validation with a direct streets endpoint lookup — if the streets endpoint returns 404, the location is genuinely invalid and we fall back to v5-derived suggestions
- Also fixed a bare `import urllib` which should be `import urllib.parse` + `import urllib.request`
- Added test case for Szczebrzeszyn, zamojski, lubelskie (from issue #5411)

Fixes #5411

## Test plan

- [ ] Existing test cases (Bukowsko/sanocki, Dębica/dębicki) still pass
- [ ] New test case (Szczebrzeszyn/zamojski/Parkowa) now passes
- [ ] Invalid district still raises `SourceArgumentNotFoundWithSuggestions` with suggestions from v5

🤖 Generated with [Claude Code](https://claude.com/claude-code)