### PR TITLE
fix: add Aare to codespell ignore list

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -132,3 +132,4 @@ RE-USE
 Parin
 appen
 re-using
+Aare


### PR DESCRIPTION
## Summary

- Adds `Aare` to `.codespellignore` — it's a Swiss river name appearing in place names such as "Büren an der Aare" and is incorrectly flagged by codespell as a misspelling of "Are"

Closes #6071

## Test plan

- [x] `codespell README.md info.md -I .codespellignore` returns no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)