### PR TITLE
docs: document all burgerportaal_nl supported operators

### DIFF
--- a/doc/source/burgerportaal_nl.md
+++ b/doc/source/burgerportaal_nl.md
@@ -22,7 +22,10 @@ waste_collection_schedule:
 Use one of the following codes as organization code:
 
 - assen
+- bat
+- groningen
 - rmn
+- utrecht
 
 **post_code**  
 *(string) (required)*
@@ -37,8 +40,11 @@ For example if you house is `2A` you will put `A` here.
 
 ## Supported Operators
 
-- `assen`: <https://21burgerportaal.mendixcloud.com/p/assen/landing/>
-- `rmn`: <https://21burgerportaal.mendixcloud.com/p/rmn/landing/>
+- `assen` (Gemeente Assen): <https://21burgerportaal.mendixcloud.com/p/assen/landing/>
+- `bat` (BAT Tilburg): <https://21burgerportaal.mendixcloud.com/p/bat/landing/>
+- `groningen` (Gemeente Groningen): <https://21burgerportaal.mendixcloud.com/p/groningen/landing/>
+- `rmn` (Reinigingsdienst Midden Nederland): <https://21burgerportaal.mendixcloud.com/p/rmn/landing/>
+- `utrecht` (Gemeente Utrecht): <https://21burgerportaal.mendixcloud.com/p/utrecht/landing/>
 
 ## Example
 


### PR DESCRIPTION
## Summary
- Source supports `assen`, `bat`, `groningen`, `rmn`, `utrecht` per `SERVICE_MAP` and `TEST_CASES`, but `doc/source/burgerportaal_nl.md` only listed `assen` and `rmn`.
- Adds the missing three operators (BAT Tilburg, Gemeente Groningen, Gemeente Utrecht) to both the organization code list and the Supported Operators section.
- Enables closing source requests #5554 (Groningen) and #5416 (Tilburg) as already supported.

## Test plan
- [x] Diff is docs-only; no source code or generated files changed
- [x] Organization names sourced directly from `source/burgerportaal_nl.py` SERVICE_MAP