### PR TITLE
arun.gov.uk: Change ICON_MAP order

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/arun_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/arun_gov_uk.py
@@ -29,12 +29,12 @@ PARAM_DESCRIPTIONS = {
     }
 }
 ICON_MAP = {
+    "garden": "mdi:leaf",
+    "food": "mdi:food-apple",
+    "recycl": "mdi:recycle",
     "waste": "mdi:trash-can",
     "rubbish": "mdi:trash-can",
     "refuse": "mdi:trash-can",
-    "recycl": "mdi:recycle",
-    "garden": "mdi:leaf",
-    "food": "mdi:food-apple",
 }
 
 


### PR DESCRIPTION
`mdi:trash-can` was applying to too many things. Moved 'specific' collection types to the start of the list, allowing 'waste' to act as a fallback.
