### PR TITLE
Add Tarnowskie Góry test case to ecoharmonogram_pl

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -194,6 +194,12 @@ TEST_CASES = {
         "house_number": "32",
         "additional_sides_matcher": "",  # Available sides are "Zabudowa wysoka" and "" (empty string)
     },
+    "Tarnowskie Góry, Gliwicka 1": {
+        "town": "Tarnowskie Góry",
+        "street": "Gliwicka",
+        "house_number": "1",
+        "additional_sides_matcher": "Zabudowa jednorodzinna",
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Adds a `TEST_CASE` for Tarnowskie Góry (Śląskie, PL) to `ecoharmonogram_pl`.
- Town confirmed in EcoHarmonogram API (id 4549, schedulePeriod 10847).
- Municipality was already listed in the generated docs; this adds CI coverage.
- Verified: fetches 76 entries for Gliwicka 1.

## Closes
- #5463 (Tarnowskie Góry)

## Test plan
- [x] `python test_sources.py -s ecoharmonogram_pl` — new test case returns 76 entries
- [x] `black` and `isort` pass with no changes