### PR TITLE
Add Lillehammer test case to minrenovasjon_no

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/minrenovasjon_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/minrenovasjon_no.py
@@ -25,7 +25,13 @@ TEST_CASES = {
         "house_number": 2,
         "street_code": 2469,
         "county_id": 3024,
-    }
+    },
+    "Lillehammer Åsmarkvegen 111": {
+        "street_name": "Åsmarkvegen",
+        "house_number": 111,
+        "street_code": 6530,
+        "county_id": 3405,
+    },
 }
 
 API_URL = (


### PR DESCRIPTION
## Summary
- Adds a `TEST_CASE` for Lillehammer municipality (kommunenr 3405) to `minrenovasjon_no`.
- Verified via MinRenovasjon API: 9 fractions listed, 5 with upcoming collection dates from 2026-04-22.
- Address: Åsmarkvegen 111 (adressekode 6530), confirmed via Geonorge.

## Closes
- #4542 (Lillehammer / GLØR)

## Test plan
- [x] MinRenovasjon API returns 5 fractions with real dates for the test address
- [x] `black` and `isort` pass with no changes