### PR TITLE
avfallsapp_se: remove unsupported sv language entries

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsapp_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsapp_se.py
@@ -42,12 +42,6 @@ PARAM_TRANSLATIONS = {
         "street_address": "Street address",
         "token": "Bearer token",
     },
-    "sv": {
-        "service_provider": "Tjänsteleverantör",
-        "api_key": "API-nyckel / enhets-ID",
-        "street_address": "Gatuadress",
-        "token": "Bearer-token",
-    },
 }
 
 PARAM_DESCRIPTIONS = {
@@ -56,12 +50,6 @@ PARAM_DESCRIPTIONS = {
         "api_key": "API key or device ID used by the mobile app.",
         "street_address": "Street address used for address lookup and registration.",
         "token": "Bearer token required by some providers.",
-    },
-    "sv": {
-        "service_provider": "Namn på Avfallsapp-leverantören.",
-        "api_key": "API-nyckel eller enhets-ID från mobilappen.",
-        "street_address": "Gatuadress som används för adressökning och registrering.",
-        "token": "Bearer-token som krävs av vissa leverantörer.",
     },
 }
 


### PR DESCRIPTION
## Summary

- Removes `sv` (Swedish) language entries from `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` in `avfallsapp_se.py`
- The framework only supports `en`, `de`, `it`, `fr` language codes (enforced by `test_source_components.py`)
- These `sv` entries were introduced in #6070 and caused a pytest failure in `test_source_components.py::test_source_has_necessary_parameters`

## Test plan

- [ ] `python -m pytest tests/` passes (was failing before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)