### PR TITLE
fix geelongaustralia_com_au: follow domain redirect for POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [City of Glen Eira](/doc/source/gleneira_vic_gov_au.md) / gleneira.vic.gov.a
 - [City of Gosnells](/doc/source/gosnells_wa_gov_au.md) / gosnells.wa.gov.au
 - [City of Greater Bendigo](/doc/source/bendigo_vic_gov_au.md) / bendigo.vic.gov.au
-- [City of Greater Geelong](/doc/source/geelongaustralia_com_au.md) / geelongaustralia.com.au
+- [City of Greater Geelong](/doc/source/geelongaustralia_com_au.md) / geelongcity.vic.gov.au
 - [City of Hobart ](/doc/source/hobartcity_com_au.md) / hobartcity.com.au
 - [City of Joondalup](/doc/source/joondalup_wa_gov_au.md) / joondalup.wa.gov.au
 - [City of Kalamunda](/doc/source/kalamunda_wa_gov_au.md) / kalamunda.wa.gov.au/kerbside-3-bin-system/collection-days/bin-day

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
@@ -6,7 +6,7 @@ from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "City of Greater Geelong"
 DESCRIPTION = "Source City of Greater Geelong rubbish collection"
-URL = "https://www.geelongaustralia.com.au/"
+URL = "https://www.geelongcity.vic.gov.au/"
 TEST_CASES = {
     "155 Mercer Street Geelong 3220": {"address": "155 Mercer Street Geelong 3220"},
     "1/271 Roslyn Road Highton 3216": {"address": "1/271 Roslyn Road Highton 3216"},
@@ -42,6 +42,7 @@ class Source:
         s = requests.Session()
         r = s.get(API_URL)
         r.raise_for_status()
+        post_url = r.url
 
         soup: BeautifulSoup = BeautifulSoup(r.text, "html.parser")
 
@@ -60,7 +61,7 @@ class Source:
 
         self._submit_args["__EVENTVALIDATION"] = str(eventvalidation["value"])
 
-        r = requests.post(API_URL, data=self._submit_args)
+        r = s.post(post_url, data=self._submit_args)
         r.raise_for_status()
 
         if "We couldn't find a match for" in r.text:
@@ -85,7 +86,7 @@ class Source:
                 entries.append(
                     Collection(
                         date=datetime.datetime.strptime(
-                            date.text, "%A, %d %B %Y"
+                            date.text.strip(), "%A, %d %B %Y"
                         ).date(),
                         t=t,  # Collection type
                         icon=ICON_MAP.get(t),  # Collection icon


### PR DESCRIPTION
## Summary

- City of Greater Geelong has rebranded and moved to `geelongcity.vic.gov.au`
- The GET request followed the redirect correctly, but the POST still targeted the old `geelongaustralia.com.au` URL, causing `ctl00_ContentBody_P_CALENDAR` not to be found
- Fix captures the final URL after the GET redirect (`post_url = r.url`) and POSTs using the session to that URL
- Also adds `.strip()` to date text parsing — the new site includes surrounding whitespace in `<li>` elements

Fixes #6117

## Test plan

- [x] All 4 existing TEST_CASES pass (12 entries each across Garbage, Recycling, Green waste)
- [x] black/isort clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)