### PR TITLE
fix winterthur_ch: update street lookup to new API endpoint

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/winterthur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/winterthur_ch.py
@@ -30,7 +30,7 @@ class Source:
         self._ics_sources = get_region_url_by_street(
             "winterthur",
             self._street,
-            "https://m.winterthur.ch/appl/ajax/index.php?id=street&usid=9749&do=lookupStreet&container=737670",
+            "https://m.winterthur.ch/api/v1/callmethod/trash/asyncLookupStreet?usid=9749&container=1066394&uri=/index.php?apid=737670",
             regex=r"(?:Tour \d{1,2} )?(.*?)(?=\s*ganze Stadt|$)",
         ).fetch()
         for source in self._ics_sources:


### PR DESCRIPTION
## Summary

- The old street lookup endpoint (`/appl/ajax/index.php?id=street&usid=9749&do=lookupStreet&container=737670`) now returns an error page
- The new endpoint is `/api/v1/callmethod/trash/asyncLookupStreet` with `q`, `usid`, `container`, and `uri` query parameters (confirmed from page JS)
- The rest of the parsing chain (waste type pages → ICS webcal links) is unchanged and still works

Fixes #6113

## Test plan

- [x] TEST_CASE `Am Iberghang` returns 129 entries across Grobmetall, Grüntour, Kehricht, Papier/Karton
- [x] black/isort clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)