### PR TITLE
fix sector27_de: use first word of street as search prefix

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sector27_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sector27_de.py
@@ -15,6 +15,10 @@ DESCRIPTION = "Source for Muellkalender in Kreis RE."
 URL = "https://muellkalender.sector27.de"
 TEST_CASES = {
     "Datteln": {"city": "Datteln", "street": "Am Bahnhof"},
+    "Datteln range street": {
+        "city": "Datteln",
+        "street": "Ahsener Straße 113 - 161 (ungerade)",
+    },
     "Marl": {"city": "Marl", "street": "Ahornweg"},
     "Oer-Erkenschick": {"city": "Oer-Erkenschwick", "street": "An der Zechenbahn"},
 }
@@ -69,7 +73,7 @@ class Source:
             )
 
         args = city
-        args["searchFor"] = self._street
+        args["searchFor"] = self._street.split()[0] if self._street else self._street
 
         r = requests.get(
             "https://muellkalender.sector27.de/web/searchForStreets",
@@ -83,7 +87,7 @@ class Source:
 
         if self._street not in streets:
             if streets:
-                SourceArgumentNotFoundWithSuggestions(
+                raise SourceArgumentNotFoundWithSuggestions(
                     "street", self._street, [x for x in streets.keys()]
                 )
             raise SourceArgumentNotFound("street", self._street)


### PR DESCRIPTION
## Summary

- The `/web/searchForStreets` API no longer returns results when the full street name with house-number ranges (e.g. `"Ahsener Straße 113 - 161 (ungerade)"`) is passed as `searchFor`
- Fix: use only the first word of the street name as the search prefix — the API returns all matching streets, then an exact match on the full name finds the correct one
- Also fixes a silent bug: `SourceArgumentNotFoundWithSuggestions` was constructed but never raised when streets were found but no exact match existed

Fixes #6078

## Test plan

- [x] Existing test cases still pass (105 / 92 / 92 entries)
- [x] New test case `"Ahsener Straße 113 - 161 (ungerade)"` (the reporter's street) returns 105 entries
- [x] black/isort clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)