### PR TITLE
fix exeter_gov_uk: handle dates without comma and img in h3

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
@@ -41,16 +41,22 @@ class Source:
 
         entries = []
         for b, d in zip(bins, dates):
-            # check cases where no date is given for a collection
-            if d and len(d.text.split(",")) > 1:
-                entries.append(
-                    Collection(
-                        date=datetime.strptime(
-                            re.compile(REGEX_ORDINALS).sub("", d.text), "%A, %d %B %Y"
-                        ).date(),
-                        t=b.text.replace(" collection", ""),
-                        icon=ICON_MAP.get(b.text.replace(" collection", "").upper()),
-                    )
+            raw_date = re.compile(REGEX_ORDINALS).sub("", d.get_text(strip=True))
+            for fmt in ("%A, %d %B %Y", "%A %d %B %Y"):
+                try:
+                    date = datetime.strptime(raw_date, fmt).date()
+                    break
+                except ValueError:
+                    continue
+            else:
+                continue
+
+            entries.append(
+                Collection(
+                    date=date,
+                    t=b.text.replace(" collection", ""),
+                    icon=ICON_MAP.get(b.text.replace(" collection", "").upper()),
                 )
+            )
 
         return entries


### PR DESCRIPTION
## Summary

- Replaces the `split(",")` guard and single-format `strptime` with a try/except loop over two date formats (`"%A, %d %B %Y"` and `"%A %d %B %Y"`)
- Switches to `get_text(strip=True)` to cleanly handle whitespace and `<img>` tags inside `<h3>` elements
- Silently skips entries with no parseable date (as before), but no longer silently drops valid dates that lack a comma

Fixes #6108

## Test plan

- [x] `python -m pytest tests/test_source_components.py` — all 6 tests pass
- [x] black check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)