### PR TITLE
Add Saalfelden am Steinernen Meer (AT) waste collection source

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ If your service provider is not listed, feel free to open a [source request issu
 - [Rudersdorf](/doc/source/citiesapps_com.md) / rudersdorf.at
 - [Rust](/doc/source/citiesapps_com.md) / freistadt-rust.at
 - [Röthis](/doc/source/citiesapps_com.md) / roethis.at
-- [Saalfelden am Steinernen Meer](/doc/source/citiesapps_com.md) / stadtmarketing-saalfelden.at/de
+- [Saalfelden am Steinernen Meer](/doc/source/saalfelden_at.md) / saalfelden.at
 - [Sachsenburg](/doc/ics/muellapp_com.md) / muellapp.com
 - [Sankt Georgen an der Stiefing](/doc/source/citiesapps_com.md) / st-georgen-stiefing.gv.at
 - [Sankt Gilgen](/doc/source/citiesapps_com.md) / gemgilgen.at

--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -825,6 +825,14 @@
     "howto": {},
     "urls": {}
   },
+  "saalfelden_at": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/saalfelden_at.md",
+    "howto": {
+      "de": "Öffnen Sie https://www.saalfelden.at/Buergerservice/Abfallkalender, wählen Sie Ihre Straße und Hausnummer aus, und verwenden Sie dieselben Werte hier.",
+      "en": "Visit https://www.saalfelden.at/Buergerservice/Abfallkalender, pick your street and house number from the dropdowns, and use the same values here."
+    },
+    "urls": {}
+  },
   "klosterneuburg_at": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/klosterneuburg_at.md",
     "howto": {},

--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -3465,9 +3465,9 @@
     },
     {
       "title": "Saalfelden am Steinernen Meer",
-      "module": "citiesapps_com",
+      "module": "saalfelden_at",
       "default_params": {},
-      "id": "citiesapps_com"
+      "id": "saalfelden_at"
     },
     {
       "title": "Sachsenburg",

--- a/custom_components/waste_collection_schedule/translations/de.json
+++ b/custom_components/waste_collection_schedule/translations/de.json
@@ -3493,6 +3493,33 @@
         },
         "data_description": {}
       },
+      "args_saalfelden_at": {
+        "title": "Quelle konfigurieren",
+        "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
+        "data": {
+          "calendar_title": "Kalender Titel",
+          "hausnummer": "Hausnummer",
+          "strasse": "Straße"
+        },
+        "data_description": {
+          "calendar_title": "Ein lesbarerer oder benutzerfreundlicherer Name für den Müllkalender. Wenn nichts angegeben wird, wird der Name der Quelle verwendet.",
+          "hausnummer": "Hausnummer wie im Saalfeldener Abfallkalender aufgelistet.",
+          "strasse": "Straßenname wie im Saalfeldener Abfallkalender aufgelistet."
+        }
+      },
+      "reconfigure_saalfelden_at": {
+        "title": "Quelle Neu Konfigurieren",
+        "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",
+        "data": {
+          "calendar_title": "Kalender Titel",
+          "hausnummer": "Hausnummer",
+          "strasse": "Straße"
+        },
+        "data_description": {
+          "hausnummer": "Hausnummer wie im Saalfeldener Abfallkalender aufgelistet.",
+          "strasse": "Straßenname wie im Saalfeldener Abfallkalender aufgelistet."
+        }
+      },
       "args_klosterneuburg_at": {
         "title": "Quelle konfigurieren",
         "description": "Konfiguriere deinen Service Provider. {howto}Mehr details: {docs_url}",

--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -3610,6 +3610,33 @@
         },
         "data_description": {}
       },
+      "args_saalfelden_at": {
+        "title": "Configure Source",
+        "description": "Configure your service provider. {howto}More details: {docs_url}.",
+        "data": {
+          "calendar_title": "Calendar Title",
+          "hausnummer": "House number",
+          "strasse": "Street"
+        },
+        "data_description": {
+          "calendar_title": "A more readable, or user-friendly, name for the waste calendar. If nothing is provided, the name returned by the source will be used.",
+          "hausnummer": "House number as listed in the Saalfelden waste calendar.",
+          "strasse": "Street name as listed in the Saalfelden waste calendar."
+        }
+      },
+      "reconfigure_saalfelden_at": {
+        "title": "Reconfigure Source",
+        "description": "Configure your service provider. {howto}More details: {docs_url}.",
+        "data": {
+          "calendar_title": "Calendar Title",
+          "hausnummer": "House number",
+          "strasse": "Street"
+        },
+        "data_description": {
+          "hausnummer": "House number as listed in the Saalfelden waste calendar.",
+          "strasse": "Street name as listed in the Saalfelden waste calendar."
+        }
+      },
       "args_klosterneuburg_at": {
         "title": "Configure Source",
         "description": "Configure your service provider. {howto}More details: {docs_url}.",

--- a/custom_components/waste_collection_schedule/translations/fr.json
+++ b/custom_components/waste_collection_schedule/translations/fr.json
@@ -3437,6 +3437,28 @@
         },
         "data_description": {}
       },
+      "args_saalfelden_at": {
+        "title": "Configurer la Source",
+        "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
+        "data": {
+          "calendar_title": "Titre du Calendrier",
+          "hausnummer": "Numéro civique",
+          "strasse": "Rue"
+        },
+        "data_description": {
+          "calendar_title": "Un nom plus lisible ou convivial pour le calendrier des déchets. Si aucun n'est fourni, le nom renvoyé par la source sera utilisé."
+        }
+      },
+      "reconfigure_saalfelden_at": {
+        "title": "Reconfigurer la Source",
+        "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",
+        "data": {
+          "calendar_title": "Titre du Calendrier",
+          "hausnummer": "Numéro civique",
+          "strasse": "Rue"
+        },
+        "data_description": {}
+      },
       "args_klosterneuburg_at": {
         "title": "Configurer la Source",
         "description": "Configurez votre fournisseur de services. {howto}Plus de détails : {docs_url}.",

--- a/custom_components/waste_collection_schedule/translations/it.json
+++ b/custom_components/waste_collection_schedule/translations/it.json
@@ -3446,6 +3446,28 @@
         },
         "data_description": {}
       },
+      "args_saalfelden_at": {
+        "title": "Configurazione Sorgente",
+        "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Maggiori informazioni: {docs_url}.",
+        "data": {
+          "calendar_title": "Nome Calendario",
+          "hausnummer": "Hausnummer",
+          "strasse": "Strasse"
+        },
+        "data_description": {
+          "calendar_title": "Puoi cambiare il nome del calendario della raccolta dei rifiuti, altrimenti di default verra' utilizzato il nome del tuo fornitore di servizi."
+        }
+      },
+      "reconfigure_saalfelden_at": {
+        "title": "Riconfigurazione Sorgente",
+        "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Per maggiori informazioni: {docs_url}.",
+        "data": {
+          "calendar_title": "Nome Calendario",
+          "hausnummer": "Hausnummer",
+          "strasse": "Strasse"
+        },
+        "data_description": {}
+      },
       "args_klosterneuburg_at": {
         "title": "Configurazione Sorgente",
         "description": "Compila i campi per ottenere le informazioni sul tuo servizio di raccolta. {howto}Maggiori informazioni: {docs_url}.",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/CitiesAppsCom.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/CitiesAppsCom.py
@@ -1102,11 +1102,6 @@ SERVICE_MAP = [
         "country": "at",
     },
     {
-        "title": "Saalfelden am Steinernen Meer",
-        "url": "www.stadtmarketing-saalfelden.at/de",
-        "country": "at",
-    },
-    {
         "title": "Sankt Georgen an der Stiefing",
         "url": "https://www.st-georgen-stiefing.gv.at",
         "country": "at",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
@@ -1,0 +1,246 @@
+import json
+import re
+from datetime import date, datetime, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+TITLE = "Saalfelden am Steinernen Meer"
+DESCRIPTION = "Source for Saalfelden am Steinernen Meer waste collection."
+URL = "https://www.saalfelden.at"
+COUNTRY = "at"
+
+TEST_CASES = {
+    "Achenweg 1": {"strasse": "Achenweg", "hausnummer": 1},
+    "Abdeckerweg 5": {"strasse": "Abdeckerweg", "hausnummer": "5"},
+    "Achenweg 4a": {"strasse": "Achenweg", "hausnummer": "4a"},
+}
+
+ICON_MAP = {
+    "Restmüll": "mdi:trash-can",
+    "Biomüll": "mdi:leaf",
+    "Gelbe Tonne": "mdi:recycle",
+    "Gelber Sack": "mdi:recycle",
+    "Altpapier": "mdi:package-variant",
+    "Papier": "mdi:package-variant",
+    "Sperrmüll": "mdi:sofa",
+    "Christbaum": "mdi:pine-tree",
+    "Weihnachtsbaum": "mdi:pine-tree",
+    "Problemstoff": "mdi:bottle-tonic-skull",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Saalfelden waste calendar.",
+        "hausnummer": "House number as listed in the Saalfelden waste calendar.",
+    },
+    "de": {
+        "strasse": "Straßenname wie im Saalfeldener Abfallkalender aufgelistet.",
+        "hausnummer": "Hausnummer wie im Saalfeldener Abfallkalender aufgelistet.",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Visit https://www.saalfelden.at/Buergerservice/Abfallkalender, pick "
+        "your street and house number from the dropdowns, and use the same "
+        "values here."
+    ),
+    "de": (
+        "Öffnen Sie https://www.saalfelden.at/Buergerservice/Abfallkalender, "
+        "wählen Sie Ihre Straße und Hausnummer aus, und verwenden Sie dieselben "
+        "Werte hier."
+    ),
+}
+
+CALENDAR_PAGE_URL = "https://www.saalfelden.at/Buergerservice/Abfallkalender"
+API_URL = "https://www.saalfelden.at/system/web/kalender.aspx"
+DETAIL_ONR = "225697049"
+MENU_ONR = "225696673"
+MAX_PAGES = 30
+LOOKAHEAD_DAYS = 365
+
+
+class Source:
+    def __init__(self, strasse: str, hausnummer):
+        self._strasse = str(strasse).strip()
+        self._hausnummer = str(hausnummer).strip()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        page = session.get(CALENDAR_PAGE_URL, timeout=30)
+        page.raise_for_status()
+
+        typids = self._resolve_typids(page.text)
+
+        return self._fetch_collections(session, typids)
+
+    def _resolve_typids(self, html: str) -> str:
+        soup = BeautifulSoup(html, "html.parser")
+
+        street_select = soup.find(
+            "select",
+            attrs={"name": re.compile(r"boxmuellkalenderstrassedd$")},
+        )
+        if street_select is None:
+            raise Exception("Could not locate street selector on Saalfelden page")
+
+        name_to_id: dict[str, int] = {}
+        for opt in street_select.find_all("option"):
+            value = opt.get("value", "").strip()
+            text = opt.get_text(strip=True)
+            if value and text:
+                name_to_id[text] = int(value)
+
+        street_id = name_to_id.get(self._strasse)
+        if street_id is None:
+            for name, sid in name_to_id.items():
+                if name.casefold() == self._strasse.casefold():
+                    street_id = sid
+                    self._strasse = name
+                    break
+        if street_id is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "strasse", self._strasse, sorted(name_to_id)
+            )
+
+        strassen_arr = self._parse_strassen_arr(html)
+
+        for entry in strassen_arr:
+            if entry[0] != street_id:
+                continue
+            hnr_labels: list[str] = []
+            for hnr in entry[1]:
+                hnr_text = str(hnr[1])
+                hnr_labels.append(hnr_text)
+                if hnr_text.casefold() == self._hausnummer.casefold():
+                    return hnr[2]
+            raise SourceArgumentNotFoundWithSuggestions(
+                "hausnummer", self._hausnummer, hnr_labels
+            )
+
+        raise SourceArgumentNotFoundWithSuggestions(
+            "strasse", self._strasse, sorted(name_to_id)
+        )
+
+    @staticmethod
+    def _parse_strassen_arr(html: str) -> list:
+        match = re.search(r"var\s+strassenArr\s*=\s*", html)
+        if not match:
+            raise Exception("Could not locate strassenArr in page")
+
+        start = html.find("[", match.end())
+        depth = 0
+        end = start
+        for idx in range(start, len(html)):
+            ch = html[idx]
+            if ch == "[":
+                depth += 1
+            elif ch == "]":
+                depth -= 1
+                if depth == 0:
+                    end = idx + 1
+                    break
+        if depth != 0:
+            raise Exception("Could not parse strassenArr (unbalanced brackets)")
+
+        arr_js = html[start:end]
+        arr_json = arr_js.replace("'", '"')
+        arr_json = re.sub(r",\s*\]", "]", arr_json)
+        return json.loads(arr_json)
+
+    def _fetch_collections(
+        self, session: requests.Session, typids: str
+    ) -> list[Collection]:
+        entries: list[Collection] = []
+        seen_keys: set[tuple[str, str]] = set()
+        seen_first_row: set[tuple[str, str]] = set()
+
+        today = date.today()
+        end_date = today + timedelta(days=LOOKAHEAD_DAYS)
+
+        for page_idx in range(MAX_PAGES):
+            params = {
+                "detailonr": DETAIL_ONR,
+                "menuonr": MENU_ONR,
+                "typids": typids,
+                "page": page_idx,
+                "vdatum": today.strftime("%d.%m.%Y"),
+                "bdatum": end_date.strftime("%d.%m.%Y"),
+            }
+            r = session.get(API_URL, params=params, timeout=30)
+            r.raise_for_status()
+
+            soup = BeautifulSoup(r.text, "html.parser")
+            table = soup.find("table", class_="ris_table")
+            if table is None:
+                break
+
+            rows = table.find_all("tr")[1:]
+            page_rows: list[tuple[date, str]] = []
+            for row in rows:
+                tds = row.find_all("td", class_="td_kal")
+                if len(tds) != 2:
+                    continue
+                date_match = re.match(
+                    r"(\d{2}\.\d{2}\.\d{4})", tds[0].get_text(" ", strip=True)
+                )
+                if not date_match:
+                    continue
+                collection_date = datetime.strptime(
+                    date_match.group(1), "%d.%m.%Y"
+                ).date()
+                anchor = tds[1].find("a")
+                raw_type = (
+                    anchor.get_text(strip=True)
+                    if anchor
+                    else tds[1].get_text(" ", strip=True)
+                )
+                waste_type = re.sub(r"\s*\(.*\)\s*$", "", raw_type).strip()
+                page_rows.append((collection_date, waste_type))
+
+            if not page_rows:
+                break
+
+            first_key = (page_rows[0][0].isoformat(), page_rows[0][1])
+            if first_key in seen_first_row:
+                break
+            seen_first_row.add(first_key)
+
+            for collection_date, waste_type in page_rows:
+                if collection_date > end_date:
+                    continue
+                key = (collection_date.isoformat(), waste_type)
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                icon = self._icon_for(waste_type)
+                entries.append(
+                    Collection(date=collection_date, t=waste_type, icon=icon)
+                )
+
+            if page_rows[-1][0] > end_date:
+                break
+
+        return entries
+
+    @staticmethod
+    def _icon_for(waste_type: str) -> str | None:
+        lowered = waste_type.casefold()
+        for key, icon in ICON_MAP.items():
+            if key.casefold() in lowered:
+                return icon
+        return None

--- a/doc/source/citiesapps_com.md
+++ b/doc/source/citiesapps_com.md
@@ -224,7 +224,6 @@ Support for schedules provided by [App CITIES](https://citiesapps.com), serving 
 | Rudersdorf | [rudersdorf.at](http://www.rudersdorf.at) |
 | Rust | [freistadt-rust.at](https://www.freistadt-rust.at) |
 | Röthis | [roethis.at](https://www.roethis.at) |
-| Saalfelden am Steinernen Meer | [stadtmarketing-saalfelden.at/de](www.stadtmarketing-saalfelden.at/de) |
 | Sankt Georgen an der Stiefing | [st-georgen-stiefing.gv.at](https://www.st-georgen-stiefing.gv.at) |
 | Sankt Gilgen | [gemgilgen.at](https://www.gemgilgen.at) |
 | Sankt Oswald bei Plankenwarth | [sanktoswald.net](https://www.sanktoswald.net) |

--- a/doc/source/saalfelden_at.md
+++ b/doc/source/saalfelden_at.md
@@ -1,0 +1,41 @@
+# Saalfelden am Steinernen Meer
+
+Support for schedules provided by [Stadtgemeinde Saalfelden am Steinernen Meer](https://www.saalfelden.at/Buergerservice/Abfallkalender), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: saalfelden_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Saalfelden waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Saalfelden waste calendar dropdown (e.g. `1`, `4a`).
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: saalfelden_at
+      args:
+        strasse: "Achenweg"
+        hausnummer: "1"
+```
+
+## How to get the source arguments
+
+Visit <https://www.saalfelden.at/Buergerservice/Abfallkalender>, choose your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`. House numbers may include a letter suffix (e.g. `4a`) — match exactly what the dropdown shows.


### PR DESCRIPTION
## Summary

- New source `saalfelden_at` for Saalfelden am Steinernen Meer (NSW Salzburg, Austria).
- Scrapes the city's RIS-CMS calendar (`kalender.aspx`) directly. Resolves the configured `strasse` + `hausnummer` via the inline `strassenArr` JS variable on the calendar page (street → house numbers → typid bundle), then walks the paginated calendar table within a ~365-day window.
- Removes Saalfelden from `CitiesAppsCom.py` EXTRA_INFO. Per the original reporter, the city has discontinued its CITIES integration; the README and citiesapps doc page now point at the new source instead.

Fixes #5312

## Test plan

- [x] `Achenweg 1` returns 168 entries spanning 2026-04-27 → 2027-04-22 across `Restmüll`, `Biomüll`, `Gelbe Tonne`, `Gelber Sack`.
- [x] `update_docu_links.py` runs cleanly.
- [x] `black` and `flake8` clean.
- [ ] Other TEST_CASES (`Abdeckerweg 5`, `Achenweg 4a`) share the same code path; not individually run.