### PR TITLE
fix Enfield address matching

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enfield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enfield_gov_uk.py
@@ -223,16 +223,28 @@ class Source:
         return (
             candidate_full == normalized_input
             or candidate_key == normalized_input
-            or candidate_key in normalized_input
-            or normalized_input in candidate_full
+            or cls._contains_normalized_phrase(normalized_input, candidate_key)
+            or cls._contains_normalized_phrase(candidate_full, normalized_input)
             or (
                 bool(postcode)
                 and bool(house_number)
                 and postcode == candidate_postcode
                 and house_number == candidate_house_number
                 and bool(candidate_street)
-                and candidate_street in normalized_input
+                and cls._contains_normalized_phrase(normalized_input, candidate_street)
             )
+        )
+
+    @staticmethod
+    def _contains_normalized_phrase(value: str, phrase: str) -> bool:
+        if not value or not phrase:
+            return False
+        return (
+            re.search(
+                rf"(?<![A-Z0-9]){re.escape(phrase)}(?![A-Z0-9])",
+                value,
+            )
+            is not None
         )
 
     @staticmethod

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -120,6 +120,27 @@ def test_no_extra_ics_mds() -> None:
         assert source in sources, f"found orphaned ics markdown file: {source}.md"
 
 
+def test_enfield_address_match_uses_whole_house_number() -> None:
+    module = _get_module("enfield_gov_uk")
+    normalized_input = module.Source._normalize_address("51 Example Road AB1 2CD")
+
+    correct_candidate = {
+        "ADDRESS": "51, EXAMPLE ROAD, EXAMPLE, AB1 2CD",
+        "PAO_START_NUMBER": "51",
+        "STREET_DESCRIPTION": "EXAMPLE ROAD",
+        "POSTCODE_LOCATOR": "AB1 2CD",
+    }
+    embedded_candidate = {
+        "ADDRESS": "1, EXAMPLE ROAD, EXAMPLE, AB1 2CD",
+        "PAO_START_NUMBER": "1",
+        "STREET_DESCRIPTION": "EXAMPLE ROAD",
+        "POSTCODE_LOCATOR": "AB1 2CD",
+    }
+
+    assert module.Source._matches_address(normalized_input, correct_candidate)
+    assert not module.Source._matches_address(normalized_input, embedded_candidate)
+
+
 def _param_translation_check(
     source: str,
     translations: Any,


### PR DESCRIPTION
## Summary

Fix Enfield Council address matching so a candidate address only matches as a whole normalized phrase, instead of matching arbitrary substrings.

## Root Cause

The Enfield source accepted substring matches between normalized address strings. This allowed addresses such as house number `1` to match an input for house number `51`, because `1 ...` was found inside `51 ...`. The lookup then became ambiguous and no collection schedule was returned for otherwise valid addresses.

## Impact

Address-based configuration for Enfield Council is less likely to fail with false ambiguous matches. UPRN-based configuration is unchanged.

## Validation

- `git pull --ff-only origin master`
- `python test_sources.py -s enfield_gov_uk -i -l`
- `pytest tests/test_source_components.py`
- `python3 -m py_compile custom_components/waste_collection_schedule/waste_collection_schedule/source/enfield_gov_uk.py tests/test_source_components.py`
- `git diff --check`

Only the source file and a focused synthetic regression test are included; generated docs, README, and info files are left for CI as requested by the contribution guide.
