### PR TITLE
Fix vafab miljo when missing bintype info

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
@@ -335,22 +335,19 @@ class Source:
                 if "v" in next_pickup:
                     date_parts = next_pickup.split()
                     month = MONTH_MAP[date_parts[1]]
-                    date_joined = "-".join([date_parts[0],
-                                           str(month), date_parts[2]])
+                    date_joined = "-".join([date_parts[0], str(month), date_parts[2]])
                     next_pickup_date = datetime.strptime(
                         date_joined, "v%W-%m-%Y"
                     ).date()
                 elif not next_pickup:
                     continue
                 else:
-                    next_pickup_date = datetime.strptime(
-                        next_pickup, "%Y-%m-%d").date()
+                    next_pickup_date = datetime.strptime(next_pickup, "%Y-%m-%d").date()
             except ValueError:
                 # In some cases the date is just a month, so parse this as the
                 # first of the month to at least get something close
                 try:
-                    next_pickup_date = datetime.strptime(
-                        next_pickup, "%b %Y").date()
+                    next_pickup_date = datetime.strptime(next_pickup, "%b %Y").date()
                 except ValueError as month_parse_error:
                     _LOGGER.warning(
                         "Failed to parse date %s, %s,",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
@@ -335,19 +335,22 @@ class Source:
                 if "v" in next_pickup:
                     date_parts = next_pickup.split()
                     month = MONTH_MAP[date_parts[1]]
-                    date_joined = "-".join([date_parts[0], str(month), date_parts[2]])
+                    date_joined = "-".join([date_parts[0],
+                                           str(month), date_parts[2]])
                     next_pickup_date = datetime.strptime(
                         date_joined, "v%W-%m-%Y"
                     ).date()
                 elif not next_pickup:
                     continue
                 else:
-                    next_pickup_date = datetime.strptime(next_pickup, "%Y-%m-%d").date()
+                    next_pickup_date = datetime.strptime(
+                        next_pickup, "%Y-%m-%d").date()
             except ValueError:
                 # In some cases the date is just a month, so parse this as the
                 # first of the month to at least get something close
                 try:
-                    next_pickup_date = datetime.strptime(next_pickup, "%b %Y").date()
+                    next_pickup_date = datetime.strptime(
+                        next_pickup, "%b %Y").date()
                 except ValueError as month_parse_error:
                     _LOGGER.warning(
                         "Failed to parse date %s, %s,",
@@ -362,15 +365,15 @@ class Source:
             waste_type = (
                 waste_type_prefix
                 + ", "
-                + item["BinType"]["ContainerType"]
+                + (item["BinType"]["ContainerType"] or "")
                 + " "
-                + str(item["BinType"]["Size"])
-                + item["BinType"]["Unit"]
+                + (str(item["BinType"]["Size"]) or "")
+                + (item["BinType"]["Unit"] or "")
             )
             # Get the icon for the waste type, default to help icon if not found
             icon = ICON_MAP.get(item["WasteType"], "mdi:help")
 
-            found = found = any(
+            found = any(
                 x.date == next_pickup_date and x.type == waste_type for x in entries
             )
             if not found:


### PR DESCRIPTION
They have inserted some "dummy" details in the json response for our area (at least) which does not contain all the bin type details resulting in string concatenation issues.
PR simply replace a `None` response with an empty string.