### PR TITLE
Fix kirklees_gov_uk: rewrite for new my.kirklees.gov.uk API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kirklees_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kirklees_gov_uk.py
@@ -1,139 +1,242 @@
-import logging
-import re
-from datetime import datetime
+from datetime import date, datetime, timedelta
+from time import time_ns
 from typing import Any
 
 import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
-_LOGGER = logging.getLogger(__name__)
 
 TITLE = "Kirklees Council"
-DESCRIPTION = "Source for waste collections for Kirklees Council"
+DESCRIPTION = "Source for waste collections for Kirklees Council (my.kirklees.gov.uk)"
 URL = "https://www.kirklees.gov.uk"
 TEST_CASES = {
-    "Test_001": {"door_num": 20, "postcode": "HD9 6LW"},
-    "test_002": {"door_num": "6", "postcode": "hd9 1js"},
-    "HD8 8NA, 1": {"door_num": "1", "postcode": "HD8 8NA", "uprn": "83194785"},
+    "Midgebottom House": {"uprn": "83074265", "postcode": "HD9 7HA"},
+    "HD8 8NA test": {"uprn": "83194785", "postcode": "HD8 8NA"},
 }
 
-BASE_URL = "https://www.kirklees.gov.uk/beta/your-property-bins-recycling/your-bins/"
+BASE_URL = "https://my.kirklees.gov.uk"
+SERVICE_PATH = "/service/Bins_and_recycling___Manage_your_bins"
+FORM_ID = "AF-Form-0d9c96d0-4067-4bea-9a5b-06f32a675be6"
 
-PARAMS = {
-    "__EVENTTARGET": "",
-    "__EVENTARGUMENT": "",
-    "__LASTFOCUS": "",
-    "__VIEWSTATE": "",
-    "__VIEWSTATEGENERATOR": "",
-    "__SCROLLPOSITIONX": "0",
-    "__SCROLLPOSITIONY": "0",
-    "__EVENTVALIDATION": "",
-    "ctl00$ctl00$cphPageBody$cphContent$hdnBinUPRN": "",
+LOOKUP_ADDRESS     = "58049013ca4c9"  # postcode → address list (keyed by UPRN)
+LOOKUP_PROP_TYPE   = "659c2c2386104"  # UPRN → GovDeliveryCategorye / PropertyType
+LOOKUP_UPRN_VALID  = "631615c4bd3b7"  # set session validatedUPRN token
+LOOKUP_COLLECTIONS = "65e08e60b299d"  # UPRN → bin collection dates (rows keyed by service ID)
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/javascript, */*; q=0.01",
+    "X-Requested-With": "XMLHttpRequest",
+    "Referer": f"{BASE_URL}{SERVICE_PATH}",
 }
-
-COLLECTION_REGEX = (
-    "(Recycling|Domestic|Garden Waste).*collection date ([0-3][0-9] [a-zA-Z]* [0-9]{4})"
-)
 
 ICON_MAP = {
-    "DOMESTIC": "mdi:trash-can",
-    "RECYCLING": "mdi:recycle",
-    "GARDEN WASTE": "mdi:leaf",
+    "recycling": "mdi:recycle",
+    "domestic":  "mdi:trash-can",
+    "garden":    "mdi:leaf",
+    "green":     "mdi:recycle",
+    "grey":      "mdi:trash-can",
+    "brown":     "mdi:leaf",
+    "blue":      "mdi:recycle",
 }
+
+
+def _icon(waste_type: str) -> str:
+    t = waste_type.lower()
+    for k, v in ICON_MAP.items():
+        if k in t:
+            return v
+    return "mdi:trash-can"
+
+
+def _run_lookup(s: requests.Session, sid: str, lookup_id: str, payload: dict) -> dict:
+    ts = time_ns() // 1_000_000
+    url = (
+        f"{BASE_URL}/apibroker/runLookup"
+        f"?id={lookup_id}&repeat_against=&noRetry=false"
+        f"&getOnlyTokens=undefined&log_id=&app_name=AF-Renderer::Self"
+        f"&_={ts}&sid={sid}"
+    )
+    r = s.post(url, headers=HEADERS, json=payload, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def _rows(data: dict) -> dict:
+    """Normalise rows_data to a dict regardless of whether the API returned a list or dict."""
+    raw = data.get("integration", {}).get("transformed", {}).get("rows_data", {})
+    if isinstance(raw, dict):
+        return raw
+    return {str(r.get("name", i)): r for i, r in enumerate(raw)}
 
 
 class Source:
-    def __init__(
-        self, door_num: str | int, postcode: str, uprn: str | int | None = None
-    ):
-        self._door_num = door_num
-        self._postcode = postcode
-        self._uprn = uprn
-        self._session = requests.Session()
-        self._params: dict[str, Any] = PARAMS
+    def __init__(self, uprn: str | int, postcode: str, predict: bool = False):
+        self._uprn = str(uprn)
+        pc = postcode.strip().upper().replace(" ", "")
+        self._postcode = pc[:-3] + " " + pc[-3:] if len(pc) >= 5 else pc
+        self._predict = predict
 
-    def _update_params(self, soup: BeautifulSoup) -> None:
-        self._params = {k: v for k, v in PARAMS.items()}
+    def fetch(self) -> list[Any]:
+        s = requests.Session()
 
-        self._params["__VIEWSTATE"] = (
-            soup.select_one("input#__VIEWSTATE") or dict[str, str]()
-        ).get("value")
-        self._params["__VIEWSTATEGENERATOR"] = (
-            soup.select_one("input#__VIEWSTATEGENERATOR") or dict[str, str]()
-        ).get("value")
-        self._params["__EVENTVALIDATION"] = (
-            soup.select_one("input#__EVENTVALIDATION") or dict[str, str]()
-        ).get("value")
+        # 1. Init session cookies
+        ts = time_ns() // 1_000_000
+        s.get(
+            f"{BASE_URL}/apibroker/domain/my.kirklees.gov.uk?_={ts}",
+            headers=HEADERS,
+            timeout=30,
+        ).raise_for_status()
 
-        if soup.find(
-            "input",
-            {"name": "ctl00$ctl00$cphPageBody$cphContent$thisGeoSearch$txtGeoPremises"},
-        ):
-            self._params[
-                "ctl00$ctl00$cphPageBody$cphContent$thisGeoSearch$txtGeoPremises"
-            ] = self._door_num
-            self._params[
-                "ctl00$ctl00$cphPageBody$cphContent$thisGeoSearch$txtGeoSearch"
-            ] = self._postcode
-            self._params[
-                "ctl00$ctl00$cphPageBody$cphContent$thisGeoSearch$butGeoSearch"
-            ] = (soup.select_one("input#butGeoSearch") or dict[str, str]()).get("value")
-
-        if soup.select_one("table#dagAddressList"):
-            self._params["ctl00$ctl00$cphPageBody$cphContent$hdnBinUPRN"] = self._uprn
-            self._params["UPRN"] = self._uprn
-            self._params[
-                "ctl00$ctl00$cphPageBody$cphContent$thisGeoSearch$butSelectAddress"
-            ] = (soup.select_one("input#butSelectAddress") or dict[str, str]()).get(
-                "value"
-            )
-
-    def fetch(self):
-        entries = []
-        self._session.cookies.set(
-            "cookiesacceptedGDPR", "true", domain=".kirklees.gov.uk"
+        # 2. Obtain auth-session SID
+        auth_url = (
+            f"{BASE_URL}/authapi/isauthenticated"
+            f"?uri=https%3A%2F%2Fmy.kirklees.gov.uk%2Fservice%2FBins_and_recycling___Manage_your_bins"
+            f"&hostname=my.kirklees.gov.uk&withCredentials=true"
         )
+        sid_r = s.get(auth_url, headers=HEADERS, timeout=30)
+        sid_r.raise_for_status()
+        sid = sid_r.json().get("auth-session")
+        if not sid:
+            raise ValueError("Kirklees API: failed to obtain session ID")
 
-        r0 = self._session.get(f"{BASE_URL}/default.aspx")
-        r0.raise_for_status()
-        r0_bs4 = BeautifulSoup(r0.text, features="html.parser")
-        self._update_params(r0_bs4)
-        r1 = self._session.get(f"{BASE_URL}/default.aspx", params=self._params)
-        r1.raise_for_status()
-        r1_bs4 = BeautifulSoup(r1.text, features="html.parser")
-
-        if r1_bs4.select_one("table#dagAddressList"):
-            # If multiple addresses are found, we need to select one with UPRN
-            if not self._uprn:
-                raise ValueError("UPRN Required for this address")
-            self._update_params(r1_bs4)
-            r1 = self._session.post(f"{BASE_URL}/default.aspx", data=self._params)
-            r1.raise_for_status()
-            r1_bs4 = BeautifulSoup(r1.text, features="html.parser")
-
-        cal_link = r1_bs4.find(
-            "a", {"id": "cphPageBody_cphContent_wtcDomestic240__LnkCalendar"}
-        )["href"]
-
-        r2 = self._session.get(f"{BASE_URL}/{cal_link}")
-        r2.raise_for_status()
-        r2_bs4 = BeautifulSoup(r2.text, features="html.parser")
-
-        for collection in r2_bs4.find_all(
-            "img",
-            {
-                "id": re.compile(
-                    "^cphPageBody_cphContent_rptr_Sticker_rptr_Collections_[0-9]_rptr_Bins_[0-9]_img_binType_[0-9]"
-                )
+        # 3. Postcode lookup — validate the UPRN is at this postcode
+        addr_data = _run_lookup(s, sid, LOOKUP_ADDRESS, {
+            "formId": FORM_ID,
+            "formValues": {
+                "Section 1": {"Postcode": {"value": self._postcode}}
             },
-        ):
-            matches = re.findall(COLLECTION_REGEX, collection["alt"])
-            entries.append(
-                Collection(
-                    date=datetime.strptime(matches[0][1], "%d %B %Y").date(),
-                    t=matches[0][0],
-                    icon=ICON_MAP.get(matches[0][0].upper()),
-                )
+        })
+        addr_rows = _rows(addr_data)
+        if self._uprn not in addr_rows:
+            raise ValueError(
+                f"Kirklees: UPRN {self._uprn} not found for postcode {self._postcode}. "
+                f"Found: {list(addr_rows.keys())}"
             )
+
+        # 4. Build shared "Search" form section (mirrors browser state after address selection)
+        prop_ref  = addr_rows[self._uprn].get("PropertyReference", "")
+        house     = addr_rows[self._uprn].get("Premise", "")
+        street    = addr_rows[self._uprn].get("Street", "")
+        town      = addr_rows[self._uprn].get("Town", "")
+        full_addr = addr_rows[self._uprn].get("display", "")
+        pc_len    = str(len(self._postcode))
+
+        search_section: dict[str, Any] = {
+            "PowerSuite_Available":  {"value": "True"},
+            "PowerSuite_Available1": {"value": "True"},
+            "productName":           {"value": "Self"},
+            "uprn2":                 {"value": self._uprn},
+            "validatedUPRN":         {"value": self._uprn},
+            "suppliedUPRN":          {"value": self._uprn},
+            "uprnFinal":             {"value": self._uprn},
+            "validPropertyFlag":     {"value": "yes"},
+            "sSection":              {"value": "1"},
+            "flatOrSubBuildingFinal":{"value": ""},
+            "houseFinal":            {"value": house},
+            "streetFinal":           {"value": street},
+            "townFinal":             {"value": town},
+            "postcodeFinal":         {"value": self._postcode},
+            "fullAddressFinal":      {"value": full_addr},
+            "customerAddress": {
+                "value": {
+                    "Section 1": {
+                        "searchForAddress":  {"value": "yes"},
+                        "Postcode":          {"value": self._postcode},
+                        "List":              {"value": self._uprn},
+                        "House":             {"value": house},
+                        "Street":            {"value": street},
+                        "Town":              {"value": town},
+                        "UPRN":              {"value": self._uprn},
+                        "PropertyReference": {"value": prop_ref},
+                        "postcode":          {"value": ""},
+                        "house":             {"value": ""},
+                        "flat":              {"value": ""},
+                        "street":            {"value": ""},
+                        "town":              {"value": ""},
+                        "fullAddress":       {"value": full_addr},
+                        "lengthPostCode":    {"value": pc_len},
+                    }
+                }
+            },
+        }
+
+        # 5. Get GovDeliveryCategorye for this property
+        prop_data = _run_lookup(s, sid, LOOKUP_PROP_TYPE, {
+            "formId": FORM_ID,
+            "formValues": {"Search": search_section},
+        })
+        prop_rows = _rows(prop_data)
+        gov_cat   = ""
+        prop_type = "Residential"
+        if prop_rows:
+            first     = next(iter(prop_rows.values()))
+            gov_cat   = first.get("GovDeliveryCategorye", "")
+            prop_type = first.get("PropertyType", "Residential") or "Residential"
+
+        search_section["binsPropertyType"] = {
+            "value": {
+                "Section 1": {
+                    "PropertyType":         {"value": prop_type},
+                    "GovDeliveryCategorye": {"value": gov_cat},
+                }
+            }
+        }
+        search_section["GovDeliveryCategorye"] = {"value": gov_cat}
+        search_section["PropertyType"]         = {"value": prop_type}
+
+        # 6. Set session validatedUPRN token
+        _run_lookup(s, sid, LOOKUP_UPRN_VALID, {
+            "formId": FORM_ID,
+            "formValues": {"Search": search_section},
+        })
+
+        # 7. Fetch collection dates
+        today     = date.today()
+        from_date = (today - timedelta(days=7)).strftime("%d/%m/%Y")
+        to_date   = (today + timedelta(days=28)).strftime("%d/%m/%Y")
+
+        col_data = _run_lookup(s, sid, LOOKUP_COLLECTIONS, {
+            "formId": FORM_ID,
+            "formValues": {
+                "Search": search_section,
+                "Your bins": {
+                    "GovDeliveryCategorye":   {"value": gov_cat},
+                    "NextCollectionFromDate": {"value": from_date},
+                    "NextCollectionToDate":   {"value": to_date},
+                },
+            },
+        })
+        col_rows = _rows(col_data)
+
+        if not col_rows:
+            raise ValueError(
+                f"Kirklees: no collection data returned for UPRN {self._uprn}."
+            )
+
+        entries: list[Any] = []
+        for row in col_rows.values():
+            date_str = row.get("NextCollectionDate", "")
+            bin_type = row.get("label", "") or row.get("ServiceItemName", "")
+            if not date_str or not bin_type:
+                continue
+            # API returns ISO format "2026-04-20T00:00:00"
+            try:
+                col_date = datetime.fromisoformat(date_str).date()
+            except ValueError:
+                continue
+            # Kirklees residential collections are fortnightly
+            dates = [col_date]
+            if self._predict:
+                for i in range(1, 365 // 14):
+                    dates.append(col_date + timedelta(days=14 * i))
+            for d in dates:
+                entries.append(
+                    Collection(date=d, t=str(bin_type), icon=_icon(str(bin_type)))
+                )
+
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kirklees_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kirklees_gov_uk.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
-
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 
 TITLE = "Kirklees Council"
 DESCRIPTION = "Source for waste collections for Kirklees Council (my.kirklees.gov.uk)"
@@ -18,10 +18,12 @@ BASE_URL = "https://my.kirklees.gov.uk"
 SERVICE_PATH = "/service/Bins_and_recycling___Manage_your_bins"
 FORM_ID = "AF-Form-0d9c96d0-4067-4bea-9a5b-06f32a675be6"
 
-LOOKUP_ADDRESS     = "58049013ca4c9"  # postcode → address list (keyed by UPRN)
-LOOKUP_PROP_TYPE   = "659c2c2386104"  # UPRN → GovDeliveryCategorye / PropertyType
-LOOKUP_UPRN_VALID  = "631615c4bd3b7"  # set session validatedUPRN token
-LOOKUP_COLLECTIONS = "65e08e60b299d"  # UPRN → bin collection dates (rows keyed by service ID)
+LOOKUP_ADDRESS = "58049013ca4c9"  # postcode → address list (keyed by UPRN)
+LOOKUP_PROP_TYPE = "659c2c2386104"  # UPRN → GovDeliveryCategorye / PropertyType
+LOOKUP_UPRN_VALID = "631615c4bd3b7"  # set session validatedUPRN token
+LOOKUP_COLLECTIONS = (
+    "65e08e60b299d"  # UPRN → bin collection dates (rows keyed by service ID)
+)
 
 HEADERS = {
     "User-Agent": (
@@ -36,12 +38,12 @@ HEADERS = {
 
 ICON_MAP = {
     "recycling": "mdi:recycle",
-    "domestic":  "mdi:trash-can",
-    "garden":    "mdi:leaf",
-    "green":     "mdi:recycle",
-    "grey":      "mdi:trash-can",
-    "brown":     "mdi:leaf",
-    "blue":      "mdi:recycle",
+    "domestic": "mdi:trash-can",
+    "garden": "mdi:leaf",
+    "green": "mdi:recycle",
+    "grey": "mdi:trash-can",
+    "brown": "mdi:leaf",
+    "blue": "mdi:recycle",
 }
 
 
@@ -81,7 +83,7 @@ class Source:
         self._postcode = pc[:-3] + " " + pc[-3:] if len(pc) >= 5 else pc
         self._predict = predict
 
-    def fetch(self) -> list[Any]:
+    def fetch(self) -> list[Collection]:
         s = requests.Session()
 
         # 1. Init session cookies
@@ -105,112 +107,129 @@ class Source:
             raise ValueError("Kirklees API: failed to obtain session ID")
 
         # 3. Postcode lookup — validate the UPRN is at this postcode
-        addr_data = _run_lookup(s, sid, LOOKUP_ADDRESS, {
-            "formId": FORM_ID,
-            "formValues": {
-                "Section 1": {"Postcode": {"value": self._postcode}}
+        addr_data = _run_lookup(
+            s,
+            sid,
+            LOOKUP_ADDRESS,
+            {
+                "formId": FORM_ID,
+                "formValues": {"Section 1": {"Postcode": {"value": self._postcode}}},
             },
-        })
+        )
         addr_rows = _rows(addr_data)
         if self._uprn not in addr_rows:
-            raise ValueError(
-                f"Kirklees: UPRN {self._uprn} not found for postcode {self._postcode}. "
-                f"Found: {list(addr_rows.keys())}"
+            raise SourceArgumentNotFoundWithSuggestions(
+                "uprn", self._uprn, list(addr_rows.keys())
             )
 
         # 4. Build shared "Search" form section (mirrors browser state after address selection)
-        prop_ref  = addr_rows[self._uprn].get("PropertyReference", "")
-        house     = addr_rows[self._uprn].get("Premise", "")
-        street    = addr_rows[self._uprn].get("Street", "")
-        town      = addr_rows[self._uprn].get("Town", "")
+        prop_ref = addr_rows[self._uprn].get("PropertyReference", "")
+        house = addr_rows[self._uprn].get("Premise", "")
+        street = addr_rows[self._uprn].get("Street", "")
+        town = addr_rows[self._uprn].get("Town", "")
         full_addr = addr_rows[self._uprn].get("display", "")
-        pc_len    = str(len(self._postcode))
+        pc_len = str(len(self._postcode))
 
         search_section: dict[str, Any] = {
-            "PowerSuite_Available":  {"value": "True"},
+            "PowerSuite_Available": {"value": "True"},
             "PowerSuite_Available1": {"value": "True"},
-            "productName":           {"value": "Self"},
-            "uprn2":                 {"value": self._uprn},
-            "validatedUPRN":         {"value": self._uprn},
-            "suppliedUPRN":          {"value": self._uprn},
-            "uprnFinal":             {"value": self._uprn},
-            "validPropertyFlag":     {"value": "yes"},
-            "sSection":              {"value": "1"},
-            "flatOrSubBuildingFinal":{"value": ""},
-            "houseFinal":            {"value": house},
-            "streetFinal":           {"value": street},
-            "townFinal":             {"value": town},
-            "postcodeFinal":         {"value": self._postcode},
-            "fullAddressFinal":      {"value": full_addr},
+            "productName": {"value": "Self"},
+            "uprn2": {"value": self._uprn},
+            "validatedUPRN": {"value": self._uprn},
+            "suppliedUPRN": {"value": self._uprn},
+            "uprnFinal": {"value": self._uprn},
+            "validPropertyFlag": {"value": "yes"},
+            "sSection": {"value": "1"},
+            "flatOrSubBuildingFinal": {"value": ""},
+            "houseFinal": {"value": house},
+            "streetFinal": {"value": street},
+            "townFinal": {"value": town},
+            "postcodeFinal": {"value": self._postcode},
+            "fullAddressFinal": {"value": full_addr},
             "customerAddress": {
                 "value": {
                     "Section 1": {
-                        "searchForAddress":  {"value": "yes"},
-                        "Postcode":          {"value": self._postcode},
-                        "List":              {"value": self._uprn},
-                        "House":             {"value": house},
-                        "Street":            {"value": street},
-                        "Town":              {"value": town},
-                        "UPRN":              {"value": self._uprn},
+                        "searchForAddress": {"value": "yes"},
+                        "Postcode": {"value": self._postcode},
+                        "List": {"value": self._uprn},
+                        "House": {"value": house},
+                        "Street": {"value": street},
+                        "Town": {"value": town},
+                        "UPRN": {"value": self._uprn},
                         "PropertyReference": {"value": prop_ref},
-                        "postcode":          {"value": ""},
-                        "house":             {"value": ""},
-                        "flat":              {"value": ""},
-                        "street":            {"value": ""},
-                        "town":              {"value": ""},
-                        "fullAddress":       {"value": full_addr},
-                        "lengthPostCode":    {"value": pc_len},
+                        "postcode": {"value": ""},
+                        "house": {"value": ""},
+                        "flat": {"value": ""},
+                        "street": {"value": ""},
+                        "town": {"value": ""},
+                        "fullAddress": {"value": full_addr},
+                        "lengthPostCode": {"value": pc_len},
                     }
                 }
             },
         }
 
         # 5. Get GovDeliveryCategorye for this property
-        prop_data = _run_lookup(s, sid, LOOKUP_PROP_TYPE, {
-            "formId": FORM_ID,
-            "formValues": {"Search": search_section},
-        })
+        prop_data = _run_lookup(
+            s,
+            sid,
+            LOOKUP_PROP_TYPE,
+            {
+                "formId": FORM_ID,
+                "formValues": {"Search": search_section},
+            },
+        )
         prop_rows = _rows(prop_data)
-        gov_cat   = ""
+        gov_cat = ""
         prop_type = "Residential"
         if prop_rows:
-            first     = next(iter(prop_rows.values()))
-            gov_cat   = first.get("GovDeliveryCategorye", "")
+            first = next(iter(prop_rows.values()))
+            gov_cat = first.get("GovDeliveryCategorye", "")
             prop_type = first.get("PropertyType", "Residential") or "Residential"
 
         search_section["binsPropertyType"] = {
             "value": {
                 "Section 1": {
-                    "PropertyType":         {"value": prop_type},
+                    "PropertyType": {"value": prop_type},
                     "GovDeliveryCategorye": {"value": gov_cat},
                 }
             }
         }
         search_section["GovDeliveryCategorye"] = {"value": gov_cat}
-        search_section["PropertyType"]         = {"value": prop_type}
+        search_section["PropertyType"] = {"value": prop_type}
 
         # 6. Set session validatedUPRN token
-        _run_lookup(s, sid, LOOKUP_UPRN_VALID, {
-            "formId": FORM_ID,
-            "formValues": {"Search": search_section},
-        })
+        _run_lookup(
+            s,
+            sid,
+            LOOKUP_UPRN_VALID,
+            {
+                "formId": FORM_ID,
+                "formValues": {"Search": search_section},
+            },
+        )
 
         # 7. Fetch collection dates
-        today     = date.today()
+        today = date.today()
         from_date = (today - timedelta(days=7)).strftime("%d/%m/%Y")
-        to_date   = (today + timedelta(days=28)).strftime("%d/%m/%Y")
+        to_date = (today + timedelta(days=28)).strftime("%d/%m/%Y")
 
-        col_data = _run_lookup(s, sid, LOOKUP_COLLECTIONS, {
-            "formId": FORM_ID,
-            "formValues": {
-                "Search": search_section,
-                "Your bins": {
-                    "GovDeliveryCategorye":   {"value": gov_cat},
-                    "NextCollectionFromDate": {"value": from_date},
-                    "NextCollectionToDate":   {"value": to_date},
+        col_data = _run_lookup(
+            s,
+            sid,
+            LOOKUP_COLLECTIONS,
+            {
+                "formId": FORM_ID,
+                "formValues": {
+                    "Search": search_section,
+                    "Your bins": {
+                        "GovDeliveryCategorye": {"value": gov_cat},
+                        "NextCollectionFromDate": {"value": from_date},
+                        "NextCollectionToDate": {"value": to_date},
+                    },
                 },
             },
-        })
+        )
         col_rows = _rows(col_data)
 
         if not col_rows:
@@ -218,7 +237,7 @@ class Source:
                 f"Kirklees: no collection data returned for UPRN {self._uprn}."
             )
 
-        entries: list[Any] = []
+        entries: list[Collection] = []
         for row in col_rows.values():
             date_str = row.get("NextCollectionDate", "")
             bin_type = row.get("label", "") or row.get("ServiceItemName", "")

--- a/doc/source/kirklees_gov_uk.md
+++ b/doc/source/kirklees_gov_uk.md
@@ -1,6 +1,7 @@
 # Kirklees Council
 
-Support for schedules provided by [Kirklees Council](https://www.kirklees.gov.uk)
+Support for schedules provided by [Kirklees Council](https://www.kirklees.gov.uk),
+served by the `my.kirklees.gov.uk` self-service portal.
 
 ## Configuration via configuration.yaml
 
@@ -9,36 +10,39 @@ waste_collection_schedule:
     sources:
     - name: kirklees_gov_uk
       args:
-        door_num: 1
-        postcode: "HD9 6RJ"
-        uprn: UPRN # only required sometimes
+        uprn: "83194785"
+        postcode: "HD8 8NA"
 ```
 
 ### Configuration Variables
 
-**door_num**  
+**uprn**  
 *(string) (required)*
 
-Door number identifier for the property
+Unique Property Reference Number (UPRN) of the property. An easy way to discover
+your UPRN is by going to <https://www.findmyaddress.co.uk/> and entering your
+address details.
 
 **postcode**  
 *(string) (required)*
 
-Postcode of the property
+Postcode of the property.
 
-**uprn**  
-*(string) (optional)*
+**predict**  
+*(boolean) (optional, default: `False`)*
 
-Unique Property Reference Number (UPRN) of the property. This is required if multiple properties are found when searching by door number and postcode. An easy way to discover your Unique Property Reference Number (UPRN) is by going to <https://www.findmyaddress.co.uk/> and entering in your address details.
+Kirklees only returns the next collection date per bin type. With `predict: true`,
+the source extrapolates a year of fortnightly dates from the next known date —
+useful when consuming the data outside Home Assistant (e.g. exporting to a static
+calendar). Home Assistant users typically don't need this, since the integration
+refreshes nightly.
 
-## Example with UPRN
+## Notes
 
-```yaml
-waste_collection_schedule:
-    sources:
-    - name: kirklees_gov_uk
-      args:
-        door_num: 1
-        postcode: "HD8 8NA"
-        uprn: 83194785
-```
+This source uses the new `my.kirklees.gov.uk` JSON API. The previous source
+scraped the now-defunct `kirklees.gov.uk/beta/your-property-bins-recycling/`
+HTML pages and stopped working when Kirklees moved to their new portal.
+
+**Breaking change:** the previous version accepted `door_num + postcode` and
+optionally `uprn`. The new API requires `uprn` directly — `door_num` is no
+longer accepted.


### PR DESCRIPTION
Kirklees migrated from the old beta/HTML site to `my.kirklees.gov.uk`'s JSON form-builder API. The current source has been broken since then (see #2988).

Rewrites the source to use the new API end-to-end:
1. `domain/my.kirklees.gov.uk` → cookies
2. `authapi/isauthenticated` → auth-session SID
3. `apibroker/runLookup` → postcode lookup, property type, `validatedUPRN`, then collection dates.

## ⚠️ Breaking change for `kirklees_gov_uk` users

| | Before | After |
|---|---|---|
| Required | `door_num + postcode` | `uprn + postcode` |
| Optional | `uprn` | — |

The new API is keyed on UPRN, so `door_num` is no longer accepted. Users can find their UPRN at <https://www.findmyaddress.co.uk/>. Doc page updated.

## Tested live (2026-04-28)

- `HD9 7HA` (UPRN `83074265`) → Grey + Green wheelie bin dates ✅
- `HD8 8NA` (UPRN `83194785`) → Grey + Green wheelie bin dates ✅

## New optional arg: `predict`

Adds `predict: bool = False`. When `True`, the source extrapolates a year of fortnightly dates from the next known date. Default `False` — no behaviour change for HA users (who get nightly refreshes anyway). Useful for consumers exporting to static `.ics` files.

Closes #2988