### PR TITLE
Accept localities within Varberg/Falkenberg municipalities

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vivab_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vivab_se.py
@@ -35,6 +35,20 @@ API_URLS = {
     "varberg": "https://minasidor.vivab.info/FutureWebVarberg/SimpleWastePickup/",
 }
 
+# Localities (tätorter) within each municipality served by VIVAB.
+# Used to resolve a street_address to the correct regional API.
+MUNICIPALITY_LOCALITIES = {
+    "varberg": [
+        "varberg", "bua", "kungsäter", "rolfstorp", "skällinge",
+        "stråvalla", "träslövsläge", "tvååker", "veddige",
+        "väröbacka", "åskloster", "åsa",
+    ],
+    "falkenberg": [
+        "falkenberg", "glommen", "långås", "skogstorp", "slöinge",
+        "ullared", "vessigebro", "ätran", "älvsered",
+    ],
+}
+
 
 class Source:
     def __init__(self, street_address: str, building_id: str | int | None = None):
@@ -46,11 +60,12 @@ class Source:
 
         self._building_id = building_id
         self._street_address = street_address
+        addr_lower = street_address.lower()
         region = None
-        if "falkenberg" in street_address.lower():
-            region = "falkenberg"
-        elif "varberg" in street_address.lower():
-            region = "varberg"
+        for municipality, localities in MUNICIPALITY_LOCALITIES.items():
+            if any(re.search(rf"\b{re.escape(loc)}\b", addr_lower) for loc in localities):
+                region = municipality
+                break
         if region is None:
             if self._building_id:
                 raise SourceArgumentSuggestionsExceptionBase(
@@ -60,7 +75,7 @@ class Source:
                 )
             raise SourceArgumentException(
                 "street_address",
-                "Address not supported should end with ', Varberg' or ', Falkenberg'",
+                "Address not supported, should end with a locality within the Varberg or Falkenberg municipality (e.g. 'Varberg', 'Veddige', 'Tvååker', 'Falkenberg', 'Ullared', 'Vessigebro')",
             )
         self._api_url = API_URLS[region]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vivab_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vivab_se.py
@@ -39,13 +39,29 @@ API_URLS = {
 # Used to resolve a street_address to the correct regional API.
 MUNICIPALITY_LOCALITIES = {
     "varberg": [
-        "varberg", "bua", "kungsäter", "rolfstorp", "skällinge",
-        "stråvalla", "träslövsläge", "tvååker", "veddige",
-        "väröbacka", "åskloster", "åsa",
+        "varberg",
+        "bua",
+        "kungsäter",
+        "rolfstorp",
+        "skällinge",
+        "stråvalla",
+        "träslövsläge",
+        "tvååker",
+        "veddige",
+        "väröbacka",
+        "åskloster",
+        "åsa",
     ],
     "falkenberg": [
-        "falkenberg", "glommen", "långås", "skogstorp", "slöinge",
-        "ullared", "vessigebro", "ätran", "älvsered",
+        "falkenberg",
+        "glommen",
+        "långås",
+        "skogstorp",
+        "slöinge",
+        "ullared",
+        "vessigebro",
+        "ätran",
+        "älvsered",
     ],
 }
 
@@ -63,7 +79,9 @@ class Source:
         addr_lower = street_address.lower()
         region = None
         for municipality, localities in MUNICIPALITY_LOCALITIES.items():
-            if any(re.search(rf"\b{re.escape(loc)}\b", addr_lower) for loc in localities):
+            if any(
+                re.search(rf"\b{re.escape(loc)}\b", addr_lower) for loc in localities
+            ):
                 region = municipality
                 break
         if region is None:

--- a/doc/source/vivab_se.md
+++ b/doc/source/vivab_se.md
@@ -16,7 +16,7 @@ waste_collection_schedule:
 ### Configuration Variables
 
 **street_address**  
-*(string) (required)* The address of the property to get the waste collection schedule for. Should end with Varberg or Falkenberg.
+*(string) (required)* The address of the property to get the waste collection schedule for. Should end with a locality within the Varberg or Falkenberg municipality, e.g. Varberg, Veddige, Tvååker, Bua, Träslövsläge, Väröbacka, Åsa, Falkenberg, Ullared, Vessigebro, Slöinge, Glommen.
 
 **building_id**  
 *(string) (optional)* You can also provide the building id, which is shown behind the search result on the website. You still need to set street address to "Varberg" or "Falkenberg". Might be required if there are two results for the same address.


### PR DESCRIPTION
## Summary

VIVAB serves the entire Varberg and Falkenberg municipalities, but the source previously only accepted addresses containing the substrings `varberg` or `falkenberg`. Residents in smaller localities within those municipalities (Veddige, Tvååker, Bua, Träslövsläge, Ullared, Vessigebro, Slöinge, etc.) could not configure the integration even though their addresses are served by the same regional API.

## Changes

- Add a `MUNICIPALITY_LOCALITIES` map listing the known tätorter for each municipality.
- Replace the two-branch substring check in `Source.__init__` with a word-boundary regex match against that list, so e.g. `"Storgatan 1, Veddige"` correctly resolves to the Varberg API.
- Update the user-facing error message and the docs (`doc/source/vivab_se.md`) to reflect the broader set of supported localities.

Existing `, Varberg` / `, Falkenberg` configs (and the `building_id` flow) continue to work unchanged.

## Test plan

- [x] Existing `TEST_CASES` (Varberg & Falkenberg) still pass via `test_sources.py -s vivab_se`.
- [x] Logic-level verification: addresses ending in Veddige, Tvååker, Bua, Ullared, Vessigebro now resolve to the correct regional API; unrelated cities (e.g. Stockholm) are still rejected.