### PR TITLE
Fix richmond_gov_uk: restore PARAM_TRANSLATIONS/PARAM_DESCRIPTIONS

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/richmond_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/richmond_gov_uk.py
@@ -17,6 +17,20 @@ TEST_CASES = {
 
 API_URL = "https://www.richmond.gov.uk/my_richmond"
 
+PARAM_TRANSLATIONS = {
+    "en": {"uprn": "Property UPRN (Unique Property Reference Number)"},
+    "de": {"uprn": "UPRN der Immobilie"},
+    "it": {"uprn": "UPRN della proprietà"},
+    "fr": {"uprn": "UPRN du bien"},
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {"uprn": "Find your UPRN at https://www.findmyaddress.co.uk/"},
+    "de": {"uprn": "Finden Sie Ihre UPRN unter https://www.findmyaddress.co.uk/"},
+    "it": {"uprn": "Trova il tuo UPRN su https://www.findmyaddress.co.uk/"},
+    "fr": {"uprn": "Trouvez votre UPRN sur https://www.findmyaddress.co.uk/"},
+}
+
 ICON_MAP = {
     "Glass, can, plastic and carton recycling": "mdi:recycle",
     "Paper and card recycling": "mdi:newspaper-variant",


### PR DESCRIPTION
Restores the `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` dicts for the `uprn` parameter that were accidentally removed in #6165. These are read by `update_docu_links.py` to generate UI labels in `translations/en.json` — without them the config flow shows the raw key `uprn` instead of a friendly label.