### PR TITLE
Fix Mid Sussex District Council URL change - Fixes #6144

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
@@ -97,9 +97,14 @@ class Source:
 
     def fetch(self) -> list[Collection]:
         entries = []
-        BASE_URL = "https://sms-wrp.whitespacews.com"
+        BASE_URL = "https://waste.services.midsussex.gov.uk"
 
         with requests.Session() as session:
+            session.headers.update({
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                'Accept-Language': 'en-GB,en;q=0.5',
+            })            
             # --- STEP 1: Get the Dynamic Track Token ---
             r1 = session.get(f"{BASE_URL}/mop.php", timeout=30)
             r1.raise_for_status()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
@@ -100,11 +100,13 @@ class Source:
         BASE_URL = "https://waste.services.midsussex.gov.uk"
 
         with requests.Session() as session:
-            session.headers.update({
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-                'Accept-Language': 'en-GB,en;q=0.5',
-            })            
+            session.headers.update(
+                {
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    "Accept-Language": "en-GB,en;q=0.5",
+                }
+            )
             # --- STEP 1: Get the Dynamic Track Token ---
             r1 = session.get(f"{BASE_URL}/mop.php", timeout=30)
             r1.raise_for_status()


### PR DESCRIPTION
Fixes #6144

**Problem:** The Mid Sussex District Council waste collection source stopped 
working because the Whitespace WRP portal migrated to a new domain. The old 
URL (https://sms-wrp.whitespacews.com) now returns "Access denied", causing 
Step 1 to fail when retrieving the dynamic Track token.

**Changes:**
- Updated BASE_URL from https://sms-wrp.whitespacews.com to https://waste.services.midsussex.gov.uk
- Added browser User-Agent and Accept headers to prevent access denied responses from the new server

**Tested:** Manually verified the full four-step scraping flow against the new 
URL — Track token retrieval, address submission, address selection, and schedule 
scraping all work correctly. Collection dates are returned correctly.