### PR TITLE
Fix srvatervinning_se: handle no-results response - Fixes #4960

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/srvatervinning_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/srvatervinning_se.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "SRV Återvinning"
 DESCRIPTION = "Source for SRV återvinning AB, Sweden"
@@ -34,6 +35,9 @@ class Source:
         r.raise_for_status()
 
         data = r.json()
+
+        if not data.get("results"):
+            raise SourceArgumentNotFound("address", self._address)
 
         entries = []
 


### PR DESCRIPTION
Fixes #4960

When the API returns no results for a given address, the source was crashing with an unhandled `IndexError: list index out of range` on `data["results"][0]`.

This adds a check for an empty results list and raises `SourceArgumentNotFound` instead, giving users a clear message that their address wasn't found.