### PR TITLE
Fix irenambiente_it: align fortnightly schedules to ISO week numbers - Fixes #6173

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/irenambiente_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/irenambiente_it.py
@@ -244,17 +244,16 @@ class Source:
     def _fortnightly_dtstart(flag_freq: str, year: int) -> datetime:
         """Compute DTSTART for fortnightly (2S) schedules.
 
-        The Iren annual calendar numbers weeks starting from the first
-        Monday of the year.  'Dispari' (odd) = weeks 1, 3, 5 …;
-        'Pari' (even) = weeks 2, 4, 6 ….
-
-        FlagFreq 'N' → dispari (start on first Monday).
-        FlagFreq 'P' → pari (start on second Monday).
+        Iren aligns odd/even weeks to ISO week numbers.
+        FlagFreq 'N' → dispari (odd ISO weeks); FlagFreq 'P' → pari (even ISO weeks).
+        The first Monday of the year may fall in an even or odd ISO week depending
+        on the year, so we check and shift by one week if needed.
         """
-        # Find first Monday of the year
         jan1 = datetime(year, 1, 1)
         first_monday = jan1 + timedelta(days=(7 - jan1.weekday()) % 7)
-        if flag_freq == "P":
+        first_monday_is_odd = first_monday.isocalendar()[1] % 2 == 1
+        want_odd = flag_freq == "N"
+        if first_monday_is_odd != want_odd:
             first_monday += timedelta(weeks=1)
         return first_monday
 


### PR DESCRIPTION
Fixes #6173

The fortnightly (2S) odd/even week alignment was off. The first Monday of 2026 falls in ISO week 2 (even), so the previous logic produced even-week dates for `FlagFreq='N'` (dispari/odd) instead of odd ones.

The fix checks the ISO week number of the first Monday of the year and shifts by one week if it doesn't match the desired alignment. This is also robust across all years — in years where the first Monday already lands on an odd ISO week, no shift is needed.