### PR TITLE
Fix fareham_gov_uk: work around malformed JSON from API - Fixes #6186

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fareham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fareham_gov_uk.py
@@ -1,3 +1,4 @@
+import json
 import re
 from datetime import date
 from typing import Iterable
@@ -99,7 +100,7 @@ class Source:
         }
         response = requests.get(API_URL, params=params, headers=headers, timeout=30)
         response.raise_for_status()
-        payload = response.json()
+        payload = json.loads(self._fix_json(response.text))
         return payload.get("data", {}).get("rows", [])
 
     def _filter_rows(self, rows: Iterable[dict]):
@@ -125,6 +126,19 @@ class Source:
             matches.append(row)
 
         return matches
+
+    @staticmethod
+    def _fix_json(text: str) -> str:
+        rows_start = text.find('"rows": [')
+        if rows_start == -1:
+            return text
+        prefix = text[:rows_start]
+        rows_section = text[rows_start:]
+        # Remove incomplete stub entries: { "Row": "N", immediately followed by another {
+        rows_section = re.sub(r'\{\s*"Row":\s*"\d+",\s*(?=\{)', "", rows_section)
+        # Add missing { after }, when the next token is a property key
+        rows_section = re.sub(r"(},)(\s*)(\")", r"\1\2{\3", rows_section)
+        return prefix + rows_section
 
     @staticmethod
     def _normalize(value: str):


### PR DESCRIPTION
Fixes #6186

The Fareham API is returning structurally invalid JSON — each row entry in the `rows` array is missing its opening `{`. The first N stub rows (containing only a `"Row"` number) also lack closing braces.

Added a `_fix_json()` pre-parse step that:
1. Removes the incomplete stub entries (`{"Row": "N",` immediately followed by another `{`)
2. Inserts the missing `{` before orphaned property lists in the rows array

The fix is scoped to the `rows` array section only, leaving the rest of the response untouched.

Note: the URL was already updated to `DomesticBinCollections2025on` (from #5054), so this also closes that issue.