### PR TITLE
Fix elmbridge_gov_uk: handle rows_data as list when API returns no results - Fixes #6187

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/elmbridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/elmbridge_gov_uk.py
@@ -43,7 +43,9 @@ class Source:
     def __init__(self, uprn: str | int):
         self._uprn = str(uprn).strip()
 
-    def get_collections(self, session_key: str, session: requests.Session) -> list[Collection]:
+    def get_collections(
+        self, session_key: str, session: requests.Session
+    ) -> list[Collection]:
         result = run_lookup(
             session,
             API_URL,
@@ -51,7 +53,8 @@ class Source:
             "663b557cdaece",
             {"Section 1": {"UPRN": {"value": self._uprn}}},
         )
-        return list(result["integration"]["transformed"]["rows_data"].values())
+        rows_data = result["integration"]["transformed"]["rows_data"]
+        return list(rows_data.values()) if isinstance(rows_data, dict) else rows_data
 
     def fetch(self) -> list[Collection]:
         session = requests.Session()


### PR DESCRIPTION
Fixes #6187

The Elmbridge API returns `rows_data` as a `dict` when results are found, but as an empty `[]` list when no results are found. The source was calling `.values()` unconditionally, crashing with `'list' object has no attribute 'values'` for any UPRN the API returns no data for.

One-line fix: check the type before calling `.values()`.