### PR TITLE
Fix grafikai_svara_lt: rewrite for TanStack server-fn API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
@@ -58,20 +58,24 @@ def _seroval_encode_request(api_path: str, tenant_id: int = _TENANT_ID) -> str:
     return json.dumps(
         {
             "t": {
-                "t": 10, "i": 0,
+                "t": 10,
+                "i": 0,
                 "p": {
                     "k": ["data"],
-                    "v": [{
-                        "t": 10, "i": 1,
-                        "p": {
-                            "k": ["apiPath", "tenantId"],
-                            "v": [
-                                {"t": 1, "s": api_path},
-                                {"t": 2, "s": tenant_id},
-                            ],
-                        },
-                        "o": 0,
-                    }],
+                    "v": [
+                        {
+                            "t": 10,
+                            "i": 1,
+                            "p": {
+                                "k": ["apiPath", "tenantId"],
+                                "v": [
+                                    {"t": 1, "s": api_path},
+                                    {"t": 2, "s": tenant_id},
+                                ],
+                            },
+                            "o": 0,
+                        }
+                    ],
                 },
                 "o": 0,
             },
@@ -148,7 +152,7 @@ def _candidate_fn_ids(session: requests.Session) -> list[str]:
         html = session.get(_BASE_URL + "/", timeout=15).text
     except requests.RequestException:
         return []
-    bundles = re.findall(r'/assets/[A-Za-z0-9._-]+\.js', html)
+    bundles = re.findall(r"/assets/[A-Za-z0-9._-]+\.js", html)
     seen: set[str] = set()
     ordered: list[str] = []
     for bundle in bundles:
@@ -222,9 +226,7 @@ class Source:
             )
         return self._fn_id
 
-    def _raw_call(
-        self, session: requests.Session, fn_id: str, api_path: str
-    ) -> dict:
+    def _raw_call(self, session: requests.Session, fn_id: str, api_path: str) -> dict:
         payload = _seroval_encode_request(api_path)
         r = session.get(
             _SERVER_FN_URL_TEMPLATE.format(fn_id=fn_id) + "?payload=" + quote(payload),
@@ -237,9 +239,7 @@ class Source:
         # Anything other than a normal JSON 200 implies the fn_id is no
         # longer valid (most likely upstream redeployed). Signal stale and
         # let the caller re-discover and retry once.
-        if r.status_code != 200 or "json" not in r.headers.get(
-            "content-type", ""
-        ):
+        if r.status_code != 200 or "json" not in r.headers.get("content-type", ""):
             raise _StaleFnId(f"fn_id {fn_id} returned HTTP {r.status_code}")
         decoded = _seroval_decode(r.json()) or {}
         if "result" not in decoded:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
@@ -1,5 +1,7 @@
 import json
+import re
 from datetime import datetime
+from urllib.parse import quote, urlencode
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
@@ -13,7 +15,6 @@ TEST_CASES = {
         "region": "Kauno m. sav.",
         "street": "Demokratų g.",
         "house_number": "7",
-        "waste_object_ids": [101358, 100858, 100860],
     },
     "Alytaus g. 2, Išlaužo k., Išlaužo sen. Prienų r. sav.": {
         "region": "Prienų r. sav.",
@@ -30,10 +31,158 @@ ICON_MAP = {
     "žaliųjų atliekų": "mdi:leaf",
 }
 
+# In late April 2026 grafikai.svara.lt was rewritten as a TanStack Start
+# (TSR) React app. The previous REST endpoints (/api/contracts,
+# /api/schedule) are gone — the new architecture proxies all data fetching
+# through a single server function: GET /_serverFn/<sha256> with a Seroval-
+# encoded payload of {data: {apiPath, tenantId}}.
+#
+# The function id is a sha256 baked into the JS bundle at build time and
+# changes every time upstream rebuilds. We scrape the live JS bundles to
+# find candidate ids and probe each against /schedule/getdistricts to pick
+# the data-fetching one — no hardcoded id, no manual updates needed when
+# upstream redeploys.
+_BASE_URL = "https://grafikai.svara.lt"
+_SERVER_FN_URL_TEMPLATE = _BASE_URL + "/_serverFn/{fn_id}"
+_TENANT_ID = 1
+
+
+def _seroval_encode_request(api_path: str, tenant_id: int = _TENANT_ID) -> str:
+    """Encode a {data: {apiPath, tenantId}} payload as Seroval JSON.
+
+    The full Seroval format is rich (handles cycles, refs, dates, regex, etc.),
+    but the request payload here is tiny and acyclic — just two scalars wrapped
+    in two object levels. We can hand-encode it directly without pulling in a
+    Seroval library.
+    """
+    return json.dumps(
+        {
+            "t": {
+                "t": 10, "i": 0,
+                "p": {
+                    "k": ["data"],
+                    "v": [{
+                        "t": 10, "i": 1,
+                        "p": {
+                            "k": ["apiPath", "tenantId"],
+                            "v": [
+                                {"t": 1, "s": api_path},
+                                {"t": 2, "s": tenant_id},
+                            ],
+                        },
+                        "o": 0,
+                    }],
+                },
+                "o": 0,
+            },
+            "f": 63,
+            "m": [],
+        },
+        separators=(",", ":"),
+    )
+
+
+def _seroval_decode(node):
+    """Decode a Seroval-encoded value tree to a Python value.
+
+    Handles the small subset of Seroval node types this API actually returns:
+        t=0 number, t=1 string, t=2 bigint (we coerce to int),
+        t=9 array, t=10/t=11 plain object.
+    """
+    if not isinstance(node, dict):
+        return node
+    t = node.get("t")
+    if t == 0:
+        return node.get("s")
+    if t == 1:
+        return node.get("s")
+    if t == 2:
+        return node.get("s")
+    if t == 9:
+        return [_seroval_decode(item) for item in node.get("a", [])]
+    if t in (10, 11):
+        p = node.get("p") or {}
+        keys = p.get("k", [])
+        vals = p.get("v", [])
+        return {k: _seroval_decode(v) for k, v in zip(keys, vals)}
+    return None
+
+
+def _probe_data_fetcher(session: requests.Session, fn_id: str) -> bool:
+    """Return True if `fn_id` is the data-fetching server function.
+
+    Probes by calling /schedule/getdistricts (the cheapest known-safe API
+    path on the upstream backend) and checking whether the decoded response
+    has a `result` field whose value is a list (the shape the data fetcher
+    returns for that endpoint). Other server functions either 4xx, return a
+    Seroval error, or return a different shape.
+    """
+    payload = _seroval_encode_request("/schedule/getdistricts?search=")
+    try:
+        r = session.get(
+            _SERVER_FN_URL_TEMPLATE.format(fn_id=fn_id) + "?payload=" + quote(payload),
+            headers={
+                "Accept": "application/json",
+                "x-tsr-serverFn": "true",
+            },
+            timeout=8,
+        )
+    except requests.RequestException:
+        return False
+    if r.status_code != 200 or "json" not in r.headers.get("content-type", ""):
+        return False
+    try:
+        decoded = _seroval_decode(r.json())
+    except (ValueError, TypeError):
+        return False
+    return isinstance(decoded, dict) and isinstance(decoded.get("result"), list)
+
+
+def _candidate_fn_ids(session: requests.Session) -> list[str]:
+    """Scrape the live page and JS bundles for sha256-shaped server-fn ids.
+
+    Returns deduplicated candidates in the order they appear in the bundle,
+    or an empty list if scraping fails.
+    """
+    try:
+        html = session.get(_BASE_URL + "/", timeout=15).text
+    except requests.RequestException:
+        return []
+    bundles = re.findall(r'/assets/[A-Za-z0-9._-]+\.js', html)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for bundle in bundles:
+        try:
+            js = session.get(_BASE_URL + bundle, timeout=15).text
+        except requests.RequestException:
+            continue
+        # 64-char hex strings used as quoted string literals (the form
+        # `createServerFn` registers them in) — narrower than matching every
+        # hex blob, but agnostic to the minified factory's mangled name.
+        for fn_id in re.findall(r'[\'"`]([0-9a-f]{64})[\'"`]', js):
+            if fn_id not in seen:
+                seen.add(fn_id)
+                ordered.append(fn_id)
+    return ordered
+
+
+def _resolve_server_fn_id(session: requests.Session) -> str | None:
+    """Discover the data-fetching server-function id from the live JS bundle.
+
+    Returns None if discovery fails — the caller raises a descriptive error
+    rather than silently using a stale hardcoded id.
+    """
+    for fn_id in _candidate_fn_ids(session):
+        if _probe_data_fetcher(session, fn_id):
+            return fn_id
+    return None
+
+
+class _StaleFnId(Exception):
+    """Raised when a cached server-fn id stops responding correctly."""
+
 
 class Source:
-    API_URL = "https://grafikai.svara.lt/api/"
-
     def __init__(
         self,
         region: str,
@@ -59,68 +208,121 @@ class Source:
                 "waste_object_ids",
                 "waste_object_ids must be a list of numeric values",
             )
+        # Cached server-fn id, populated lazily on first fetch and
+        # invalidated when an upstream redeploy makes the cached id stale.
+        self._fn_id: str | None = None
 
-    def fetch(self):
+    def _ensure_fn_id(self, session: requests.Session) -> str:
+        if self._fn_id is None:
+            self._fn_id = _resolve_server_fn_id(session)
+        if self._fn_id is None:
+            raise Exception(
+                "Could not discover grafikai.svara.lt server-function id; "
+                "site structure may have changed unexpectedly"
+            )
+        return self._fn_id
 
-        address_query = {
-            "pageSize": 20,
-            "pageIndex": 0,
-            "address": self._street,
-            "region": self._region,
-            "houseNumber": self._house_number,
-            "subDistrict": self._district,
-            "matchHouseNumber": "true",
-        }
-        r = requests.get(
-            self.API_URL + "contracts",
-            params=address_query,
+    def _raw_call(
+        self, session: requests.Session, fn_id: str, api_path: str
+    ) -> dict:
+        payload = _seroval_encode_request(api_path)
+        r = session.get(
+            _SERVER_FN_URL_TEMPLATE.format(fn_id=fn_id) + "?payload=" + quote(payload),
+            headers={
+                "Accept": "application/json, application/x-tss-framed, application/x-ndjson",
+                "x-tsr-serverFn": "true",
+            },
+            timeout=20,
         )
+        # Anything other than a normal JSON 200 implies the fn_id is no
+        # longer valid (most likely upstream redeployed). Signal stale and
+        # let the caller re-discover and retry once.
+        if r.status_code != 200 or "json" not in r.headers.get(
+            "content-type", ""
+        ):
+            raise _StaleFnId(f"fn_id {fn_id} returned HTTP {r.status_code}")
+        decoded = _seroval_decode(r.json()) or {}
+        if "result" not in decoded:
+            raise _StaleFnId(
+                f"fn_id {fn_id} returned unexpected shape: {r.text[:120]!r}"
+            )
+        return decoded
 
-        data = json.loads(r.text)
-
-        self.check_for_error_status(data)
-
-        entries = []
-
-        for collection in data["data"]:
+    def _call(self, session: requests.Session, api_path: str) -> dict:
+        # On first call, discover. On a stale-id signal (e.g. upstream
+        # redeployed since we cached the id), invalidate and re-discover
+        # exactly once before failing.
+        for attempt in range(2):
+            fn_id = self._ensure_fn_id(session)
             try:
-                type = collection["descriptionPlural"].casefold()
-                if self.check_if_waste_object_defined(collection["wasteObjectId"]):
-                    waste_object_query = {"wasteObjectId": collection["wasteObjectId"]}
-
-                    rwo = requests.get(
-                        self.API_URL + "schedule",
-                        params=waste_object_query,
+                return self._raw_call(session, fn_id, api_path)
+            except _StaleFnId:
+                self._fn_id = None
+                if attempt == 1:
+                    raise Exception(
+                        f"grafikai.svara.lt rejected request to {api_path!r} "
+                        "even after re-discovering the server-function id"
                     )
-                    data_waste_object = json.loads(rwo.text)
-                    self.check_for_error_status(data_waste_object)
+        raise AssertionError("unreachable")
 
-                    for collection_waste_object in data_waste_object:
-                        entries.append(
-                            Collection(
-                                date=datetime.strptime(
-                                    collection_waste_object["date"], "%Y-%m-%dT%H:%M:%S"
-                                ).date(),
-                                t=collection["descriptionFmt"].title(),
-                                icon=ICON_MAP.get(type),
-                            )
-                        )
-            except ValueError:
-                pass  # ignore date conversion failure for not scheduled collections
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        contracts_path = "/schedule/getcontracts?" + urlencode(
+            {
+                "address": self._street,
+                "city": "",
+                "houseNumber": self._house_number,
+                "matchHouseNumber": "true",
+                "pageIndex": 0,
+                "pageSize": 50,
+                "region": self._region,
+                "subDistrict": self._district or "",
+            }
+        )
+        contracts_resp = self._call(session, contracts_path)
+        result = contracts_resp.get("result") or {}
+        rows = result.get("data") or []
+
+        entries: list[Collection] = []
+        for row in rows:
+            waste_object_id = row.get("wasteObjectId")
+            if waste_object_id is None:
+                continue
+            if (
+                self._waste_object_ids
+                and int(waste_object_id) not in self._waste_object_ids
+            ):
+                continue
+            description_plural = (row.get("descriptionPlural") or "").casefold()
+            description_fmt = (row.get("descriptionFmt") or "").title()
+
+            schedule_path = "/schedule/getschedule?" + urlencode(
+                {
+                    "address": "-",
+                    "houseNumber": "-",
+                    "pageIndex": 0,
+                    "pageSize": 50,
+                    "region": "-",
+                    "subDistrict": "-",
+                    "wasteObjectId": waste_object_id,
+                }
+            )
+            schedule_resp = self._call(session, schedule_path)
+            for d in schedule_resp.get("result") or []:
+                date_str = d.get("dateFmt") or (d.get("date") or "")[:10]
+                if not date_str:
+                    continue
+                try:
+                    date = datetime.strptime(date_str, "%Y-%m-%d").date()
+                except ValueError:
+                    continue
+                entries.append(
+                    Collection(
+                        date=date,
+                        t=description_fmt,
+                        icon=ICON_MAP.get(description_plural),
+                    )
+                )
 
         return entries
-
-    def check_if_waste_object_defined(self, waste_object_id):
-        if len(self._waste_object_ids) <= 0:
-            return True
-        if waste_object_id in self._waste_object_ids:
-            return True
-        return False
-
-    def check_for_error_status(self, collection):
-        if "status" in collection:
-            raise Exception(
-                "Error: failed to fetch get data, got status: {}".format(
-                    collection["status"]
-                )
-            )

--- a/doc/source/grafikai_svara_lt.md
+++ b/doc/source/grafikai_svara_lt.md
@@ -9,30 +9,28 @@ waste_collection_schedule:
   sources:
     - name: grafikai_svara_lt
       args:
-        region: CITY
+        region: REGION
         street: STREET_NAME
         house_number: HOUSE_NUMBER
         district: DISTRICT
-        waste_object_ids:
-          - WASTE_OBJECT_ID
 ```
 
 ### Configuration Variables
 
-**region**  
+**region**
 *(string) (required)*
 
-**street**  
+**street**
 *(string) (required)*
 
-**house_number**  
+**house_number**
 *(string) (required)*
 
-**district**  
+**district**
 *(string) (optional)*
 
-**waste_object_ids**  
-*(list) (optional)*
+**waste_object_ids**
+*(list of int) (optional)* — see [Filtering by wasteObjectId](#filtering-by-wasteobjectid) below.
 
 ## Example
 
@@ -44,20 +42,23 @@ waste_collection_schedule:
         region: Kauno m. sav.
         street: Demokratų g.
         house_number: 7
-        district: DISTRICT
-        waste_object_ids:
-          - 101358
-          - 100858
-          - 100860
 ```
 
 ## How to get the source arguments
 
-Visit the [Grafikai](http://grafikai.svara.lt) page and search for your address.  The arguments should exactly match the following table below. To include waste object id's at search results page, copy url from "Atsisiųsti" button and take "wasteObjectId" parameter.
+Visit the [Grafikai](https://grafikai.svara.lt) page and search for your address. The dropdown labels on the page map to YAML arguments as follows:
 
-| Parameter name in grafikai.svara.lt | Argument in yaml |
-|-------------------------------------|------------------|
-| Regionas                            | region            |
-| Gatvė                               | street             |
-| Namo nr.                            | house_number             |
-| Seniūnija                           | district             |
+| Page field            | YAML argument |
+|-----------------------|---------------|
+| Regionas              | region        |
+| Seniūnija             | district      |
+| Gatvė                 | street        |
+| Namo numeris          | house_number  |
+
+## Filtering by wasteObjectId
+
+By default the source returns every collection scheduled for the address. If multiple containers are registered there (e.g. mixed waste, paper/plastic, glass) and you want only some of them, set `waste_object_ids` to a list of numeric IDs.
+
+Find the IDs by searching for your address on [grafikai.svara.lt](https://grafikai.svara.lt) with your browser's DevTools open: in the Network tab, locate the `getcontracts` server-function request and inspect its response. Each row contains a `wasteObjectId` integer field — pick the ones you want.
+
+Note: numeric `wasteObjectId` values from before the April 2026 grafikai.svara.lt rebuild are no longer valid; if your config carries old IDs, look them up again.


### PR DESCRIPTION
## Summary                                             

  In late April 2026 the upstream Kauno švara website (grafikai.svara.lt) was rebuilt as a TanStack Start (TSR) React app. The previous REST endpoints (`/api/contracts`, `/api/schedule`) now return 404, so the existing source fails  
  for everyone with `JSONDecodeError: Expecting value` (it tries to JSON-parse a 404 HTML page). Cached events keep showing for a while after the change but the calendar effectively stops updating.
                                                                                                                                                                                                                                         
  The new architecture routes all data fetching through a single TanStack server function:

  ```
  GET /_serverFn/<sha256>?payload=<seroval-encoded-json>
  x-tsr-serverFn: true                                                                                                                                                                                                                   
  ```
                                                                                                                                                                                                                                         
  This PR rewrites the source against that new contract. 

  ## What changed

  - **Discover the data-fetching server-fn id fully dynamically.** The 64-char sha256 is baked into the JS bundle at build time and changes on every upstream rebuild — so there is no hardcoded id at all. The source scrapes `/`, finds
   every referenced JS bundle, extracts every quoted 64-char hex literal, and probes each candidate against the cheap `/schedule/getdistricts` endpoint to pick the one with the data-fetcher shape.
  - **Per-instance cache with auto-invalidation.** The discovered id is cached on the `Source` instance. When upstream redeploys and the cached id stops working (any non-200 / wrong-shape response), the source invalidates the cache  
  and re-discovers exactly once before failing. Net effect: an upstream rebuild causes one transient failure on a single polling cycle, then automatic recovery — no code change needed.                                                 
  - **Hand-rolled tiny Seroval encoder/decoder in pure stdlib.** No new dependency. Only the small subset of node types these endpoints actually return is handled (`t=0` number, `t=1` string, `t=2` bigint, `t=9` array, `t=10/11`
  object).                                                                                                                                                                                                                               
  - **Public input arguments unchanged** (`region`, `street`, `house_number`, `district`, `waste_object_ids`), so existing user configs keep working without edits.
  - **Doc updates.** Dropped the stale `waste_object_ids` example values (the numeric IDs changed during the rebuild). Replaced the obsolete "copy URL from Atsisiųsti button" discovery trick with a DevTools-based recipe, and noted   
  that pre-rebuild IDs are no longer valid.                                                                                                                                                                                              
  - **TEST_CASES kept** — both upstream addresses (Demokratų g. 7, Alytaus g. 2) verified to return non-empty results against the new API; just removed the now-stale hardcoded `waste_object_ids` from the Demokratų entry.             
                                                                                                                                                                                                                                         
  ## Test plan                                           
                                                                                                                                                                                                                                         
  - [x] Verified end-to-end against three addresses including both upstream `TEST_CASES`. Demokratų g. 7 returns 7 contracts, Alytaus g. 2 returns 3 contracts, my own address returns 38 schedule entries across 6 months.
  - [x] Verified the dynamic discovery with the hardcoded id removed: cold start picks the right server-fn from the live JS bundle.                                                                                                      
  - [x] Verified cache reuse: subsequent fetches don't redo discovery.                                                                                                                                                                   
  - [x] Verified stale-id recovery: injecting a fake fn id and calling `fetch()` triggers re-discovery and returns correct data.                                                                                                         
  - [x] Verified the failure case: when discovery legitimately can't find a working id, the source raises a clear, descriptive error rather than silently using a broken id.                                                             
  - [x] Running on my own HA instance — `calendar.kauno_svara` is back to `on` with today's "Mišrios komunalinės" event.                                                                                                                 
                                                                                                                                                                                                                                         
  ## Caveats                                                                                                                                                                                                                             
                                                         
  The dynamic discovery scrapes a JS bundle, which is fragile by nature — TanStack internals can change the way server-fn ids are emitted. The current heuristic is "any 64-char hex literal in any `/assets/*.js` referenced from `/`". 
  If TSR ever stops emitting plain string literals (e.g. moves to import-maps or splits ids across template strings), the scrape returns no candidates and the source raises a loud, actionable error. That seems strictly better than   
  silently freezing on a stale id.