### PR TITLE
Fix awido_de: stale test case and address-list handling in get_json_data

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
@@ -436,7 +436,7 @@ TEST_CASES = {
     },
     "Daaden-Herdorf": {
         "customer": "awb-ak",
-        "city": "VG Daaden-Herdorf - Kernstadt Herdorf",
+        "city": "VG Daaden-Herdorf",
     },
     "Mühldorf": {
         "customer": "lra-mue",
@@ -670,17 +670,16 @@ class Source:
         for calitem in calendar:
             date = datetime.datetime.strptime(calitem["dt"], "%Y%m%d").date()
 
-            # Extract extra attributes from calendar item
-            # 'ad' contains the location/address for the collection event
-            # (None for public holidays, which are already filtered above)
-            extra: dict = {}
-            ad = calitem.get("ad")
-            if ad and isinstance(ad, str):
-                extra["description"] = ad
+            # 'ad' is a list of addresses, one per fraction entry in 'fr'
+            ad_list = calitem.get("ad") or []
+            fr_list = calitem.get("fr") or []
 
             # Add all fractions for this date
-            for fracitem in calitem["fr"]:
+            for i, fracitem in enumerate(fr_list):
                 waste_type = fractions[fracitem]
+                extra: dict = {}
+                if i < len(ad_list) and ad_list[i]:
+                    extra["description"] = ad_list[i]
                 c = Collection(date, waste_type)
                 c.update(extra)
                 entries.append(c)


### PR DESCRIPTION
Two small fixes to `awido_de.py` found during investigation of #3619.

## Changes

**1. Stale test case for Daaden-Herdorf**

The `VG Daaden-Herdorf - Kernstadt Herdorf` city name no longer exists in the `awb-ak` API — the current value is `VG Daaden-Herdorf`. Updated to match.

**2. Fix `get_json_data` address handling**

The `ad` field in the JSON calendar response is a list of address strings (one per fraction), not a plain string. The previous code checked `isinstance(ad, str)` which never matched, so the `description` extra attribute was never populated for any collection event fetched via the JSON path. Fixed to iterate with index and assign the correct address per fraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)