### PR TITLE
Fix ICS: strip TZID from VALUE=DATE properties to prevent naive/aware datetime comparison error

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -52,7 +52,7 @@ class ICS:
 
     def convert(self, ics_data: str) -> List[Tuple[datetime.date, str]]:
         # calculate start- and end-date for recurring events
-        start_date = datetime.datetime.now().replace(
+        start_date = datetime.datetime.now(datetime.timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
         if self._offset is not None:
@@ -70,6 +70,17 @@ class ICS:
         ics_data = re.sub(
             r"(DT(?:START|END)[^:]*:\d{8})T(\r?\n)",
             r"\g<1>T000000\g<2>",
+            ics_data,
+        )
+
+        # Strip TZID from all-day (VALUE=DATE) DTSTART/DTEND lines.
+        # TZID is only valid on DATETIME values; combining it with VALUE=DATE is
+        # malformed ICS. When present, icalendar creates timezone-aware datetime
+        # objects for the recurrence rule while EXDATE lines (which lack TZID)
+        # stay naive, causing a TypeError when dateutil compares them.
+        ics_data = re.sub(
+            r"(DT(?:START|END));TZID=[^;:]+;(VALUE=DATE:)",
+            r"\1;\2",
             ics_data,
         )
 
@@ -128,7 +139,7 @@ class ICS:
 
     def convert_events(self, ics_data: str) -> List[IcsEvent]:
         # calculate start- and end-date for recurring events
-        start_date = datetime.datetime.now().replace(
+        start_date = datetime.datetime.now(datetime.timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
         if self._offset is not None:
@@ -138,6 +149,13 @@ class ICS:
         ics_data = re.sub(
             r"(EXDATE;VALUE=DATE:[0-9]+)\r?\n",
             lambda m: m.group(1) + "T010000\n",
+            ics_data,
+        )
+
+        # Strip TZID from all-day (VALUE=DATE) DTSTART/DTEND lines — see convert().
+        ics_data = re.sub(
+            r"(DT(?:START|END));TZID=[^;:]+;(VALUE=DATE:)",
+            r"\1;\2",
             ics_data,
         )
 


### PR DESCRIPTION
## Problem

Some ICS generators (reported in #6201 for AWM München, but potentially affects other sources too) emit malformed `DTSTART` lines that combine `TZID` with `VALUE=DATE`:

```
DTSTART;TZID=Europe/Berlin;VALUE=DATE:20260106
RRULE:FREQ=WEEKLY;UNTIL=20261231;BYDAY=TU;WKST=MO
EXDATE;VALUE=DATE:20261222T000000
```

Per RFC 5545, `TZID` is only valid on `DATETIME` values, not `DATE` values. When both are present, `icalendar` creates **timezone-aware** recurrence instances from the `RRULE`, while `EXDATE` lines (which have no `TZID`) stay **naive**. When `dateutil`'s rrule tries to filter out exclusion dates it compares aware vs naive datetimes and raises:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

This surfaces to users as:
> The source returned an invalid response: "can't compare offset-naive and offset-aware datetimes"

## Fix

Two changes to `ICS.py`:

1. **Preprocessing step** (in both `convert()` and `convert_events()`): strip the `TZID` parameter from any `DTSTART`/`DTEND` line that also carries `VALUE=DATE`. This makes the recurrence instances naive and consistent with the `EXDATE` values.

   ```python
   ics_data = re.sub(
       r"(DT(?:START|END));TZID=[^;:]+;(VALUE=DATE:)",
       r"\1;\2",
       ics_data,
   )
   ```
   
   Converts `DTSTART;TZID=Europe/Berlin;VALUE=DATE:20260106` → `DTSTART;VALUE=DATE:20260106`.

2. **UTC-aware `start_date`/`end_date`**: changed `datetime.datetime.now()` to `datetime.datetime.now(datetime.timezone.utc)` so that any ICS file with timezone-aware events (not just the `VALUE=DATE` case) can be compared without error.

## Testing

All four `awm_muenchen_de` test cases now pass (previously all failed with `TypeError`):

```
Waltenbergerstr. 1:    70 entries ✓
Geretsrieder Str. 10a: 17 entries ✓
Bellinzonastraße 19:   70 entries ✓
Marienplatz 1:        157 entries ✓
```

Closes #6201