### PR TITLE
recyclecoach_com: add Circular Materials Ontario municipalities to EXTRA_INFO

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -253,6 +253,60 @@ EXTRA_INFO = [
             "district_id": "GLENORCHY",
         },
     },
+    {
+        "title": "Toronto (ON) - Circular Materials",
+        "url": "https://www.toronto.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "CIRCMATONT", "district_id": "TORONTO"},
+    },
+    {
+        "title": "Mississauga (ON)",
+        "url": "https://www.mississauga.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3179", "district_id": "MISS"},
+    },
+    {
+        "title": "Brampton (ON)",
+        "url": "https://www.brampton.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3179", "district_id": "BRAMP"},
+    },
+    {
+        "title": "Caledon (ON)",
+        "url": "https://www.caledon.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3179", "district_id": "CALED"},
+    },
+    {
+        "title": "Burlington (ON)",
+        "url": "https://www.burlington.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3169", "district_id": "BURL"},
+    },
+    {
+        "title": "Oakville (ON)",
+        "url": "https://www.oakville.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3169", "district_id": "OAKV"},
+    },
+    {
+        "title": "Milton (ON)",
+        "url": "https://www.milton.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3169", "district_id": "MILT"},
+    },
+    {
+        "title": "Halton Hills (ON)",
+        "url": "https://www.haltonhills.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3169", "district_id": "HALT"},
+    },
+    {
+        "title": "Guelph (ON)",
+        "url": "https://guelph.ca/",
+        "country": "ca",
+        "default_params": {"project_id": "3194", "district_id": "GUEL"},
+    },
 ]
 
 TEST_CASES = {


### PR DESCRIPTION
## Summary

Adds 9 Ontario municipalities served by Circular Materials to the `recyclecoach_com` EXTRA_INFO list so they appear in the source catalogue and UI provider dropdown:

- Toronto (ON) — via Circular Materials project `CIRCMATONT`/`TORONTO` (standard city lookup finds the old project at stage 2, which the source rejects)
- Mississauga, Brampton, Caledon (ON) — Peel Region, project `3179`
- Burlington, Oakville, Milton, Halton Hills (ON) — Halton Region, project `3169`
- Guelph (ON) — project `3194`

Closes #5272

🤖 Generated with [Claude Code](https://claude.ai/claude-code)