### PR TITLE
mein_abfallkalender_online: add Karben

### DIFF
--- a/doc/ics/yaml/mein_abfallkalender_online.yaml
+++ b/doc/ics/yaml/mein_abfallkalender_online.yaml
@@ -43,6 +43,8 @@ extra_info:
   - title: awb-wetterau.de (not all municipalities)
     url: https://awb-wetterau.de
     # Altenstadt, Bad Nauheim, Büdingen, Butzbach, Echzell, Florstadt, Friedberg, Gedern, Glauburg, Hirzenhain, Karben, Kefenrod, Limeshain, Ober-Mörlen, Ortenberg, Ranstadt, Reichelsheim, Rockenberg, Rosbach v.d.H., Wölfersheim, Wöllstadt
+  - title: Karben
+    url: https://www.karben.de
   - title: Petershagen
     url: https://www.petershagen.de/
   - title: Witzenhausen


### PR DESCRIPTION
## Summary

- Adds Karben as a dedicated `extra_info` entry in `mein_abfallkalender_online.yaml`

Karben was previously only mentioned in a comment under the `awb-wetterau.de` entry but had no dedicated listing. It has its own subdomain (`karben.mein-abfallkalender.online`) and should appear in the source catalogue.

Closes #6158

🤖 Generated with [Claude Code](https://claude.ai/claude-code)