### PR TITLE
recollect: add City of Beaumont AB and Bassetlaw District Council

### DIFF
--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -174,6 +174,12 @@ extra_info:
   - title: Spruce Grove, AB
     url: https://www.sprucegrove.org
     country: ca
+  - title: City of Beaumont, AB
+    url: https://www.beaumont.ab.ca/
+    country: ca
+  - title: Bassetlaw District Council
+    url: https://www.bassetlaw.gov.uk/
+    country: uk
 
 howto:
   en: |
@@ -223,6 +229,8 @@ howto:
     |Rogue Disposal & Recycling (Medford, OR)|USA|[roguedisposal.com](https://roguedisposal.com/resources/recycling-schedule)|
     |Grey Highlands, ON|Canada|[greyhighlands.ca](https://www.greyhighlands.ca/my-home/waste-recycling/collection-schedule/)|
     |Spruce Grove, AB|Canada|[sprucegrove.org](https://www.sprucegrove.org/services/garbage-organics-recycling/sort-with-success/)|
+    |City of Beaumont, AB|Canada|[beaumont.ab.ca](https://www.beaumont.ab.ca/1159/Waste-and-Recycling)|
+    |Bassetlaw District Council|UK|[bassetlaw.gov.uk](https://www.bassetlaw.gov.uk/bins-recycling-and-waste/bins-for-recycling-and-waste/bin-collection-days/)|
 
     and probably a lot more.
 


### PR DESCRIPTION
## Summary

Adds two missing ReCollect-supported providers to `recollect.yaml`:

- **City of Beaumont, AB** (Canada) — confirmed ReCollect provider (area: Beaumont, service: 303). Closes #6143
- **Bassetlaw District Council** (UK) — confirmed ReCollect provider via their bin collection page. Closes #4717, closes #6166

Both entries added to `extra_info` and the `howto.en` table. Users can obtain their personal ICS URL by visiting their council's bin collection page and using the "Get a calendar" flow as described in the how-to instructions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)