### PR TITLE
Add Le Havre Seine Métropole to publidata_fr

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -272,6 +272,11 @@ EXTRA_INFO = [
         "url": "https://www.sivom-rivedroite.fr/",
         "default_params": {"instance_id": 1027},
     },
+    {
+        "title": "Le Havre Seine Métropole",
+        "url": "https://tripratik.lehavreseinemetropole.fr/",
+        "default_params": {"instance_id": 1408},
+    },
 ]
 
 _CALENDAR_DAY_VERY_ABBR = {


### PR DESCRIPTION
## Summary

- Adds Le Havre Seine Métropole (TriPtratik / Publidata instance 1408) to the `publidata_fr` EXTRA_INFO list
- No code changes — just a new entry in the supported providers list

Closes #6180

## Test plan

- [x] Verified API returns results for Le Havre addresses via `https://api.publidata.io/v2/search?instances[]=1408`
- [x] Existing `publidata_fr` test cases unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)