### PR TITLE
Add AHP to waste collection mappings for southglos_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southglos_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southglos_gov_uk.py
@@ -16,12 +16,14 @@ ICON_MAP = {  # Optional: Dict of waste types and suitable mdi icons
     "RECYCLING": "mdi:recycle",
     "GARDEN WASTE": "mdi:leaf",
     "FOOD BIN": "mdi:food",
+    "AHP BIN": "mdi:diaper-outline",
 }
 WASTE_MAP = {  # map new collection names to old collection names for compatibility
     "Refuse": "BLACK BIN",
     "Recycling": "RECYCLING",
     "Garden": "GARDEN WASTE",
     "Food": "FOOD BIN",
+    "AHP": "AHP BIN",
 }
 
 


### PR DESCRIPTION
South Gloucestershire council now have AHP (Absorbent Hygiene Product) collections.
The introduction of AHP broke the integration for me as AHP wasn't mapped.
I've tested this fix locally and it has resolved my issue.