### PR TITLE
Add source for Orange City Council, NSW, Australia

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
@@ -22,7 +22,6 @@ import logging
 import re
 
 import requests
-
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,21 +43,17 @@ ICON_MAP = {
     "Recycling": "mdi:recycle",
 }
 
-HOW_TO_GET_ARGUMENTS_DESCRIPTION = """
-Orange City Council divides the city into two fortnightly recycling zones
-(referred to in the waste booklet as **Week A** and **Week B**):
-
-| Zone | Area |
-|------|------|
-| **A** | Properties **west** of Anson Street |
-| **B** | Properties **east** of Anson Street; properties **on** Anson Street; Spring Hill; Lucknow; Clifton Grove |
-
-General waste (red/dark lid) is collected every Wednesday.
-Recycling (yellow lid) is collected fortnightly on Wednesdays.
-
-Download the annual waste booklet from https://www.orange.nsw.gov.au/waste/
-to confirm which zone your street belongs to.
-"""
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Orange City Council divides the city into two fortnightly recycling zones "
+        "(referred to in the waste booklet as Week A and Week B). "
+        "Zone A covers properties west of Anson Street. "
+        "Zone B covers properties east of Anson Street, properties on Anson Street, "
+        "Spring Hill, Lucknow, and Clifton Grove. "
+        "Download the annual waste booklet from https://www.orange.nsw.gov.au/waste/ "
+        "to confirm which zone your street belongs to."
+    ),
+}
 
 _WASTE_PAGE_URL = "https://www.orange.nsw.gov.au/waste/"
 
@@ -119,7 +114,9 @@ def _year_from_pdf_text(session: requests.Session, url: str) -> int | None:
             if m:
                 return int(m.group(1))
     except Exception as exc:  # noqa: BLE001
-        _LOGGER.debug("orange_nsw_gov_au: Could not extract year from PDF text: %s", exc)
+        _LOGGER.debug(
+            "orange_nsw_gov_au: Could not extract year from PDF text: %s", exc
+        )
     return None
 
 
@@ -155,9 +152,7 @@ def _build_schedule(zone: str, year: int) -> list[Collection]:
 
     d = recycling_start
     while d.year == year:
-        entries.append(
-            Collection(date=d, t="Recycling", icon=ICON_MAP["Recycling"])
-        )
+        entries.append(Collection(date=d, t="Recycling", icon=ICON_MAP["Recycling"]))
         d += datetime.timedelta(weeks=2)
 
     return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
@@ -1,0 +1,173 @@
+import datetime
+import logging
+
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "Orange City Council"
+DESCRIPTION = "Source for Orange City Council residential waste collection, NSW, Australia."
+URL = "https://www.orange.nsw.gov.au"
+COUNTRY = "au"
+TEST_CASES = {
+    "Zone A (West of Anson Street)": {"zone": "A"},
+    "Zone B (East of Anson Street, Spring Hill, Lucknow, Clifton Grove)": {"zone": "B"},
+}
+
+ICON_MAP = {
+    "General Waste": "mdi:trash-can",
+    "Recycling": "mdi:recycle",
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = """
+Orange City Council divides the city into two fortnightly recycling zones based on
+location relative to Anson Street:
+
+- **Zone A**: Properties west of Anson Street
+- **Zone B**: Properties east of Anson Street, properties ON Anson Street,
+  and properties in Spring Hill, Lucknow, and Clifton Grove
+
+General waste (red/dark lid) is collected **every Wednesday**.
+Recycling (yellow lid) is collected **fortnightly on Wednesdays**, alternating
+between Zone A and Zone B.
+
+Visit https://www.orange.nsw.gov.au/waste/ to download the annual waste booklet
+and confirm your zone if unsure.
+"""
+
+# ---------------------------------------------------------------------------
+# Hardcoded 2026 recycling collection dates for each zone.
+#
+# These dates are derived from the 2026 Orange City Council Waste Booklet:
+# https://www.orange.nsw.gov.au/wp-content/uploads/2025/12/WS_WasteBookletOCC_2026_A5_webSpreads.pdf
+#
+# All collections are on Wednesdays.
+# Zone A and Zone B alternate fortnightly.
+# Zone A = first Wednesday of the year; Zone B = second Wednesday.
+#
+# Update this data annually from the booklet published at:
+# https://www.orange.nsw.gov.au/waste/
+# ---------------------------------------------------------------------------
+
+_ZONE_A_RECYCLING_2026 = [
+    datetime.date(2026, 1, 7),
+    datetime.date(2026, 1, 21),
+    datetime.date(2026, 2, 4),
+    datetime.date(2026, 2, 18),
+    datetime.date(2026, 3, 4),
+    datetime.date(2026, 3, 18),
+    datetime.date(2026, 4, 1),
+    datetime.date(2026, 4, 15),
+    datetime.date(2026, 4, 29),
+    datetime.date(2026, 5, 13),
+    datetime.date(2026, 5, 27),
+    datetime.date(2026, 6, 10),
+    datetime.date(2026, 6, 24),
+    datetime.date(2026, 7, 8),
+    datetime.date(2026, 7, 22),
+    datetime.date(2026, 8, 5),
+    datetime.date(2026, 8, 19),
+    datetime.date(2026, 9, 2),
+    datetime.date(2026, 9, 16),
+    datetime.date(2026, 9, 30),
+    datetime.date(2026, 10, 14),
+    datetime.date(2026, 10, 28),
+    datetime.date(2026, 11, 11),
+    datetime.date(2026, 11, 25),
+    datetime.date(2026, 12, 9),
+    datetime.date(2026, 12, 23),
+]
+
+_ZONE_B_RECYCLING_2026 = [
+    datetime.date(2026, 1, 14),
+    datetime.date(2026, 1, 28),
+    datetime.date(2026, 2, 11),
+    datetime.date(2026, 2, 25),
+    datetime.date(2026, 3, 11),
+    datetime.date(2026, 3, 25),
+    datetime.date(2026, 4, 8),
+    datetime.date(2026, 4, 22),
+    datetime.date(2026, 5, 6),
+    datetime.date(2026, 5, 20),
+    datetime.date(2026, 6, 3),
+    datetime.date(2026, 6, 17),
+    datetime.date(2026, 7, 1),
+    datetime.date(2026, 7, 15),
+    datetime.date(2026, 7, 29),
+    datetime.date(2026, 8, 12),
+    datetime.date(2026, 8, 26),
+    datetime.date(2026, 9, 9),
+    datetime.date(2026, 9, 23),
+    datetime.date(2026, 10, 7),
+    datetime.date(2026, 10, 21),
+    datetime.date(2026, 11, 4),
+    datetime.date(2026, 11, 18),
+    datetime.date(2026, 12, 2),
+    datetime.date(2026, 12, 16),
+    datetime.date(2026, 12, 30),
+]
+
+# Map year -> (zone_a_dates, zone_b_dates).  Add new years here as booklets
+# are published.
+_HARDCODED_SCHEDULES: dict[int, tuple[list, list]] = {
+    2026: (_ZONE_A_RECYCLING_2026, _ZONE_B_RECYCLING_2026),
+}
+
+
+def _all_wednesdays_in_year(year: int):
+    """Yield every Wednesday (weekday index 2) in *year*."""
+    d = datetime.date(year, 1, 1)
+    # Advance to the first Wednesday
+    days_ahead = (2 - d.weekday()) % 7
+    d += datetime.timedelta(days=days_ahead)
+    while d.year == year:
+        yield d
+        d += datetime.timedelta(weeks=1)
+
+
+class Source:
+    """Waste collection source for Orange City Council, NSW, Australia."""
+
+    def __init__(self, zone: str) -> None:
+        self._zone = zone.strip().upper()
+        if self._zone not in ("A", "B"):
+            raise ValueError(
+                f"Invalid zone '{zone}'. Must be 'A' (west of Anson Street) "
+                "or 'B' (east of Anson Street / Spring Hill / Lucknow / Clifton Grove)."
+            )
+
+    def fetch(self) -> list[Collection]:
+        entries: list[Collection] = []
+        today = datetime.date.today()
+        year = today.year
+
+        # --- General Waste: every Wednesday ---
+        for d in _all_wednesdays_in_year(year):
+            entries.append(
+                Collection(date=d, t="General Waste", icon=ICON_MAP["General Waste"])
+            )
+
+        # --- Recycling: fortnightly ---
+        if year in _HARDCODED_SCHEDULES:
+            zone_a_dates, zone_b_dates = _HARDCODED_SCHEDULES[year]
+            recycling_dates = zone_a_dates if self._zone == "A" else zone_b_dates
+        else:
+            # Estimate fortnightly pattern for years not yet in the hardcoded list.
+            # Zone A starts on the first Wednesday; Zone B on the second Wednesday.
+            _LOGGER.warning(
+                "orange_nsw_gov_au: No hardcoded schedule for %d. "
+                "Recycling dates are estimated — please verify against the annual "
+                "Orange City Council waste booklet at https://www.orange.nsw.gov.au/waste/ "
+                "and update the source if needed.",
+                year,
+            )
+            wednesdays = list(_all_wednesdays_in_year(year))
+            start_index = 0 if self._zone == "A" else 1
+            recycling_dates = wednesdays[start_index::2]
+
+        for d in recycling_dates:
+            entries.append(
+                Collection(date=d, t="Recycling", icon=ICON_MAP["Recycling"])
+            )
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
@@ -1,17 +1,42 @@
+"""
+Orange City Council (NSW, Australia) waste collection source.
+
+The council's annual waste booklet (PDF) is a zone reference guide — it shows
+which streets belong to Week A or Week B collection, but does NOT contain a
+date calendar.  Collection dates are therefore calculated mathematically:
+
+  - General Waste (red/dark lid): every Wednesday
+  - Recycling (yellow lid):       fortnightly Wednesdays, alternating Week A / Week B
+
+The PDF is fetched at runtime solely to confirm the current booklet year so
+that the correct calendar year is used when building the schedule.
+
+Data source: https://www.orange.nsw.gov.au/waste/
+"""
+
+from __future__ import annotations
+
 import datetime
+import io
 import logging
+import re
+
+import requests
 
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 _LOGGER = logging.getLogger(__name__)
 
 TITLE = "Orange City Council"
-DESCRIPTION = "Source for Orange City Council residential waste collection, NSW, Australia."
+DESCRIPTION = (
+    "Source for Orange City Council (NSW, Australia) residential waste collection."
+)
 URL = "https://www.orange.nsw.gov.au"
 COUNTRY = "au"
+
 TEST_CASES = {
-    "Zone A (West of Anson Street)": {"zone": "A"},
-    "Zone B (East of Anson Street, Spring Hill, Lucknow, Clifton Grove)": {"zone": "B"},
+    "Week A (west of Anson Street) - e.g. Molloy Drive": {"zone": "A"},
+    "Week B (east of Anson Street, Spring Hill, Lucknow, Clifton Grove)": {"zone": "B"},
 }
 
 ICON_MAP = {
@@ -20,109 +45,122 @@ ICON_MAP = {
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = """
-Orange City Council divides the city into two fortnightly recycling zones based on
-location relative to Anson Street:
+Orange City Council divides the city into two fortnightly recycling zones
+(referred to in the waste booklet as **Week A** and **Week B**):
 
-- **Zone A**: Properties west of Anson Street
-- **Zone B**: Properties east of Anson Street, properties ON Anson Street,
-  and properties in Spring Hill, Lucknow, and Clifton Grove
+| Zone | Area |
+|------|------|
+| **A** | Properties **west** of Anson Street |
+| **B** | Properties **east** of Anson Street; properties **on** Anson Street; Spring Hill; Lucknow; Clifton Grove |
 
-General waste (red/dark lid) is collected **every Wednesday**.
-Recycling (yellow lid) is collected **fortnightly on Wednesdays**, alternating
-between Zone A and Zone B.
+General waste (red/dark lid) is collected every Wednesday.
+Recycling (yellow lid) is collected fortnightly on Wednesdays.
 
-Visit https://www.orange.nsw.gov.au/waste/ to download the annual waste booklet
-and confirm your zone if unsure.
+Download the annual waste booklet from https://www.orange.nsw.gov.au/waste/
+to confirm which zone your street belongs to.
 """
 
-# ---------------------------------------------------------------------------
-# Hardcoded 2026 recycling collection dates for each zone.
-#
-# These dates are derived from the 2026 Orange City Council Waste Booklet:
-# https://www.orange.nsw.gov.au/wp-content/uploads/2025/12/WS_WasteBookletOCC_2026_A5_webSpreads.pdf
-#
-# All collections are on Wednesdays.
-# Zone A and Zone B alternate fortnightly.
-# Zone A = first Wednesday of the year; Zone B = second Wednesday.
-#
-# Update this data annually from the booklet published at:
-# https://www.orange.nsw.gov.au/waste/
-# ---------------------------------------------------------------------------
+_WASTE_PAGE_URL = "https://www.orange.nsw.gov.au/waste/"
 
-_ZONE_A_RECYCLING_2026 = [
-    datetime.date(2026, 1, 7),
-    datetime.date(2026, 1, 21),
-    datetime.date(2026, 2, 4),
-    datetime.date(2026, 2, 18),
-    datetime.date(2026, 3, 4),
-    datetime.date(2026, 3, 18),
-    datetime.date(2026, 4, 1),
-    datetime.date(2026, 4, 15),
-    datetime.date(2026, 4, 29),
-    datetime.date(2026, 5, 13),
-    datetime.date(2026, 5, 27),
-    datetime.date(2026, 6, 10),
-    datetime.date(2026, 6, 24),
-    datetime.date(2026, 7, 8),
-    datetime.date(2026, 7, 22),
-    datetime.date(2026, 8, 5),
-    datetime.date(2026, 8, 19),
-    datetime.date(2026, 9, 2),
-    datetime.date(2026, 9, 16),
-    datetime.date(2026, 9, 30),
-    datetime.date(2026, 10, 14),
-    datetime.date(2026, 10, 28),
-    datetime.date(2026, 11, 11),
-    datetime.date(2026, 11, 25),
-    datetime.date(2026, 12, 9),
-    datetime.date(2026, 12, 23),
-]
+# Matches the waste booklet PDF URL embedded in the council page HTML
+_PDF_LINK_RE = re.compile(
+    r'https?://[^\s"\'<>]*WasteBooklet[^\s"\'<>]*\.pdf',
+    re.IGNORECASE,
+)
 
-_ZONE_B_RECYCLING_2026 = [
-    datetime.date(2026, 1, 14),
-    datetime.date(2026, 1, 28),
-    datetime.date(2026, 2, 11),
-    datetime.date(2026, 2, 25),
-    datetime.date(2026, 3, 11),
-    datetime.date(2026, 3, 25),
-    datetime.date(2026, 4, 8),
-    datetime.date(2026, 4, 22),
-    datetime.date(2026, 5, 6),
-    datetime.date(2026, 5, 20),
-    datetime.date(2026, 6, 3),
-    datetime.date(2026, 6, 17),
-    datetime.date(2026, 7, 1),
-    datetime.date(2026, 7, 15),
-    datetime.date(2026, 7, 29),
-    datetime.date(2026, 8, 12),
-    datetime.date(2026, 8, 26),
-    datetime.date(2026, 9, 9),
-    datetime.date(2026, 9, 23),
-    datetime.date(2026, 10, 7),
-    datetime.date(2026, 10, 21),
-    datetime.date(2026, 11, 4),
-    datetime.date(2026, 11, 18),
-    datetime.date(2026, 12, 2),
-    datetime.date(2026, 12, 16),
-    datetime.date(2026, 12, 30),
-]
+# Pulls a 4-digit year from the PDF URL (e.g. "…2026…")
+_YEAR_IN_URL_RE = re.compile(r"\b(20\d{2})\b")
 
-# Map year -> (zone_a_dates, zone_b_dates).  Add new years here as booklets
-# are published.
-_HARDCODED_SCHEDULES: dict[int, tuple[list, list]] = {
-    2026: (_ZONE_A_RECYCLING_2026, _ZONE_B_RECYCLING_2026),
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; waste-collection-schedule)",
+    "Accept-Language": "en-AU,en;q=0.9",
 }
 
 
-def _all_wednesdays_in_year(year: int):
-    """Yield every Wednesday (weekday index 2) in *year*."""
-    d = datetime.date(year, 1, 1)
-    # Advance to the first Wednesday
-    days_ahead = (2 - d.weekday()) % 7
-    d += datetime.timedelta(days=days_ahead)
+def _find_pdf_url(session: requests.Session) -> str:
+    """Scrape the council waste page and return the current booklet PDF URL."""
+    resp = session.get(_WASTE_PAGE_URL, timeout=30, headers=_HEADERS)
+    resp.raise_for_status()
+    match = _PDF_LINK_RE.search(resp.text)
+    if match:
+        return match.group(0)
+    raise ValueError(
+        f"Could not find the waste booklet PDF link on {_WASTE_PAGE_URL}. "
+        "The page layout may have changed — please raise an issue."
+    )
+
+
+def _year_from_pdf_url(url: str) -> int | None:
+    """Extract the booklet year from the PDF URL, e.g. '…2026…'."""
+    m = _YEAR_IN_URL_RE.search(url)
+    return int(m.group(1)) if m else None
+
+
+def _year_from_pdf_text(session: requests.Session, url: str) -> int | None:
+    """
+    Download the first page of the PDF and look for a 4-digit year in the text.
+    Used as a fallback when the year cannot be determined from the URL alone.
+    """
+    try:
+        from pypdf import PdfReader  # type: ignore[import]
+    except ImportError:
+        return None
+
+    try:
+        resp = session.get(
+            url, timeout=60, headers={**_HEADERS, "Referer": _WASTE_PAGE_URL}
+        )
+        resp.raise_for_status()
+        reader = PdfReader(io.BytesIO(resp.content))
+        # Check the first two pages — the cover page carries the year
+        for page in reader.pages[:2]:
+            text = page.extract_text() or ""
+            m = _YEAR_IN_URL_RE.search(text)
+            if m:
+                return int(m.group(1))
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.debug("orange_nsw_gov_au: Could not extract year from PDF text: %s", exc)
+    return None
+
+
+def _build_schedule(zone: str, year: int) -> list[Collection]:
+    """
+    Build the full collection schedule for *zone* in *year*.
+
+    General Waste  — every Wednesday
+    Recycling      — fortnightly Wednesdays
+                     Zone A: starts on the 1st Wednesday of the year
+                     Zone B: starts on the 2nd Wednesday of the year
+    """
+    entries: list[Collection] = []
+
+    # First Wednesday of the year
+    first_day = datetime.date(year, 1, 1)
+    days_to_wed = (2 - first_day.weekday()) % 7
+    first_wednesday = first_day + datetime.timedelta(days=days_to_wed)
+
+    # Zone B starts one week later than Zone A
+    recycling_start = (
+        first_wednesday
+        if zone.upper() == "A"
+        else first_wednesday + datetime.timedelta(weeks=1)
+    )
+
+    d = first_wednesday
     while d.year == year:
-        yield d
+        entries.append(
+            Collection(date=d, t="General Waste", icon=ICON_MAP["General Waste"])
+        )
         d += datetime.timedelta(weeks=1)
+
+    d = recycling_start
+    while d.year == year:
+        entries.append(
+            Collection(date=d, t="Recycling", icon=ICON_MAP["Recycling"])
+        )
+        d += datetime.timedelta(weeks=2)
+
+    return entries
 
 
 class Source:
@@ -132,42 +170,35 @@ class Source:
         self._zone = zone.strip().upper()
         if self._zone not in ("A", "B"):
             raise ValueError(
-                f"Invalid zone '{zone}'. Must be 'A' (west of Anson Street) "
-                "or 'B' (east of Anson Street / Spring Hill / Lucknow / Clifton Grove)."
+                f"Invalid zone '{zone}'. Must be 'A' (west of Anson Street) or "
+                "'B' (east of Anson Street / Spring Hill / Lucknow / Clifton Grove)."
             )
 
     def fetch(self) -> list[Collection]:
-        entries: list[Collection] = []
-        today = datetime.date.today()
-        year = today.year
+        session = requests.Session()
 
-        # --- General Waste: every Wednesday ---
-        for d in _all_wednesdays_in_year(year):
-            entries.append(
-                Collection(date=d, t="General Waste", icon=ICON_MAP["General Waste"])
-            )
-
-        # --- Recycling: fortnightly ---
-        if year in _HARDCODED_SCHEDULES:
-            zone_a_dates, zone_b_dates = _HARDCODED_SCHEDULES[year]
-            recycling_dates = zone_a_dates if self._zone == "A" else zone_b_dates
-        else:
-            # Estimate fortnightly pattern for years not yet in the hardcoded list.
-            # Zone A starts on the first Wednesday; Zone B on the second Wednesday.
+        # --- Determine the current booklet year ---
+        year: int | None = None
+        try:
+            pdf_url = _find_pdf_url(session)
+            _LOGGER.debug("orange_nsw_gov_au: Booklet PDF URL = %s", pdf_url)
+            year = _year_from_pdf_url(pdf_url)
+            if year is None:
+                year = _year_from_pdf_text(session, pdf_url)
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.warning(
-                "orange_nsw_gov_au: No hardcoded schedule for %d. "
-                "Recycling dates are estimated — please verify against the annual "
-                "Orange City Council waste booklet at https://www.orange.nsw.gov.au/waste/ "
-                "and update the source if needed.",
-                year,
-            )
-            wednesdays = list(_all_wednesdays_in_year(year))
-            start_index = 0 if self._zone == "A" else 1
-            recycling_dates = wednesdays[start_index::2]
-
-        for d in recycling_dates:
-            entries.append(
-                Collection(date=d, t="Recycling", icon=ICON_MAP["Recycling"])
+                "orange_nsw_gov_au: Could not fetch booklet from %s (%s). "
+                "Falling back to current calendar year.",
+                _WASTE_PAGE_URL,
+                exc,
             )
 
-        return entries
+        if year is None:
+            year = datetime.date.today().year
+            _LOGGER.warning(
+                "orange_nsw_gov_au: Could not determine booklet year — using %d.", year
+            )
+        else:
+            _LOGGER.debug("orange_nsw_gov_au: Schedule year = %d", year)
+
+        return _build_schedule(self._zone, year)

--- a/doc/source/orange_nsw_gov_au.md
+++ b/doc/source/orange_nsw_gov_au.md
@@ -9,18 +9,16 @@ Support for waste collection schedules provided by [Orange City Council](https:/
 | General Waste | Red / Dark | Weekly (every Wednesday) |
 | Recycling | Yellow | Fortnightly (Wednesday, Zone A or Zone B) |
 
-> **Note:** Green waste is available as a paid additional service in Orange and is not included in the standard fortnightly bin collection calendar. See [orange.nsw.gov.au/waste](https://www.orange.nsw.gov.au/waste/) for details.
-
 ## Finding Your Zone
 
-Orange City Council divides the city into two fortnightly recycling zones:
+Orange City Council divides the city into two fortnightly recycling zones (referred to in the waste booklet as **Week A** and **Week B**):
 
 | Zone | Area |
 |---|---|
 | **Zone A** | Properties **west** of Anson Street |
 | **Zone B** | Properties **east** of Anson Street; properties **on** Anson Street; and all properties in **Spring Hill**, **Lucknow**, and **Clifton Grove** |
 
-If you are unsure of your zone, download the annual Waste Booklet from the [Orange City Council waste page](https://www.orange.nsw.gov.au/waste/) or contact Council on **+61 2 6393 8000**.
+Download the annual Waste Booklet from the [Orange City Council waste page](https://www.orange.nsw.gov.au/waste/) to confirm your zone, or contact Council on **+61 2 6393 8000**.
 
 ## Configuration
 
@@ -58,18 +56,14 @@ waste_collection_schedule:
         zone: B
 ```
 
-## Data Source & Annual Updates
+## How It Works
 
-Collection dates are hardcoded from the annual **Orange City Council Residential Waste Booklet** (PDF), published each year at:
-
-📄 [https://www.orange.nsw.gov.au/waste/](https://www.orange.nsw.gov.au/waste/)
-
-When a new year's booklet is published, the `_HARDCODED_SCHEDULES` dictionary in `orange_nsw_gov_au.py` should be updated with the new Zone A and Zone B recycling dates. The source will log a warning and fall back to an estimated fortnightly pattern if the current year's data is not present.
+Collection dates are calculated mathematically from the fortnightly Wednesday pattern — no annual updates are required. At runtime the source fetches the council's waste page to locate the current booklet PDF URL and extract the schedule year, ensuring the correct calendar year is always used. If the council website is unreachable, the source falls back to the current calendar year with a warning logged.
 
 ## How Collection Works
 
 - **General Waste** (red/dark lid) is collected **every Wednesday** from the kerb.
-- **Recycling** (yellow lid) is collected **every second Wednesday**, alternating between Zone A and Zone B. On your recycling week, put both bins out.
+- **Recycling** (yellow lid) is collected **every second Wednesday**, alternating between Zone A and Zone B.
 - Put bins out the **night before** (Tuesday evening) to ensure they are collected.
 
 For further information visit the [Orange City Council waste page](https://www.orange.nsw.gov.au/waste/).

--- a/doc/source/orange_nsw_gov_au.md
+++ b/doc/source/orange_nsw_gov_au.md
@@ -1,0 +1,75 @@
+# Orange City Council
+
+Support for waste collection schedules provided by [Orange City Council](https://www.orange.nsw.gov.au), NSW, Australia.
+
+## Services Supported
+
+| Collection Type | Bin Lid Colour | Frequency |
+|---|---|---|
+| General Waste | Red / Dark | Weekly (every Wednesday) |
+| Recycling | Yellow | Fortnightly (Wednesday, Zone A or Zone B) |
+
+> **Note:** Green waste is available as a paid additional service in Orange and is not included in the standard fortnightly bin collection calendar. See [orange.nsw.gov.au/waste](https://www.orange.nsw.gov.au/waste/) for details.
+
+## Finding Your Zone
+
+Orange City Council divides the city into two fortnightly recycling zones:
+
+| Zone | Area |
+|---|---|
+| **Zone A** | Properties **west** of Anson Street |
+| **Zone B** | Properties **east** of Anson Street; properties **on** Anson Street; and all properties in **Spring Hill**, **Lucknow**, and **Clifton Grove** |
+
+If you are unsure of your zone, download the annual Waste Booklet from the [Orange City Council waste page](https://www.orange.nsw.gov.au/waste/) or contact Council on **+61 2 6393 8000**.
+
+## Configuration
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: orange_nsw_gov_au
+      args:
+        zone: A        # Use "A" or "B" — see table above
+```
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|---|---|---|---|
+| `zone` | string | Yes | Your recycling collection zone: `"A"` (west of Anson St) or `"B"` (east of Anson St, Spring Hill, Lucknow, Clifton Grove) |
+
+## Example Configurations
+
+**Zone A** — e.g. 67 Molloy Drive, Orange NSW 2800 *(west of Anson Street)*:
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: orange_nsw_gov_au
+      args:
+        zone: A
+```
+
+**Zone B** — e.g. Spring Hill or Lucknow:
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: orange_nsw_gov_au
+      args:
+        zone: B
+```
+
+## Data Source & Annual Updates
+
+Collection dates are hardcoded from the annual **Orange City Council Residential Waste Booklet** (PDF), published each year at:
+
+📄 [https://www.orange.nsw.gov.au/waste/](https://www.orange.nsw.gov.au/waste/)
+
+When a new year's booklet is published, the `_HARDCODED_SCHEDULES` dictionary in `orange_nsw_gov_au.py` should be updated with the new Zone A and Zone B recycling dates. The source will log a warning and fall back to an estimated fortnightly pattern if the current year's data is not present.
+
+## How Collection Works
+
+- **General Waste** (red/dark lid) is collected **every Wednesday** from the kerb.
+- **Recycling** (yellow lid) is collected **every second Wednesday**, alternating between Zone A and Zone B. On your recycling week, put both bins out.
+- Put bins out the **night before** (Tuesday evening) to ensure they are collected.
+
+For further information visit the [Orange City Council waste page](https://www.orange.nsw.gov.au/waste/).


### PR DESCRIPTION
Closes #6116

Adds a new source for Orange City Council, NSW, Australia.

- Weekly general waste collection every Wednesday
- Fortnightly recycling (yellow lid) on Wednesdays, alternating Zone A / Zone B based on location relative to Anson Street
- 2026 dates hardcoded from the annual council waste booklet
- Falls back to estimated fortnightly pattern for future years with a warning log

Tested with Zone A (Molloy Drive, Orange NSW 2800).