### PR TITLE
Add Gelnhausen to jumomind mymuell; remove from mein_abfallkalender_online

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -141,6 +141,7 @@ SERVICE_MAP = {
             "Darmstadt",
             "Esens",
             "Flensburg",
+            "Gelnhausen",
             "Grävenwiesbach",
             "Großkrotzenburg",
             "Hainburg",

--- a/doc/ics/yaml/mein_abfallkalender_online.yaml
+++ b/doc/ics/yaml/mein_abfallkalender_online.yaml
@@ -72,8 +72,6 @@ extra_info:
     url: https://www.eschborn.de/
   - title: Friedrichsdorf
     url: https://www.friedrichsdorf.de/
-  - title: Gelnhausen
-    url: https://www.gelnhausen.de
   - title: Heusenstamm
     url: https://www.heusenstamm.de/
   - title: Hochheim


### PR DESCRIPTION
Closes #3435

Gelnhausen left the mein-abfallkalender.online platform in January 2026 and is now served via the MyMuell app (jumomind).

- Adds `Gelnhausen` to the `mymuell` extra_info list in `jumomind_de.py`
- Removes `Gelnhausen` from `mein_abfallkalender_online.yaml`