### PR TITLE
fix(cityofparramatta): make FOGO/Garden Organics weekly instead of fortnightly

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cityofparramatta_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cityofparramatta_nsw_gov_au.py
@@ -186,14 +186,11 @@ class Source:
                 )
             )
 
-        # Garden Organics / FOGO (Alternate Fortnightly)
-        fogo_dates = self.get_collection_dates(
-            collection_day, is_area_1, is_recycling=False
-        )
-        for d in fogo_dates:
+        # Garden Organics / FOGO (Weekly since late 2024 rollout)
+        for i in range(4):
             entries.append(
                 Collection(
-                    date=d,
+                    date=next_general + timedelta(days=i * 7),
                     t="Garden Organics (Green Bin)",
                     icon=ICON_MAP.get("Garden Organics (Green Bin)"),
                 )


### PR DESCRIPTION
## Summary

- City of Parramatta rolled out weekly FOGO (Garden Organics / green bin) collection from late 2024
- The source was incorrectly generating fortnightly FOGO dates alternating with recycling
- Fix makes FOGO weekly, matching the same pattern as General Waste

Fixes #6227

## Test plan

- [ ] Verify Garden Organics (Green Bin) dates are now generated weekly (every 7 days)
- [ ] Verify Recycling (Yellow Bin) remains fortnightly
- [ ] Verify General Waste (Red Bin) remains weekly

🤖 Generated with [Claude Code](https://claude.com/claude-code)