### PR TITLE
fix(boroondara_vic_gov_au): Recycling weekly, General Waste/FOGO fortnightly

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/boroondara_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/boroondara_vic_gov_au.py
@@ -144,10 +144,10 @@ class Source:
         entries: list[Collection] = []
 
         for d in _next_weekly(day):
-            entries.append(Collection(d, "General Waste", ICON_MAP["General Waste"]))
-            entries.append(Collection(d, "FOGO", ICON_MAP["FOGO"]))
+            entries.append(Collection(d, "Recycling", ICON_MAP["Recycling"]))
 
         for d in _next_fortnightly(day, week):
-            entries.append(Collection(d, "Recycling", ICON_MAP["Recycling"]))
+            entries.append(Collection(d, "General Waste", ICON_MAP["General Waste"]))
+            entries.append(Collection(d, "FOGO", ICON_MAP["FOGO"]))
 
         return entries

--- a/doc/source/boroondara_vic_gov_au.md
+++ b/doc/source/boroondara_vic_gov_au.md
@@ -35,6 +35,6 @@ Enter your street address as it appears on the [Boroondara bin day finder](https
 
 Collection types returned:
 
-- **General Waste** — weekly
-- **FOGO** (Food Organics and Garden Organics) — weekly, same day as General Waste
-- **Recycling** — fortnightly
+- **Recycling** — weekly
+- **General Waste** — fortnightly
+- **FOGO** (Food Organics and Garden Organics) — fortnightly, same day as General Waste


### PR DESCRIPTION
## Summary

Fixes the collection type mapping for City of Boroondara, reported in #6237.

The previous code had General Waste + FOGO collected weekly and Recycling fortnightly — the reverse of the actual schedule. Recycling is weekly; General Waste and FOGO are fortnightly.

- Swapped `_next_weekly` / `_next_fortnightly` assignments in `fetch()`
- Updated `doc/source/boroondara_vic_gov_au.md` to reflect correct frequencies

Fixes #6237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)