### PR TITLE
fix(winterthur_ch): share HTTP session across all A_region_ch requests

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
@@ -39,6 +39,7 @@ class A_region_ch:
         region_url: str,
         district: str | None = None,
         regex: str | None = None,
+        session: requests.Session | None = None,
     ):
         if service not in SERVICES:
             raise Exception(f"service '{service}' not found")
@@ -48,6 +49,7 @@ class A_region_ch:
 
         self._municipality_url = region_url
         self._district = district
+        self._session = session or _session()
 
     def fetch(self) -> list[ICS]:
         waste_types = self.get_waste_types(self._municipality_url)
@@ -107,7 +109,7 @@ class A_region_ch:
     def get_waste_types(self, link: str) -> dict[str, str]:
         if not link.startswith("http"):
             link = f"{self._base_url}{link}"
-        r = _session().get(link)
+        r = self._session.get(link)
         r.raise_for_status()
 
         waste_types = {}
@@ -135,7 +137,7 @@ class A_region_ch:
     def get_ICS_sources(self, link: str, tour: str) -> list[ICS]:
         if not link.startswith("http"):
             link = f"{self._base_url}{link}"
-        r = _session().get(link)
+        r = self._session.get(link)
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, features="html.parser")
@@ -188,7 +190,8 @@ def get_region_url_by_street(
     district: str | None = None,
     regex: str | None = None,
 ) -> A_region_ch:
-    r = _session().get(search_url, params={"q": street})
+    session = _session()
+    r = session.get(search_url, params={"q": street})
     r.raise_for_status()
 
     soup = BeautifulSoup(r.text, features="html.parser")
@@ -205,6 +208,6 @@ def get_region_url_by_street(
         if a.get_text(strip=True).lower().replace(" ", "") == street.lower().replace(
             " ", ""
         ):
-            return A_region_ch(service, href, district, regex)
+            return A_region_ch(service, href, district, regex, session=session)
 
     raise SourceArgumentNotFoundWithSuggestions("street", street, streets)


### PR DESCRIPTION
## Summary

- `A_region_ch` was creating a new HTTP session for every request in the fetch flow, giving the server no cookies or connection continuity
- Sharing a single session across `get_waste_types` and all `get_ICS_sources` calls reduces TCP overhead and preserves server-set cookies, making the flow less susceptible to 429 rate limiting
- `get_region_url_by_street` now creates one session, uses it for the street-lookup, and passes it into the returned `A_region_ch` instance

Fixes #6241

## Test plan

- [x] `winterthur_ch` test case (`Am Iberghang`) returns 131 entries
- [x] `A_region_ch` accepts optional `session` parameter — backwards-compatible, existing callers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)