### PR TITLE
Add source for Fredrikstad kommune, Norway

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fredrikstad_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fredrikstad_no.py
@@ -1,0 +1,85 @@
+import datetime
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+TITLE = "Fredrikstad kommune"
+DESCRIPTION = "Source for Fredrikstad kommune waste collection."
+URL = "https://www.fredrikstad.kommune.no"
+TEST_CASES = {
+    "Kanelveien 4": {"address": "Kanelveien 4"},
+}
+
+BASE_URL = "https://arcgis.fredrikstad.kommune.no/server/rest/services/Renovasjon/MinRenovasjon/MapServer"
+SCHEDULE_DAYS = 365
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        waste_types = _get_waste_types(session)
+        avt_lnr = self._get_avt_lnr(session)
+
+        today = datetime.date.today()
+        end_date = today + datetime.timedelta(days=SCHEDULE_DAYS)
+
+        r = session.get(
+            f"{BASE_URL}/1/query",
+            params={
+                "f": "json",
+                "orderByFields": "Dato",
+                "outFields": "Dato,AvfallId",
+                "returnGeometry": "false",
+                "spatialRel": "esriSpatialRelIntersects",
+                "where": (
+                    f"AvtLnr = {avt_lnr} "
+                    f"AND Dato >= date '{today.isoformat()}' "
+                    f"AND Dato <= date '{end_date.isoformat()}'"
+                ),
+            },
+        )
+        r.raise_for_status()
+
+        entries = []
+        for feature in r.json().get("features", []):
+            attr = feature["attributes"]
+            epoch_ms = attr["Dato"]
+            avfall_id = attr["AvfallId"]
+            collection_date = datetime.date.fromtimestamp(epoch_ms / 1000)
+            waste_name = waste_types.get(avfall_id, f"Avfall {avfall_id}")
+            entries.append(Collection(date=collection_date, t=waste_name))
+
+        return entries
+
+    def _get_avt_lnr(self, session: requests.Session) -> int:
+        r = session.get(
+            f"{BASE_URL}/0/query",
+            params={
+                "f": "json",
+                "outFields": "AvtLnr",
+                "returnGeometry": "false",
+                "spatialRel": "esriSpatialRelIntersects",
+                "where": f"UPPER(Adresse) = '{self._address.upper()}' AND AvtStatus = 0",
+            },
+        )
+        r.raise_for_status()
+        features = r.json().get("features", [])
+        if not features:
+            raise ValueError(f"Address not found: {self._address}")
+        return features[0]["attributes"]["AvtLnr"]
+
+
+def _get_waste_types(session: requests.Session) -> dict[int, str]:
+    """Return AvfallId → name mapping from the layer's coded value domain."""
+    r = session.get(f"{BASE_URL}/1", params={"f": "json"})
+    r.raise_for_status()
+    for field in r.json().get("fields", []):
+        if field["name"] == "AvfallId":
+            domain = field.get("domain") or {}
+            if domain.get("type") == "codedValue":
+                return {cv["code"]: cv["name"] for cv in domain["codedValues"]}
+    return {}

--- a/doc/source/fredrikstad_no.md
+++ b/doc/source/fredrikstad_no.md
@@ -1,0 +1,20 @@
+# Fredrikstad kommune
+
+Source for [Fredrikstad kommune](https://www.fredrikstad.kommune.no) waste collection.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: fredrikstad_no
+      args:
+        address: "Kanelveien 4"
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Your street address as it appears on the [Fredrikstad tømmekalender](https://arcgis.fredrikstad.kommune.no/webapps/tommekalender/fredrikstad/) — typically street name and house number, e.g. `Kanelveien 4`.


### PR DESCRIPTION
## Summary

- Adds `fredrikstad_no` source for Fredrikstad kommune (Norway) waste collection
- Closes #2525
- Uses the municipality's ArcGIS MinRenovasjon service directly (not the public Norkart proxy, which doesn't cover Fredrikstad's private deployment)

## How it works

1. Queries `MapServer/0` to resolve a street address to an `AvtLnr` contract number
2. Fetches waste type names from the `AvfallId` coded value domain in the `MapServer/1` layer schema
3. Queries `MapServer/1` with the `AvtLnr` and a 365-day date window to retrieve all upcoming collection dates

## Configuration

```yaml
waste_collection_schedule:
  sources:
    - name: fredrikstad_no
      args:
        address: "Kanelveien 4"
```

## Test plan

- [ ] Verify `fredrikstad_no` appears with correct TITLE, URL, TEST_CASES structure
- [ ] Confirm waste type names resolve correctly from the ArcGIS layer domain (not falling back to "Avfall N")
- [ ] Confirm `update_docu_links.py` picks up the new source and doc file post-merge