### PR TITLE
fix(harrow_gov_uk): improve error handling for empty/failed API responses

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/harrow_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/harrow_gov_uk.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
@@ -40,12 +39,21 @@ class Source:
 
     def fetch(self):
         r = requests.get(API_URL.format(uprn=self._uprn))
-        rubbish_data = json.loads(r.content)
+        r.raise_for_status()
+
+        if not r.content:
+            raise ValueError(
+                f"No data returned for UPRN {self._uprn} — the service may be temporarily unavailable"
+            )
+
+        rubbish_data = r.json()
 
         entries = []
 
         for next_collection in rubbish_data["results"]["collections"]["next"]:
-            collection_type = COLLECTION_MAP[next_collection["binType"]]
+            collection_type = COLLECTION_MAP.get(next_collection["binType"])
+            if collection_type is None:
+                continue
             collection_date = next_collection["eventTime"]
             entries.append(
                 Collection(


### PR DESCRIPTION
## Summary

- Adds `raise_for_status()` to surface HTTP errors clearly
- Guards against empty response body with a descriptive `ValueError` (previously caused a cryptic `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`)
- Switches from `json.loads(r.content)` to `r.json()`
- Skips unknown `binType` values gracefully instead of raising a `KeyError`

Prompted by #6245, where a transient empty response from Harrow's server produced a confusing error message.

## Test plan

- [ ] Existing TEST_CASES still return collections
- [ ] Empty response body now raises a clear `ValueError` naming the UPRN