### PR TITLE
Add source for Shire of Dardanup, WA, Australia

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dardanup_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dardanup_wa_gov_au.py
@@ -1,0 +1,218 @@
+import re
+from datetime import date, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "Shire of Dardanup"
+DESCRIPTION = "Source for Shire of Dardanup (WA) waste collection."
+URL = "https://www.dardanup.wa.gov.au"
+COUNTRY = "au"
+TEST_CASES = {
+    "Hale Street (Area 1, Tuesday)": {
+        "street": "Hale Street",
+        "recycling_in_even_week": True,
+    },
+    "Burekup": {
+        "street": "Burekup",
+        "recycling_in_even_week": True,
+    },
+    "Dardanup West via collection_day": {
+        "collection_day": "Monday",
+        "recycling_in_even_week": True,
+    },
+}
+
+ICON_MAP = {
+    "FOGO": "mdi:leaf",
+    "Recycling": "mdi:recycle",
+    "General Waste": "mdi:trash-can",
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Visit https://www.dardanup.wa.gov.au/our-services/waste-and-recycling/"
+        "find-your-bin-day.aspx and find your street in the list to determine "
+        "your collection day. Enter your street name (without house number) as "
+        "the 'street' argument, or enter the day directly as 'collection_day' "
+        "(for Dardanup West / Ferguson Valley residents). "
+        "For recycling_in_even_week: check your last recycling collection date "
+        "and see if its ISO week number (https://whatweekisit.org/) was even "
+        "(True) or odd (False)."
+    ),
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street": (
+            "Your street name without a house number, e.g. 'Hale Street' or "
+            "'Flinders Street'. Used to look up your collection day automatically."
+        ),
+        "collection_day": (
+            "Your collection day as a string: 'Monday', 'Tuesday', 'Wednesday', "
+            "'Thursday', or 'Friday'. Use this instead of 'street' for Dardanup "
+            "West (Monday) and Ferguson Valley residents, or if street lookup fails."
+        ),
+        "recycling_in_even_week": (
+            "Set to True if your recycling bin is collected on even ISO week "
+            "numbers, False if on odd ISO week numbers. Check your last recycling "
+            "collection date to determine this."
+        ),
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "street": "Street Name",
+        "collection_day": "Collection Day (override)",
+        "recycling_in_even_week": "Recycling collected on even ISO weeks",
+    },
+}
+
+COLLECTION_URL = (
+    "https://www.dardanup.wa.gov.au/our-services/waste-and-recycling/"
+    "find-your-bin-day.aspx"
+)
+
+DAY_NAME_TO_WEEKDAY = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+}
+
+
+def _next_weekday(ref: date, weekday: int) -> date:
+    days_ahead = weekday - ref.weekday()
+    if days_ahead < 0:
+        days_ahead += 7
+    return ref + timedelta(days=days_ahead)
+
+
+def _clean_street(raw: str) -> str:
+    """Strip range qualifiers like '(numbers 4-64)' or '(odd numbers 2-46)'."""
+    return re.sub(r"\s*\([^)]+\)", "", raw).strip()
+
+
+class Source:
+    def __init__(
+        self,
+        street: str | None = None,
+        collection_day: str | None = None,
+        recycling_in_even_week: bool = True,
+    ):
+        if not street and not collection_day:
+            raise SourceArgumentNotFound(
+                "street",
+                "Provide either 'street' (your street name) or 'collection_day' "
+                "('Monday'–'Friday').",
+            )
+        self._street = street.strip() if street else None
+        self._collection_day = (
+            collection_day.strip().lower() if collection_day else None
+        )
+        self._recycling_in_even_week = recycling_in_even_week
+
+    def fetch(self) -> list[Collection]:
+        if self._collection_day:
+            if self._collection_day not in DAY_NAME_TO_WEEKDAY:
+                raise SourceArgumentNotFound(
+                    "collection_day",
+                    f"'{self._collection_day}' is not a valid day. "
+                    f"Use one of: {', '.join(DAY_NAME_TO_WEEKDAY)}.",
+                )
+            weekday = DAY_NAME_TO_WEEKDAY[self._collection_day]
+        else:
+            weekday = self._lookup_street_day()
+
+        return self._build_entries(weekday)
+
+    def _lookup_street_day(self) -> int:
+        r = requests.get(COLLECTION_URL, timeout=30)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        street_lower = self._street.lower()
+        all_streets: list[str] = []
+        found_weekday: int | None = None
+
+        for accordion in soup.select("div.accordion div.accordion"):
+            current_day: int | None = None
+
+            for child in accordion.children:
+                if not hasattr(child, "name"):
+                    continue
+
+                if child.name == "h2":
+                    heading = child.get_text(strip=True).lower()
+                    current_day = None
+                    for day_name, wd in DAY_NAME_TO_WEEKDAY.items():
+                        if heading.startswith(day_name):
+                            current_day = wd
+                            break
+
+                elif child.name == "p":
+                    para_text = child.get_text(strip=True)
+                    if not para_text:
+                        continue
+
+                    thursday_match = re.match(
+                        r"^(.+?)\s*[-–]\s*(monday|tuesday|wednesday|thursday|friday)",
+                        para_text,
+                        re.IGNORECASE,
+                    )
+                    if thursday_match:
+                        suburb = thursday_match.group(1).strip().lower()
+                        day_str = thursday_match.group(2).strip().lower()
+                        all_streets.append(thursday_match.group(1).strip())
+                        if suburb in street_lower or street_lower in suburb:
+                            found_weekday = DAY_NAME_TO_WEEKDAY.get(day_str)
+                        continue
+
+                    if current_day is not None:
+                        for raw in para_text.split(","):
+                            cleaned = _clean_street(raw)
+                            if cleaned:
+                                all_streets.append(cleaned)
+                                if cleaned.lower() == street_lower:
+                                    found_weekday = current_day
+                                elif street_lower in cleaned.lower():
+                                    found_weekday = current_day
+
+        if found_weekday is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street", self._street, sorted(set(all_streets))
+            )
+
+        return found_weekday
+
+    def _build_entries(self, weekday: int) -> list[Collection]:
+        entries: list[Collection] = []
+        today = date.today()
+        first_day = _next_weekday(today, weekday)
+
+        for week in range(26):
+            d = first_day + timedelta(weeks=week)
+            iso_week = d.isocalendar()[1]
+            even_week = iso_week % 2 == 0
+
+            entries.append(Collection(date=d, t="FOGO", icon=ICON_MAP["FOGO"]))
+
+            if even_week == self._recycling_in_even_week:
+                entries.append(
+                    Collection(date=d, t="Recycling", icon=ICON_MAP["Recycling"])
+                )
+            else:
+                entries.append(
+                    Collection(
+                        date=d, t="General Waste", icon=ICON_MAP["General Waste"]
+                    )
+                )
+
+        return entries

--- a/doc/source/dardanup_wa_gov_au.md
+++ b/doc/source/dardanup_wa_gov_au.md
@@ -1,0 +1,60 @@
+# Shire of Dardanup
+
+Support for schedules provided by [Shire of Dardanup](https://www.dardanup.wa.gov.au/our-services/waste-and-recycling/find-your-bin-day.aspx).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: dardanup_wa_gov_au
+      args:
+        street: STREET_NAME
+        recycling_in_even_week: true
+```
+
+### Configuration Variables
+
+**street**
+*(string) (optional)*
+
+Your street name without a house number, e.g. `Hale Street` or `Flinders Street`. Used to automatically look up your collection day from the Shire website. Provide either `street` or `collection_day`.
+
+**collection_day**
+*(string) (optional)*
+
+Your collection day as a string: `Monday`, `Tuesday`, `Wednesday`, `Thursday`, or `Friday`. Use this instead of `street` for Dardanup West (Monday) and Ferguson Valley residents, or if street lookup fails.
+
+**recycling_in_even_week**
+*(boolean) (optional, default: `true`)*
+
+Set to `true` if your recycling bin is collected on even ISO week numbers, `false` if on odd ISO week numbers. Check your last recycling collection date to determine this (use [whatweekisit.org](https://whatweekisit.org/)).
+
+## Example — street lookup
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: dardanup_wa_gov_au
+      args:
+        street: Hale Street
+        recycling_in_even_week: true
+```
+
+## Example — direct day (Dardanup West / Ferguson Valley)
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: dardanup_wa_gov_au
+      args:
+        collection_day: Monday
+        recycling_in_even_week: false
+```
+
+## How to get the source arguments
+
+1. Visit the [Shire of Dardanup Find Your Bin Day page](https://www.dardanup.wa.gov.au/our-services/waste-and-recycling/find-your-bin-day.aspx).
+2. Find your street in the accordion lists for Area 1 or Area 2, or note your collection day directly (Area 3 = Monday; Ferguson Valley residents should check the Waste Guide PDF linked on that page).
+3. Enter your street name (without house number) as `street`, or enter the day as `collection_day`.
+4. To determine `recycling_in_even_week`: note the date of your last recycling collection, look up its ISO week number (e.g. using [whatweekisit.org](https://whatweekisit.org/)), and set `true` if even, `false` if odd.


### PR DESCRIPTION
## Summary

Closes #6247

Adds `dardanup_wa_gov_au` source for Shire of Dardanup (Western Australia), based on the implementation submitted by @aynema in the issue.

- Scrapes the [Find Your Bin Day](https://www.dardanup.wa.gov.au/our-services/waste-and-recycling/find-your-bin-day.aspx) page to resolve a street name → collection weekday
- Handles the "Suburb - Day" pattern for Burekup and Dardanup Townsite entries
- Supports a `collection_day` override for Dardanup West / Ferguson Valley residents
- Generates 26 weeks of FOGO (weekly) + alternating Recycling / General Waste (fortnightly, determined by ISO week parity)
- One minor tweak from the original: removed an unused `_THURSDAY_SUBURBS` constant

## Test plan

- [ ] `Hale Street` resolves to Tuesday
- [ ] `Burekup` resolves to Thursday via the suburb–day paragraph pattern
- [ ] `collection_day: Monday` works without fetching the page
- [ ] Invalid street raises `SourceArgumentNotFoundWithSuggestions`