### PR TITLE
fix(lancaster_gov_uk): preserve distinct recycling stream names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lancaster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lancaster_gov_uk.py
@@ -15,7 +15,8 @@ API_URL = "https://lcc-wrp.whitespacews.com"
 ICON_MAP = {
     "Domestic Waste": "mdi:trash-can",
     "Garden Waste": "mdi:leaf",
-    # Dynamic (non-PDF) calendar does not split the types of recycling other than garden and food.
+    "Recycling Red": "mdi:recycle",
+    "Recycling Yellow": "mdi:recycle",
     "Recycling": "mdi:recycle",
     "Food Waste": "mdi:food",
 }
@@ -51,9 +52,14 @@ class Source:
 
         entries = []
         for date_str, type_str in schedule:
-            collection_type = next(
-                (key for key in ICON_MAP if type_str.startswith(key)),
-                _clean_collection_type(type_str),
+            cleaned = _clean_collection_type(type_str)
+            collection_type = (
+                cleaned
+                if cleaned in ICON_MAP
+                else next(
+                    (key for key in ICON_MAP if type_str.startswith(key)),
+                    cleaned,
+                )
             )
             try:
                 entries.append(


### PR DESCRIPTION
## Summary

Lancaster City Council now operates two distinct recycling streams on a rotating 3-week cycle. The source was collapsing both to a single `Recycling` type via prefix-matching in ICON_MAP, making it impossible for users to distinguish them or create separate sensors.

## Root cause

The Whitespace WRP API returns `'Recycling Red Collection Service'` and `'Recycling Yellow Collection Service'` as distinct strings. The old prefix-match iterated ICON_MAP and matched the first key that was a prefix of the type string — since `"Recycling"` appeared before any stream-specific keys, both streams collapsed to the same label.

## Changes

- Added `"Recycling Red"` and `"Recycling Yellow"` to ICON_MAP (both `mdi:recycle`)
- Refactored type resolution to strip the suffix first, then try exact ICON_MAP lookup before falling back to prefix-matching — eliminates dict-ordering sensitivity
- Removed the stale comment acknowledging the limitation

## Test plan

- [x] Test cases now return `Recycling Red` and `Recycling Yellow` as distinct types on correct alternating dates
- [x] All existing collection types (Domestic Waste, Food Waste) unaffected

Closes #6263 / reported via discussion #6254