### PR TITLE
fix(midsussex_gov_uk): harden address selector and URL construction

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
@@ -147,17 +148,21 @@ class Source:
 
             search_text = self._number.upper()
 
-            address_link = soup2.find(
-                "a",
-                class_="app-subnav__link",
-                string=lambda t: t and search_text in t.upper(),
+            all_address_links = soup2.find_all("a", class_="app-subnav__link")
+            address_link = next(
+                (
+                    link
+                    for link in all_address_links
+                    if search_text in link.get_text(strip=True).upper()
+                ),
+                None,
             )
 
             if not address_link:
                 raise SourceArgumentNotFound("number", self._number)
 
             final_link_path = address_link["href"]  # type: ignore[index]
-            final_schedule_url = f"{BASE_URL}/{final_link_path}"
+            final_schedule_url = urljoin(BASE_URL + "/", final_link_path)
 
             # --- STEP 4: Scrape the Final Schedule ---
             r3 = session.get(final_schedule_url, timeout=30)


### PR DESCRIPTION
## Summary

The `midsussex_gov_uk` source was reported broken in discussion #6159 / issue #6262. Investigation showed the source itself already works correctly (the domain fix in April resolved the root cause), but two defensive improvements are worth making.

## Changes

**Address link matching:** Replaced `soup.find("a", string=lambda t: ...)` with `find_all` + `get_text(strip=True)` matching. BeautifulSoup's `string=` parameter only matches a bare `NavigableString` — if the site ever adds a child element inside `<a>` (e.g. a `<span>`), `string` returns `None` and fails silently. `get_text()` is immune to this.

**URL construction:** Replaced `f"{BASE_URL}/{path}"` with `urljoin(BASE_URL + "/", path)`. Handles both the current relative `href="mop.php?..."` format and any future switch to absolute URLs without breaking.

## Test plan

- [x] All 3 existing TEST_CASES pass (8 entries each)
- [x] pytest 5/5 pass
- [x] black/isort clean

Closes #6262 / reported via discussion #6159