### PR TITLE
fix(harrow_gov_uk): add User-Agent header to bypass AWS ELB block

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/harrow_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/harrow_gov_uk.py
@@ -32,13 +32,17 @@ COLLECTION_MAP = {
 
 API_URL = "https://www.harrow.gov.uk/ajax/bins?u={uprn}"
 
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+}
+
 
 class Source:
     def __init__(self, uprn: str | int):
         self._uprn: str = str(uprn).zfill(12)
 
     def fetch(self):
-        r = requests.get(API_URL.format(uprn=self._uprn))
+        r = requests.get(API_URL.format(uprn=self._uprn), headers=HEADERS)
         r.raise_for_status()
 
         if not r.content:


### PR DESCRIPTION
## Summary

- Harrow's API (`/ajax/bins`) now returns 403 for requests carrying the default `python-requests` User-Agent, filtered by AWS ELB
- Adds a browser-like `User-Agent` header (Chrome/120 on Windows) — no `curl_cffi` needed, a plain header override is sufficient
- Both existing TEST_CASES verified passing after the fix

Fixes #6245