### PR TITLE
fix(a_region_ch): add svgIconImg class to waste type selector (#6276)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
@@ -119,8 +119,10 @@ class A_region_ch:
         for download in downloads:
             # href ::= "/index.php?apid=12731252&amp;apparentid=5011362"
             href = download.get("href")
-            if download.find("div", class_="badgeIcon") or download.find(
-                "img", class_="rowImg"
+            if (
+                download.find("div", class_="badgeIcon")
+                or download.find("img", class_="rowImg")
+                or download.find("img", class_="svgIconImg")
             ):
                 titles = download.find_all("div", class_="title")
                 if "PDF" in titles:


### PR DESCRIPTION
## Summary

- a-region.ch updated its frontend to use `<img class="svgIconImg">` inside waste-type anchor tags, replacing the legacy `badgeIcon`/`rowImg` classes
- The `get_waste_types()` method in `service/A_region_ch.py` did not match the new class, returning an empty dict for all 36 municipalities silently
- Adds `svgIconImg` to the existing OR-condition — one line change, backwards-compatible with any municipality still using the old markup

Fixes #6276

## Test plan

- [x] Tested Andwil: 43 entries returned (was 0)
- [x] Tested Rorschach: 59 entries returned (was 0)
- [x] Fix confirmed by reporter (zuerom) on Speicher with v2.22.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)