### PR TITLE
fix(ICS): apply truncated DTSTART/DTEND fix to convert_events()

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -152,6 +152,14 @@ class ICS:
             ics_data,
         )
 
+        # Fix truncated DTSTART/DTEND values where the time portion is missing
+        # after the 'T' separator (e.g. "DTSTART;TZID=Europe/Berlin:20260505T").
+        ics_data = re.sub(
+            r"(DT(?:START|END)[^:]*:\d{8})T(\r?\n)",
+            r"\g<1>T000000\g<2>",
+            ics_data,
+        )
+
         # Strip TZID from all-day (VALUE=DATE) DTSTART/DTEND lines — see convert().
         ics_data = re.sub(
             r"(DT(?:START|END));TZID=[^;:]+;(VALUE=DATE:)",


### PR DESCRIPTION
## Summary

PR #6046 pre-processed malformed ICS `DTSTART` values (e.g. `DTSTART;TZID=Europe/Berlin:20260505T` — truncated, missing `HHMMSS` after `T`) in `ICS.convert()` only. However, `ics.py` calls `ICS.convert_events()`, not `ICS.convert()`, so the fix never reached the actual production code path. The azv-hof.de Leupoldsgrün calendar continued to fail in v2.21 and v2.22 with:

```
AttributeError: 'NoneType' object has no attribute 'dt'
```

This PR applies the identical `re.sub` fix to `convert_events()`, in the same position (after the EXDATE workaround, before the TZID VALUE=DATE strip).

Fixes #6033.

## Test plan

- [ ] Manually test against the azv-hof.de Leupoldsgrün ICS URL (the one from the issue) — should now return collection entries without error
- [ ] Run existing ICS test cases to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)