### PR TITLE
fix(abfall_io): handle HTTP 401 in wizard for providers migrated to v3 GraphQL API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io.py
@@ -13,7 +13,6 @@ package_dir = Path(__file__).resolve().parents[2]
 site.addsitedir(str(package_dir))
 from waste_collection_schedule.service.AbfallIO import SERVICE_MAP  # type: ignore # isort:skip # noqa: E402
 
-
 MODUS_KEY = "d6c5855a62cf32a4dadbc2831f0f295f"
 HEADERS = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
 
@@ -174,10 +173,18 @@ def select_and_query(data, answers):
         questions = [inquirer.Text(parser.text_name, message=message)]
         answers.update(inquirer.prompt(questions))
 
+    waction_matches = ACTION_EXTRACTOR_PATTERN.findall(data)
+    if not waction_matches:
+        raise ValueError(
+            "Unexpected response from abfall.io API (no waction found). "
+            "This provider may have migrated to the new abfall.io v3 GraphQL API. "
+            "Try using the abfall_io_graphql wizard instead: "
+            "wizard/abfall_io_graphql.py"
+        )
     args = {
         "key": answers["key"],
         "modus": MODUS_KEY,
-        "waction": ACTION_EXTRACTOR_PATTERN.findall(data)[0],
+        "waction": waction_matches[0],
     }
     r = requests.post(
         "https://api.abfall.io", params=args, data=answers, headers=HEADERS
@@ -198,6 +205,15 @@ def main():
     # prompt for first level
     args = {"key": answers["key"], "modus": MODUS_KEY, "waction": "init"}
     r = requests.get("https://api.abfall.io", params=args, headers=HEADERS)
+
+    if r.status_code == 401:
+        raise ValueError(
+            f"API key '{answers['key']}' returned HTTP 401. "
+            "This provider has likely migrated to the new abfall.io v3 GraphQL API. "
+            "Please use the abfall_io_graphql wizard instead: "
+            "wizard/abfall_io_graphql.py"
+        )
+    r.raise_for_status()
 
     data = r.text
     while True:


### PR DESCRIPTION
## Summary
- Fixes #4820
- The `abfall_io` wizard crashes with `IndexError: list index out of range` when a provider has migrated to the abfall.io v3 GraphQL API (which returns HTTP 401 from the legacy endpoint)
- Adds explicit HTTP 401 detection in `main()` with a clear error message directing users to `abfall_io_graphql.py`
- Also guards `select_and_query()` against responses where the `waction` attribute is absent, for the same reason

## Test plan
- [ ] Run `wizard/abfall_io.py` and select "Göttinger Entsorgungsbetriebe" — should now print a clear `ValueError` instead of an `IndexError`
- [ ] Run `wizard/abfall_io.py` and select a working provider (e.g. "Stadt Landshut") — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)