### PR TITLE
fix(durham_gov_uk): switch from HTML scraping to JSON-RPC API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/durham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/durham_gov_uk.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+import json
+import re
+from datetime import date, datetime
 
 import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Durham County Council"
@@ -11,29 +12,92 @@ TEST_CASES = {
     "Test_001": {"uprn": "100110414978"},
     "Test_002": {"uprn": 100110427200},
 }
-ICON_MAP = {"RECYCLE": "mdi:recycle", "GARDEN": "mdi:leaf", "RUBBISH": "mdi:trash-can"}
+
+API_URL = "https://www.durham.gov.uk/apiserver/ajaxlibrary/"
+ICON_MAP = {
+    "Rubbish bin": "mdi:trash-can",
+    "Recycle bin": "mdi:recycle",
+    "Garden waste bin": "mdi:leaf",
+    "Food waste bin": "mdi:food-apple",
+    "Clinical Waste": "mdi:medical-bag",
+}
+
+NAME_MAP = {
+    "Empty Bin Refuse": "Rubbish bin",
+    "Empty Bin Recycling": "Recycle bin",
+    "Empty Bin Organic": "Garden waste bin",
+    "Empty Bin Food": "Food waste bin",
+    "Empty Bin Clinical": "Clinical Waste",
+}
+
+
+def _map_bin_name(name: str) -> str:
+    for prefix, display in NAME_MAP.items():
+        if name.startswith(prefix):
+            return display
+    return name
 
 
 class Source:
     def __init__(self, uprn: str | int):
         self._uprn = str(uprn)
 
-    def fetch(self):
+    def fetch(self) -> list[Collection]:
         s = requests.Session()
-        r = s.get(f"https://www.durham.gov.uk/bincollections?uprn={self._uprn}")
-        soup = BeautifulSoup(r.text, "html.parser")
+        s.headers.update(
+            {
+                "Content-Type": "application/json",
+                "Referer": f"https://www.durham.gov.uk/bincollections?uprn={self._uprn}",
+            }
+        )
 
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "durham.Localities.GetBartecCalendar",
+                "params": {"uprn": self._uprn},
+                "id": "21",
+                "name": "V2 AJAX End Point Library Worker",
+            }
+        )
+        r = s.post(API_URL, data=payload)
+        r.raise_for_status()
+
+        result = r.json()
+        xml_str = result.get("result", "")
+
+        today = date.today()
         entries = []
-        for waste in ICON_MAP:
-            w = soup.find_all("tr", {"class": f"{waste.lower()}"})
-            for item in w:
-                x = item.find_all("td")
-                entries.append(
-                    Collection(
-                        date=datetime.strptime(x[-1].text, "%d %B %Y").date(),
-                        t=x[0].text,
-                        icon=ICON_MAP.get(waste),
-                    )
+
+        for match in re.finditer(r"<Job>(.*?)</Job>", xml_str, re.DOTALL):
+            job_xml = match.group(1)
+
+            name_match = re.search(r"<Name[^>]*>([^<]+)</Name>", job_xml)
+            sched_match = re.search(
+                r"<ScheduledStart>([^<]+)</ScheduledStart>", job_xml
+            )
+
+            if not name_match or not sched_match:
+                continue
+
+            name = name_match.group(1).strip()
+            sched_str = sched_match.group(1).strip()
+
+            try:
+                collection_date = datetime.fromisoformat(sched_str).date()
+            except ValueError:
+                continue
+
+            if collection_date < today:
+                continue
+
+            waste_type = _map_bin_name(name)
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type),
                 )
+            )
 
         return entries


### PR DESCRIPTION
## Summary
- Durham County Council redesigned their bin collections page — collection dates are no longer in the static HTML and are instead loaded via a JSON-RPC API call to `durham.Localities.GetBartecCalendar`
- Rewrites the source to POST to `https://www.durham.gov.uk/apiserver/ajaxlibrary/` and parse the XML response
- Adds `Clinical Waste` and `Food waste bin` mappings discovered in the API data
- Bin type names preserved for backward compatibility with existing user configs ("Rubbish bin", "Recycle bin", "Garden waste bin")

## Test plan
- [ ] Both existing TEST_CASES return future collection entries
- [ ] Reporter's UPRN (100110493335, postcode DL16 7AB) returns entries
- [ ] Bin type names are compatible with existing user customise configs

Fixes #6283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)