### PR TITLE
Add source: Gänserndorf City (gaenserndorf_city_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gaenserndorf_city_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gaenserndorf_city_at.py
@@ -1,0 +1,157 @@
+import hashlib
+import logging
+from base64 import b64encode
+from datetime import datetime
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "Gänserndorf City / Gänserndorf App"
+DESCRIPTION = (
+    "Source for waste collection schedule for the city of Gänserndorf, Austria. "
+    "Uses the Jolioo mobile app API."
+)
+URL = "https://www.gaenserndorf.at/"
+COUNTRY = "at"
+TEST_CASES = {
+    "Baumschulweg": {"street": "Baumschulweg"},
+    "Ahornweg": {"street": "Ahornweg"},
+    "Siebenbrunner Straße (first calendar)": {
+        "street": "Siebenbrunner Straße",
+        "calendar_index": 0,
+    },
+}
+
+# ────────────────── API credentials ──────────────────
+_API_URL = "https://app.jolioo.com/api/mobile-app/"
+_API_KEY = "e74b7a2955428b2ab520"
+_API_SECRET = "3646728f96cf464aff7e"
+_API_USERNAME = "mopedshop"
+_API_PASSWORD = "T4P4qSur"
+_USER_AGENT = f"JoliooMobileApp-{_API_KEY}"
+
+
+def _basic_auth() -> str:
+    """Return the Basic-Auth header value."""
+    raw = f"{_API_USERNAME}:{_API_PASSWORD}"
+    return "Basic " + b64encode(raw.encode()).decode()
+
+
+def _api_hash(endpoint_path: str, body: str) -> str:
+    """Compute the APIHASH exactly as the app does (no user token)."""
+    hash_input = f"{_API_SECRET}@{endpoint_path}@{body}"
+    return hashlib.sha1(hash_input.encode()).hexdigest()
+
+
+def _post(endpoint: str, params: dict) -> dict:
+    """Send an authenticated POST to the API and return parsed JSON."""
+    body = "&".join(f"{k}={v}" for k, v in params.items())
+    endpoint_path = f"api/mobile-app/{endpoint}"
+    apihash = _api_hash(endpoint_path, body)
+
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "APIHASH": apihash,
+        "APIKEY": _API_KEY,
+        "VERSION": "1",
+        "Authorization": _basic_auth(),
+        "User-Agent": _USER_AGENT,
+    }
+
+    resp = requests.post(
+        f"{_API_URL}{endpoint}", headers=headers, data=body, timeout=30
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    if not data.get("success"):
+        raise RuntimeError(f"Jolioo API returned error for {endpoint}: {data}")
+
+    return data["data"]
+
+
+class Source:
+    """Waste collection schedule source for Jolioo / Gänserndorf App."""
+
+    def __init__(self, street: str, calendar_index: int = 0):
+        self._street = street
+        self._calendar_index = calendar_index
+
+    def fetch(self):
+        """Fetch the waste collection schedule."""
+
+        # Step 1: get streets + calendars index
+        index_data = _post(
+            "garbagecalendarindexwithstreets",
+            {"language": "de", "garbage_calendar_id": "1"},
+        )
+
+        streets = index_data.get("street_structure", [])
+
+        # find the requested street (case-insensitive)
+        match = None
+        for s in streets:
+            if s["garbage_calendar_street"].lower() == self._street.lower():
+                match = s
+                break
+
+        if match is None:
+            available = sorted(s["garbage_calendar_street"] for s in streets)
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street", self._street, available
+            )
+
+        cal_ids = match["garbage_calendars_available"]
+        if self._calendar_index >= len(cal_ids):
+            raise SourceArgumentNotFoundWithSuggestions(
+                "calendar_index",
+                self._calendar_index,
+                list(range(len(cal_ids))),
+            )
+
+        calendar_id = cal_ids[self._calendar_index]
+        _LOGGER.debug(
+            "Fetching garbage calendar %s for street '%s'",
+            calendar_id,
+            self._street,
+        )
+
+        # Step 2: fetch the actual dates for this calendar
+        cal_data = _post(
+            "garbagecalendar",
+            {"language": "de", "garbage_calendar_id": str(calendar_id)},
+        )
+
+        # build a label-id → title lookup (only child labels that have a
+        # garbage_label_label field, i.e. the ones that actually appear on items)
+        labels = {}
+        for lbl in cal_data.get("labels", []):
+            if lbl.get("garbage_label_id_parent") is not None:
+                labels[lbl["garbage_label_id"]] = lbl["garbage_label_title"]
+
+        # parse items
+        entries = []
+        for item in cal_data.get("items", []):
+            label_id = item["garbage_label_id"]
+            # skip parent-only labels that have no actual schedule meaning
+            if label_id not in labels:
+                continue
+            date_str = item["garbage_calendar_item_date"]  # "DD.MM.YYYY"
+            date = datetime.strptime(date_str, "%d.%m.%Y").date()
+            waste_type = labels[label_id]
+
+            entries.append(Collection(date=date, t=waste_type))
+
+        _LOGGER.debug(
+            "Fetched %d collection entries for '%s' (calendar %s)",
+            len(entries),
+            self._street,
+            calendar_id,
+        )
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gaenserndorf_city_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gaenserndorf_city_at.py
@@ -18,12 +18,41 @@ DESCRIPTION = (
 )
 URL = "https://www.gaenserndorf.at/"
 COUNTRY = "at"
+EXTRA_INFO = [
+    {
+        "title": "Gänserndorf",
+        "url": "https://www.gaenserndorf.at/",
+        "country": "at",
+    },
+]
 TEST_CASES = {
     "Baumschulweg": {"street": "Baumschulweg"},
     "Ahornweg": {"street": "Ahornweg"},
     "Siebenbrunner Straße (first calendar)": {
         "street": "Siebenbrunner Straße",
         "calendar_index": 0,
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "street": "Street Name",
+        "calendar_index": "Calendar Index",
+    },
+    "de": {
+        "street": "Straßenname",
+        "calendar_index": "Kalender-Index",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street": "The name of your street as shown in the Gänserndorf App.",
+        "calendar_index": "Index of the calendar to use when a street maps to multiple calendars (starting at 0).",
+    },
+    "de": {
+        "street": "Der Straßenname, wie er in der Gänserndorf-App angezeigt wird.",
+        "calendar_index": "Index des zu verwendenden Kalenders, wenn eine Straße mehreren Kalendern zugeordnet ist (beginnt bei 0).",
     },
 }
 

--- a/doc/source/gaenserndorf_city_at.md
+++ b/doc/source/gaenserndorf_city_at.md
@@ -1,0 +1,68 @@
+# Gänserndorf City / Gänserndorf App
+
+Support for schedules provided by [Gänserndorf City](https://www.gaenserndorf.at/) located in Gänserndorf, Austria. Uses the Jolioo mobile app API.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: gaenserndorf_city_at
+      args:
+        street: STREET
+```
+
+### Configuration Variables
+
+**street**  
+*(string) (required)*
+
+The name of your street, e.g. `"Baumschulweg"`.
+
+**calendar_index**  
+*(integer) (optional, default: `0`)*
+
+Some streets map to multiple waste calendars. Use this to select which calendar to use (starting at `0`).
+
+### How to get the source arguments
+
+Use the street name as shown in the [Gänserndorf App](https://www.gans-gaenserndorf.at/).
+If you have mispelled your street, check the debug output for all the valid streetnames which will be returned there. 
+
+If your street has multiple calendars, you can specify the `calendar_index` parameter.
+
+### Waste types
+
+Please check the app for the waste types in your area as these names are the waste types it will return. 
+Some of the most common waste types are:
+
+* Biomüll
+* Sondermüll
+* Restmüll
+* Restmüll Wohnblöcke 2-Wochen-Tour
+* Altpapier Großcontainer
+* Leicht- & Metallverpackungen/Gelbe Tonne/Gelber Sack
+
+## Examples
+
+**Simple**
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: gaenserndorf_city_at
+      args:
+        street: "Baumschulweg"
+```
+
+**Street with multiple calendars**
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: gaenserndorf_city_at
+      args:
+        street: "Siebenbrunner Straße"
+        calendar_index: 0
+```
+

--- a/doc/source/gaenserndorf_city_at.md
+++ b/doc/source/gaenserndorf_city_at.md
@@ -27,13 +27,13 @@ Some streets map to multiple waste calendars. Use this to select which calendar 
 ### How to get the source arguments
 
 Use the street name as shown in the [Gänserndorf App](https://www.gans-gaenserndorf.at/).
-If you have mispelled your street, check the debug output for all the valid streetnames which will be returned there. 
+If you have misspelled your street, check the debug output for all the valid streetnames which will be returned there.
 
 If your street has multiple calendars, you can specify the `calendar_index` parameter.
 
 ### Waste types
 
-Please check the app for the waste types in your area as these names are the waste types it will return. 
+Please check the app for the waste types in your area as these names are the waste types it will return.
 Some of the most common waste types are:
 
 * Biomüll
@@ -65,4 +65,3 @@ waste_collection_schedule:
         street: "Siebenbrunner Straße"
         calendar_index: 0
 ```
-


### PR DESCRIPTION
  Adds a new source for the city of Gänserndorf, Austria which is also requested in #3536 
  
  This is the city itself and not the district Gänserndorf which is covered in this [source](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/umweltverbaende_at.md).
  
     - New source: `gaenserndorf_city_at`
     - Documentation: `doc/source/gaenserndorf_city_at.md`
     - 3 test cases, all passing
     
Test output

```
Testing source gaenserndorf_city_at ...
  found 106 entries for Baumschulweg
  found 106 entries for Ahornweg
  found 106 entries for Siebenbrunner Straße (first calendar)
```

Closes #3536 