### PR TITLE
fix(recyclecoach_com): replace dead us-api-city host with api-city

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -534,7 +534,7 @@ class Source:
         if not self.zone_id:
             self._lookup_zones()
 
-        collection_def_url = f"https://us-api-city.recyclecoach.com/collections?project_id={self.project_id}&district_id={self.district_id}&zone_id={self.zone_id}&lang_cd=en_US"
+        collection_def_url = f"https://api-city.recyclecoach.com/collections?project_id={self.project_id}&district_id={self.district_id}&zone_id={self.zone_id}&lang_cd=en_US"
 
         schedule_urls = [  # Some regions use different one of these should work
             f"https://api-city.recyclecoach.com/app_data_zone_schedules?project_id={self.project_id}&district_id={self.district_id}&zone_id={self.zone_id}",


### PR DESCRIPTION
## Summary
- `us-api-city.recyclecoach.com` no longer resolves (DNS NameResolutionError), breaking all RecycleCoach configurations that provide `project_id`/`district_id`/`zone_id` directly (no address lookup needed)
- All other API calls in the source already use `api-city.recyclecoach.com`; this PR aligns the `collection_def_url` to use the same working host
- One-line change; manually verified against Vaughan, Ontario (project_id=576, district_id=VAU, zone_id=zone-z1627)

## Test plan
- [x] Verified `api-city.recyclecoach.com/collections` returns `{"status":"success"}` for Vaughan parameters
- [x] Confirmed `us-api-city.recyclecoach.com` is fully unresolvable (DNS failure)
- [ ] Run `test_sources.py -s recyclecoach_com -l` after merge to validate all TEST_CASES

Fixes #6289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)