### PR TITLE
fix: correct COUNTRY codes on three orphaned sources

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_gov_uk.py
@@ -11,7 +11,7 @@ DESCRIPTION = (
     "Source for waste collection schedules provided by Ipswich Borough Council, UK."
 )
 URL = "https://www.ipswich.gov.uk"
-COUNTRY = "gb"
+COUNTRY = "uk"
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": (

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/shawinigan_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/shawinigan_ca.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 TITLE = "Shawinigan"
 DESCRIPTION = "Source for Shawinigan, Canada waste collection schedule."
 URL = "https://geoweb.shawinigan.ca/CollecteMatieresResiduelles/"
-COUNTRY = "CA"
+COUNTRY = "ca"
 
 TEST_CASES = {
     "Shawinigan": {"address": "1760 Avenue de la Paix, Shawinigan, QC G9N 6H7"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southribble_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southribble_gov_uk.py
@@ -10,7 +10,7 @@ DESCRIPTION = (
     "Source for southribble.gov.uk services for South Ribble Borough Council, UK."
 )
 URL = "https://www.southribble.gov.uk"
-COUNTRY = "gb"
+COUNTRY = "uk"
 TEST_CASES = {
     "South Ribble Borough Council, Civic Centre, W Paddock, Leyland PR25 1DH": {
         "postcode": "PR25 1DH",

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -291,13 +291,17 @@ def test_source_has_necessary_parameters() -> None:
             module.Source, "fetch"
         ), f"missing fetch method in Source class of source {source}"
 
+        # If the module declares COUNTRY it must be a valid code — update_docu_links.py
+        # uses this value directly and silently orphans the source if it doesn't match.
+        if hasattr(module, "COUNTRY"):
+            assert _is_supported_country_code(
+                module.COUNTRY
+            ), f"unsupported country code {module.COUNTRY!r} in source {source}"
+
         if source not in SOURCES_NO_COUNTRY and not _has_supported_country_code(source):
             assert hasattr(
                 module, "COUNTRY"
             ), f"missing COUNTRY in source {source} or supported countrycode in filename"
-            assert _is_supported_country_code(
-                module.COUNTRY
-            ), f"unsupported country code in source {source}"
 
         if hasattr(module, "EXTRA_INFO"):
             _test_source_has_necessary_parameters_extra_info(


### PR DESCRIPTION
## Summary

Three recently-added sources were silently orphaned out of `README.md`, `info.md`, and `sources.json` — making them invisible in the config wizard. Reported by @CJEBond on #6220 (https://github.com/mampfes/hacs_waste_collection_schedule/pull/6220#issuecomment-4418325422).

| Source | Old COUNTRY | New COUNTRY |
|--------|-------------|-------------|
| `shawinigan_ca` | `"CA"` (uppercase) | `"ca"` |
| `ipswich_gov_uk` | `"gb"` | `"uk"` |
| `southribble_gov_uk` | `"gb"` | `"uk"` |

`update_docu_links.py` uses `module.COUNTRY` directly to bucket sources by country. Its `COUNTRYCODES` list uses lowercase `"ca"` and `"uk"` (the convention every other CA/UK source already follows), so the three values above didn't match and the sources fell into the `orphans` list — printed to stdout but not failing CI.

## Test hardening

`tests/test_source_components.py` already had a `_is_supported_country_code` check, but it only ran when the **filename** suffix was *not* a valid code. Since `_ca`/`_uk` are valid suffixes, the value of the `COUNTRY` attribute itself was never inspected. This PR splits the two checks so the value is always validated when present — which would have caught all three of these at PR time.

## Test plan

- [x] `python -m pytest tests/test_source_components.py` passes locally
- [ ] CI green
- [ ] After merge, the post-merge `Update Documentation` workflow re-runs `update_docu_links.py` and the three sources appear in `README.md` / `info.md` / `sources.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)