### PR TITLE
[Source] Add NVOA - Nacka Vatten och Avfall (Sweden)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
@@ -114,6 +114,10 @@ TEST_CASES = {
         "street_address": "Gasverksgatan 7, Västerås",
         "service_provider": "vafabmiljo",
     },
+    "NVOA - Nacka (Fogdevägen)": {
+        "street_address": "Fogdevägen 13, Saltsjö-Duvnäs",
+        "service_provider": "nvoa",
+    },
 }
 
 COUNTRY = "se"
@@ -241,6 +245,11 @@ SERVICE_PROVIDERS = {
         "title": "Vafab Miljö",
         "url": "https://vafabmiljo.se",
         "api_url": "https://services.vafabmiljo.se/FutureWebVKFHus/SimpleWastePickup",
+    },
+    "nvoa": {
+        "title": "NVOA - Nacka Vatten och Avfall",
+        "url": "https://www.nacka.se/nackavattenavfall/avfall/sophamtning/tomningsdag/",
+        "api_url": "https://futureweb.nvoa.se/EDP/FutureWebBasic/SimpleWastePickup",
     },
 }
 


### PR DESCRIPTION
## Source request

Adds NVOA (Nacka Vatten och Avfall) as a service provider in `edpevent_se.py`.

Closes #5501

## Details

NVOA is the waste management company for Nacka municipality (Sweden). Their
portal runs on the same FutureWeb/SimpleWastePickup platform as the other
EDPEvent providers already in this file, so only a new SERVICE_PROVIDERS entry
and a test case are needed.

- API base URL: `https://futureweb.nvoa.se/EDP/FutureWebBasic/SimpleWastePickup`
- Waste types returned: Restavfall, Matavfall (and any others configured per address)
- Test address: Fogdevägen 13, Saltsjö-Duvnäs (verified against the live API)