### PR TITLE
fix: handle "Today"/"Tomorrow" date strings in nwleics_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nwleics_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nwleics_gov_uk.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+
 import requests
 from bs4 import BeautifulSoup
 from dateutil import parser
@@ -6,9 +8,15 @@ from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 TITLE = "North West Leicestershire District Council"  # Title will show up in README.md and info.md
 DESCRIPTION = "Source for www.nwleics.gov.uk services for the city of North West Leicestershire District Council, UK"  # Describe your source
 URL = "https://nwleics.gov.uk/"  # Insert url to service homepage. URL will show up in README.md and info.md
+COUNTRY = "uk"
 TEST_CASES = {  # Insert arguments for test cases to be used by test_sources.py script
     "Dunmore": {"uprn": "10002359002"},
     "Station Road": {"uprn": 100030573554},
+}
+
+RELATIVE_DATE_MAP = {
+    "today": lambda: date.today(),
+    "tomorrow": lambda: date.today() + timedelta(days=1),
 }
 
 API_URL = "https://my.nwleics.gov.uk/location?put=nwl{uprn}&rememberme=0&redirect=%2F"
@@ -42,7 +50,12 @@ class Source:
             strong_tag = li.find("strong")
             a_tag = li.find("a")
 
-            collection_date = parser.parse(strong_tag.contents[0]).date()
+            date_str = strong_tag.contents[0].strip()
+            date_str_lower = date_str.lower()
+            if date_str_lower in RELATIVE_DATE_MAP:
+                collection_date = RELATIVE_DATE_MAP[date_str_lower]()
+            else:
+                collection_date = parser.parse(date_str).date()
             bin_type = a_tag.contents[0]
 
             entries.append(


### PR DESCRIPTION
## Summary

- Fixes setup failure when a collection is due today or tomorrow for North West Leicestershire District Council.
- The council website returns the literal strings "Today" or "Tomorrow" instead of a date, which `dateutil.parser.parse()` cannot handle.
- Adds a `RELATIVE_DATE_MAP` lookup before parsing, resolving those strings to `date.today()` or `date.today() + timedelta(days=1)`.
- Also adds the missing `COUNTRY = "uk"` field, which was silently omitting this source from README/sources.json.

Closes #3955
Closes #6302

## Test plan

- [x] `python test_sources.py -s nwleics_gov_uk -l` returns entries for both test UPRNs (today's date correctly resolved from "Today")
- [x] No generated files in diff