### PR TITLE
fix: add Food Waste mapping for cannock_chase_dc_gov_uk (closes #6314)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cannock_chase_dc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cannock_chase_dc_gov_uk.py
@@ -20,6 +20,7 @@ ICON_MAP = {
     "REFUSE": "mdi:trash-can",
     "RECYCLING": "mdi:recycle",
     "GARDEN WASTE": "mdi:leaf",
+    "FOOD WASTE": "mdi:food-apple",
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
@@ -36,6 +37,7 @@ SERVICE_NAME_MAP = {
     "Refuse Collection Service": "Refuse",
     "Recycle Collection Service": "Recycling",
     "Garden Collection Service": "Garden waste",
+    "Food Waste Collection Service": "Food waste",
 }
 
 


### PR DESCRIPTION
## Summary
- Cannock Chase Council recently added a weekly Food Waste collection service
- The API now returns `"Food Waste Collection Service"` which was not in `SERVICE_NAME_MAP` or `ICON_MAP`
- Added mapping to friendly name `"Food waste"` and icon `mdi:food-apple`

## Test plan
- [ ] Run `python test_sources.py -s cannock_chase_dc_gov_uk -l` — all four TEST_CASES should include "Food waste" entries
- [ ] Verified locally: all four cases pass with the new mapping

Closes #6314

🤖 Generated with [Claude Code](https://claude.com/claude-code)