### PR TITLE
feat: add Chesapeake, VA trash collection source (closes #6301)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesapeake_va_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesapeake_va_us.py
@@ -1,0 +1,90 @@
+from datetime import date, timedelta
+
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import (
+    ArcGisError,
+    geocode,
+    query_feature_layer,
+)
+
+TITLE = "Chesapeake, VA"
+DESCRIPTION = "Source for Chesapeake, VA trash collection."
+URL = "https://www.cityofchesapeake.net"
+COUNTRY = "us"
+
+TEST_CASES = {
+    "460 Sawyers Mill Xing": {"address": "460 Sawyers Mill Xing, Chesapeake, VA 23323"},
+}
+
+ICON_MAP = {
+    "Trash": "mdi:trash-can",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Full street address including city and state (e.g. '460 Sawyers Mill Xing, Chesapeake, VA 23323')",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+MAPSERVER_URL = "https://gis.cityofchesapeake.net/mapping/rest/services/WasteManagement/Trash_Collection_Areas/MapServer/0"
+
+WEEKDAYS = {
+    "Monday": 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+    "Saturday": 5,
+    "Sunday": 6,
+}
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        try:
+            location = geocode(self._address)
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        try:
+            features = query_feature_layer(
+                MAPSERVER_URL,
+                geometry=location,
+                out_fields="PICKUP_DAY",
+            )
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        attrs = features[0]
+        pickup_day = (attrs.get("PICKUP_DAY") or "").strip().title()
+
+        if not pickup_day or pickup_day not in WEEKDAYS:
+            raise SourceArgumentNotFound("address", self._address)
+
+        return self._weekly_dates(pickup_day, "Trash")
+
+    @staticmethod
+    def _weekly_dates(day_name: str, waste_type: str) -> list[Collection]:
+        weekday = WEEKDAYS[day_name]
+        today = date.today()
+        days_ahead = (weekday - today.weekday()) % 7
+        next_date = today + timedelta(days=days_ahead)
+        icon = ICON_MAP.get(waste_type)
+        return [
+            Collection(
+                date=next_date + timedelta(weeks=i),
+                t=waste_type,
+                icon=icon,
+            )
+            for i in range(26)
+        ]

--- a/doc/source/chesapeake_va_us.md
+++ b/doc/source/chesapeake_va_us.md
@@ -1,0 +1,36 @@
+# Chesapeake, VA
+
+Support for schedules provided by [Chesapeake, VA](https://www.cityofchesapeake.net).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: chesapeake_va_us
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Full street address including city and state.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: chesapeake_va_us
+      args:
+        address: 460 Sawyers Mill Xing, Chesapeake, VA 23323
+```
+
+## How to get the source arguments
+
+Use your full street address including city, state, and ZIP code (e.g. "460 Sawyers Mill Xing, Chesapeake, VA 23323"). The source geocodes the address via the ArcGIS World Geocoder and then queries the city's trash-collection zone layer to determine your weekly pickup day.
+
+Note: Chesapeake has suspended recycling collection city-wide. Only trash collection is currently supported. Recycling support can be added once the city resumes the service.


### PR DESCRIPTION
## Summary
- Adds `chesapeake_va_us` source for Chesapeake, Virginia trash collection
- Geocodes the user's address via ArcGIS World Geocoder, then performs a point-in-polygon query against the city's ArcGIS MapServer to determine the weekly trash pickup day
- Recycling has been suspended city-wide indefinitely; support can be added when the city resumes it

## Notes
The MapServer (`gis.cityofchesapeake.net`) is accessible from within the US but times out from outside. Live TEST_CASES require a US-based network.

## Test plan
- [ ] `python test_sources.py -s chesapeake_va_us -l` from a US network
- [ ] Verify address returns weekly Trash entries
- [ ] Verify an address in a "No Service" zone raises `SourceArgumentNotFound`

Closes #6301

🤖 Generated with [Claude Code](https://claude.com/claude-code)