### PR TITLE
fix: correct Clarence Valley Council URL typo in impactapps_com_au

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
@@ -352,7 +352,7 @@ SERVICE_MAP = (
         },
         {
             "name": "Clarence Valley Council",
-            "url": "https://clarane.waste-info.com.au",
+            "url": "https://clarence.waste-info.com.au",
             "website": "https://www.clarence.nsw.gov.au",
         },
     ]


### PR DESCRIPTION
## Summary
- Corrects a one-character typo in the `SERVICE_MAP` entry for Clarence Valley Council
- `clarane.waste-info.com.au` → `clarence.waste-info.com.au`
- The old subdomain responded HTTP 200 but returned zero localities from the API, causing address lookups to silently fail
- Confirmed `clarence.waste-info.com.au` returns 106 collection entries for the test address

Fixes #6320

## Test plan
- [ ] `python test_sources.py -s impactapps_com_au -l` — confirm Clarence Valley Council returns entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)