### PR TITLE
fix: add Stradella, San Cipriano Po, and Broni to junker_app

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -322,6 +322,9 @@ SERVICE_PROVIDERS = {
     "Lodè - Eco Flap - Ciclat",
     "Toro",
     "C.C.S. - Consorzio Campale Stabile",
+    "Broni",
+    "San Cipriano Po",
+    "Stradella",
 }
 
 


### PR DESCRIPTION
## Summary
- Adds Stradella, San Cipriano Po, and Broni (Italy) to the `SERVICE_PROVIDERS` discoverability list in `junker_app.py`
- All three municipalities are confirmed to work with the existing Junker App source
- Stradella and Broni require the `area` parameter (zones: "Bar e ristoranti", "Utenze domestiche")
- San Cipriano Po has no zones and works without `area`

Closes #6325, closes #6326, closes #6327

## Test plan
- [ ] `python test_sources.py -s junker_app -l` — existing test cases still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)