### PR TITLE
feat: add Reinach BL (reinach_bl_ch) waste collection source (closes #6332)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/reinach_bl_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/reinach_bl_ch.py
@@ -1,0 +1,115 @@
+"""Source for Reinach BL, Switzerland."""
+
+import re
+from datetime import datetime
+from typing import List
+from xml.etree import ElementTree
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "Reinach BL"
+DESCRIPTION = (
+    "Source for waste collection schedule of Gemeinde Reinach BL, Switzerland."
+)
+URL = "https://www.reinach-bl.ch"
+COUNTRY = "ch"
+
+RSS_URL = "https://www.reinach-bl.ch/de/abfallwirtschaft/abfallkalender/rss.php"
+
+VALID_ZONES = ["Kreis Ost", "Kreis West"]
+
+TEST_CASES = {
+    "Kreis Ost": {"zone": "Kreis Ost"},
+    "Kreis West": {"zone": "Kreis West"},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Select your collection zone (Kreis Ost or Kreis West). "
+        "You can find your zone on the official Reinach BL waste calendar "
+        "page at https://www.reinach-bl.ch/de/abfallwirtschaft/abfallkalender."
+    ),
+    "de": (
+        "Wählen Sie Ihren Abfuhrkreis (Kreis Ost oder Kreis West). "
+        "Den Kreis finden Sie auf dem Abfallkalender der Gemeinde Reinach BL "
+        "unter https://www.reinach-bl.ch/de/abfallwirtschaft/abfallkalender."
+    ),
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {"zone": "Collection zone"},
+    "de": {"zone": "Abfuhrkreis"},
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {"zone": "Collection zone: 'Kreis Ost' or 'Kreis West'."},
+    "de": {"zone": "Abfuhrkreis: 'Kreis Ost' oder 'Kreis West'."},
+}
+
+ICON_MAP = {
+    "Hauskehricht": "mdi:trash-can",
+    "Grünabfuhr/Bioabfall": "mdi:leaf",
+    "Häckseldienst": "mdi:chainsaw",
+    "Papier": "mdi:newspaper-variant-outline",
+    "Karton": "mdi:package-variant",
+    "Metalle": "mdi:nail",
+}
+
+
+class Source:
+    def __init__(self, zone: str):
+        if zone not in VALID_ZONES:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "zone",
+                zone,
+                suggestions=VALID_ZONES,
+            )
+        self._zone = zone
+
+    def fetch(self) -> List[Collection]:
+        response = requests.get(RSS_URL, timeout=30)
+        response.raise_for_status()
+
+        root = ElementTree.fromstring(response.content)
+
+        entries: List[Collection] = []
+        for item in root.iter("item"):
+            title_el = item.find("title")
+            description_el = item.find("description")
+            if title_el is None or description_el is None:
+                continue
+
+            waste_type = (title_el.text or "").strip()
+            description = (description_el.text or "").strip()
+
+            # Description format: "DD.MM.YYYY<br/>Zone: Kreis Ost"
+            date_match = re.search(r"(\d{2})\.(\d{2})\.(\d{4})", description)
+            zone_match = re.search(r"Zone:\s*(.+?)\s*$", description)
+
+            if not date_match or not zone_match:
+                continue
+
+            zone = zone_match.group(1).strip()
+            if zone != self._zone:
+                continue
+
+            try:
+                collection_date = datetime.strptime(
+                    date_match.group(0), "%d.%m.%Y"
+                ).date()
+            except ValueError:
+                continue
+
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type),
+                )
+            )
+
+        return entries

--- a/doc/source/reinach_bl_ch.md
+++ b/doc/source/reinach_bl_ch.md
@@ -1,0 +1,53 @@
+# Reinach BL
+
+Support for waste collection schedules provided by [Gemeinde Reinach BL](https://www.reinach-bl.ch/de/abfallwirtschaft/abfallkalender), Switzerland.
+
+The source consumes the official Reinach BL RSS feed:
+`https://www.reinach-bl.ch/de/abfallwirtschaft/abfallkalender/rss.php`
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: reinach_bl_ch
+      args:
+        zone: ZONE
+```
+
+### Configuration Variables
+
+**zone**
+*(string) (required)*
+
+The collection zone within Reinach BL. Must be one of:
+
+- `Kreis Ost`
+- `Kreis West`
+
+## How to find your `zone`
+
+Open the [official Reinach BL waste calendar](https://www.reinach-bl.ch/de/abfallwirtschaft/abfallkalender). The page shows the two collection zones (`Kreis Ost` and `Kreis West`) and indicates which streets belong to each zone.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: reinach_bl_ch
+      args:
+        zone: "Kreis Ost"
+```
+
+## Bin types returned
+
+The RSS feed uses the German waste-type names listed below. Unknown types are still returned with no icon.
+
+| Provider description | Returned type        | Icon                              |
+|----------------------|----------------------|-----------------------------------|
+| Hauskehricht         | Hauskehricht         | `mdi:trash-can`                   |
+| Grünabfuhr/Bioabfall | Grünabfuhr/Bioabfall | `mdi:leaf`                        |
+| Häckseldienst        | Häckseldienst        | `mdi:chainsaw`                    |
+| Papier               | Papier               | `mdi:newspaper-variant-outline`   |
+| Karton               | Karton               | `mdi:package-variant`             |
+| Metalle              | Metalle              | `mdi:nail`                        |


### PR DESCRIPTION
## Summary
- Adds a new source for Reinach BL, Switzerland (`reinach_bl_ch`)
- Fetches from the public RSS feed at `https://www.reinach-bl.ch/de/abfallwirtschaft/abfallkalender/rss.php`
- Single parameter: `zone` (`"Kreis Ost"` or `"Kreis West"`)
- Six waste types mapped to icons: Hauskehricht, Grünabfuhr/Bioabfall, Häckseldienst, Papier, Karton, Metalle
- Live test: 86–87 collections fetched per zone through end of 2026

## Test plan
- [x] `python test_sources.py -s reinach_bl_ch -l` — 86/87 entries fetched
- [x] `python -m pytest tests/test_source_components.py` — passes

Closes #6332

🤖 Generated with [Claude Code](https://claude.com/claude-code)