### PR TITLE
Add source: Schwalbach am Taunus (schwalbach_am_taunus_de)

### DIFF
--- a/doc/ics/yaml/schwalbach_am_taunus_de.yaml
+++ b/doc/ics/yaml/schwalbach_am_taunus_de.yaml
@@ -4,18 +4,22 @@ url: https://www.schwalbach.de
 howto:
   en: |
     - Go to <https://www.schwalbach.de/Rathaus-und-Buergerservice/Buergerservice/Abfallentsorgung/Digitaler-Abfallkalender.htm> and navigate to the digital waste calendar.
-    - Select your street from the dropdown.
-    - Right-click on the yellow calendar download button (e.g. "Termine mit wöchentlicher Restmüll-Abholung") and copy the link address.
-    - The link will look like: `https://www.schwalbach.de/city_info/display/ical/m_calendar_ical.cfm?region_id=431&year=2026&city_id=1&street_id=XXXXX`
-    - Replace the year value with `{year}` or use `year_field: year` in your config to keep it up to date automatically.
-    - Use this link as the `url` parameter.
+    - Select your street from the dropdown. Note your **Abfuhrbezirk** number (1–4) shown next to the street.
+    - Right-click on the yellow calendar download button (e.g. "Termine mit wöchentlicher Restmüll-Abholung für den Abfuhrbezirk 1 - 2026") and copy the link address.
+    - The link will look like: `https://www.schwalbach.de/city_data/assets/431/ical/2026_Abfuhrbezirk-1_woechentlich.ics`
+    - Replace the year (`2026`) with `{%Y}` and add `version: 1` to your config so the year is updated automatically.
+    - Use this modified link as the `url` parameter.
   de: |
     - Öffnen Sie <https://www.schwalbach.de/Rathaus-und-Buergerservice/Buergerservice/Abfallentsorgung/Digitaler-Abfallkalender.htm> und navigieren Sie zum digitalen Abfallkalender.
-    - Wählen Sie Ihre Straße aus dem Dropdown-Menü.
-    - Klicken Sie mit der rechten Maustaste auf den gelben Download-Button (z. B. "Termine mit wöchentlicher Restmüll-Abholung") und kopieren Sie die Link-Adresse.
-    - Der Link sieht so aus: `https://www.schwalbach.de/city_info/display/ical/m_calendar_ical.cfm?region_id=431&year=2026&city_id=1&street_id=XXXXX`
-    - Verwenden Sie diesen Link als `url`-Parameter und fügen Sie `year_field: year` hinzu, damit das Jahr automatisch aktualisiert wird.
+    - Wählen Sie Ihre Straße aus dem Dropdown-Menü. Notieren Sie Ihren **Abfuhrbezirk** (1–4), der neben der Straße angezeigt wird.
+    - Klicken Sie mit der rechten Maustaste auf den gelben Download-Button (z. B. "Termine mit wöchentlicher Restmüll-Abholung für den Abfuhrbezirk 1 - 2026") und kopieren Sie die Link-Adresse.
+    - Der Link sieht so aus: `https://www.schwalbach.de/city_data/assets/431/ical/2026_Abfuhrbezirk-1_woechentlich.ics`
+    - Ersetzen Sie die Jahreszahl (`2026`) durch `{%Y}` und fügen Sie `version: 1` zur Konfiguration hinzu, damit das Jahr automatisch aktualisiert wird.
+    - Verwenden Sie diesen angepassten Link als `url`-Parameter.
 test_cases:
-  Pommernstraße:
-    url: "https://www.schwalbach.de/city_info/display/ical/m_calendar_ical.cfm?region_id=431&year=2026&city_id=1&street_id=76874"
-    year_field: year
+  Abfuhrbezirk 1 wöchentlich:
+    url: "https://www.schwalbach.de/city_data/assets/431/ical/{%Y}_Abfuhrbezirk-1_woechentlich.ics"
+    version: 1
+  Abfuhrbezirk 2 14-täglich:
+    url: "https://www.schwalbach.de/city_data/assets/431/ical/{%Y}_Abfuhrbezirk-2_14-taegig.ics"
+    version: 1

--- a/doc/ics/yaml/schwalbach_am_taunus_de.yaml
+++ b/doc/ics/yaml/schwalbach_am_taunus_de.yaml
@@ -1,0 +1,21 @@
+---
+title: Schwalbach am Taunus
+url: https://www.schwalbach.de
+howto:
+  en: |
+    - Go to <https://www.schwalbach.de/Rathaus-und-Buergerservice/Buergerservice/Abfallentsorgung/Digitaler-Abfallkalender.htm> and navigate to the digital waste calendar.
+    - Select your street from the dropdown.
+    - Right-click on the yellow calendar download button (e.g. "Termine mit wöchentlicher Restmüll-Abholung") and copy the link address.
+    - The link will look like: `https://www.schwalbach.de/city_info/display/ical/m_calendar_ical.cfm?region_id=431&year=2026&city_id=1&street_id=XXXXX`
+    - Replace the year value with `{year}` or use `year_field: year` in your config to keep it up to date automatically.
+    - Use this link as the `url` parameter.
+  de: |
+    - Öffnen Sie <https://www.schwalbach.de/Rathaus-und-Buergerservice/Buergerservice/Abfallentsorgung/Digitaler-Abfallkalender.htm> und navigieren Sie zum digitalen Abfallkalender.
+    - Wählen Sie Ihre Straße aus dem Dropdown-Menü.
+    - Klicken Sie mit der rechten Maustaste auf den gelben Download-Button (z. B. "Termine mit wöchentlicher Restmüll-Abholung") und kopieren Sie die Link-Adresse.
+    - Der Link sieht so aus: `https://www.schwalbach.de/city_info/display/ical/m_calendar_ical.cfm?region_id=431&year=2026&city_id=1&street_id=XXXXX`
+    - Verwenden Sie diesen Link als `url`-Parameter und fügen Sie `year_field: year` hinzu, damit das Jahr automatisch aktualisiert wird.
+test_cases:
+  Pommernstraße:
+    url: "https://www.schwalbach.de/city_info/display/ical/m_calendar_ical.cfm?region_id=431&year=2026&city_id=1&street_id=76874"
+    year_field: year


### PR DESCRIPTION
## Summary

- Adds ICS-based waste collection schedule support for **Schwalbach am Taunus**, Germany
- Uses the existing `city_info/m_calendar_ical.cfm` endpoint (same platform as Neuenrade)
- No Python source needed â€” implemented as a single ICS YAML file

## How to get the parameters

1. Go to https://www.schwalbach.de/Rathaus-und-Buergerservice/Buergerservice/Abfallentsorgung/Digitaler-Abfallkalender.htm
2. Select your street from the dropdown
3. Right-click the yellow calendar download button and copy the link address
4. Use the URL as the `url` parameter with `year_field: year`

## Example configuration

```yaml
waste_collection_schedule:
  sources:
    - name: ics
      args:
        url: https://www.schwalbach.de/city_info/display/ical/m_calendar_ical.cfm?region_id=431&year=2026&city_id=1&street_id=76874
        year_field: year
```

## Test case

- **PommernstraÃŸe** (`street_id=76874`) â€” verified to return BioabfÃ¤lle, RestmÃ¼ll, Gelbe SÃ¤cke / Container, Altpapier
