### PR TITLE
fix: buergerportal_de show_volume reads wrong key after VolumenObj migration

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/buergerportal_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/buergerportal_de.py
@@ -221,8 +221,9 @@ class Source:
                         icon = tested_icon
 
                 if self.show_volume:
+                    vol_key = "VolumenObj" if self.new_params else "Volumen"
                     volume = int(
-                        collection["Abfuhrplan"]["GefaesstarifArt"]["Volumen"][
+                        collection["Abfuhrplan"]["GefaesstarifArt"][vol_key][
                             "VolumenWert"
                         ]
                     )


### PR DESCRIPTION
## Summary

- `show_volume` block in `buergerportal_de.py` was hard-coded to read `"Volumen"` from the API response, but PR #4903 migrated the API requests to use `"VolumenObj"` (with a fallback to `"Volumen"` via the `new_params` flag)
- This caused the integration to crash for users with `show_volume: true` on providers using the new `VolumenObj` key
- Fix: use `"VolumenObj"` or `"Volumen"` consistent with the `new_params` flag already used by `_do_fetch_request`

## Test plan

- [ ] Integration loads without error for providers using `VolumenObj` (new API) with `show_volume: true`
- [ ] Fallback still works for providers using legacy `Volumen` key

Closes #4888

🤖 Generated with [Claude Code](https://claude.com/claude-code)