### PR TITLE
fix: switch southderbyshire_gov_uk to curl_cffi to bypass User-Agent block (closes #6344)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southderbyshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southderbyshire_gov_uk.py
@@ -1,8 +1,8 @@
 import re
 from datetime import datetime
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
@@ -37,7 +37,7 @@ class Source:
     def fetch(self):
         entries = []
 
-        session = requests.Session()
+        session = requests.Session(impersonate="chrome")
 
         r = session.get(f"{API_URL}{self._uprn}")
         soup = BeautifulSoup(


### PR DESCRIPTION
## Summary

- The South Derbyshire District Council API (`maps.southderbyshire.gov.uk`) started returning 403 for requests with the default `python-requests` User-Agent.
- The resulting HTML response caused a `JSONDecodeError` when the source tried to parse it as JSON.
- Fix: switch to `curl_cffi` with `impersonate="chrome"` — the same approach used by other sources in this repo that face User-Agent filtering.

## Test plan

- [x] Both existing TEST_CASES return entries (13 and 12 respectively)
- [x] Black, Green, and Brown bin types are all correctly extracted
- [x] Dates parse correctly

Closes #6344