### PR TITLE
Add Mid-Western Regional Council (NSW, Australia) waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midwestern_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midwestern_nsw_gov_au.py
@@ -1,0 +1,59 @@
+from datetime import date, timedelta
+
+from waste_collection_schedule import Collection
+
+TITLE = "Mid-Western Regional Council"
+DESCRIPTION = "Waste collection source for Mid-Western Regional Council NSW"
+URL = "https://www.midwestern.nsw.gov.au/"
+
+TEST_CASES = {
+    "Mudgee North Monday": {"area": "mudgee_north_monday"},
+}
+
+ICON_MAP = {
+    "Landfill": "mdi:trash-can",
+    "FOGO": "mdi:leaf",
+    "Recycling": "mdi:recycle",
+    "Paper/Cardboard": "mdi:newspaper",
+}
+
+AREAS = {
+    "mudgee_north_monday": 0,
+    "mudgee_north_thursday": 3,
+    "mudgee_south_tuesday": 1,
+    "mudgee_south_wednesday": 2,
+    "gulgong_monday": 0,
+    "gulgong_thursday": 3,
+    "kandos_rylstone_friday": 4,
+}
+
+
+class Source:
+    def __init__(self, area):
+        if area not in AREAS:
+            raise ValueError(f"Unknown area: {area}")
+
+        self._area = area
+        self._collection_day = AREAS[area]
+
+    def fetch(self):
+        entries = []
+        today = date.today()
+
+        for i in range(365):
+            current = today + timedelta(days=i)
+
+            if current.weekday() != self._collection_day:
+                continue
+
+            entries.append(Collection(date=current, t="Landfill"))
+            entries.append(Collection(date=current, t="FOGO"))
+
+            # TEMP anchor until we confirm the exact MWRC alternating week pattern.
+            # Even ISO weeks = Recycling, odd ISO weeks = Paper/Cardboard.
+            if current.isocalendar().week % 2 == 0:
+                entries.append(Collection(date=current, t="Recycling"))
+            else:
+                entries.append(Collection(date=current, t="Paper/Cardboard"))
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midwestern_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midwestern_nsw_gov_au.py
@@ -54,8 +54,8 @@ class Source:
             # TEMP anchor until confirmed against MWRC calendar.
             # If the wrong fortnightly bin appears, swap recycle/paper below.
             if current.isocalendar().week % 2 == 0:
-                entries.append(Collection(date=current, t="recycle"))
-            else:
                 entries.append(Collection(date=current, t="paper"))
+            else:
+                entries.append(Collection(date=current, t="recycle"))
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midwestern_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midwestern_nsw_gov_au.py
@@ -11,10 +11,10 @@ TEST_CASES = {
 }
 
 ICON_MAP = {
-    "Landfill": "mdi:trash-can",
-    "FOGO": "mdi:leaf",
-    "Recycling": "mdi:recycle",
-    "Paper/Cardboard": "mdi:newspaper",
+    "waste": "mdi:trash-can-outline",
+    "organic": "mdi:leaf",
+    "recycle": "mdi:recycle",
+    "paper": "mdi:newspaper",
 }
 
 AREAS = {
@@ -46,14 +46,16 @@ class Source:
             if current.weekday() != self._collection_day:
                 continue
 
-            entries.append(Collection(date=current, t="Landfill"))
-            entries.append(Collection(date=current, t="FOGO"))
+            # Weekly collections
+            entries.append(Collection(date=current, t="waste"))
+            entries.append(Collection(date=current, t="organic"))
 
-            # TEMP anchor until we confirm the exact MWRC alternating week pattern.
-            # Even ISO weeks = Recycling, odd ISO weeks = Paper/Cardboard.
+            # Fortnightly alternating collections
+            # TEMP anchor until confirmed against MWRC calendar.
+            # If the wrong fortnightly bin appears, swap recycle/paper below.
             if current.isocalendar().week % 2 == 0:
-                entries.append(Collection(date=current, t="Recycling"))
+                entries.append(Collection(date=current, t="recycle"))
             else:
-                entries.append(Collection(date=current, t="Paper/Cardboard"))
+                entries.append(Collection(date=current, t="paper"))
 
         return entries

--- a/doc/source/midwestern_nsw_gov_au.md
+++ b/doc/source/midwestern_nsw_gov_au.md
@@ -1,0 +1,23 @@
+# Mid-Western Regional Council
+
+Support for waste collection schedules from Mid-Western Regional Council NSW, Australia.
+
+## Supported Areas
+
+- mudgee_north_monday
+- mudgee_north_thursday
+- mudgee_south_tuesday
+- mudgee_south_wednesday
+- gulgong_monday
+- gulgong_thursday
+- kandos_rylstone_friday
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: midwestern_nsw_gov_au
+      args:
+        area: mudgee_north_monday
+```


### PR DESCRIPTION
Adds support for Mid-Western Regional Council NSW, Australia.

Supported areas:
- Mudgee North Monday
- Mudgee North Thursday
- Mudgee South Tuesday
- Mudgee South Wednesday
- Gulgong Monday
- Gulgong Thursday
- Kandos/Rylstone Friday

Includes:
- Weekly /general waste
- Weekly FOGO
- Fortnightly recycling
- Fortnightly paper/cardboard

Tested locally with Home Assistant and TrashCard.