### PR TITLE
Add Lakeshore (ON) to RecycleCoach source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -245,6 +245,15 @@ EXTRA_INFO = [
         },
     },
     {
+        "title": "Lakeshore (ON)",
+        "url": "https://www.lakeshore.ca/",
+        "country": "ca",
+        "default_params": {
+            "project_id": "583",
+            "district_id": "LAK",
+        },
+    },
+    {
         "title": "Glenorchy City Council (TAS)",
         "url": "https://www.gcc.tas.gov.au/",
         "country": "au",
@@ -406,6 +415,11 @@ TEST_CASES = {
         "district_id": "GLENORCHY",
         "project_id": 657,
         "zone_id": "zone-z15322-z16165-z16823",
+    },
+    "Lakeshore, ON, Canada (with district_id, project_id & zone_id)": {
+        "district_id": "LAK",
+        "project_id": 583,
+        "zone_id": "zone-z9942",
     },
 }
 


### PR DESCRIPTION
## Summary
- Adds Town of Lakeshore, Ontario to the `recyclecoach_com` EXTRA_INFO list
- Uses `project_id: 583`, `district_id: LAK` (confirmed via RecycleCoach city-search API)
- Adds a TEST_CASE with pre-resolved `zone_id: zone-z9942` for 1372 Crosswinds Dr, Lakeshore ON

Closes #6353

## Test plan
- [ ] `python test_sources.py -s recyclecoach_com -l` passes the new test case
- [ ] No generated files modified