### PR TITLE
Add source: Landkreis Mecklenburgische Seenplatte (lk_mecklenburgische_seenplatte_de)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lk_mecklenburgische_seenplatte_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lk_mecklenburgische_seenplatte_de.py
@@ -1,0 +1,137 @@
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Landkreis Mecklenburgische Seenplatte"
+DESCRIPTION = "Source for Landkreis Mecklenburgische Seenplatte waste collection."
+URL = "https://www.lk-mecklenburgische-seenplatte.de"
+COUNTRY = "de"
+TEST_CASES = {
+    "Atelierstraße (Neubrandenburg)": {
+        "city": "Neubrandenburg",
+        "street": "Atelierstraße",
+    },
+    "Dargun": {"city": "Dargun", "street": "Dargun"},
+    "Ahornweg (Altentreptow)": {"city": "Altentreptow", "street": "Ahornweg"},
+}
+
+CALENDAR_URL = "https://www.lk-mecklenburgische-seenplatte.de/Abfallkalender"
+AUTOCOMPLETE_URL = (
+    "https://www.lk-mecklenburgische-seenplatte.de/output/autocomplete.php"
+)
+DOWNLOAD_URL = "https://www.lk-mecklenburgische-seenplatte.de/output/options.php"
+
+PARAM_TRANSLATIONS = {
+    "de": {
+        "city": "Ort",
+        "street": "Straße",
+    },
+    "en": {
+        "city": "City",
+        "street": "Street",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "city": "Name of the municipality (as shown in the dropdown on the Abfallkalender page).",
+        "street": "Street or district name. For entries shown with parentheses (e.g. 'Dargun (Dargun)') use only the part before the parenthesis (e.g. 'Dargun').",
+    },
+    "de": {
+        "city": "Name der Gemeinde (wie im Dropdown auf der Abfallkalender-Seite angezeigt).",
+        "street": "Straßen- oder Ortsteilname. Bei Einträgen mit Klammern (z.B. 'Dargun (Dargun)') nur den Teil vor der Klammer verwenden (z.B. 'Dargun').",
+    },
+}
+
+
+class Source:
+    def __init__(self, city: str, street: str):
+        self._city = city
+        self._street = street
+        self._ics = ICS()
+
+    def fetch(self):
+        # Step 1: Fetch the calendar page and parse the city dropdown
+        r = requests.get(CALENDAR_URL)
+        if not r.ok:
+            raise Exception(f"Error: failed to fetch url: {CALENDAR_URL}")
+
+        soup = BeautifulSoup(r.text, "html.parser")
+        select = soup.find("select", id="sf_locid")
+        if not select:
+            raise Exception("Could not find city dropdown on calendar page")
+
+        options = {
+            o.string: o["value"]
+            for o in select.find_all("option")
+            if o.get("value") and o.string
+        }
+
+        if self._city not in options:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "city", self._city, list(options.keys())
+            )
+
+        refid = options[self._city]
+
+        # Step 2: Query the autocomplete endpoint to find the street/district pois ID
+        r = requests.get(
+            AUTOCOMPLETE_URL,
+            params={
+                "out": "json",
+                "type": "abto",
+                "mode": "",
+                "select": "2",
+                "refid": refid,
+                "term": self._street,
+            },
+        )
+        if not r.ok:
+            raise Exception(f"Error: failed to fetch url: {r.request.url}")
+
+        # The API returns JSON null for search terms containing parentheses
+        data = r.json() or []
+
+        matches = [item for item in data if self._street in item[1]]
+        if not matches:
+            # Fetch all streets for suggestions
+            r_all = requests.get(
+                AUTOCOMPLETE_URL,
+                params={
+                    "out": "json",
+                    "type": "abto",
+                    "mode": "",
+                    "select": "2",
+                    "refid": refid,
+                    "term": "",
+                },
+            )
+            all_streets = [item[1] for item in (r_all.json() or [])]
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street", self._street, all_streets
+            )
+
+        pois_id = matches[0][0]
+
+        # Step 3: Download and parse the ICS calendar
+        r = requests.get(
+            DOWNLOAD_URL,
+            params={
+                "ModID": "48",
+                "call": "ical",
+                "pois": pois_id,
+            },
+        )
+        if not r.ok:
+            raise Exception(f"Error: failed to fetch url: {r.request.url}")
+
+        dates = self._ics.convert(r.text)
+
+        entries = []
+        for d in dates:
+            entries.append(Collection(d[0], d[1]))
+        return entries

--- a/doc/source/lk_mecklenburgische_seenplatte_de.md
+++ b/doc/source/lk_mecklenburgische_seenplatte_de.md
@@ -1,0 +1,45 @@
+# Landkreis Mecklenburgische Seenplatte
+
+Support for schedules provided by [Landkreis Mecklenburgische Seenplatte](https://www.lk-mecklenburgische-seenplatte.de) located in Mecklenburg-Vorpommern, Germany.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: lk_mecklenburgische_seenplatte_de
+      args:
+        city: Neubrandenburg
+        street: Atelierstraße
+```
+
+### Configuration Variables
+
+**city**
+*(string) (required)*
+
+Name of the municipality, as shown in the dropdown on the [Abfallkalender](https://www.lk-mecklenburgische-seenplatte.de/Abfallkalender) page.
+
+**street**
+*(string) (required)*
+
+Street or district name. See the note below on how to find the correct value.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: lk_mecklenburgische_seenplatte_de
+      args:
+        city: Altentreptow
+        street: Ahornweg
+```
+
+## How to get the source arguments
+
+1. Open the [Abfallkalender](https://www.lk-mecklenburgische-seenplatte.de/Abfallkalender) page.
+2. Select your municipality from the **Ort** dropdown. The value to use for `city` is the name shown in the list (e.g. `Neubrandenburg`, `Dargun`, `Altentreptow`).
+3. Start typing your street name in the **Straße** field and note the matching suggestion.
+
+**Note on parentheses in street names:** The autocomplete API does not handle search terms containing parentheses. Many entries are displayed as "StreetName (CityName)" (e.g. "Dargun (Dargun)"), but you should use only the part before the parenthesis as the `street` value (e.g. `Dargun`). The source will still find the correct match.


### PR DESCRIPTION
## Summary

- Adds `lk_mecklenburgische_seenplatte_de` source for Landkreis Mecklenburgische Seenplatte, Germany.
- Uses the IKISS platform (same pattern as `kwb_goslar_de` / `landkreis_wittmund_de`): city dropdown parse → street autocomplete → ICS download.
- Two parameters: `city` (municipality name from dropdown) and `street` (partial street/district name).
- Handles the API quirk where the autocomplete returns JSON `null` for search terms containing parentheses.

Closes #6351

## Test plan
- [x] `Atelierstraße (Neubrandenburg)` — 41 entries
- [x] `Dargun` — Dargun (Dargun) district
- [x] `Ahornweg (Altentreptow)` — 48 entries