### PR TITLE
fix: switch mzvhegau_de to admin-post text endpoint (closes #6352)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzvhegau_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzvhegau_de.py
@@ -1,6 +1,9 @@
+import re
+from datetime import datetime
+
 import requests
 from waste_collection_schedule import Collection
-from waste_collection_schedule.service.ICS import ICS
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 
 TITLE = "MZV Hegau"
 DESCRIPTION = "Source for mzvhegau.de services for MZV Hegau, Germany."
@@ -8,7 +11,8 @@ URL = "https://www.mzvhegau.de"
 COUNTRY = "de"
 TEST_CASES = {
     "Engen": {"city": "Engen"},
-    "Singen": {"city": "Singen"},
+    "Gai (Gailingen)": {"city": "Gai"},
+    "GM (Gottmadingen)": {"city": "GM"},
 }
 
 ICON_MAP = {
@@ -17,6 +21,7 @@ ICON_MAP = {
     "Gelber Sack": "mdi:recycle",
     "Papier": "mdi:newspaper",
     "Grünschnitt": "mdi:tree",
+    "Christbaum": "mdi:pine-tree",
 }
 
 PARAM_TRANSLATIONS = {
@@ -26,45 +31,63 @@ PARAM_TRANSLATIONS = {
 
 PARAM_DESCRIPTIONS = {
     "en": {
-        "city": "Your city or municipality name, e.g. Engen.",
+        "city": "Your city or municipality shorthand, e.g. Engen, Gai, GM.",
     },
     "de": {
-        "city": "Ihre Stadt oder Gemeinde, z.B. Engen.",
+        "city": "Ihre Stadt oder Gemeinde (Kürzel), z.B. Engen, Gai, GM.",
     },
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
-    "en": "Enter your city/municipality in the " "MZV Hegau service area.",
-    "de": "Stadt/Gemeinde im MZV Hegau " "Verbandsgebiet eingeben.",
+    "en": "Enter your city/municipality shorthand in the MZV Hegau service area.",
+    "de": "Stadt/Gemeinde-Kürzel im MZV Hegau Verbandsgebiet eingeben.",
 }
 
-API_URL = "https://www.mzvhegau.de/abfallkalender/{city}.ics"
+API_URL = "https://www.mzvhegau.de/wp-admin/admin-post.php?action=mzv_ics_download&slug={city}&whole_year=1&format=text"
+PICKUPS_URL = "https://www.mzvhegau.de/wp-json/flexia/v2/pickups"
+
+DATE_RE = re.compile(r"^(\d{2}\.\d{2}\.\d{4}):\s*(.+)$")
 
 
 class Source:
     def __init__(self, city: str):
         self._city = city.strip()
-        self._ics = ICS()
+
+    def _get_suggestions(self) -> list[str]:
+        try:
+            r = requests.get(PICKUPS_URL, timeout=10)
+            r.raise_for_status()
+            data = r.json()
+            return [entry["shorthand"] for entry in data if "shorthand" in entry]
+        except Exception:
+            return []
 
     def fetch(self) -> list[Collection]:
         url = API_URL.format(city=self._city)
-        r = requests.get(url)
-        # Server returns 500 but with valid ICS content
-        if not r.text.startswith("BEGIN:VCALENDAR"):
-            r.raise_for_status()
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+
+        if "Ungültiger Ort" in r.text:
+            suggestions = self._get_suggestions()
+            raise SourceArgumentNotFoundWithSuggestions("city", self._city, suggestions)
 
         entries = []
-        for date, name in self._ics.convert(r.text):
-            # Strip "Abholung: " prefix and emoji
-            clean = name
-            if ": " in clean:
-                clean = clean.split(": ", 1)[1]
-            # Remove emoji prefix
-            clean = clean.strip()
-            while clean and not clean[0].isalpha():
-                clean = clean[1:].strip()
+        for line in r.text.splitlines():
+            m = DATE_RE.match(line.strip())
+            if not m:
+                continue
+            date_str, rest = m.group(1), m.group(2)
+            date = datetime.strptime(date_str, "%d.%m.%Y").date()
 
-            icon = ICON_MAP.get(clean)
-            entries.append(Collection(date=date, t=clean, icon=icon))
+            # Some lines have multiple collections separated by ", "
+            for part in rest.split(", "):
+                part = part.strip()
+                # Strip leading emoji characters and whitespace
+                while part and not part[0].isalpha():
+                    part = part[1:].strip()
+                if not part:
+                    continue
+                icon = ICON_MAP.get(part)
+                entries.append(Collection(date=date, t=part, icon=icon))
 
         return entries


### PR DESCRIPTION
## Summary

- The `/abfallkalender/{city}.ics` endpoint on mzvhegau.de has a server-side mapping bug that returns data for the wrong city regardless of the `city` parameter (e.g. `Engen.ics` returns Gottmadingen events).
- Switches to the site's `admin-post.php?action=mzv_ics_download&slug={city}&whole_year=1&format=text` endpoint, which returns correct per-city data.
- Parses multi-collection lines correctly (some dates have multiple waste types separated by `, `).
- Adds `SourceArgumentNotFoundWithSuggestions` with live suggestions from `/wp-json/flexia/v2/pickups`.
- Fixes `TEST_CASES`: replaces `Singen` (not served by this provider) with `Gai` and `GM`.
- Adds `Christbaum` icon to `ICON_MAP`.

Credit to @sukobus for identifying the working endpoint.

Closes #6352.

## Test plan
- [x] `python test_sources.py -s mzvhegau_de -l` passes all three test cases
- [x] Engen returns its own schedule (different dates than Gottmadingen)
- [x] Invalid city raises `SourceArgumentNotFoundWithSuggestions`