### PR TITLE
fix: boroondara FOGO frequency — weekly with Recycling

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/boroondara_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/boroondara_vic_gov_au.py
@@ -145,9 +145,9 @@ class Source:
 
         for d in _next_weekly(day):
             entries.append(Collection(d, "Recycling", ICON_MAP["Recycling"]))
+            entries.append(Collection(d, "FOGO", ICON_MAP["FOGO"]))
 
         for d in _next_fortnightly(day, week):
             entries.append(Collection(d, "General Waste", ICON_MAP["General Waste"]))
-            entries.append(Collection(d, "FOGO", ICON_MAP["FOGO"]))
 
         return entries

--- a/doc/source/boroondara_vic_gov_au.md
+++ b/doc/source/boroondara_vic_gov_au.md
@@ -36,5 +36,5 @@ Enter your street address as it appears on the [Boroondara bin day finder](https
 Collection types returned:
 
 - **Recycling** — weekly
+- **FOGO** (Food Organics and Garden Organics) — weekly, same day as Recycling
 - **General Waste** — fortnightly
-- **FOGO** (Food Organics and Garden Organics) — fortnightly, same day as General Waste


### PR DESCRIPTION
## Summary

Follow-up to #6237. The original reporter's suggested fix put FOGO on the fortnightly cycle alongside General Waste; cross-checking against the [Boroondara bin day finder](https://www.boroondara.vic.gov.au/services/waste-and-recycling/bins/find-your-bin-day) confirms:

- Household waste (General Waste) — every 2 weeks (fortnightly)
- FOGO bin — every week (weekly)
- Recycling bin — every week (weekly)

This PR moves FOGO from the fortnightly block to the weekly block (same day as Recycling) and updates the doc accordingly.

## Test plan
- [x] \`python test_sources.py -s boroondara_vic_gov_au -l\` passes all three test cases
- [x] FOGO appears on every weekly collection day alongside Recycling
- [x] General Waste appears only on the fortnightly cycle