### PR TITLE
feat: document ROAF in minrenovasjon_no EXTRA_INFO

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/minrenovasjon_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/minrenovasjon_no.py
@@ -34,6 +34,20 @@ TEST_CASES = {
     },
 }
 
+EXTRA_INFO = [
+    {
+        "title": "ROAF (Romerike Avfallsforedling IKS)",
+        "url": "https://www.roaf.no",
+        "country": "no",
+        "default_params": {
+            "street_name": "Solvangen",
+            "house_number": 2,
+            "street_code": 12950,
+            "county_id": 3205,
+        },
+    },
+]
+
 API_URL = (
     "https://norkartrenovasjon.azurewebsites.net/proxyserver.ashx?server="
     "https://komteksky.norkart.no/MinRenovasjon.Api/api/"


### PR DESCRIPTION
Adds an EXTRA_INFO entry so ROAF (Romerike Avfallsforedling IKS) is discoverable via the existing minrenovasjon_no Norkart Komtek platform support.

Closes #6365