### PR TITLE
feat: add "Ignore Duplicate Entries per Day" option to UI

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE
 from homeassistant.core import callback
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     DurationSelector,
     DurationSelectorConfig,
     IconSelector,
@@ -53,6 +54,8 @@ from .const import (
     CONF_DAY_OFFSET,
     CONF_DAY_OFFSET_DEFAULT,
     CONF_DAY_SWITCH_TIME,
+    CONF_IGNORE_DUPLICATES,
+    CONF_IGNORE_DUPLICATES_DEFAULT,
     CONF_DAY_SWITCH_TIME_DEFAULT,
     CONF_DEDICATED_CALENDAR_TITLE,
     CONF_DETAILS_FORMAT,
@@ -1053,6 +1056,12 @@ class WasteCollectionOptionsFlow(OptionsFlow):
                         CONF_DAY_OFFSET, CONF_DAY_OFFSET_DEFAULT
                     ),
                 ): int,
+                vol.Optional(
+                    CONF_IGNORE_DUPLICATES,
+                    default=self._entry.options.get(
+                        CONF_IGNORE_DUPLICATES, CONF_IGNORE_DUPLICATES_DEFAULT
+                    ),
+                ): BooleanSelector(),
                 vol.Optional(
                     "sensor_select",
                 ): SelectSelector(

--- a/custom_components/waste_collection_schedule/const.py
+++ b/custom_components/waste_collection_schedule/const.py
@@ -35,6 +35,8 @@ CONF_USE_DEDICATED_CALENDAR: Final = "use_dedicated_calendar"
 CONF_DEDICATED_CALENDAR_TITLE: Final = "dedicated_calendar_title"
 CONF_DAY_OFFSET = "day_offset"
 CONF_DAY_OFFSET_DEFAULT = 0
+CONF_IGNORE_DUPLICATES: Final = "ignore_duplicates"
+CONF_IGNORE_DUPLICATES_DEFAULT: Final = False
 
 CONF_SEPARATOR_DEFAULT: Final = ", "
 CONF_FETCH_TIME_DEFAULT: Final = "01:00"

--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -60,6 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[const.CONF_SOURCE_ARGS],
         options.get(const.CONF_SOURCE_CALENDAR_TITLE),
         options.get(const.CONF_DAY_OFFSET, const.CONF_DAY_OFFSET_DEFAULT),
+        options.get(const.CONF_IGNORE_DUPLICATES, const.CONF_IGNORE_DUPLICATES_DEFAULT),
     )
 
     coordinator = WCSCoordinator(

--- a/custom_components/waste_collection_schedule/translations/en.json
+++ b/custom_components/waste_collection_schedule/translations/en.json
@@ -25727,7 +25727,8 @@
           "random_fetch_time_offset": "Random Fetch Time Offset",
           "day_switch_time": "Day Switch Time",
           "fetch_interval_days": "Days between fetches",
-          "day_offset": "Day Offset"
+          "day_offset": "Day Offset",
+          "ignore_duplicates": "Ignore Duplicate Entries per Day"
         },
         "data_description": {
           "sensor_select": "Select the sensor you want to modify. (select 'Add new sensor' to create a new sensor)",
@@ -25738,7 +25739,8 @@
           "random_fetch_time_offset": "Randomly offsets the Fetch Time by up to x minutes. Can be used to distribute Home Assistant fetch commands over a longer time frame to avoid peak loads at service providers.",
           "day_switch_time": "Time of the day in 'HH:MM' that Home Assistant dismisses the current entry and moves to the next entry.",
           "fetch_interval_days": "Specifies how often Home Assistant fetches waste collection events from this calendar source. The default value is 1 day. With a value of 2, waste collection events are fetched every 2 days.",
-          "day_offset": "Offset in days to add to the collection date (can be negative). If no value is entered, the default of 0 is used"
+          "day_offset": "Offset in days to add to the collection date (can be negative). If no value is entered, the default of 0 is used",
+          "ignore_duplicates": "When enabled, duplicate collection entries with the same waste type on the same day are removed, keeping only one entry per type per day."
         }
       },
       "customize": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -110,6 +110,7 @@ class SourceShell:
         calendar_title: Optional[str],
         unique_id: str,
         day_offset: int,
+        ignore_duplicates: bool = False,
     ):
         self._source = source
         self._customize = customize
@@ -121,6 +122,7 @@ class SourceShell:
         self._refreshtime: datetime.datetime | None = None
         self._entries: List[Collection] = []
         self._day_offset = day_offset
+        self._ignore_duplicates = ignore_duplicates
 
     @property
     def refreshtime(self):
@@ -176,7 +178,20 @@ class SourceShell:
         if self._day_offset != 0:
             entries = map(lambda x: apply_day_offset(x, self._day_offset), entries)
 
-        self._entries = list(entries)
+        result = list(entries)
+
+        # remove duplicate (date, type) pairs, keeping first occurrence
+        if self._ignore_duplicates:
+            seen: set[tuple] = set()
+            unique: List[Collection] = []
+            for e in result:
+                key = (e.date, e.type)
+                if key not in seen:
+                    seen.add(key)
+                    unique.append(e)
+            result = unique
+
+        self._entries = result
 
     def get_dedicated_calendar_types(self) -> set[str]:
         """Return set of waste types with a dedicated calendar."""
@@ -210,6 +225,7 @@ class SourceShell:
         source_args,
         calendar_title: Optional[str] = None,
         day_offset: int = 0,
+        ignore_duplicates: bool = False,
     ) -> "SourceShell | None":
         # load source module
         try:
@@ -240,6 +256,7 @@ class SourceShell:
             calendar_title=calendar_title,
             unique_id=calc_unique_source_id(source_name, source_args),
             day_offset=day_offset,
+            ignore_duplicates=ignore_duplicates,
         )
 
         return g


### PR DESCRIPTION
## Summary

- Adds a new boolean option **"Ignore Duplicate Entries per Day"** (default: off) to the per-source options UI
- When enabled, collection entries sharing the same waste type and date are deduplicated at fetch time, keeping the first occurrence
- Deduplication runs at the end of the `SourceShell.fetch()` pipeline — after whitespace stripping, filtering, customization, and day-offset — so aliases and offsets are respected before comparison

## Motivation

Some waste collection providers (e.g. via shared platforms or buggy APIs) return the same waste type for the same day multiple times. This causes sensors and the HA calendar to show redundant entries. Rather than fixing every source individually, this opt-in flag gives users a simple one-click fix via the integration's options flow.

## Changes

| File | What changed |
|---|---|
| `const.py` | Added `CONF_IGNORE_DUPLICATES` constant and `CONF_IGNORE_DUPLICATES_DEFAULT = False` |
| `source_shell.py` | `ignore_duplicates` param added to `__init__` and `create()`; dedup loop appended to `fetch()` |
| `init_ui.py` | Reads the new option from `entry.options` and passes it to `SourceShell.create()` |
| `config_flow.py` | Imports `BooleanSelector`; adds the checkbox after "Day Offset" in `async_step_init` |
| `translations/en.json` | Label + description for the new field in `options.step.init` (hand-maintained section) |

## Reviewer notes

- Default is `False` → zero behaviour change for existing users
- No migration needed (the option simply defaults to `False` when absent)
- No generated files were touched

## Test plan

- [ ] Install integration, open Options for a source → new "Ignore Duplicate Entries per Day" toggle is visible
- [ ] Enable the toggle for a source that returns duplicates → duplicate entries disappear from sensor/calendar
- [ ] Disable the toggle → duplicates reappear
- [ ] Sources without duplicates are unaffected when the flag is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)