### PR TITLE
fix: switch uk_cloud9_apps to curl_cffi to resolve SSL issue (fixes #6369)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/uk_cloud9_apps.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/uk_cloud9_apps.py
@@ -2,7 +2,7 @@ import re
 from datetime import date, datetime
 from typing import Any, Optional, Sequence, cast
 
-import requests
+from curl_cffi import requests
 from waste_collection_schedule import Collection
 from waste_collection_schedule.exceptions import (
     SourceArgAmbiguousWithSuggestions,
@@ -165,7 +165,7 @@ class Cloud9Client:
         self._authority = authority
         self._icon_keywords: dict[str, str] = icon_keywords or {}
         self._base_url = f"{API_DOMAIN}/{authority}{API_BASE}"
-        self._session = requests.Session()
+        self._session = requests.Session(impersonate="chrome")
         self._session.headers.update(BASE_HEADERS)
 
     def _resolve_icon(self, label: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

- Replaces `requests` with `curl_cffi` in the shared `uk_cloud9_apps` service module to resolve an SSL hostname mismatch error reported under Python 3.14
- The `*.cloud9technologies.com` wildcard cert fails Python 3.14's stricter OpenSSL-native hostname checking; `curl_cffi` uses libcurl's TLS stack and handles this correctly
- Affects all three councils using this shared service: `rugby_gov_uk`, `northherts_gov_uk`, and `arun_gov_uk`

## Test plan

- [x] `python test_sources.py -s rugby_gov_uk -l` — 3/3 test cases pass
- [x] `python test_sources.py -s northherts_gov_uk -l` — 4/4 test cases pass
- [x] `python test_sources.py -s arun_gov_uk -l` — 4/4 test cases pass

Fixes #6369

🤖 Generated with [Claude Code](https://claude.com/claude-code)