### PR TITLE
fix: expand recurring weekly collections in innerwest_nsw_gov_au (#1361)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
@@ -11,12 +11,12 @@ TEST_CASES = {
     "Random Marrickville address": {
         "suburb": "Tempe",
         "street_name": "Princes Highway",
-        "street_number": "810",
+        "street_number": "813",
     },
     "Random Leichhardt address": {
         "suburb": "Rozelle",
         "street_name": "Darling Street",
-        "street_number": "599",
+        "street_number": "597",
     },
     "Random Ashfield address": {
         "suburb": "Summer Hill",
@@ -114,21 +114,48 @@ class Source:
         entries = []
 
         for item in data:
-            if "start" not in item and "start_date" not in item:
+            event_type = item.get("event_type")
+            if not event_type:
                 continue
-            key = (
-                "start"
-                if "start" in item
-                else "start_date" if "start_date" in item else ""
-            )
-            collection_date = date.fromisoformat(item[key])
-            if (collection_date - today).days >= 0:
-                entries.append(
-                    Collection(
-                        date=collection_date,
-                        t=item["event_type"],
-                        icon=ICON_MAP.get(item["event_type"]),
+
+            icon = ICON_MAP.get(event_type)
+
+            if "dow" in item or "daysOfWeek" in item:
+                # Recurring weekly collection: the API returns a single entry with a
+                # start_date and day-of-week info rather than listing each occurrence.
+                # Expand it into individual weekly entries across the window.
+                if "start_date" not in item:
+                    continue
+                collection_date = date.fromisoformat(item["start_date"])
+                # Ensure we start from today or later
+                if collection_date < today:
+                    collection_date = today
+                while collection_date <= nextmonth:
+                    entries.append(
+                        Collection(
+                            date=collection_date,
+                            t=event_type,
+                            icon=icon,
+                        )
                     )
+                    collection_date += timedelta(7)
+            else:
+                # Single-occurrence collection: use the explicit start date
+                key = (
+                    "start"
+                    if "start" in item
+                    else "start_date" if "start_date" in item else None
                 )
+                if key is None:
+                    continue
+                collection_date = date.fromisoformat(item[key])
+                if (collection_date - today).days >= 0:
+                    entries.append(
+                        Collection(
+                            date=collection_date,
+                            t=event_type,
+                            icon=icon,
+                        )
+                    )
 
         return entries


### PR DESCRIPTION
## Summary

- The `waste-info` API returns some collections (organic, and sometimes waste) as a recurring weekly rule — a single JSON object with `dow`/`daysOfWeek` + `start_date` — rather than one entry per occurrence.
- The `fetch()` loop was not handling this pattern, so only a single `Collection` was created for the entire window instead of one per week.
- Fix: detect the `dow` key and expand the recurring event into weekly entries from `start_date` through the 30-day query window.
- Also corrects test case addresses that no longer exist in the live API (810 → 813 Princes Highway Tempe; 599 → 597 Darling Street Rozelle).

Fixes #1361.

## Test plan
- [ ] `python test_sources.py -s innerwest_nsw_gov_au -l` returns multiple weekly organic (and where applicable, waste) entries for all three test addresses
- [ ] Recycle entries (explicit dates) continue to appear correctly
- [ ] No duplicate entries