### PR TITLE
chore(agents): require inline file content in execution plans

### DIFF
--- a/.claude/agents/issue-executor.md
+++ b/.claude/agents/issue-executor.md
@@ -14,9 +14,10 @@ You are an issue execution agent for mampfes/hacs_waste_collection_schedule. You
 - Execute every step in the order given.
 - Do not deviate, skip, or add steps.
 - If a step fails, stop immediately and report the full error output — do not attempt workarounds or improvise alternatives.
-- For code edits described in natural language, apply them precisely as described using the Edit tool.
-- For new source files, write them exactly as provided in the plan.
-- The worktree starts on a temporary branch. Use `git checkout -b <branch-name>` as the first step to create the correct feature branch.
+- **You start in a fresh worktree on master.** You do NOT inherit any files, branches, or working-tree changes from the issue-triager that produced this plan. Anything the plan asks you to "write" must be created from scratch using the file content provided inline in the plan.
+- For any step that says "Write file `<path>` with this exact content: …", use the Write tool to create or overwrite the file with that exact content. Do not Edit — overwrite. Do not paraphrase, reformat, or "improve" the content.
+- If the plan asks you to modify a file but does not include the complete final content inline, stop and report — the plan is incomplete.
+- The worktree starts on a temporary branch. Use `git checkout -b <branch-name>` as the first step to create the correct feature branch. If the branch already exists (e.g. the planner left a stale branch behind), report this and stop.
 
 ## On completion
 

--- a/.claude/agents/issue-triager.md
+++ b/.claude/agents/issue-triager.md
@@ -107,16 +107,24 @@ Prepare an appropriate info-request or "not planned" comment.
 ["Commit, push, create PR, post comment" / "Post comment and close" / "Post comment, leave open" / "Post comment, apply label corrections" / etc.]
 
 ### Execution Plan
-[Numbered list of exact steps for the issue-executor agent. Use verbatim bash commands where possible; for code edits, describe precisely (file path, what to find, what to replace); for new files, include the complete file content inline.]
-[For Category A/B/C where a branch was created:]
+[Numbered list of exact steps for the issue-executor agent. Use verbatim bash commands where possible.
+
+**CRITICAL — the executor does not share your worktree.** The executor spawns in a fresh isolated worktree starting from master; it cannot see any files you edited, branches you created, or commits you made locally. For every file the executor must write or modify (new OR existing), include the **complete final file content** inline in a fenced code block — the executor will use Write to put down that exact content, not Edit. Never write "the file has already been written" or describe a partial diff. If you cannot fit the full content inline (very large files), say so explicitly and stop — do not produce a plan the executor cannot follow.]
+
+[For Category A/B/C where a branch needs to be created:]
 1. `git checkout -b <branch-name>`
-2. [edit steps or "Write file <path>: <complete content>"]
+2. Write file `<absolute or repo-relative path>` with this exact content:
+   ```<language>
+   <complete final file content>
+   ```
+   (Repeat for each file the executor must create or overwrite.)
 3. [format commands: `python -m black <file>` and/or `python -m isort --profile black <file>`]
-4. `git add <files>`
-5. `git commit -m "<exact commit message>"`
-6. `git push origin HEAD:<branch-name>`
-7. `gh pr create --repo mampfes/hacs_waste_collection_schedule --title "<title>" --body "<exact body>"`
-8. `gh issue comment <ISSUE_NUMBER> --repo mampfes/hacs_waste_collection_schedule --body "<exact comment text>"`
+4. [optional live test: `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s <id> -l`]
+5. `git add <files>`
+6. `git commit -m "<exact commit message>"`
+7. `git push origin HEAD:<branch-name>`
+8. `gh pr create --repo mampfes/hacs_waste_collection_schedule --title "<title>" --body "<exact body>"`
+9. `gh issue comment <ISSUE_NUMBER> --repo mampfes/hacs_waste_collection_schedule --body "<exact comment text>"`
 [For Category D/E/F (comment only):]
 1. `gh issue comment <ISSUE_NUMBER> --repo mampfes/hacs_waste_collection_schedule --body "<exact comment text>"`
 [Add close/label steps as needed]

--- a/.claude/agents/pr-executor.md
+++ b/.claude/agents/pr-executor.md
@@ -14,7 +14,9 @@ You are a PR execution agent for mampfes/hacs_waste_collection_schedule. You rec
 - Execute every step in the order given.
 - Do not deviate, skip, or add steps.
 - If a step fails, stop immediately and report the full error output — do not attempt workarounds or improvise alternatives.
-- For code edits described in natural language, apply them precisely as described using the Edit tool.
+- **You start in a fresh worktree on master.** You do NOT inherit any files, branches, or working-tree changes from the pr-reviewer planner that produced this plan. `gh pr checkout` gives you the contributor's PR HEAD as a baseline; everything beyond that must come from the plan's inline content.
+- For any step that says "Write file `<path>` with this exact content: …", use the Write tool to create or overwrite the file with that exact content. Do not Edit — overwrite. Do not paraphrase, reformat, or "improve" the content.
+- If the plan asks you to modify a file but does not include the complete final content inline (and it is not a pure formatter step), stop and report — the plan is incomplete.
 - The worktree starts on a temporary branch. Use `gh pr checkout <N> --repo mampfes/hacs_waste_collection_schedule` as the first step to switch to the correct PR branch.
 
 ## On completion

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -95,10 +95,20 @@ Revert these with `git checkout upstream/master -- <file>` if found:
 [Approve with tweaks / Request changes / Approve as-is]
 
 ### Execution Plan
-[Numbered list of exact steps for the pr-executor agent to run. Use verbatim bash commands where possible; for code edits, describe precisely (file path, what to find, what to replace). Include every step in order:]
+[Numbered list of exact steps for the pr-executor agent to run. Use verbatim bash commands where possible.
+
+**CRITICAL — the executor does not share your worktree.** The executor spawns in a fresh isolated worktree starting from master; it cannot see any files you edited or commits you made locally. It will run `gh pr checkout <PR_NUMBER>` to get the contributor's PR HEAD — that gives it the same starting point you had, but **none of your subsequent local edits transfer**. For every file you modified beyond running deterministic formatters (black/isort), include the **complete final file content** inline in a fenced code block so the executor can use Write to overwrite. Pure formatter-only changes can be reproduced by re-running the formatter and do not need inline content. New files (e.g. a missing `doc/source/<id>.md`) must always include the complete final content inline.]
+
 1. `gh pr checkout <PR_NUMBER> --repo mampfes/hacs_waste_collection_schedule`
 2. [revert commands if needed: `git checkout upstream/master -- <file>`]
-3. [edit steps: "Edit <file>: find <X>, replace with <Y>" — or omit if no edits]
+3. For each file you modified beyond a pure formatter pass, or for each new file:
+   ```
+   Write file <path> with this exact content:
+   ```<language>
+   <complete final file content>
+   ```
+   ```
+   (Repeat per file. Omit this step if no edits or new files.)
 4. [format commands: `python -m black <file>` and/or `python -m isort --profile black <file>`]
 5. `git add <files>`
 6. `git commit -m "<exact commit message>"`


### PR DESCRIPTION
## Summary

- Fix a structural gap in the issue-triager/issue-executor and pr-reviewer/pr-executor agent pairs: the planner works in one isolated worktree, the executor spawns in a separate fresh worktree, and the previous execution-plan template only required complete file content for *new* files. For *modified* files it accepted "edit file X to do Y" instructions, which silently fail in the fresh worktree.
- All four agent prompts now require the planner to inline complete final file content for every file the executor must write or modify, and the executor is explicit it starts fresh, must Write (overwrite) rather than Edit, and must stop if the plan is incomplete.
- Discovered today while running `/review-issue 1361`: the file the triager modified was only recoverable because I read it manually out of the locked worktree before spawning the executor.

## Test plan
- [ ] Run `/review-issue` against any issue that involves a code fix (e.g. a future regression triage) and confirm the executor reproduces the planner's changes without manual intervention.