### PR TITLE
feat(static): support date ranges in excludes parameter

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
@@ -53,6 +53,16 @@ TEST_CASES = {
         "frequency": "WEEKLY",
         "weekdays": "FR",
     },
+    "Recurrence with exclude date range": {
+        "type": "Weekly excluding summer break",
+        "frequency": "WEEKLY",
+        "weekdays": "MO",
+        "start": "2022-01-03",
+        "until": "2022-12-31",
+        "excludes": [
+            {"start": "2022-07-01", "end": "2022-08-31"},
+        ],
+    },
 }
 
 FREQ_TYPE = Literal["YEARLY", "MONTHLY", "WEEKLY", "DAILY"]
@@ -120,6 +130,45 @@ def get_tyep(params):
     return type(params)
 
 
+def parse_excludes(
+    excludes: list,
+) -> set[datetime.date]:
+    """Parse an excludes list that may contain individual date strings or
+    range dicts (``{"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}``).
+
+    Returns a flat set of all excluded dates.
+    """
+    result: set[datetime.date] = set()
+    for entry in excludes:
+        if isinstance(entry, datetime.date):
+            result.add(entry)
+        elif isinstance(entry, str):
+            result.add(parser.isoparse(entry).date())
+        elif isinstance(entry, dict):
+            if "start" not in entry or "end" not in entry:
+                raise SourceArgumentException(
+                    "excludes",
+                    "Range entries must have 'start' and 'end' keys.",
+                )
+            range_start = parser.isoparse(entry["start"]).date()
+            range_end = parser.isoparse(entry["end"]).date()
+            if range_start > range_end:
+                raise SourceArgumentException(
+                    "excludes",
+                    f"Range start '{entry['start']}' must not be after end '{entry['end']}'.",
+                )
+            day = range_start
+            while day <= range_end:
+                result.add(day)
+                day += datetime.timedelta(days=1)
+        else:
+            raise SourceArgumentException(
+                "excludes",
+                f"Invalid excludes entry: {entry!r}. Expected a date string or a dict with 'start' and 'end' keys.",
+            )
+    return result
+
+
 class Source:
     def __init__(
         self,
@@ -155,7 +204,9 @@ class Source:
                 self.add_weekday(weekdays, 1)
 
             else:
-                raise SourceArgumentException("weekdays", f"Invalid weekdays format: {weekdays}")
+                raise SourceArgumentException(
+                    "weekdays", f"Invalid weekdays format: {weekdays}"
+                )
 
             if self._weekdays == []:
                 self._weekdays = None
@@ -184,10 +235,9 @@ class Source:
         else:
             self._until = None
             self._count = count if count else 10
-        self._excludes = [
-            d if isinstance(d, datetime.date) else parser.isoparse(d).date()
-            for d in excludes or []
-        ]
+        self._excludes: set[datetime.date] = (
+            parse_excludes(excludes) if excludes else set()
+        )
 
     def add_weekday(self, weekday, count: int):
         if self._weekdays is None:
@@ -214,7 +264,7 @@ class Source:
             for ruleentry in ruledates:
                 date = ruleentry.date()
 
-                if self._excludes is not None and date in self._excludes:
+                if date in self._excludes:
                     continue
 
                 dates.append(date)

--- a/doc/source/static.md
+++ b/doc/source/static.md
@@ -62,7 +62,19 @@ Defines the (maximum) number of returned dates. Only used if `until` is not spec
 **EXCLUDES**  
 *(list) (optional)*
 
-A list of dates in format `YYYY-MM-DD` which should be excluded from the recurrence.
+A list of dates and/or date ranges to exclude from the recurrence. Each entry may be:
+
+- A single date string in format `YYYY-MM-DD`, or
+- A range dict with `start` and `end` keys (both in `YYYY-MM-DD` format), which excludes every date in that range (inclusive).
+
+Example with mixed individual dates and a range:
+
+```yaml
+excludes:
+  - '2022-07-15'
+  - start: '2022-08-01'
+    end: '2022-08-31'
+```
 
 **WEEKDAYS**  
 *(weekday | dictionary of weekday and occurrence) (optional)*


### PR DESCRIPTION
## Summary

- Adds support for range dicts in the static source's `excludes` list, so users can write `{start: 'YYYY-MM-DD', end: 'YYYY-MM-DD'}` instead of listing every individual date.
- Existing single-date string syntax is fully preserved — no breaking change.
- Internally `_excludes` is now a `set` (faster membership tests) rather than a list.
- Updates `doc/source/static.md` to document the new syntax.

## Test plan

- [x] All existing TEST_CASES pass (`python test_sources.py -s static -l`)
- [x] New TEST_CASE "Recurrence with exclude date range" correctly omits all Mondays in Jul–Aug 2022

Closes #1634