### PR TITLE
chore(ci): run pre-commit on PR-changed files

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
@@ -33,6 +35,11 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run pre-commit (PR changes only)
+        if: github.event_name == 'pull_request'
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
## Summary

- Adds a `pre-commit/action@v3.0.0` step to the `validate.yaml` workflow.
- Scoped to PR-changed files only (`--from-ref` / `--to-ref`), so legacy state in master can't fail the workflow.
- Only runs on `pull_request` events — `push` to master is left alone, since master may carry pre-existing issues that we'd want to clean up separately rather than blocking on.

This runs the existing `.pre-commit-config.yaml` hooks (black, isort, mypy, bandit, codespell, yamlfmt, pyupgrade) on every PR, which should catch the formatting and lint issues that currently only get caught locally.

Closes #2358