### PR TITLE
feat: add source for Tendring District Council (tendring_gov_uk)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tendring_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tendring_gov_uk.py
@@ -1,0 +1,118 @@
+from datetime import datetime
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.AchieveForms import init_session, run_lookup
+
+TITLE = "Tendring District Council"
+DESCRIPTION = "Source for Tendring District Council, Essex, UK."
+URL = "https://www.tendringdc.gov.uk"
+TEST_CASES = {
+    "1 Queens Road, Clacton-on-Sea": {"uprn": "100090613962"},
+    "18 High Street, Manningtree": {"uprn": 100091459763},
+}
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Find your UPRN by visiting "
+        "https://tendring-self.achieveservice.com/en/service/Rubbish_and_recycling_collection_days "
+        "and searching for your address. Your UPRN can also be found at "
+        "https://www.findmyaddress.co.uk/."
+    )
+}
+PARAM_TRANSLATIONS = {
+    "en": {
+        "uprn": "UPRN",
+    }
+}
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number (UPRN) for your address.",
+    }
+}
+COUNTRY = "uk"
+
+BASE_URL = "https://tendring-self.achieveservice.com"
+SERVICE_URL = f"{BASE_URL}/en/service/Rubbish_and_recycling_collection_days"
+AUTH_URL = f"{BASE_URL}/authapi/isauthenticated"
+API_URL = f"{BASE_URL}/apibroker/runLookup"
+HOSTNAME = "tendring-self.achieveservice.com"
+
+LOOKUP_COLLECTIONS = "6347acbadc425"
+
+ICON_MAP = {
+    "residual": "mdi:trash-can",
+    "green": "mdi:recycle",
+    "red": "mdi:recycle",
+    "food": "mdi:food",
+    "garden": "mdi:leaf",
+}
+
+# (api_field, waste_type_label, icon_key, conditional_field)
+# conditional_field: if set, skip this waste type if the field value is falsy
+COLLECTION_FIELDS = [
+    ("nextResidualCollection", "Residual waste", "residual", None),
+    ("nextGreenCollection", "Green recycling box", "green", None),
+    ("nextRedCollection", "Red recycling box", "red", None),
+    ("nextFoodCollection", "Food waste", "food", "eligibleFoodCollection"),
+    ("nextGardenCollection", "Garden waste", "garden", "activeGardenCollection"),
+]
+
+
+class Source:
+    def __init__(self, uprn: str | int):
+        self._uprn = str(uprn).strip()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        sid = init_session(
+            session,
+            SERVICE_URL,
+            AUTH_URL,
+            HOSTNAME,
+        )
+        result = run_lookup(
+            session,
+            API_URL,
+            sid,
+            LOOKUP_COLLECTIONS,
+            {"Address": {"selectedUPRN": {"value": self._uprn}}},
+        )
+
+        rows = result.get("integration", {}).get("transformed", {}).get("rows_data", {})
+        row = rows.get("0", {}) if isinstance(rows, dict) else (rows[0] if rows else {})
+
+        if not row:
+            raise SourceArgumentNotFound("uprn", self._uprn)
+
+        entries = []
+        for date_field, waste_type, icon_key, condition_field in COLLECTION_FIELDS:
+            # Skip conditional waste types if the service is not active
+            # API returns string "True"/"False" for boolean fields
+            if condition_field and row.get(condition_field, "").lower() != "true":
+                continue
+
+            date_str = row.get(date_field, "").strip()
+            if not date_str:
+                continue
+            try:
+                # API returns dates as "DD/MM/YYYY HH:MM:SS"
+                collection_date = datetime.strptime(date_str[:10], "%d/%m/%Y").date()
+            except ValueError:
+                continue
+            # Skip sentinel date returned when service has no next collection
+            if collection_date.year < 2000:
+                continue
+
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(icon_key),
+                )
+            )
+
+        if not entries:
+            raise SourceArgumentNotFound("uprn", self._uprn)
+
+        return entries

--- a/doc/source/tendring_gov_uk.md
+++ b/doc/source/tendring_gov_uk.md
@@ -1,0 +1,35 @@
+# Tendring District Council
+
+Support for schedules provided by [Tendring District Council](https://www.tendringdc.gov.uk), Essex, UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: tendring_gov_uk
+      args:
+        uprn: UPRN
+```
+
+### Configuration Variables
+
+**uprn**
+*(string) (required)*
+
+Your Unique Property Reference Number (UPRN).
+
+## How to find your UPRN
+
+1. Visit the [Tendring collection days checker](https://tendring-self.achieveservice.com/en/service/Rubbish_and_recycling_collection_days) and search for your address.
+2. Alternatively, look up your address at [findmyaddress.co.uk](https://www.findmyaddress.co.uk/).
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: tendring_gov_uk
+      args:
+        uprn: "YOUR_UPRN_HERE"
+```


### PR DESCRIPTION
## Summary

- Adds `tendring_gov_uk` source for [Tendring District Council](https://www.tendringdc.gov.uk), Essex, using the AchieveForms (Granicus) platform already shared with Epping Forest, Spelthorne, Elmbridge, and Watford.
- Single runLookup call (`6347acbadc425`) with UPRN input returns next collection dates for residual waste, green/red recycling boxes, food waste (conditional), and garden waste (conditional).

Closes #1372.

## Test plan
- [x] `python test_sources.py -s tendring_gov_uk -l` returns valid collection dates for two public Tendring UPRNs (1 Queens Road, Clacton and 18 High Street, Manningtree)