### PR TITLE
feat: add source for Eilenburg waste collection (eilenburg_de)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eilenburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eilenburg_de.py
@@ -1,0 +1,99 @@
+import re
+from typing import List
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Eilenburg"
+DESCRIPTION = "Source for waste collection in Eilenburg (Saxony, Germany)."
+URL = "https://www.eilenburg.de"
+COUNTRY = "de"
+TEST_CASES = {
+    "EB Berg + EB 1": {"areas": ["EB Berg", "EB 1"]},
+    "EB Stadt + EB 3": {"areas": ["EB Stadt", "EB 3"]},
+    "EB Ortsteile": {"areas": ["EB Ortsteile Dörfer"]},
+}
+
+PARAM_TRANSLATIONS = {
+    "de": {
+        "areas": "Entsorgungsbezirke",
+    },
+    "en": {
+        "areas": "Collection areas",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "de": {
+        "areas": "Liste der Entsorgungsbezirke, z. B. ['EB Berg', 'EB 1']. Restmüll/Papier-Bezirke: EB Berg, EB Stadt, EB Ost, EB Ortsteile Dörfer. Gelber-Sack-Bezirke: EB 1 bis EB 5.",
+    },
+    "en": {
+        "areas": "List of collection areas, e.g. ['EB Berg', 'EB 1']. Residual/paper areas: EB Berg, EB Stadt, EB Ost, EB Ortsteile Dörfer. Yellow-bag areas: EB 1 to EB 5.",
+    },
+}
+
+CALENDAR_PAGE_URL = (
+    "https://www.eilenburg.de/portal/seiten/abfallwirtschaft-900000136-27670.html"
+)
+
+ICS_LINK_PATTERN = re.compile(
+    r'data-extension="ICS"[^>]*href="(https://www\.eilenburg\.de/downloads/datei/[^"]+)"[^>]*title="[^"]*&quot;([^&]+\.ics)&quot;'
+)
+AREA_NAME_PATTERN = re.compile(r"- (EB .+?)\.ics$")
+
+
+class Source:
+    def __init__(self, areas: List[str]):
+        self._areas = areas
+        self._ics = ICS()
+
+    def fetch(self) -> List[Collection]:
+        # Fetch the waste calendar page
+        r = requests.get(
+            CALENDAR_PAGE_URL,
+            headers={"User-Agent": "Mozilla/5.0"},
+            timeout=30,
+        )
+        r.raise_for_status()
+        html = r.text
+
+        # Extract all ICS download links and their area names
+        available: dict[str, str] = {}
+        for ics_url, filename in ICS_LINK_PATTERN.findall(html):
+            m = AREA_NAME_PATTERN.search(filename)
+            if m:
+                area_name = m.group(1)
+                available[area_name] = ics_url
+
+        entries: List[Collection] = []
+        for area in self._areas:
+            # Case-insensitive match
+            matched_url = None
+            for available_area, ics_url in available.items():
+                if available_area.lower() == area.lower():
+                    matched_url = ics_url
+                    break
+
+            if matched_url is None:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "areas",
+                    area,
+                    list(available.keys()),
+                )
+
+            ics_r = requests.get(
+                matched_url,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=30,
+            )
+            ics_r.raise_for_status()
+            ics_text = ics_r.text
+
+            for date, waste_type in self._ics.convert(ics_text):
+                entries.append(Collection(date, waste_type))
+
+        return entries

--- a/doc/source/eilenburg_de.md
+++ b/doc/source/eilenburg_de.md
@@ -1,0 +1,69 @@
+# Eilenburg
+
+Support for waste collection schedules provided by [Eilenburg](https://www.eilenburg.de), serving Eilenburg (Saxony), Germany.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: eilenburg_de
+      args:
+        areas:
+        - AREA_1
+        - AREA_2
+```
+
+### Configuration Variables
+
+**areas**
+*(list) (required)*
+
+List of collection areas you want to track. Each address in Eilenburg belongs to one Restmüll/Papier area and one Gelber Sack (yellow bag) area.
+
+**Restmüll and Papier areas:**
+
+| Area name | Description |
+|---|---|
+| `EB Berg` | Berg district |
+| `EB Stadt` | Stadt (city centre) district |
+| `EB Ost` | Ost (east) district |
+| `EB Ortsteile Dörfer` | Outlying villages |
+
+**Gelber Sack (yellow bag) areas:**
+
+| Area name |
+|---|
+| `EB 1` |
+| `EB 2` |
+| `EB 3` |
+| `EB 4` |
+| `EB 5` |
+
+## Examples
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: eilenburg_de
+      args:
+        areas:
+        - EB Berg
+        - EB 1
+```
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: eilenburg_de
+      args:
+        areas:
+        - EB Stadt
+        - EB 3
+```
+
+## How to get the source arguments
+
+Visit [https://www.eilenburg.de/portal/seiten/abfallwirtschaft-900000136-27670.html](https://www.eilenburg.de/portal/seiten/abfallwirtschaft-900000136-27670.html) and download the PDF collection maps to find which area (Entsorgungsbezirk) your address belongs to.
+
+You will typically need one area from the Restmüll/Papier group and one from the Gelber Sack group.


### PR DESCRIPTION
## Summary

- Adds `eilenburg_de` source for waste collection in Eilenburg, Saxony, Germany
- Scrapes the city's waste calendar page to discover current-year ICS download URLs (one per collection zone), avoiding hardcoded URL dependencies
- Supports all 9 collection zones: EB Berg, EB Stadt, EB Ost, EB Ortsteile Dörfer (Restmüll/Papier) and EB 1–EB 5 (Gelber Sack)
- Users specify a list of areas; a helpful suggestion error is raised if an area name is not recognised

Closes #2711

## Test plan

- [x] `python test_sources.py -s eilenburg_de` — 3/3 test cases pass
- [x] `pytest tests/test_source_components.py` — 5/5 pass
- [x] `black` and `isort --profile black` — clean