### PR TITLE
chore: add Rouge to codespell ignore list

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -133,3 +133,4 @@ Parin
 appen
 re-using
 Aare
+Rouge


### PR DESCRIPTION
## Summary

- Adds \`Rouge\` to \`.codespellignore\`.
- \"Baton Rouge\" (Louisiana) is a US city referenced in the auto-generated \`README.md\` and \`info.md\`, not a misspelling of \"Rogue\". Codespell was flagging it on every PR that included README/info in its diff range.