### PR TITLE
Skip creating default calendar if all calendars are marked dedicated

### DIFF
--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -129,33 +129,38 @@ def create_calendar_entries(
     coordinator: WCSCoordinator | None = None,
 ) -> list[WasteCollectionCalendar]:
     entities: list[WasteCollectionCalendar] = []
+
     for shell in shells:
-        dedicated_calendar_types = shell.get_dedicated_calendar_types()
-        for type in dedicated_calendar_types:
+        aggregator = CollectionAggregator([shell])
+        dedicated_types = shell.get_dedicated_calendar_types()
+        dedicated_calendar_types = {
+            shell.get_collection_type_name(type) for type in dedicated_types
+        }
+
+        for type in dedicated_types:
             entities.append(
                 WasteCollectionCalendar(
                     api=api,
                     coordinator=coordinator,
-                    aggregator=CollectionAggregator([shell]),
+                    aggregator=aggregator,
                     name=shell.get_calendar_title_for_type(type),
                     include_types={shell.get_collection_type_name(type)},
                     unique_id=calc_unique_calendar_id(shell, type),
                 )
             )
 
-        entities.append(
-            WasteCollectionCalendar(
-                api=api,
-                coordinator=coordinator,
-                aggregator=CollectionAggregator([shell]),
-                name=shell.calendar_title,
-                exclude_types={
-                    shell.get_collection_type_name(type)
-                    for type in dedicated_calendar_types
-                },
-                unique_id=calc_unique_calendar_id(shell),
+        if aggregator.types != dedicated_calendar_types:
+            entities.append(
+                WasteCollectionCalendar(
+                    api=api,
+                    coordinator=coordinator,
+                    aggregator=aggregator,
+                    name=shell.calendar_title,
+                    exclude_types=dedicated_calendar_types,
+                    unique_id=calc_unique_calendar_id(shell),
+                )
             )
-        )
+
     return entities
 
 


### PR DESCRIPTION
Tried to fix the issue of creating the default calendar if all calendars are marked as dedicated ones. Therefore the default calendar won't get created at all.  See #1408 for details. 

Disclaimer: I'm not very familiar with Python coding in general, so feel free to correct my code if I made a mistake.


