### PR TITLE
feat: add source for Hilchenbach waste collection (hilchenbach_de)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hilchenbach_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hilchenbach_de.py
@@ -1,0 +1,81 @@
+from curl_cffi import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+)
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Stadt Hilchenbach"
+DESCRIPTION = "Source for 'Abfallkalender Stadt Hilchenbach'."
+URL = "https://www.hilchenbach.de"
+COUNTRY = "de"
+TEST_CASES = {
+    "Dammstraße (Hilchenbach)": {"strasse": "Dammstr"},
+    "Am Bühl (Allenbach)": {"strasse": "Am Bühl"},
+}
+
+ICON_MAP = {
+    "Biomüll": Icons.BIO_KITCHEN,
+    "Papier": Icons.PAPER,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Gelbe Tonne": Icons.PLASTIC_PACKAGING,
+    "Astschnitt": Icons.GARDEN,
+    "Schadstoffsammlung": Icons.HAZARDOUS,
+    "Abfuhr Weihnachtsbäume": Icons.CHRISTMAS_TREE,
+}
+
+PARAM_TRANSLATIONS: dict = {}
+PARAM_DESCRIPTIONS: dict = {}
+
+
+class Source:
+    def __init__(self, strasse):
+        self._strasse = strasse
+        self._ics = ICS()
+        self._session = requests.Session(impersonate="chrome")
+
+    def fetch(self):
+        args = {
+            "out": "json",
+            "type": "abto",
+            "select": "2",
+            "term": self._strasse,
+        }
+        header = {"Referer": URL}
+        r = self._session.get(
+            "https://hilchenbach.de/output/autocomplete.php",
+            params=args,
+            headers=header,
+            timeout=30,
+        )
+        r.raise_for_status()
+
+        ids = r.json()
+
+        if not isinstance(ids, list):
+            raise Exception("Unexpected autocomplete response")
+
+        if not ids:
+            raise SourceArgumentNotFound(f"No address found for '{self._strasse}'")
+
+        if len(ids) > 1:
+            raise SourceArgAmbiguousWithSuggestions(
+                "strasse", self._strasse, [id[1] for id in ids]
+            )
+
+        args = {"ModID": 48, "call": "ical", "pois": ids[0][0], "kat": 1, "alarm": 0}
+        r = self._session.get(
+            "https://hilchenbach.de/output/options.php",
+            params=args,
+            headers=header,
+            timeout=30,
+        )
+        r.raise_for_status()
+
+        dates = self._ics.convert(r.text)
+
+        return [
+            Collection(date, waste_type, ICON_MAP.get(waste_type, "mdi:trash-can"))
+            for date, waste_type in dates
+        ]

--- a/doc/source/hilchenbach_de.md
+++ b/doc/source/hilchenbach_de.md
@@ -1,0 +1,38 @@
+# Stadt Hilchenbach
+
+Support for schedules provided by [Stadt Hilchenbach](https://www.hilchenbach.de), Germany.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: hilchenbach_de
+      args:
+        strasse: STRASSE
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name or partial street name. Must match exactly one entry.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: hilchenbach_de
+      args:
+        strasse: "Dammstr"
+```
+
+## How to get the source arguments
+
+1. Go to [Abfallkalender online](https://www.hilchenbach.de/Bauen-Wohnen/Abfallbeseitigung/Abfallkalender/Abfallkalender-online/).
+2. Select your district (Stadtteil) and enter your street name.
+3. Use the street name (or a unique partial match) as the `strasse` value.
+
+*Note:* The value must match exactly one street. If multiple streets match, use a more specific search term. Street names are followed by the district in parentheses, e.g. `Dammstraße (Hilchenbach)` — you can search by partial name such as `Dammstr`.


### PR DESCRIPTION
## Summary

Adds a new source for waste collection schedules provided by Stadt Hilchenbach, Germany.

- Uses the same ikiss/ABIS platform as `abfall_neunkirchen_siegerland_de`
- Two-step API: JSON autocomplete to resolve street → ICS export
- Site is Cloudflare-protected, so uses `curl_cffi` with Chrome impersonation
- Street name search works across all Hilchenbach Stadtteile without requiring a district parameter
- Supports all collection types: Restmüll, Biomüll, Gelbe Tonne, Papier, Astschnitt, Schadstoffsammlung, Abfuhr Weihnachtsbäume

Closes #5579

## Test plan

- [ ] `python test_sources.py -s hilchenbach_de -l` passes for both TEST_CASES
- [ ] Ambiguous street name raises `SourceArgAmbiguousWithSuggestions`
- [ ] Unknown street name raises `SourceArgumentNotFound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)