### PR TITLE
fix: update kiertokapula_fi for Vingo 2.0 portal migration (#6405)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiertokapula_fi.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiertokapula_fi.py
@@ -1,110 +1,120 @@
 import logging
-from datetime import datetime
+from datetime import date, datetime
 
 import requests
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Kiertokapula Finland"
-DESCRIPTION = "Schedule for kiertokapula FI"
+DESCRIPTION = "Schedule for Kiertokapula Finland waste collection"
 URL = "https://www.kiertokapula.fi"
+COUNTRY = "fi"
 TEST_CASES = {
     "Test1": {
-        "bill_number": "!secret kiertonkapula_fi_bill_number",
-        "password": "!secret kiertonkapula_fi_bill_password",
+        "username": "!secret kiertokapula_fi_username",
+        "password": "!secret kiertokapula_fi_password",
     }
 }
-ICON_MAP = {
-    "SEK": Icons.GENERAL_WASTE,
-    "MUO": Icons.GENERAL_WASTE,
-    "KAR": Icons.PAPER,
-    "LAS": Icons.GLASS_COLORED,
-    "MET": Icons.METAL,
-    "BIO": Icons.ORGANIC,
+
+API_URL = "https://asiakasnetti.kiertokapula.fi/api/customers"
+TENANT_ID = "493c3a57-70d8-4515-aa94-05dd1185b986"
+
+PARAM_TRANSLATIONS = {
+    "en": {"username": "Username", "password": "Password"},
+    "fi": {"username": "Käyttäjätunnus", "password": "Salasana"},
 }
-NAME_DEF = {
-    "SEK": "Sekajäte",
-    "MUO": "Muovi",
-    "KAR": "Kartonki",
-    "LAS": "Lasi",
-    "MET": "Metalli",
-    "BIO": "Bio",
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "username": "Your Kiertokapula e-services username (previously the bill/customer number)",
+        "password": "Your Kiertokapula e-services password",
+    }
 }
-API_URL = "https://asiakasnetti.kiertokapula.fi/kiertokapula"
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class Source:
-    def __init__(
-        self,
-        bill_number,
-        password,
-    ):
-        self._bill_number = bill_number
+    def __init__(self, username: str = "", password: str = "", bill_number: str = ""):
+        # Accept bill_number as a backward-compatible alias for username
+        self._username = username or bill_number
         self._password = password
 
-    def fetch(self):
+    def fetch(self) -> list[Collection]:
         session = requests.Session()
-        session.headers.update({"X-Requested-With": "XMLHttpRequest"})
-        session.get(API_URL)
 
-        # sign in
+        # Authenticate against new Vingo 2.0 API
+        login_headers = {
+            "Content-Type": "application/json;charset=utf-8",
+            "Accept-Language": "fi",
+            "Tenant-Id": TENANT_ID,
+        }
         r = session.post(
-            API_URL + "/j_acegi_security_check?target=2",
-            data={
-                "j_username": self._bill_number,
-                "j_password": self._password,
-                "remember-me": "false",
-            },
+            f"{API_URL}/Users/login",
+            json={"userName": self._username, "password": self._password},
+            headers=login_headers,
         )
         r.raise_for_status()
+        token_data = r.json()
+        token = token_data["token"]
 
-        # get customer info
+        # All subsequent requests use the Vingo bearer token
+        auth_headers = {
+            "Content-Type": "application/json;charset=utf-8",
+            "Accept-Language": "fi",
+            "Authorization": f"Vingo-e-services {token}",
+        }
 
-        r = session.get(API_URL + "/secure/get_customer_datas.do")
+        # Get all emptying locations for the account
+        r = session.get(
+            f"{API_URL}/Customers/emptying-infos",
+            headers=auth_headers,
+        )
         r.raise_for_status()
-        data = r.json()
+        emptying_infos = r.json() or []
 
-        entries = []
+        entries: list[Collection] = []
 
-        for estate in data.values():
-            for customer in estate:
-                r = session.get(
-                    API_URL + "/secure/get_services_by_customer_numbers.do",
-                    params={"customerNumbers[]": customer["asiakasnro"]},
-                )
-                r.raise_for_status()
-                data = r.json()
-                for service in data:
-                    if service["tariff"].get("productgroup", "PER") == "PER":
-                        continue
-                    next_date_str = None
-                    if (
-                        "ASTSeurTyhj" in service
-                        and service["ASTSeurTyhj"] is not None
-                        and len(service["ASTSeurTyhj"]) > 0
-                    ):
-                        next_date_str = service["ASTSeurTyhj"]
-                    elif (
-                        "ASTNextDate" in service
-                        and service["ASTNextDate"] is not None
-                        and len(service["ASTNextDate"]) > 0
-                    ):
-                        next_date_str = service["ASTNextDate"]
+        for info in emptying_infos:
+            emptying_id = info.get("id")
+            if not emptying_id:
+                continue
 
-                    if next_date_str is None:
-                        continue
+            # Get active contracts for this emptying location
+            r = session.get(
+                f"{API_URL}/Customers/emptying-infos/{emptying_id}/contracts",
+                headers=auth_headers,
+            )
+            r.raise_for_status()
+            contracts = r.json() or []
 
-                    next_date = datetime.strptime(next_date_str, "%Y-%m-%d").date()
-                    entries.append(
-                        Collection(
-                            date=next_date,
-                            t=service.get(
-                                "ASTNimi",
-                                NAME_DEF.get(service["tariff"]["productgroup"], "N/A"),
-                            ),
-                            icon=ICON_MAP.get(service["tariff"]["productgroup"]),
-                        )
+            today = date.today()
+            for contract in contracts:
+                # Filter to active contracts (status Unspecified or Approved, not expired)
+                status = contract.get("status", "")
+                if status not in ("Unspecified", "Approved"):
+                    continue
+                end_date_str = contract.get("endDate")
+                if end_date_str:
+                    try:
+                        end_date = datetime.fromisoformat(end_date_str).date()
+                        if end_date <= today:
+                            continue
+                    except (ValueError, TypeError):
+                        pass
+
+                next_emptying_str = contract.get("nextEmptying")
+                if not next_emptying_str:
+                    continue
+
+                try:
+                    next_emptying = datetime.fromisoformat(next_emptying_str).date()
+                except (ValueError, TypeError):
+                    _LOGGER.warning(
+                        "Could not parse nextEmptying date: %s", next_emptying_str
                     )
+                    continue
+
+                waste_type = contract.get("name") or "Waste"
+                entries.append(Collection(date=next_emptying, t=waste_type))
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiertokapula_fi.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiertokapula_fi.py
@@ -20,7 +20,6 @@ TENANT_ID = "493c3a57-70d8-4515-aa94-05dd1185b986"
 
 PARAM_TRANSLATIONS = {
     "en": {"username": "Username", "password": "Password"},
-    "fi": {"username": "Käyttäjätunnus", "password": "Salasana"},
 }
 
 PARAM_DESCRIPTIONS = {


### PR DESCRIPTION
## Summary

Fixes #6405. Kiertokapula Finland migrated their customer portal from a legacy Java/Spring system to a React SPA called "Vingo 2.0". This completely changes the authentication flow and API endpoints.

- New authentication: `POST /api/customers/Users/login` with `Tenant-Id` header returns `{token, expiresAt}`; all API requests use `Authorization: Vingo-e-services {token}`
- New data endpoint: `GET /api/customers/Customers/emptying-infos` then per-location `/contracts` to get waste type names and next emptying dates
- `bill_number` accepted as backward-compatible alias for the new `username` parameter
- Adds missing `COUNTRY = "fi"` field

Root cause determined via JS bundle analysis of the new Vingo 2.0 portal (`asiakasnetti.kiertokapula.fi/e-services/kiertokapula`). Cannot live-test without real credentials (TEST_CASES use `!secret`).

## Test plan

- [ ] Test with real Kiertokapula e-services credentials
- [ ] Verify Collection entries returned with Finnish waste type names and upcoming pickup dates
- [ ] Verify backward compatibility: existing configs using `bill_number` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)