### PR TITLE
docs(agents): enforce CI structural rules in maintainer agent prompts

### DIFF
--- a/.claude/agents/issue-executor.md
+++ b/.claude/agents/issue-executor.md
@@ -2,7 +2,7 @@
 name: issue-executor
 description: Executes a pre-approved issue resolution plan for mampfes/hacs_waste_collection_schedule. Receives a verbatim step-by-step plan from the issue-triager and executes it exactly in an isolated worktree. Every listed action is pre-authorised — no confirmation gates.
 model: sonnet
-tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git add *), Bash(git branch *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git push *), Bash(git remote *), Bash(git status *), Bash(python -m black *), Bash(python -m isort *), Bash(python test_sources.py *), Read, Edit, Write, Grep
+tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git add *), Bash(git branch *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git push *), Bash(git remote *), Bash(git status *), Bash(python -m black *), Bash(python -m isort *), Bash(python -m pytest *), Bash(python test_sources.py *), Read, Edit, Write, Grep
 ---
 
 You are an issue execution agent for mampfes/hacs_waste_collection_schedule. You receive a pre-approved execution plan from the issue-triager and carry it out exactly as written in an isolated worktree.
@@ -18,6 +18,7 @@ You are an issue execution agent for mampfes/hacs_waste_collection_schedule. You
 - For any step that says "Write file `<path>` with this exact content: …", use the Write tool to create or overwrite the file with that exact content. Do not Edit — overwrite. Do not paraphrase, reformat, or "improve" the content.
 - If the plan asks you to modify a file but does not include the complete final content inline, stop and report — the plan is incomplete.
 - The worktree starts on a temporary branch. Use `git checkout -b <branch-name>` as the first step to create the correct feature branch. If the branch already exists (e.g. the planner left a stale branch behind), report this and stop.
+- **Non-skippable structural-test gate.** Whenever the plan touches any file under `custom_components/waste_collection_schedule/waste_collection_schedule/source/` (new or modified), run `python -m pytest tests/test_source_components.py -q` after lint and before `git add`. If the plan does not list it, run it anyway. If any test fails, stop and report — do not commit or push.
 
 ## On completion
 

--- a/.claude/agents/issue-triager.md
+++ b/.claude/agents/issue-triager.md
@@ -26,6 +26,16 @@ You are a specialised issue triager for mampfes/hacs_waste_collection_schedule, 
 - Lint: `python -m black <file> && python -m isort --profile black <file>`
 - Test: `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s <id> -l`
 
+### CI-enforced structural invariants — must validate at design time
+
+`tests/test_source_components.py` runs in CI on every PR and rejects:
+
+1. **Languages outside `{"en", "de", "it", "fr"}` in `PARAM_TRANSLATIONS` / `PARAM_DESCRIPTIONS`.** Default behaviour when the natural fit is a non-allowlisted language (e.g. `fi`, `es`, `nl`, `pl`): **strip the unsupported language from this source's translation dicts**, and add a `### Follow-up issue` section to the Phase 1 report describing a separate issue to open titled `Add <lang> (xx) language support to PARAM_TRANSLATIONS allowlist`, linked back to this issue, asking for contributors to help with the full translation pipeline (allowlist + `update_docu_links.py` + `translations/<xx>.json`). Never silently include an unsupported language — CI will reject the PR.
+2. **Raw `"mdi:..."` strings in `ICON_MAP`.** Values MUST be members of the `Icons` enum: `from waste_collection_schedule import Icons` then e.g. `Icons.GENERAL_WASTE`. Catalogue at `custom_components/waste_collection_schedule/waste_collection_schedule/icons.py`.
+3. **`COUNTRY` not in the lowercase allowlist** (as already noted above).
+
+After writing any source file, run `python -m pytest tests/test_source_components.py -q` against your worktree before producing the Phase 1 report — and add it as an explicit step in the Execution Plan you hand to the executor.
+
 ## Workflow
 
 ### Phase 1 — Analysis and local implementation (runs automatically on invocation)
@@ -120,11 +130,12 @@ Prepare an appropriate info-request or "not planned" comment.
    (Repeat for each file the executor must create or overwrite.)
 3. [format commands: `python -m black <file>` and/or `python -m isort --profile black <file>`]
 4. [optional live test: `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s <id> -l`]
-5. `git add <files>`
-6. `git commit -m "<exact commit message>"`
-7. `git push origin HEAD:<branch-name>`
-8. `gh pr create --repo mampfes/hacs_waste_collection_schedule --title "<title>" --body "<exact body>"`
-9. `gh issue comment <ISSUE_NUMBER> --repo mampfes/hacs_waste_collection_schedule --body "<exact comment text>"`
+5. **Mandatory structural test (do not skip even if live-test was blocked or impossible):** `python -m pytest tests/test_source_components.py -q` — must pass before commit.
+6. `git add <files>`
+7. `git commit -m "<exact commit message>"`
+8. `git push origin HEAD:<branch-name>`
+9. `gh pr create --repo mampfes/hacs_waste_collection_schedule --title "<title>" --body "<exact body>"`
+10. `gh issue comment <ISSUE_NUMBER> --repo mampfes/hacs_waste_collection_schedule --body "<exact comment text>"`
 [For Category D/E/F (comment only):]
 1. `gh issue comment <ISSUE_NUMBER> --repo mampfes/hacs_waste_collection_schedule --body "<exact comment text>"`
 [Add close/label steps as needed]

--- a/.claude/agents/pr-executor.md
+++ b/.claude/agents/pr-executor.md
@@ -2,7 +2,7 @@
 name: pr-executor
 description: Executes a pre-approved PR completion plan for mampfes/hacs_waste_collection_schedule. Receives a verbatim step-by-step plan from the pr-reviewer planner and executes it exactly in an isolated worktree. Every listed action is pre-authorised — no confirmation gates.
 model: sonnet
-tools: Bash(gh pr *), Bash(gh api *), Bash(gh issue *), Bash(git add *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git merge-base *), Bash(git remote *), Bash(git push *), Bash(git status *), Bash(python -m black *), Bash(python -m isort *), Read, Edit, Write, Grep
+tools: Bash(gh pr *), Bash(gh api *), Bash(gh issue *), Bash(git add *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git merge-base *), Bash(git remote *), Bash(git push *), Bash(git status *), Bash(python -m black *), Bash(python -m isort *), Bash(python -m pytest *), Read, Edit, Write, Grep
 ---
 
 You are a PR execution agent for mampfes/hacs_waste_collection_schedule. You receive a pre-approved execution plan from the pr-reviewer planner and carry it out exactly as written in an isolated worktree.
@@ -18,6 +18,7 @@ You are a PR execution agent for mampfes/hacs_waste_collection_schedule. You rec
 - For any step that says "Write file `<path>` with this exact content: …", use the Write tool to create or overwrite the file with that exact content. Do not Edit — overwrite. Do not paraphrase, reformat, or "improve" the content.
 - If the plan asks you to modify a file but does not include the complete final content inline (and it is not a pure formatter step), stop and report — the plan is incomplete.
 - The worktree starts on a temporary branch. Use `gh pr checkout <N> --repo mampfes/hacs_waste_collection_schedule` as the first step to switch to the correct PR branch.
+- **Non-skippable structural-test gate.** Whenever the plan touches any file under `custom_components/waste_collection_schedule/waste_collection_schedule/source/` (new or modified), run `python -m pytest tests/test_source_components.py -q` after lint and before `git add`. If the plan does not list it, run it anyway. If any test fails, stop and report — do not commit or push.
 
 ## On completion
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -27,6 +27,13 @@ Revert these with `git checkout upstream/master -- <file>` if found:
 - Every new source needs a `doc/source/<id>.md` file (create it if missing)
 - `COUNTRY` must be a lowercase code from `update_docu_links.py`'s `COUNTRYCODES` list. Common gotchas: UK sources use `"uk"` NOT `"gb"`; Canada uses `"ca"` NOT `"CA"`. The legacy test only validated COUNTRY when the filename suffix was invalid, so case/synonym mismatches used to slip through and silently orphan the source out of README.md / info.md / sources.json. Always grep the actual value.
 
+### CI-enforced structural invariants (`tests/test_source_components.py`)
+
+These cause CI failure if violated. Check the diff for each:
+
+1. **Language allowlist:** `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` keys must be in `{"en", "de", "it", "fr"}`. **If a contributor's PR includes another language (e.g. `fi`, `es`, `nl`):** strip that language block from the source's translation dicts as part of the local fix, and surface in the Phase 1 report that a separate follow-up issue should be opened (`Add <lang> (xx) language support to PARAM_TRANSLATIONS allowlist`) so contributors can help with the full pipeline (allowlist + `update_docu_links.py` + `translations/<xx>.json`). Never approve a PR that retains an unsupported language.
+2. **Icons enum:** `ICON_MAP` values must be members of the `Icons` enum (`from waste_collection_schedule import Icons`). Migrate any raw `"mdi:..."` strings to the matching enum member (catalogue at `custom_components/waste_collection_schedule/waste_collection_schedule/icons.py`) as part of the local fix.
+
 ### Review philosophy
 - **Minor issues** (fix automatically): style, whitespace, small bugs, missing doc files, lint
 - **Substantive issues** (escalate — do NOT attempt to fix): hardcoded data, missing API integration, security issues, fundamentally wrong approach, no TEST_CASES
@@ -67,7 +74,13 @@ Revert these with `git checkout upstream/master -- <file>` if found:
    python -m isort --profile black <file>
    ```
 
-8. Return your Phase 1 report in this exact structure, then STOP — do NOT commit, push, or post anything:
+8. **Run the structural test suite against the post-fix state** — do not skip even if live-test is impossible:
+   ```bash
+   python -m pytest tests/test_source_components.py -q
+   ```
+   If anything fails, fix it locally before producing the report. Include the result ("6 passed") in your "Fixes applied locally" section.
+
+9. Return your Phase 1 report in this exact structure, then STOP — do NOT commit, push, or post anything:
 
 ---
 ## PR Review Report
@@ -110,11 +123,12 @@ Revert these with `git checkout upstream/master -- <file>` if found:
    ```
    (Repeat per file. Omit this step if no edits or new files.)
 4. [format commands: `python -m black <file>` and/or `python -m isort --profile black <file>`]
-5. `git add <files>`
-6. `git commit -m "<exact commit message>"`
-7. `git push https://github.com/<HEAD_OWNER>/hacs_waste_collection_schedule.git HEAD:<HEAD_BRANCH>`
-8. `gh api repos/mampfes/hacs_waste_collection_schedule/pulls/<PR_NUMBER>/reviews -f body="<exact review text>" -f event="<APPROVE or REQUEST_CHANGES>"`
-[If no local changes: omit steps 3–7 and go straight to step 8]
+5. **Mandatory structural test (do not skip):** `python -m pytest tests/test_source_components.py -q` — must pass before commit.
+6. `git add <files>`
+7. `git commit -m "<exact commit message>"`
+8. `git push https://github.com/<HEAD_OWNER>/hacs_waste_collection_schedule.git HEAD:<HEAD_BRANCH>`
+9. `gh api repos/mampfes/hacs_waste_collection_schedule/pulls/<PR_NUMBER>/reviews -f body="<exact review text>" -f event="<APPROVE or REQUEST_CHANGES>"`
+[If no local changes: omit steps 3–8 and go straight to step 9]
 ---
 
 ### Phase 2 — Execute approved actions (only when continued via SendMessage)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,16 @@ Optional:
 - `HOW_TO_GET_ARGUMENTS_DESCRIPTION` — per-language guidance shown in the config wizard.
 - `PARAM_TRANSLATIONS` / `PARAM_DESCRIPTIONS` — per-language argument labels and descriptions. Currently still required on master (read by `update_docu_links.py` to generate `translations/en.json`). A future i18n YAML migration will replace these but is not yet merged — keep them.
 
+### CI-enforced structural rules
+
+`tests/test_source_components.py` runs in CI on every PR and enforces:
+
+1. **Language allowlist:** `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` keys MUST be in `{"en", "de", "it", "fr"}`. **Default behaviour when a contributor / agent wants to use any other language** (e.g. `fi`, `es`, `nl`, `pl`): strip the unsupported-language block from the source's translation dicts in the current PR, and open a *separate* issue titled `Add <lang> (xx) language support to PARAM_TRANSLATIONS allowlist` linked back to the original PR/issue, asking for contributors to help with the full translation pipeline (allowlist + `update_docu_links.py` + `translations/<xx>.json`). Never silently include an unsupported language — CI will reject the PR.
+2. **Icons enum:** `ICON_MAP` values MUST be members of the `Icons` enum (`from waste_collection_schedule import Icons`). Raw `"mdi:..."` strings fail the `test_icon_map_uses_canonical_icons` check. The canonical catalogue is at `custom_components/waste_collection_schedule/waste_collection_schedule/icons.py` — pick the nearest sensible member; do not extend the enum in a source PR.
+3. **COUNTRY allowlist** as already noted above.
+
+Run `python -m pytest tests/test_source_components.py -q` locally after any source-module change and before committing; do not rely on CI to catch these.
+
 ### Exception handling
 
 Use `SourceArgumentNotFound` / `SourceArgumentNotFoundWithSuggestions` from `waste_collection_schedule.exceptions`, not generic `Exception`. The HA UI surfaces these to the user with helpful context.


### PR DESCRIPTION
## Summary

Tightens the maintainer-side agent definitions (`.claude/agents/*.md`) and `CLAUDE.md` so the structural rules enforced by `tests/test_source_components.py` are caught at design time and re-validated before commit. Triggered by two same-session CI failures:

- PR #6406 (airdrie_ca): `test_icon_map_uses_canonical_icons` failed because `ICON_MAP` used raw `mdi:` strings.
- PR #6408 (kiertokapula_fi, fixes #6405): `test_source_has_necessary_parameters` failed because `PARAM_TRANSLATIONS` contained an unsupported `fi` key.

Both shipped because planners didn't list the rule and executors didn't run `pytest tests/test_source_components.py` before commit.

## Changes

- **`CLAUDE.md`** — new "CI-enforced structural rules" subsection: language allowlist (`en/de/it/fr`), `Icons` enum requirement, and the **default behaviour when a non-allowlisted language is encountered**: strip from the current PR and open a separate `Add <lang> (xx) language support` issue (see #6409 for the worked example).
- **`issue-triager.md` / `pr-reviewer.md`** — design-time invariants listed; mandatory `python -m pytest tests/test_source_components.py -q` in both Phase 1 validation and Execution Plan template.
- **`issue-executor.md` / `pr-executor.md`** — non-skippable structural-test gate before `git add` for any source-module change; `Bash(python -m pytest *)` added to tool allowlist.

The `source-implementer` agent (contributor-side) already had these rules and ran pytest — only the maintainer-side agents needed the fix.

## Test plan

- [ ] Future PR reviews and issue triages run pytest before commit.
- [ ] Phase 1 reports flag unsupported languages with a follow-up-issue suggestion rather than including them inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)