### PR TITLE
fix: disambiguate same-named waste types via subtitle in AppAbfallplusDe

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -3,7 +3,7 @@ import json
 import re
 import time
 import uuid
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 from datetime import date, datetime
 
 import requests
@@ -959,10 +959,10 @@ class AppAbfallplusDe:
         if not soup_array or not isinstance(soup_array, Tag):
             raise Exception("No array found.")
 
-        categories = {}
-
+        # First pass: collect id, name, subtitle for all categories
+        raw_categories: list[tuple[str, str, str]] = []
         for category in soup_array.find_all("dict"):
-            id = category.find("key", text="id").find_next_sibling("string").text
+            cat_id = category.find("key", text="id").find_next_sibling("string").text
             name = (
                 category.find("key", text="name")
                 .find_next_sibling("string")
@@ -970,16 +970,27 @@ class AppAbfallplusDe:
                 .replace("]]", "")
                 .strip()
             )
-            if any(s_id in id for s_id in self._needs_subtitle):
-                subtitle = (
-                    category.find("key", text="subtitle")
-                    .find_next_sibling("string")
-                    .text.replace("![CDATA[", "")
-                    .replace("]]", "")
-                    .strip()
-                )
+            subtitle_tag = category.find("key", text="subtitle")
+            subtitle = (
+                subtitle_tag.find_next_sibling("string")
+                .text.replace("![CDATA[", "")
+                .replace("]]", "")
+                .strip()
+                if subtitle_tag
+                else ""
+            )
+            raw_categories.append((cat_id, name, subtitle))
+
+        # Detect names that appear more than once (need subtitle to distinguish)
+        name_counts = Counter(name for _, name, _ in raw_categories)
+
+        categories = {}
+        for cat_id, name, subtitle in raw_categories:
+            if any(s_id in cat_id for s_id in self._needs_subtitle) or (
+                name_counts[name] > 1 and subtitle
+            ):
                 name += " - " + subtitle
-            categories[id] = name
+            categories[cat_id] = name
 
         collections: list[dict] = []
         for collection in (


### PR DESCRIPTION
## Summary

- Fixes #3002 — providers like `de.k4systems.avea` (Leverkusen) expose two
  collection schedules with the same name (e.g. "Restmülltonne") but different
  cycles, distinguished only by their subtitle in the API XML.
- The existing `_needs_subtitle` mechanism only handled `value="0"` inputs;
  it did not cover this general case.
- The fix adds a two-pass build of the categories dict in `get_collections()`:
  names that appear more than once across categories automatically get their
  subtitle appended (` - <subtitle>`), making them distinguishable.
- Single-occurrence names are unaffected — fully backward-compatible.

## Test plan

- [ ] Run existing TEST_CASES: `python test_sources.py -s app_abfallplus_de -l`
- [ ] Manually test with `de.k4systems.avea` + a Leverkusen street to confirm two
      distinct Restmülltonne entries appear with their cycle labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)