### PR TITLE
feat: add source for Cheltenham Borough Council (cheltenham_gov_uk)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cheltenham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cheltenham_gov_uk.py
@@ -1,0 +1,152 @@
+import logging
+import re
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+TITLE = "Cheltenham Borough Council"
+DESCRIPTION = "Source for Cheltenham Borough Council waste collection schedule"
+URL = "https://www.cheltenham.gov.uk"
+COUNTRY = "uk"
+TEST_CASES = {
+    "282 Hatherley Road GL51 6HR": {"property_id": 56299},
+}
+
+LOGGER = logging.getLogger(__name__)
+
+BASE_URL = "https://cheltenham-host01.oncreate.app"
+WEBPAGE_TOKEN = "3e546dda8816902a52a5e3f68096b16d45e279f1f634e9433b899675b5349448"
+SUBPAGE_ID = "PAG0000686GBCNH1"
+CELL_ID = "PCL0005127GBCNH1"
+FRAGMENT_ID = "PCF0019732GBCNH1"
+WIDGET_GROUP_ID = "PWG0002596GBCNH1"
+SUBMIT_FRAGMENT_ID = "PCF0016614GBCNH1"
+
+ICON_MAP = {
+    "Refuse": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "Food": Icons.BIO_KITCHEN,
+    "Garden": Icons.GARDEN,
+    "Paper": Icons.PAPER,
+    "Card": Icons.PAPER,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "property_id": "Property ID",
+    }
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "property_id": "Internal numeric property identifier from Cheltenham's bin checker (e.g. 56299)",
+    }
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Visit https://cheltenham-host01.oncreate.app/w/webpage/collection-lookup, enter your postcode, select your address, then note the numeric property ID shown in the page.",
+}
+
+
+class Source:
+    def __init__(self, property_id: int | str):
+        self._property_id = str(property_id)
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                "X-Requested-With": "XMLHttpRequest",
+            }
+        )
+
+        page_url = f"{BASE_URL}/w/webpage/collection-lookup?webpage_subpage_id={SUBPAGE_ID}&webpage_token={WEBPAGE_TOKEN}"
+
+        # Establish session cookie
+        session.get(f"{BASE_URL}/w/webpage/collection-lookup")
+
+        # Step 1: Retrieve form to get CSRF token and collection key
+        r1 = session.post(
+            page_url,
+            data={
+                "webpage_cell_id": CELL_ID,
+                "webpage_fragment_id": FRAGMENT_ID,
+                "webpage_widget_group_id": WIDGET_GROUP_ID,
+            },
+        )
+        r1.raise_for_status()
+        data1 = r1.json().get("data", "")
+
+        form_check_match = re.search(r'name="form_check" value="([a-f0-9]+)"', data1)
+        if not form_check_match:
+            raise Exception("Could not extract CSRF token from form response")
+        form_check = form_check_match.group(1)
+
+        collection_key_match = re.search(r'data-unique_key="(C_[a-f0-9]+)"', data1)
+        if not collection_key_match:
+            raise Exception("Could not extract collection key from form response")
+        collection_key = collection_key_match.group(1)
+
+        # Step 2: Submit property_id to get bin schedule
+        r2 = session.post(
+            page_url,
+            data={
+                "form_check": form_check,
+                "submitted_page_storage_key": "/w/webpage/collection-lookup",
+                "submitted_page_id": SUBPAGE_ID,
+                "submitted_widget_group_id": WIDGET_GROUP_ID,
+                "submitted_widget_group_type": "search",
+                f"payload[{SUBPAGE_ID}][{WIDGET_GROUP_ID}][{CELL_ID}][search][{collection_key}][{FRAGMENT_ID}]": self._property_id,
+                f"payload[{SUBPAGE_ID}][{WIDGET_GROUP_ID}][{CELL_ID}][search][{collection_key}][{SUBMIT_FRAGMENT_ID}]": "Next",
+            },
+        )
+        r2.raise_for_status()
+        data2 = r2.json().get("data", "")
+
+        return self._parse_schedule(data2)
+
+    def _parse_schedule(self, html: str) -> list[Collection]:
+        soup = BeautifulSoup(html, "html.parser")
+        rows = soup.find_all("tr", class_="page_fragment_collection")
+
+        if not rows:
+            raise SourceArgumentNotFound(
+                "property_id",
+                self._property_id,
+                "no collection data found — please check your property_id is correct",
+            )
+
+        entries = []
+        for row in rows:
+            current_value = row.get("data-current_value", "")
+            if not current_value:
+                continue
+            # Format: bin_size_detail|bin_type_name|id|last_date_dd/mm/yyyy|next_date_dd/mm/yyyy|schedule
+            parts = current_value.split("|")
+            if len(parts) < 5:
+                continue
+            bin_type = parts[1].strip()
+            next_date_str = parts[4].strip()
+            if not next_date_str or next_date_str == "N/A":
+                continue
+            try:
+                next_date = datetime.strptime(next_date_str, "%d/%m/%Y").date()
+            except ValueError:
+                LOGGER.warning(
+                    "Could not parse date %r for bin type %r", next_date_str, bin_type
+                )
+                continue
+
+            icon = None
+            for keyword, mapped_icon in ICON_MAP.items():
+                if keyword.lower() in bin_type.lower():
+                    icon = mapped_icon
+                    break
+
+            entries.append(Collection(date=next_date, t=bin_type, icon=icon))
+
+        return entries

--- a/doc/source/cheltenham_gov_uk.md
+++ b/doc/source/cheltenham_gov_uk.md
@@ -1,0 +1,38 @@
+# Cheltenham Borough Council
+
+Support for schedules provided by [Cheltenham Borough Council](https://www.cheltenham.gov.uk), serving Cheltenham, Gloucestershire, UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: cheltenham_gov_uk
+      args:
+        property_id: PROPERTY_ID
+```
+
+### Configuration Variables
+
+**property_id**
+*(integer) (required)*
+
+The internal numeric property identifier used by Cheltenham Borough Council's waste collection system. See below for how to find yours.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: cheltenham_gov_uk
+      args:
+        property_id: 56299
+```
+
+## How to get the source argument
+
+1. Visit <https://cheltenham-host01.oncreate.app/w/webpage/collection-lookup>
+2. Enter your postcode and select your address from the dropdown.
+3. Once your bin schedule loads, note the numeric **property ID** — it will be visible in the address selection form. Typical values are 5-digit numbers (e.g. `56299`).
+
+Alternatively, open your browser's developer tools (F12 → Network tab), enter your postcode, select your address, and look for a POST request. The property ID is the numeric value submitted in the form payload.


### PR DESCRIPTION
## Summary

Closes #1316.

Adds a new source module for Cheltenham Borough Council's waste collection schedule.

- Uses the Liberty Create (Netcall) platform at `cheltenham-host01.oncreate.app`
- 2-step POST flow: first POST retrieves the form (extracting a CSRF token and collection key), second POST submits the `property_id` and receives the bin schedule as JSON-wrapped HTML
- Parses `<tr class="page_fragment_collection">` rows for bin type and next collection date
- Single required parameter: `property_id` (visible in the council's online bin checker)
- Returns Refuse, Recycling, Food, Garden, and Paper/Card collection types with appropriate icons

## Test plan

- [x] `python test_sources.py -s cheltenham_gov_uk -l` passes with property_id=56299
- [x] `python -m black` and `python -m isort --profile black` clean
- [x] `python -m pytest tests/test_source_components.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)