### PR TITLE
fix: Fix preston_gov_uk — WAF bypass, two-step flow, missing Food Waste bin

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/preston_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/preston_gov_uk.py
@@ -1,13 +1,19 @@
+import logging
 from datetime import date, datetime
 from typing import Optional
 
 from bs4 import BeautifulSoup
-from requests import Session
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (  # type: ignore[attr-defined]
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
 
 TITLE = "Preston City Council"
 DESCRIPTION = "Source for preston.gov.uk services for Preston City Council, UK."
 URL = "https://preston.gov.uk"
+COUNTRY = "uk"
 SRV_URL = (
     "https://selfservice.preston.gov.uk/service/Forms/FindMyNearest.aspx?Service=bins"
 )
@@ -18,9 +24,11 @@ TEST_CASES = {
 }
 
 ICON_MAP = {
+    "Food waste:": Icons.BIO_KITCHEN,
     "Commercial -  general waste:": Icons.COMMERCIAL,
     "Commercial -  cardboard and paper:": Icons.PAPER,
     "Commercial - plastic cans and glass:": Icons.PLASTIC_PACKAGING,
+    "Commercial -  food waste:": Icons.BIO_KITCHEN,
     "Black/grey bin (general waste):": Icons.GENERAL_WASTE,
     "Yellow lidded recycling container (glass/cans/plastics):": Icons.PLASTIC_PACKAGING,
     "Red lidded recycling container (paper/card):": Icons.PAPER,
@@ -28,31 +36,29 @@ ICON_MAP = {
 }
 
 HEADER_MAP = {
+    "Food waste:": "Food Waste",
     "Commercial -  general waste:": "General Waste (Commercial)",
     "Commercial -  cardboard and paper:": "Cardboard (Commercial)",
     "Commercial - plastic cans and glass:": "Plastic (Commercial)",
+    "Commercial -  food waste:": "Food Waste (Commercial)",
     "Black/grey bin (general waste):": "General Waste (Black/Grey bin)",
     "Yellow lidded recycling container (glass/cans/plastics):": "Glass/Cans/Plastics (Yellow bin)",
     "Red lidded recycling container (paper/card):": "Cardboard/Paper (Red bin)",
     "Brown bin (garden waste):": "Garden/Green Waste (Brown bin)",
 }
 
-PARAMS = {
-    "__VIEWSTATE": "",
-    "__VIEWSTATEGENERATOR": "",
-    "__EVENTVALIDATION": "",
-    "__EVENTTARGET": "ctl00$MainContent$btnSearch",
-    "__EVENTARGUMENT": "",
-    "__LASTFOCUS": "",
-    "__SCROLLPOSITIONX": "0",
-    "__SCROLLPOSITIONY": "0",
-    "ctl00$MainContent$hdnService": "bins",
-    "ctl00$MainContent$hdnActivityId": "",
-    "ctl00$MainContent$hdnPropertyEntityAddress": "",
-    "ctl00$MainContent$hdnPropertyEntityValue": "",
-    "ctl00$MainContent$txtAddress": "",
-    "ctl00$MainContent$hdnUPRN": "",
-}
+_LOGGER = logging.getLogger(__name__)
+
+
+def _extract_hidden_inputs(soup: BeautifulSoup) -> dict:
+    """Extract all hidden input fields from a BeautifulSoup page."""
+    params = {}
+    for inp in soup.find_all("input", {"type": "hidden"}):
+        name = inp.get("name")
+        value = inp.get("value", "")
+        if name:
+            params[name] = value
+    return params
 
 
 class Source:
@@ -60,49 +66,105 @@ class Source:
         self._street = street
         self._uprn = str(uprn)
 
-    def _update_params(self, soup: BeautifulSoup) -> None:
-        self._params = {k: v for k, v in PARAMS.items()}
+    def fetch(self) -> list:
+        session = requests.Session(impersonate="chrome")
 
-        for k, v in PARAMS.items():
-            try:
-                self._params[k] = soup.find("input", {"name": k})["value"]
-            except KeyError:
-                self._params[k] = ""
-            except TypeError:
-                self._params[k] = ""
-
-        self._params["__EVENTTARGET"] = "ctl00$MainContent$btnSearch"
-        self._params["ctl00$MainContent$hdnService"] = "bins"
-        self._params["ctl00$MainContent$txtAddress"] = self._street
-        self._params["ctl00$MainContent$hdnUPRN"] = self._uprn
-
-    def fetch(self):
-        return self._get()
-
-    def _get(self):
-        #
-        # Initial fetch to get session information
-        #
-        session = Session()
-
+        # Step 1: GET the initial page to obtain session cookies and hidden ASP.NET fields
         r0 = session.get(SRV_URL)
         r0.raise_for_status()
-        r0_bs4 = BeautifulSoup(r0.text, features="html.parser")
-        self._update_params(r0_bs4)
+        soup0 = BeautifulSoup(r0.text, features="html.parser")
 
-        #
-        # Post with Street
-        #
-        r1 = session.post(SRV_URL, data=self._params)
+        # Step 2: POST the search request with address/UPRN
+        params1 = _extract_hidden_inputs(soup0)
+        params1["__EVENTTARGET"] = "ctl00$MainContent$btnSearch"
+        params1["__EVENTARGUMENT"] = ""
+        params1["ctl00$MainContent$hdnService"] = "bins"
+        params1["ctl00$MainContent$txtAddress"] = (
+            self._street if self._street else self._uprn
+        )
+        params1["ctl00$MainContent$hdnUPRN"] = self._uprn
+
+        r1 = session.post(SRV_URL, data=params1)
         r1.raise_for_status()
-        bs = BeautifulSoup(r1.text, features="html.parser")
+        soup1 = BeautifulSoup(r1.text, features="html.parser")
 
-        return self._parse(bs)
+        # Check whether the search already returned collection data
+        cnt = soup1.select_one("span#MainContent_lblMoreCollectionDates")
+        if cnt and cnt.find_all("div", {"id": "container"}):
+            return self._parse(cnt)
 
-    @staticmethod
-    def _entries(entries, header: str, date_obj: date, ico: Optional[str]):
-        entries.append(Collection(t=header, date=date_obj, icon=ico))
-        return entries
+        # Step 3: Select from the address dropdown (triggered by ddlSearchResults change)
+        select_el = soup1.find("select", {"name": "ctl00$MainContent$ddlSearchResults"})
+        if not select_el:
+            raise SourceArgumentNotFound(
+                argument="street" if self._street else "uprn",
+                value=self._street if self._street else self._uprn,
+            )
+
+        options = [
+            opt
+            for opt in select_el.find_all("option")
+            if opt.get("value", "").startswith("170|")
+            or opt.get("value", "").count("|") >= 4
+        ]
+
+        if not options:
+            # Build suggestions from all non-placeholder options
+            all_opts = [
+                opt.text.strip()
+                for opt in select_el.find_all("option")
+                if opt.get("value", "") not in ("Make a selection from the list", "")
+            ]
+            if self._uprn:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    argument="uprn",
+                    value=self._uprn,
+                    suggestions=all_opts,
+                )
+            raise SourceArgumentNotFoundWithSuggestions(
+                argument="street",
+                value=self._street,
+                suggestions=all_opts,
+            )
+
+        # Pick the best matching option
+        selected_option = options[0]
+        if self._uprn:
+            for opt in options:
+                if self._uprn in (opt.get("value", "") + opt.text):
+                    selected_option = opt
+                    break
+
+        if len(options) > 1 and not self._uprn:
+            _LOGGER.warning(
+                "Multiple addresses found for %r, using first: %s",
+                self._street,
+                selected_option.text.strip(),
+            )
+
+        selected_value = selected_option.get("value", "")
+
+        params2 = _extract_hidden_inputs(soup1)
+        params2["__EVENTTARGET"] = "ctl00$MainContent$ddlSearchResults"
+        params2["__EVENTARGUMENT"] = ""
+        params2["ctl00$MainContent$hdnService"] = "bins"
+        params2["ctl00$MainContent$txtAddress"] = (
+            self._street if self._street else self._uprn
+        )
+        params2["ctl00$MainContent$ddlSearchResults"] = selected_value
+
+        r2 = session.post(SRV_URL, data=params2)
+        r2.raise_for_status()
+        soup2 = BeautifulSoup(r2.text, features="html.parser")
+
+        cnt = soup2.select_one("span#MainContent_lblMoreCollectionDates")
+        if not cnt or not cnt.find_all("div", {"id": "container"}):
+            raise SourceArgumentNotFound(
+                argument="street" if self._street else "uprn",
+                value=self._street if self._street else self._uprn,
+            )
+
+        return self._parse(cnt)
 
     @staticmethod
     def _date(date_string: str) -> Optional[date]:
@@ -112,27 +174,25 @@ class Source:
             return None
 
     @staticmethod
-    def _parse(bs):
+    def _parse(cnt) -> list:
         entries = []
 
-        cnt = bs.select_one("span#MainContent_lblMoreCollectionDates")
-        if not cnt:  # no tables in HTML means the address lookup failed
-            raise Exception("Address lookup failed")
-
         for blk in cnt.find_all("div", {"id": "container"}):
-            headerSel = blk.select_one("ul > b")
-            headerTxt = headerSel.text
+            header_sel = blk.select_one("ul > b")
+            if not header_sel:
+                continue
+            header_txt = header_sel.text.strip()
 
-            hdr = HEADER_MAP.get(headerTxt) or headerTxt
-            ico = ICON_MAP.get(headerTxt)
+            hdr = HEADER_MAP.get(header_txt) or header_txt.rstrip(":")
+            ico = ICON_MAP.get(header_txt)
 
-            itms = blk.select("ul > li")
-            for itm in itms:
-                dateTxt = itm.select_one("span")
-                dateObj = (Source._date(dateTxt.text),)
-                if dateObj is None:
+            for itm in blk.select("ul > li"):
+                date_span = itm.select_one("span")
+                if not date_span:
                     continue
-
-                entries = Source._entries(entries, hdr, dateObj[0], ico)
+                date_obj = Source._date(date_span.text.strip())
+                if date_obj is None:
+                    continue
+                entries.append(Collection(t=hdr, date=date_obj, icon=ico))
 
         return entries


### PR DESCRIPTION
## Summary

Fixes #6337 — Preston City Council source broken after site infrastructure change.

- Switch `requests` → `curl_cffi` (`impersonate="chrome"`) to bypass Barracuda WAF
- Implement proper two-step address flow: search → select from dropdown → parse results
- Fix hidden-input extraction to capture all fields including `__ncforminfo` (Barracuda field)
- Add missing `Food waste:` bin type to `ICON_MAP` / `HEADER_MAP`
- Replace generic `Exception` with `SourceArgumentNotFound` / `SourceArgumentNotFoundWithSuggestions`
- Add explicit `COUNTRY = "uk"`

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] Live test with `python test_sources.py -s preston_gov_uk -l` returns collections for both TEST_CASES (requires network access to selfservice.preston.gov.uk)

Thanks to @ppslim for the detailed investigation and HTML sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)