### PR TITLE
fix(colchester_gov_uk): drop textiles and combine recycling streams

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
@@ -17,7 +17,6 @@ ICON_MAP = {
     "Black bags": Icons.GENERAL_WASTE,
     "Glass": Icons.GLASS,
     "Cans": Icons.METAL,
-    "Textiles": Icons.TEXTILE,
     "Paper/card": Icons.PAPER,
     "Plastics": Icons.PLASTIC_PACKAGING,
     "Garden waste": Icons.GARDEN,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
@@ -13,12 +13,17 @@ TEST_CASES = {
     "The Lane, Colchester": {"llpgid": "7cd96a3d-6027-e711-80fa-5065f38b56d1"},
 }
 
+# Colchester's API still emits "Paper/card" for the combined mixed-recycling
+# stream (paper/card, plastics, tins and cans) that replaced the separate
+# rounds.
+NAME_MAP = {
+    "Paper/card": "Mixed recycling",
+}
+
 ICON_MAP = {
     "Black bags": Icons.GENERAL_WASTE,
     "Glass": Icons.GLASS,
-    "Cans": Icons.METAL,
-    "Paper/card": Icons.PAPER,
-    "Plastics": Icons.PLASTIC_PACKAGING,
+    "Paper/card": Icons.RECYCLING,
     "Garden waste": Icons.GARDEN,
     "Food waste": Icons.BIO_KITCHEN,
 }
@@ -57,12 +62,14 @@ class Source:
                         )
                         if not weeks["WeekOne"]:
                             date = date + timedelta(days=7)
+                        name = NAME_MAP.get(day["Name"], day["Name"].title())
+                        icon = ICON_MAP.get(day["Name"])
                         if date > datetime.now():
                             entries.append(
                                 Collection(
                                     date=date.date(),
-                                    t=day["Name"].title(),
-                                    icon=ICON_MAP.get(day["Name"]),
+                                    t=name,
+                                    icon=icon,
                                 )
                             )
                         # As Colchester.gov.uk only provides the current collection cycle, the next must be extrapolated
@@ -71,8 +78,8 @@ class Source:
                         entries.append(
                             Collection(
                                 date=date.date() + timedelta(days=14),
-                                t=day["Name"].title(),
-                                icon=ICON_MAP.get(day["Name"]),
+                                t=name,
+                                icon=icon,
                             )
                         )
                     except ValueError:


### PR DESCRIPTION
## Summary

  Colchester changed two parts of its kerbside collection schedule in 2026:

  - **2026-04-03**, textiles moved from kerbside collection to a [bookable
  service](https://www.colchester.gov.uk/recycling-and-rubbish/book-textile-collection/) and no longer appear on the recycling calendar. Removes the
  `Textiles` entry from `ICON_MAP`.
  - **2026-06-01**, paper/card, plastics, tins and cans are now collected together as a single "Mixed recycling" stream (per the [council's strategy page](https://www.new.colchester.gov.uk/recycling-and-rubbish/recycling-and-waste-strategy-2025-2040-implementation/calendar-collection)). The API has already cut over (no collection entries returned before the cutover date), so the old `Cans` and `Plastics` row names no longer appear in the response.
  The API still emits `"Paper/card"` as the row name for the new combined stream, so a small `NAME_MAP` rewrites the display name to `"Mixed recycling"`, and the icon is switched from `PAPER` to `RECYCLING`. The now-unused `Cans` and `Plastics` entries are removed from `ICON_MAP`.

  The two commits are kept separate so each change can be reverted independently.

  ## Test plan

  - [x] `python -m pytest tests/test_source_components.py`: 6 passed
  - [x] `python test_sources.py -s colchester_gov_uk -l`: both `Church Road, Colchester` and `The Lane, Colchester` TEST_CASES return collections with the
  expected `Mixed recycling` label, no Textiles/Cans/Plastics entries
  - [x] `black`, `isort`, `flake8`: clean