### PR TITLE
Adds support for Town of Cambridge (AU - WA)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cambridge_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cambridge_wa_gov_au.py
@@ -1,0 +1,156 @@
+import logging
+import re
+import typing
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+from curl_cffi import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import (
+    SourceArgumentExceptionMultiple,
+)
+
+TITLE = "Town of Cambridge (WA)"
+DESCRIPTION = "Source for Town of Cambridge (Western Australia) rubbish collection."
+URL = "https://www.cambridge.wa.gov.au"
+TEST_CASES = {
+    "Geolocation ID": {"geolocation_id": "ec16b372-7aab-4082-8519-2163c431777d"},
+    "Cambridge Library": {"street_address": "99 The Boulevard, FLOREAT 6014"},
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+ICON_MAP = {
+    "general waste": Icons.GENERAL_WASTE,
+    "green waste": Icons.GARDEN,
+    "fogo": Icons.ORGANIC,
+    "recycling": Icons.RECYCLING,
+}
+
+
+class SourceConfigurationError(ValueError):
+    pass
+
+
+class SourceParseError(ValueError):
+    pass
+
+
+class Source:
+    OC_GEOLOCATION_SEARCH_URL = "https://www.cambridge.wa.gov.au/api/v1/myarea/search"
+
+    OC_SESSION_URL = (
+        "https://www.cambridge.wa.gov.au/Residents/Waste-Recycling/Find-My-Bin-Day"
+    )
+    OC_CALENDAR_URL = (
+        "https://www.cambridge.wa.gov.au/ocapi/Public/myarea/wasteservices"
+    )
+
+    OC_RE_DATE_STR = re.compile(r"[^\s]+\s(\d{1,2}/\d{1,2}/\d{4})")
+
+    def __init__(
+        self,
+        street_address: typing.Optional[str] = None,
+        geolocation_id: typing.Optional[str] = None,
+    ):
+        if street_address is None and geolocation_id is None:
+            raise SourceArgumentExceptionMultiple(
+                ["street_address", "geolocation_id"],
+                "Either street_address or geolocation_id must have a value",
+            )
+
+        self._street_address = street_address
+        self._geolocation_id = geolocation_id
+
+    def fetch(self) -> typing.List[Collection]:
+        # Use curl_cffi session to bypass Incapsula bot protection
+        session = requests.Session(impersonate="chrome")
+
+        geolocation_id = self._geolocation_id
+        if geolocation_id is None:
+            # Search for geolocation ID
+            geolocation_response = session.get(
+                self.OC_GEOLOCATION_SEARCH_URL,
+                params={"keywords": self._street_address, "maxresults": 1},
+                headers={"Accept": "application/json"},
+            )
+            geolocation_response.raise_for_status()
+
+            # Pull ID from results
+            geolocation_result = geolocation_response.json()
+            _LOGGER.debug(f"Search response: {geolocation_response!r}")
+
+            if "success" in geolocation_result and not geolocation_result["success"]:
+                raise SourceParseError(
+                    "Unspecified server-side error when searching address"
+                )
+
+            if (
+                "Items" not in geolocation_result
+                or geolocation_result["Items"] is None
+                or len(geolocation_result["Items"]) < 1
+            ):
+                raise SourceParseError(
+                    "Expected list of locations from address search, got empty or missing list"
+                )
+
+            geolocation_data = geolocation_result["Items"][0]
+
+            if "Id" not in geolocation_data:
+                raise SourceParseError(
+                    "Location in address search result but missing geolocation ID"
+                )
+
+            geolocation_id = geolocation_data["Id"]
+            _LOGGER.info(
+                f"Address {self._street_address} mapped to geolocation ID {geolocation_id}"
+            )
+
+        calendar_request = session.get(self.OC_SESSION_URL)
+        calendar_request.raise_for_status()
+
+        calendar_request = session.get(
+            self.OC_CALENDAR_URL,
+            params={"geolocationid": geolocation_id, "ocsvclang": "en-AU"},
+        )
+        calendar_request.raise_for_status()
+
+        calendar_result = calendar_request.json()
+        _LOGGER.debug(f"Calendar response: {calendar_result!r}")
+
+        if "success" in calendar_result and not calendar_result["success"]:
+            raise SourceParseError(
+                "Unspecified server-side error when getting calendar"
+            )
+
+        # Extract entries from bundled HTML
+        calendar_parser = BeautifulSoup(
+            calendar_result["responseContent"], "html.parser"
+        )
+
+        pickup_entries = []
+
+        for element in calendar_parser.find_all("article"):
+            _LOGGER.debug(f"Parsing collection: {element!r}")
+
+            waste_type = element.h3.string
+
+            # Extract and parse collection date
+            waste_date_match = self.OC_RE_DATE_STR.match(
+                element.find(class_="next-service").string.strip()
+            )
+
+            if waste_date_match is None:
+                continue
+
+            waste_date = datetime.strptime(waste_date_match[1], "%d/%m/%Y").date()
+
+            # Base icon on type
+            waste_icon = ICON_MAP.get(waste_type.lower())
+
+            pickup_entries.append(Collection(waste_date, waste_type, waste_icon))
+            _LOGGER.info(
+                f"Collection for {waste_type} (icon: {waste_icon}) on {waste_date}"
+            )
+
+        return pickup_entries

--- a/doc/source/cambridge_wa_gov_au.md
+++ b/doc/source/cambridge_wa_gov_au.md
@@ -1,0 +1,47 @@
+# Town of Cambridge (WA)
+
+Support for schedules provided by [Town of Cambridge](https://www.cambridge.wa.gov.au/), serving Western Australian suburbs including Floreat, Wembley, City Beach, West Leederville and Mount Claremont. The implementation uses the same OpenCities (OCAPI) back-end pattern as other Australian council sources.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cambridge_wa_gov_au
+      args:
+        street_address: STREET_ADDRESS
+```
+
+### Configuration Variables
+
+**street_address**  
+*(string) (optional)*
+
+**geolocation_id**  
+*(string) (optional)*
+
+At least one argument must be provided.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cambridge_wa_gov_au
+      args:
+        street_address: 99 The Boulevard, FLOREAT 6014
+```
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cambridge_wa_gov_au
+      args:
+        geolocation_id: ec16b372-7aab-4082-8519-2163c431777d
+```
+
+## How to get the source arguments
+
+Visit the [Town of Cambridge Find My Bin Day](https://www.cambridge.wa.gov.au/Residents/Waste-Recycling/Find-My-Bin-Day) page and search for your address. The ```street_address``` argument should exactly match the street address shown in the autocomplete result. For unlisted addresses use an adjacent listed address.
+
+The ```geolocation_id``` argument can be used to bypass the initial address lookup on first use. This value can be discovered using the developer console in any modern browser and inspecting the request sent once an address is selected and the search button is clicked. The request URL takes the format: ```https://www.cambridge.wa.gov.au/ocapi/Public/myarea/wasteservices?geolocationid=<GEOLOCATION ID>&ocsvclang=en-AU```.


### PR DESCRIPTION
## Summary

Adds a new source `cambridge_wa_gov_au` for the **Town of Cambridge** (Western Australia), covering the suburbs of Floreat, Wembley, City Beach, West Leederville and Mount Claremont.

The Town of Cambridge runs on the OpenCities (OCAPI) platform, the same back-end pattern used by ~30 existing Australian council sources in this repo. Implementation cloned from `banyule_vic_gov_au.py` with only the three URLs changed plus an extra ICON_MAP entry for FOGO.

- **Module:** `cambridge_wa_gov_au`
- **Country:** `au`
- **Transport:** `curl_cffi` with `impersonate="chrome"` — the site sits behind Akamai/Incapsula, plain `requests` returns 403. Note: `chrome124` also returns 403 here; only the unversioned `chrome` profile passes.
- **Args:** `street_address` and/or `geolocation_id` (at least one required)
- **Waste types observed:** General Waste, Recycling, Green Waste, FOGO

## Checklist

- [x] New source module at `custom_components/waste_collection_schedule/waste_collection_schedule/source/cambridge_wa_gov_au.py`
- [x] Doc page at `doc/source/cambridge_wa_gov_au.md`
- [x] `ICON_MAP` uses `Icons` enum members only (no raw `mdi:*` strings)
- [x] `COUNTRY = "au"` (lowercase, in the allowlist)
- [x] `TEST_CASES` non-empty and all return non-empty Collections
- [x] Uses `SourceArgumentExceptionMultiple` rather than generic `Exception`
- [x] `python -m pytest tests/test_source_components.py` passes
- [x] Live `test_sources.py -s cambridge_wa_gov_au -l` returns entries for every test case
- [x] No generated files in the diff (no README.md / info.md / sources.json / translations changes)

## Test cases

| Name | Args | Result |
|---|---|---|
| Geolocation ID | `geolocation_id: ec16b372-7aab-4082-8519-2163c431777d` | 3 entries |
| Cambridge Library | `street_address: 99 The Boulevard, FLOREAT 6014` | 4 entries |