### PR TITLE
Add garden waste support for St Helens source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_helens_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_helens_gov_uk.py
@@ -19,19 +19,20 @@ TEST_CASES = {
 }
 
 ICON_MAP = {
-    "BROWN BIN": Icons.BIO_KITCHEN,
-    "GREEN BIN": Icons.RECYCLING,
+    "General Waste": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "Garden Waste": Icons.GARDEN,
 }
 
 WASTE_TYPE_MAP = {
     "General non-recyclable waste": "General Waste",
     "Recycling": "Recycling",
+    "Garden waste": "Garden Waste",
 }
 
 
 class Source:
     def __init__(self, postcode: str, uprn: str):
-
         if not postcode:
             raise SourceArgumentException("postcode", "Postcode is required")
         if not uprn.isdigit():


### PR DESCRIPTION
## Summary

Adds support for Garden waste collections in the St Helens Council source.

The St Helens collection table can include `Garden waste`, but the source currently only maps:

- `General non-recyclable waste`
- `Recycling`

As a result, garden waste rows are parsed but then silently skipped because they are not present in `WASTE_TYPE_MAP`.

This PR adds `Garden waste` to the map and aligns `ICON_MAP` keys with the normalised values returned by `WASTE_TYPE_MAP`.

## Testing

Tested locally in Home Assistant using the St Helens source. After applying the change and running `waste_collection_schedule.fetch_data`, garden waste collections were returned correctly alongside recycling and general waste.

## Notes

This keeps the existing output behaviour of the source intact by leaving `t=waste_type` unchanged.