### PR TITLE
Add source: London Borough of Hillingdon (hillingdon_gov_uk)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hillingdon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hillingdon_gov_uk.py
@@ -1,0 +1,200 @@
+"""Source for London Borough of Hillingdon, UK."""
+
+import re
+from datetime import date, datetime, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+TITLE = "London Borough of Hillingdon"
+DESCRIPTION = "Source for London Borough of Hillingdon, UK."
+URL = "https://www.hillingdon.gov.uk"
+COUNTRY = "uk"
+
+TEST_CASES = {
+    "Property with garden waste subscription, UB10 (Wednesday)": {"uprn": "100021484600"},
+    "Property with food waste, UB10 (Wednesday)": {"uprn": "100021484628"},
+    "Property with residual waste suffix, UB10 (Tuesday)": {"uprn": "100021484620"},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "You need your Unique Property Reference Number (UPRN). An easy way to find it is by going to https://www.findmyaddress.co.uk/ and entering your address details.",
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {"uprn": "Unique Property Reference Number (UPRN)"},
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "uprn": "An easy way to discover your Unique Property Reference Number (UPRN) is by going to https://www.findmyaddress.co.uk/ and entering in your address details."
+    },
+    "de": {
+        "uprn": "Eine einfache Möglichkeit, Ihre Unique Property Reference Number (UPRN) zu finden, besteht darin, auf https://www.findmyaddress.co.uk/ zu gehen und Ihre Adressdaten einzugeben."
+    },
+}
+
+ICON_MAP = {
+    "household waste": Icons.GENERAL_WASTE,
+    "residual household waste": Icons.GENERAL_WASTE,
+    "trade sacks general waste": Icons.COMMERCIAL,
+    "dry mixed recycling": Icons.RECYCLING,
+    "garden waste": Icons.GARDEN,
+    "food waste": Icons.BIO_KITCHEN,
+}
+
+API_URL = "https://www.hillingdon.gov.uk/apiserver/ajaxlibrary"
+BANK_HOLIDAY_URL = "https://www.hillingdon.gov.uk/bank-holiday-collections"
+
+WEEKDAYS = {
+    "Monday": 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+    "Saturday": 5,
+    "Sunday": 6,
+}
+
+
+def _get_icon(waste_type: str) -> Icons | None:
+    """Match waste type to icon using case-insensitive keyword matching."""
+    lower = waste_type.lower()
+    if "recycling" in lower:
+        return Icons.RECYCLING
+    if "food" in lower:
+        return Icons.BIO_KITCHEN
+    if "garden" in lower:
+        return Icons.GARDEN
+    if "trade" in lower:
+        return Icons.COMMERCIAL
+    if "waste" in lower:
+        return Icons.GENERAL_WASTE
+    return ICON_MAP.get(lower)
+
+
+def _strip_suffix(waste_type: str) -> str:
+    """Strip parenthetical suffixes like ' ( - 31/05/2026 23:59)' or ' ( - )'."""
+    return re.sub(r"\s*\(.*?\)\s*$", "", waste_type).strip()
+
+
+def _fetch_bank_holiday_substitutions() -> dict[date, date]:
+    """Fetch the bank holiday table and return a mapping of normal date -> revised date."""
+    substitutions: dict[date, date] = {}
+    try:
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        }
+        r = requests.get(BANK_HOLIDAY_URL, headers=headers, timeout=10)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+        table = soup.find("table")
+        if not table:
+            return substitutions
+
+        today = date.today()
+
+        for row in table.find_all("tr"):
+            cells = row.find_all("td")
+            if len(cells) < 2:
+                continue
+
+            normal_text = cells[0].get_text(strip=True)
+            revised_text = cells[1].get_text(strip=True)
+
+            # Strip parenthetical like "(Bank Holiday)"
+            normal_text = re.sub(r"\s*\(.*?\)", "", normal_text).strip()
+
+            # Parse dates - they don't include year
+            try:
+                normal_dt = datetime.strptime(normal_text, "%A %d %B")
+                revised_dt = datetime.strptime(revised_text, "%A %d %B")
+            except ValueError:
+                continue
+
+            # Assign year: use current year, but if date has passed, use next year
+            normal_date = normal_dt.replace(year=today.year).date()
+            if normal_date < today - timedelta(days=30):
+                normal_date = normal_date.replace(year=today.year + 1)
+
+            revised_date = revised_dt.replace(year=normal_date.year).date()
+
+            substitutions[normal_date] = revised_date
+
+    except Exception:
+        # Silently skip if page unavailable
+        pass
+
+    return substitutions
+
+
+class Source:
+    def __init__(self, uprn: str):
+        self._uprn = str(uprn)
+
+    def fetch(self) -> list[Collection]:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "Hillingdon.DatasourceQueries.alloy.GetBinCollectionDay",
+            "params": {"UPRN": self._uprn},
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Referer": "https://www.hillingdon.gov.uk/article/1171/Look-up-my-collection-day",
+        }
+
+        r = requests.post(API_URL, json=payload, headers=headers, timeout=10)
+        r.raise_for_status()
+        data = r.json()
+
+        result = data.get("result", {})
+        if not result.get("success"):
+            raise SourceArgumentNotFound(
+                "uprn",
+                self._uprn,
+                "No collection data found for this UPRN. Please verify it is correct.",
+            )
+
+        collection_day = result.get("collectionDay", "")
+        waste_types = result.get("collection", [])
+
+        if not collection_day or collection_day not in WEEKDAYS:
+            raise SourceArgumentNotFound(
+                "uprn",
+                self._uprn,
+                f"Invalid collection day returned: '{collection_day}'",
+            )
+
+        # Fetch bank holiday substitutions
+        substitutions = _fetch_bank_holiday_substitutions()
+
+        # Generate next 8 weekly occurrences of the collection day
+        target_weekday = WEEKDAYS[collection_day]
+        today = date.today()
+        days_ahead = (target_weekday - today.weekday()) % 7
+        if days_ahead == 0:
+            # Include today if it's the collection day
+            next_date = today
+        else:
+            next_date = today + timedelta(days=days_ahead)
+
+        collection_dates = []
+        for i in range(8):
+            d = next_date + timedelta(weeks=i)
+            # Apply bank holiday substitution if applicable
+            if d in substitutions:
+                d = substitutions[d]
+            collection_dates.append(d)
+
+        # Build Collection entries
+        entries: list[Collection] = []
+        for waste_type_raw in waste_types:
+            waste_type = _strip_suffix(waste_type_raw)
+            icon = _get_icon(waste_type)
+            for d in collection_dates:
+                entries.append(Collection(date=d, t=waste_type, icon=icon))
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hillingdon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hillingdon_gov_uk.py
@@ -14,7 +14,9 @@ URL = "https://www.hillingdon.gov.uk"
 COUNTRY = "uk"
 
 TEST_CASES = {
-    "Property with garden waste subscription, UB10 (Wednesday)": {"uprn": "100021484600"},
+    "Property with garden waste subscription, UB10 (Wednesday)": {
+        "uprn": "100021484600"
+    },
     "Property with food waste, UB10 (Wednesday)": {"uprn": "100021484628"},
     "Property with residual waste suffix, UB10 (Tuesday)": {"uprn": "100021484620"},
 }

--- a/doc/source/hillingdon_gov_uk.md
+++ b/doc/source/hillingdon_gov_uk.md
@@ -1,0 +1,44 @@
+# London Borough of Hillingdon
+
+Support for waste collection schedules provided by [London Borough of Hillingdon](https://www.hillingdon.gov.uk), UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: hillingdon_gov_uk
+      args:
+        uprn: UPRN
+```
+
+### Configuration Variables
+
+**uprn**
+*(string) (required)*
+
+Your Unique Property Reference Number (UPRN).
+
+## How to find your `uprn`
+
+An easy way to discover your UPRN is by going to [FindMyAddress](https://www.findmyaddress.co.uk/) and entering your address details.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: hillingdon_gov_uk
+      args:
+        uprn: "100021484628"
+```
+
+## Bin types returned
+
+| Provider description | Returned type | Icon |
+|---------------------|--------------|------|
+| Dry mixed recycling | Dry mixed recycling | `Icons.RECYCLING` |
+| Household waste | Household waste | `Icons.GENERAL_WASTE` |
+| Garden waste | Garden waste | `Icons.GARDEN` |
+| Food waste | Food waste | `Icons.BIO_KITCHEN` |
+| Trade Sacks General Waste | Trade Sacks General Waste | `Icons.COMMERCIAL` |

--- a/tests/test_hillingdon_gov_uk.py
+++ b/tests/test_hillingdon_gov_uk.py
@@ -1,0 +1,571 @@
+"""
+Unit tests for London Borough of Hillingdon waste collection source.
+
+Note: This test file is not auto-discovered by pytest due to pytest.ini configuration
+(python_files = test_source_components.py). Run it explicitly:
+
+    pytest tests/test_hillingdon_gov_uk.py
+    pytest tests/test_hillingdon_gov_uk.py -v
+"""
+
+import os
+import sys
+from datetime import date as real_date
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule import Icons  # noqa: E402
+from waste_collection_schedule.exceptions import SourceArgumentNotFound  # noqa: E402
+from waste_collection_schedule.source import hillingdon_gov_uk  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared fixtures and helpers
+# ---------------------------------------------------------------------------
+
+# 2026-06-01 is a Monday; used to pin date.today() for deterministic tests.
+FROZEN_MONDAY = real_date(2026, 6, 1)
+# 2026-05-27 is a Wednesday.
+FROZEN_WEDNESDAY = real_date(2026, 5, 27)
+
+
+def _api_response(collection_day="Monday", collection=None, success=True):
+    """Build a minimal Hillingdon JSON-RPC API response dict."""
+    if collection is None:
+        collection = ["Dry mixed recycling", "Household waste"]
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "result": {
+            "success": success,
+            "collection": collection,
+            "collectionDay": collection_day,
+            "gardenWasteCollectionDate": "",
+        },
+    }
+
+
+BANK_HOLIDAY_HTML = """
+<html><body>
+<table>
+  <tr><th>Normal Day</th><th>Revised Day</th></tr>
+  <tr><td>Monday 25 May (Bank Holiday)</td><td>Tuesday 26 May</td></tr>
+  <tr><td>Tuesday 26 May</td><td>Wednesday 27 May</td></tr>
+</table>
+</body></html>
+"""
+
+BANK_HOLIDAY_HTML_NO_TABLE = "<html><body><p>No table here.</p></body></html>"
+
+BANK_HOLIDAY_HTML_MALFORMED = """
+<html><body>
+<table>
+  <tr><th>Normal Day</th><th>Revised Day</th></tr>
+  <tr><td>Not a date at all</td><td>Also not a date</td></tr>
+  <tr><td>Monday 25 May (Bank Holiday)</td><td>Tuesday 26 May</td></tr>
+</table>
+</body></html>
+"""
+
+
+class MockResponse:
+    """Minimal requests.Response stand-in."""
+
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json = json_data
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            from requests import HTTPError
+
+            raise HTTPError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+# ---------------------------------------------------------------------------
+# Section 1: _strip_suffix (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_suffix_removes_expiry():
+    result = hillingdon_gov_uk._strip_suffix("Garden Waste ( - 31/05/2026 23:59)")
+    assert result == "Garden Waste"
+
+
+def test_strip_suffix_no_op_on_clean_name():
+    assert hillingdon_gov_uk._strip_suffix("Dry mixed recycling") == "Dry mixed recycling"
+
+
+def test_strip_suffix_handles_empty_parenthetical():
+    assert hillingdon_gov_uk._strip_suffix("Waste ( - )") == "Waste"
+
+
+def test_strip_suffix_preserves_name_with_no_suffix():
+    assert hillingdon_gov_uk._strip_suffix("Food waste") == "Food waste"
+
+
+def test_strip_suffix_strips_trailing_whitespace():
+    result = hillingdon_gov_uk._strip_suffix("Household waste  ( - 01/01/2027 00:00)  ")
+    assert result == "Household waste"
+
+
+# ---------------------------------------------------------------------------
+# Section 2: _get_icon (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_get_icon_recycling():
+    assert hillingdon_gov_uk._get_icon("Dry mixed recycling") == Icons.RECYCLING
+
+
+def test_get_icon_food_waste():
+    assert hillingdon_gov_uk._get_icon("Food waste") == Icons.BIO_KITCHEN
+
+
+def test_get_icon_garden_waste():
+    assert hillingdon_gov_uk._get_icon("Garden Waste") == Icons.GARDEN
+
+
+def test_get_icon_household_waste():
+    assert hillingdon_gov_uk._get_icon("Household waste") == Icons.GENERAL_WASTE
+
+
+def test_get_icon_residual_waste():
+    assert hillingdon_gov_uk._get_icon("Residual Household Waste") == Icons.GENERAL_WASTE
+
+
+def test_get_icon_trade_commercial():
+    assert hillingdon_gov_uk._get_icon("Trade Sacks General Waste") == Icons.COMMERCIAL
+
+
+def test_get_icon_case_insensitive():
+    assert hillingdon_gov_uk._get_icon("DRY MIXED RECYCLING") == Icons.RECYCLING
+    assert hillingdon_gov_uk._get_icon("FOOD WASTE") == Icons.BIO_KITCHEN
+
+
+def test_get_icon_unknown_returns_none():
+    assert hillingdon_gov_uk._get_icon("Unrecognised Stream") is None
+
+
+def test_get_icon_returns_icons_enum_member():
+    icon = hillingdon_gov_uk._get_icon("Dry mixed recycling")
+    assert isinstance(icon, Icons)
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Source.__init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_stores_uprn_as_string():
+    s = hillingdon_gov_uk.Source(uprn="100021484628")
+    assert s._uprn == "100021484628"
+
+
+def test_init_coerces_integer_uprn_to_string():
+    s = hillingdon_gov_uk.Source(uprn=100021484628)
+    assert isinstance(s._uprn, str)
+    assert s._uprn == "100021484628"
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Source.fetch() — happy path
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_returns_8_dates_per_waste_type(mock_requests, mock_bh):
+    """2 waste types × 8 weeks = 16 entries."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Wednesday", ["Dry mixed recycling", "Household waste"])
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    assert len(entries) == 16
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_all_dates_on_correct_weekday(mock_requests, mock_bh):
+    """All returned dates must fall on Wednesday when collectionDay is 'Wednesday'."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Wednesday", ["Household waste"])
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    assert len(entries) == 8
+    for entry in entries:
+        assert entry.date.weekday() == 2, (
+            f"Expected Wednesday (weekday 2), got {entry.date} (weekday {entry.date.weekday()})"
+        )
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_all_dates_today_or_future(mock_requests, mock_bh):
+    """No date returned should be in the past."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Monday", ["Household waste"])
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    today = real_date.today()
+    for entry in entries:
+        assert entry.date >= today, f"Collection date {entry.date} is in the past"
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_strips_subscription_expiry_suffix(mock_requests, mock_bh):
+    """'Garden Waste ( - 31/05/2026 23:59)' should appear as 'Garden Waste'."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response(
+            "Monday",
+            ["Garden Waste ( - 31/05/2026 23:59)", "Food waste"],
+        )
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    waste_types = {e.type for e in entries}
+    assert "Garden Waste" in waste_types
+    assert not any("( -" in t for t in waste_types), (
+        "Raw suffix should have been stripped from waste type"
+    )
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_icons_assigned_correctly(mock_requests, mock_bh):
+    """Icons must match the Icons enum for known waste types."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response(
+            "Monday",
+            ["Dry mixed recycling", "Household waste", "Garden waste", "Food waste"],
+        )
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    by_type = {e.type: e.icon for e in entries}
+    assert by_type["Dry mixed recycling"] == Icons.RECYCLING
+    assert by_type["Household waste"] == Icons.GENERAL_WASTE
+    assert by_type["Garden waste"] == Icons.GARDEN
+    assert by_type["Food waste"] == Icons.BIO_KITCHEN
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_posts_correct_uprn_in_payload(mock_requests, mock_bh):
+    """The UPRN must appear in the JSON-RPC params as the string 'UPRN' key."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Monday", ["Household waste"])
+    )
+
+    hillingdon_gov_uk.Source(uprn="999888777").fetch()
+
+    call_kwargs = mock_requests.post.call_args
+    payload = call_kwargs[1]["json"]
+    assert payload["params"]["UPRN"] == "999888777"
+    assert payload["method"] == "Hillingdon.DatasourceQueries.alloy.GetBinCollectionDay"
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_dates_span_roughly_two_months(mock_requests, mock_bh):
+    """8 weekly dates should span exactly 7 weeks from the first date."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Thursday", ["Household waste"])
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+    dates = sorted({e.date for e in entries})
+
+    assert len(dates) == 8
+    assert dates[-1] - dates[0] == timedelta(weeks=7)
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Source.fetch() — bank holiday substitution
+# ---------------------------------------------------------------------------
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.date")
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_applies_bank_holiday_substitution(mock_requests, mock_bh, mock_date):
+    """When the first collection day falls on a bank holiday, it should be shifted."""
+    # Freeze today to a known Monday
+    mock_date.today.return_value = FROZEN_MONDAY  # 2026-06-01 (Monday)
+
+    # Substitute the first Monday → Tuesday
+    tuesday = FROZEN_MONDAY + timedelta(days=1)
+    mock_bh.return_value = {FROZEN_MONDAY: tuesday}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Monday", ["Household waste"])
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    dates = sorted({e.date for e in entries})
+    assert FROZEN_MONDAY not in dates, "Bank holiday date should have been substituted"
+    assert tuesday in dates, "Revised date should appear in collections"
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.date")
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_only_affected_date_is_substituted(mock_requests, mock_bh, mock_date):
+    """Only the specific bank holiday date should shift; the other 7 stay on Monday."""
+    mock_date.today.return_value = FROZEN_MONDAY
+
+    tuesday = FROZEN_MONDAY + timedelta(days=1)
+    mock_bh.return_value = {FROZEN_MONDAY: tuesday}
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Monday", ["Household waste"])
+    )
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    dates = sorted({e.date for e in entries})
+    # 7 of the 8 dates should still be Mondays
+    mondays = [d for d in dates if d.weekday() == 0]
+    assert len(mondays) == 7
+    # The shifted date is a Tuesday
+    tuesdays = [d for d in dates if d.weekday() == 1]
+    assert len(tuesdays) == 1
+    assert tuesdays[0] == tuesday
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_succeeds_when_bank_holiday_page_unavailable(mock_requests):
+    """Network error fetching bank holiday page must not prevent collections returning."""
+    mock_requests.post.return_value = MockResponse(
+        json_data=_api_response("Wednesday", ["Household waste"])
+    )
+    mock_requests.get.side_effect = ConnectionError("Network unreachable")
+
+    entries = hillingdon_gov_uk.Source(uprn="123").fetch()
+
+    assert len(entries) == 8
+    for entry in entries:
+        assert entry.date.weekday() == 2  # Still Wednesdays, no substitution
+
+
+# ---------------------------------------------------------------------------
+# Section 6: Source.fetch() — error handling
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_raises_source_not_found_when_api_reports_failure(mock_requests, mock_bh):
+    """result.success=false must raise SourceArgumentNotFound, not return []."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data={"jsonrpc": "2.0", "id": "1", "result": {"success": False}}
+    )
+
+    with pytest.raises(SourceArgumentNotFound) as exc_info:
+        hillingdon_gov_uk.Source(uprn="000000000000").fetch()
+
+    assert exc_info.value.argument == "uprn"
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_raises_source_not_found_for_nobin(mock_requests, mock_bh):
+    """'NOBIN' collection day (large commercial bins) must raise SourceArgumentNotFound."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "success": True,
+                "collection": ["1100 ltr General Waste"],
+                "collectionDay": "NOBIN",
+            },
+        }
+    )
+
+    with pytest.raises(SourceArgumentNotFound) as exc_info:
+        hillingdon_gov_uk.Source(uprn="100021484646").fetch()
+
+    assert exc_info.value.argument == "uprn"
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_raises_source_not_found_for_unknown_day(mock_requests, mock_bh):
+    """An unrecognised collectionDay string must raise SourceArgumentNotFound."""
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(
+        json_data={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "success": True,
+                "collection": ["Household waste"],
+                "collectionDay": "Someday",
+            },
+        }
+    )
+
+    with pytest.raises(SourceArgumentNotFound):
+        hillingdon_gov_uk.Source(uprn="123").fetch()
+
+
+@patch(
+    "waste_collection_schedule.source.hillingdon_gov_uk._fetch_bank_holiday_substitutions"
+)
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_fetch_http_error_propagates(mock_requests, mock_bh):
+    """An HTTP error from the API must propagate (not be swallowed)."""
+    from requests import HTTPError
+
+    mock_bh.return_value = {}
+    mock_requests.post.return_value = MockResponse(status_code=503)
+
+    with pytest.raises(HTTPError):
+        hillingdon_gov_uk.Source(uprn="123").fetch()
+
+
+# ---------------------------------------------------------------------------
+# Section 7: _fetch_bank_holiday_substitutions
+# ---------------------------------------------------------------------------
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.date")
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_bank_holiday_parses_table_correctly(mock_requests, mock_date):
+    """Should return a dict mapping normal date → revised date for each table row."""
+    # Freeze today so year assignment is deterministic
+    mock_date.today.return_value = real_date(2026, 5, 20)
+
+    mock_requests.get.return_value = MockResponse(text=BANK_HOLIDAY_HTML)
+
+    result = hillingdon_gov_uk._fetch_bank_holiday_substitutions()
+
+    assert real_date(2026, 5, 25) in result
+    assert result[real_date(2026, 5, 25)] == real_date(2026, 5, 26)
+    assert real_date(2026, 5, 26) in result
+    assert result[real_date(2026, 5, 26)] == real_date(2026, 5, 27)
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_bank_holiday_returns_empty_on_network_error(mock_requests):
+    """A connection error must be silently caught and return an empty dict."""
+    mock_requests.get.side_effect = ConnectionError("DNS failure")
+
+    result = hillingdon_gov_uk._fetch_bank_holiday_substitutions()
+
+    assert result == {}
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_bank_holiday_returns_empty_on_http_error(mock_requests):
+    """A 404/500 response must be silently caught and return an empty dict."""
+    mock_requests.get.return_value = MockResponse(status_code=404)
+
+    result = hillingdon_gov_uk._fetch_bank_holiday_substitutions()
+
+    assert result == {}
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_bank_holiday_returns_empty_when_no_table(mock_requests):
+    """Page with no <table> element should return an empty dict."""
+    mock_requests.get.return_value = MockResponse(text=BANK_HOLIDAY_HTML_NO_TABLE)
+
+    result = hillingdon_gov_uk._fetch_bank_holiday_substitutions()
+
+    assert result == {}
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.date")
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_bank_holiday_skips_malformed_rows_parses_valid_ones(mock_requests, mock_date):
+    """Rows that cannot be parsed as dates should be silently skipped."""
+    mock_date.today.return_value = real_date(2026, 5, 20)
+    mock_requests.get.return_value = MockResponse(text=BANK_HOLIDAY_HTML_MALFORMED)
+
+    result = hillingdon_gov_uk._fetch_bank_holiday_substitutions()
+
+    # The malformed row is skipped; the valid row is parsed
+    assert real_date(2026, 5, 25) in result
+    assert result[real_date(2026, 5, 25)] == real_date(2026, 5, 26)
+
+
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.date")
+@patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
+def test_bank_holiday_assigns_next_year_for_past_dates(mock_requests, mock_date):
+    """Dates more than 30 days in the past should roll over to next year."""
+    # Freeze today to December — January bank holidays should use next year
+    mock_date.today.return_value = real_date(2026, 12, 15)
+
+    html = """
+    <html><body>
+    <table>
+      <tr><td>Monday 5 January (Bank Holiday)</td><td>Tuesday 6 January</td></tr>
+    </table>
+    </body></html>
+    """
+    mock_requests.get.return_value = MockResponse(text=html)
+
+    result = hillingdon_gov_uk._fetch_bank_holiday_substitutions()
+
+    # Jan 5 is >30 days before Dec 15, so it should be assigned year 2027
+    assert real_date(2027, 1, 5) in result
+    assert result[real_date(2027, 1, 5)] == real_date(2027, 1, 6)

--- a/tests/test_hillingdon_gov_uk.py
+++ b/tests/test_hillingdon_gov_uk.py
@@ -252,7 +252,7 @@ def test_fetch_all_dates_today_or_future(mock_requests, mock_bh):
 )
 @patch("waste_collection_schedule.source.hillingdon_gov_uk.requests")
 def test_fetch_strips_subscription_expiry_suffix(mock_requests, mock_bh):
-    """'Garden Waste ( - 31/05/2026 23:59)' should appear as 'Garden Waste'."""
+    """Garden waste with the ``( - DD/MM/YYYY HH:MM)`` suffix is stripped to ``Garden Waste``."""
     mock_bh.return_value = {}
     mock_requests.post.return_value = MockResponse(
         json_data=_api_response(

--- a/tests/test_hillingdon_gov_uk.py
+++ b/tests/test_hillingdon_gov_uk.py
@@ -12,7 +12,7 @@ import os
 import sys
 from datetime import date as real_date
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -109,7 +109,9 @@ def test_strip_suffix_removes_expiry():
 
 
 def test_strip_suffix_no_op_on_clean_name():
-    assert hillingdon_gov_uk._strip_suffix("Dry mixed recycling") == "Dry mixed recycling"
+    assert (
+        hillingdon_gov_uk._strip_suffix("Dry mixed recycling") == "Dry mixed recycling"
+    )
 
 
 def test_strip_suffix_handles_empty_parenthetical():
@@ -147,7 +149,9 @@ def test_get_icon_household_waste():
 
 
 def test_get_icon_residual_waste():
-    assert hillingdon_gov_uk._get_icon("Residual Household Waste") == Icons.GENERAL_WASTE
+    assert (
+        hillingdon_gov_uk._get_icon("Residual Household Waste") == Icons.GENERAL_WASTE
+    )
 
 
 def test_get_icon_trade_commercial():
@@ -220,9 +224,9 @@ def test_fetch_all_dates_on_correct_weekday(mock_requests, mock_bh):
 
     assert len(entries) == 8
     for entry in entries:
-        assert entry.date.weekday() == 2, (
-            f"Expected Wednesday (weekday 2), got {entry.date} (weekday {entry.date.weekday()})"
-        )
+        assert (
+            entry.date.weekday() == 2
+        ), f"Expected Wednesday (weekday 2), got {entry.date} (weekday {entry.date.weekday()})"
 
 
 @patch(
@@ -261,9 +265,9 @@ def test_fetch_strips_subscription_expiry_suffix(mock_requests, mock_bh):
 
     waste_types = {e.type for e in entries}
     assert "Garden Waste" in waste_types
-    assert not any("( -" in t for t in waste_types), (
-        "Raw suffix should have been stripped from waste type"
-    )
+    assert not any(
+        "( -" in t for t in waste_types
+    ), "Raw suffix should have been stripped from waste type"
 
 
 @patch(


### PR DESCRIPTION
- JSON-RPC API (GOSS iCM / Alloy backend) via POST to /apiserver/ajaxlibrary
- Generates next 8 weekly occurrences from collectionDay weekday name
- Scrapes bank holiday substitution table from hillingdon.gov.uk/bank-holiday-collections
- Strips subscription expiry suffixes from waste type names
- 36 unit tests covering helpers, fetch logic, bank holiday parsing, and error paths