### PR TITLE
Fix grafikai_svara_lt: send Sec-Fetch-Site: same-origin

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
@@ -128,6 +128,7 @@ def _probe_data_fetcher(session: requests.Session, fn_id: str) -> bool:
             headers={
                 "Accept": "application/json",
                 "x-tsr-serverFn": "true",
+                "Sec-Fetch-Site": "same-origin",
             },
             timeout=8,
         )
@@ -233,6 +234,9 @@ class Source:
             headers={
                 "Accept": "application/json, application/x-tss-framed, application/x-ndjson",
                 "x-tsr-serverFn": "true",
+                # Upstream enforces Sec-Fetch-Site: same-origin on _serverFn
+                # calls — without it the edge returns 403 Forbidden.
+                "Sec-Fetch-Site": "same-origin",
             },
             timeout=20,
         )


### PR DESCRIPTION
Upstream grafikai.svara.lt now rejects _serverFn requests with HTTP 403 unless Sec-Fetch-Site: same-origin is present. Without this header both the discovery probe and the data calls fail, so the integration produces no events and the calendar stays empty.

Add the header to both _probe_data_fetcher and _raw_call.