### PR TITLE
fix: [gotland_se] add support for two new types of bins, 'Fyrfack 1' and 'Fyrfack 2'

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gotland_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gotland_se.py
@@ -18,6 +18,7 @@ ICON_MAP = {
     "Fyrfack 2": Icons.RECYCLING,
 }
 
+
 class Source:
     def __init__(self, uprn):
         self._uprn = uprn
@@ -32,7 +33,12 @@ class Source:
 
         entries = []
         for item in data["RhServices"]:
-            if item["WasteType"] not in {"Restavfall", "Matavfall", "Fyrfack 1", "Fyrfack 2"}:
+            if item["WasteType"] not in {
+                "Restavfall",
+                "Matavfall",
+                "Fyrfack 1",
+                "Fyrfack 2",
+            }:
                 continue
 
             next_pickup = item["NextWastePickup"]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gotland_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gotland_se.py
@@ -14,8 +14,9 @@ TEST_CASES = {
 ICON_MAP = {
     "Restavfall": Icons.GENERAL_WASTE,
     "Matavfall": Icons.BIO_KITCHEN,
+    "Fyrfack 1": Icons.GENERAL_WASTE,
+    "Fyrfack 2": Icons.RECYCLING,
 }
-
 
 class Source:
     def __init__(self, uprn):
@@ -31,7 +32,7 @@ class Source:
 
         entries = []
         for item in data["RhServices"]:
-            if item["WasteType"] != "Restavfall" and item["WasteType"] != "Matavfall":
+            if item["WasteType"] not in {"Restavfall", "Matavfall", "Fyrfack 1", "Fyrfack 2"}:
                 continue
 
             next_pickup = item["NextWastePickup"]


### PR DESCRIPTION
Region gotland are in the process of deploying new bin types that will replace the old ones. The PR adds them to the script and also keeps the old ones for the customers that are still using theese.

Test output:
Testing source gotland_se ...
  found 1 entries for TestService
    2026-09-23 : Restavfall [mdi:trash-can]