### PR TITLE
fix(ics): switch to curl_cffi to handle stricter Python 3.14 SSL validation

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -5,7 +5,7 @@ from os import getcwd
 from pathlib import Path
 from typing import Literal
 
-import requests
+from curl_cffi import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgumentException,
@@ -209,14 +209,31 @@ class Source:
             return self.fetch_file(self._file)
 
     def fetch_url(self, url, params=None):
-        # get ics file
+        # curl_cffi stringifies list-valued params as Python repr instead of
+        # repeating the key like `requests` does; flatten to (key, value) pairs.
+        flat_params = (
+            [
+                (k, item)
+                for k, v in params.items()
+                for item in (v if isinstance(v, list) else [v])
+            ]
+            if params
+            else None
+        )
+
         if self._method == "GET":
             r = requests.get(
-                url, params=params, headers=self._headers, verify=self._verify_ssl
+                url,
+                params=flat_params,
+                headers=self._headers,
+                verify=self._verify_ssl,
             )
         elif self._method == "POST":
             r = requests.post(
-                url, data=params, headers=self._headers, verify=self._verify_ssl
+                url,
+                data=flat_params,
+                headers=self._headers,
+                verify=self._verify_ssl,
             )
         else:
             raise SourceArgumentNotFoundWithSuggestions(
@@ -227,10 +244,10 @@ class Source:
 
         r.raise_for_status()
 
-        if r.apparent_encoding == "UTF-8-SIG":
+        if r.content.startswith(b"\xef\xbb\xbf"):
             r.encoding = "UTF-8-SIG"
         else:
-            r.encoding = "utf-8"  # requests doesn't guess the encoding correctly
+            r.encoding = "utf-8"
 
         return self._convert(r.text)
 


### PR DESCRIPTION
## Summary

Python 3.14 tightened SSL certificate chain validation, breaking ICS fetches from providers serving certificates with intermediate CAs not in Python's default trust store. Users currently work around this with `verify_ssl: false`, which disables verification entirely. `curl_cffi` uses libcurl's TLS stack, which handles intermediate-CA scenarios with verification still enabled.

- Swap `requests` for `curl_cffi.requests` (no browser impersonation, to minimise header-fingerprinting changes for the ~hundreds of ICS YAML providers that depend on this module).
- Flatten list-valued params to `(key, value)` pairs — curl_cffi stringifies list values as Python repr instead of repeating the key like `requests` does. This preserves identical wire behaviour.
- Replace `apparent_encoding` check with explicit BOM detection (curl_cffi `Response` has no `apparent_encoding` attribute).
- `verify_ssl` and `headers` parameters preserved unchanged.

Closes #6442. Related: #6369, #6426.

## Test plan

Compared output against `master` baseline using `python test_sources.py -s ics -l`:

| Test case | master | this PR |
|---|---|---|
| Esslingen, Bahnhof | failed (401, upstream) | failed (401, upstream) |
| Test File | 0 entries | 0 entries |
| Test File (recurring) | 135 entries | 135 entries |
| München, Bahnstr. 11 | failed (HTML, upstream) | failed (HTML, upstream) |
| Abfall Zollernalbkreis | failed (DNS, environment) | failed (DNS, environment) |
| ReCollect, Ottawa | 46 entries | 46 entries |
| ReCollect, Simcoe County | 54 entries | 54 entries |
| Erlensee, Am Haspel | 85 entries | 85 entries |
| UTF-8-SIG | 0 entries | 0 entries |

All behaviour matches master — pre-existing failures are environment/credential-specific, not caused by this change.

- [x] `python test_sources.py -s ics -l` matches master baseline
- [x] `python -m pytest tests/test_source_components.py -q` passes