### PR TITLE
fix(opendata_bordeauxmetropole_fr): correct lon/lat coordinate swap

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/opendata_bordeauxmetropole_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/opendata_bordeauxmetropole_fr.py
@@ -262,7 +262,8 @@ class Source:
                 "address", "No results found for the given address and INSEE code"
             )
 
-        lat, lon = data[0]["geometry"]["coordinates"]
+        # GeoJSON coordinates are [longitude, latitude]
+        lon, lat = data[0]["geometry"]["coordinates"]
         return {
             "lat": lat,
             "lon": lon,
@@ -278,9 +279,10 @@ class Source:
             x, y = point
             n = len(polygon)
             inside = False
-            p1y, p1x = polygon[0]
+            # Polygon vertices are [longitude, latitude]; unpack as (x=lon, y=lat)
+            p1x, p1y = polygon[0]
             for i in range(n + 1):
-                p2y, p2x = polygon[i % n]
+                p2x, p2y = polygon[i % n]
                 if y > min(p1y, p2y):
                     if y <= max(p1y, p2y):
                         if x <= max(p1x, p2x):


### PR DESCRIPTION
## Summary

GeoJSON coordinates are `[longitude, latitude]`, but the Bordeaux Métropole source unpacked them as `lat, lon` in `_get_address_params` and as `p1y, p1x` in `is_point_in_polygon`. The two swaps partially cancel for addresses well inside a sector — which is why the source mostly works and all TEST_CASES pass on master. But for addresses near sector boundaries, the point-in-polygon test matches the wrong polygon and the source returns collection days for a neighbouring sector.

The reporter (@Swiiney) narrowed it down precisely: their Mérignac address matches sector gid 4206 (airport area, Thu/Fri) instead of gid 4209 (their actual area, Mon/Tue) — exactly the symptom of swapped axes near a boundary.

Closes #4037.

## Test plan

All existing TEST_CASES return identical entry counts before and after the fix (they're all sector-interior addresses, so the swap-cancellation hides the bug for them):

```
$ python test_sources.py -s opendata_bordeauxmetropole_fr
Bordeaux: 44 entries
Mérignac: 16 entries
Gradignan: 8 entries
... (21 total, all matching master)
```

- [x] All TEST_CASES pass and match master baseline
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python -m black` / `python -m isort` clean

The fix itself is unambiguously correct per the GeoJSON spec (RFC 7946 §3.1.1) which mandates `[longitude, latitude]` ordering.