### PR TITLE
fix(swale_gov_uk): switch to curl_cffi to bypass Cloudflare WAF

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -2,8 +2,8 @@ import logging
 from datetime import date, datetime, timedelta
 from time import sleep
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 _LOGGER = logging.getLogger(__name__)
@@ -11,9 +11,6 @@ _LOGGER = logging.getLogger(__name__)
 TITLE = "Swale Borough Council"
 DESCRIPTION = "Source for swale.gov.uk services for Swale, UK."
 URL = "https://swale.gov.uk"
-HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-}
 API_URL = (
     "https://swale.gov.uk/bins-littering-and-the-environment/bins/my-collection-day"
 )
@@ -60,7 +57,7 @@ class Source:
         return dt
 
     def fetch(self) -> list[Collection]:
-        s = requests.Session()
+        s = requests.Session(impersonate="chrome")
 
         # mimic postcode search
         payload: dict = {
@@ -71,7 +68,6 @@ class Source:
         }
         r = s.post(
             "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day",
-            headers=HEADERS,
             data=payload,
         )
         r.raise_for_status()
@@ -86,7 +82,6 @@ class Source:
         }
         r = s.post(
             "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day",
-            headers=HEADERS,
             data=payload,
         )
         r.raise_for_status()


### PR DESCRIPTION
## Summary

swale.gov.uk has added Cloudflare protection that returns 403 on POST requests from plain `requests`. Switching to `curl_cffi` with Chrome impersonation restores access. The redundant `HEADERS` dict is dropped — curl_cffi supplies appropriate browser headers automatically.

Closes #6431.

## Test plan

```
$ python test_sources.py -s swale_gov_uk
Testing source swale_gov_uk ...
  found 4 entries for Swale House
  found 4 entries for 1 Harrier Drive
  found 6 entries for garden waste test
```

- [x] All three TEST_CASES pass
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python -m black` / `python -m isort` clean

Note: the source already has a built-in `sleep(5)` between the two POST steps because swale.gov.uk rate-limits aggressively.