### PR TITLE
fix(great_yarmouth_gov_uk): switch to curl_cffi to bypass Cloudflare WAF

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/great_yarmouth_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/great_yarmouth_gov_uk.py
@@ -3,8 +3,8 @@ import json
 import re
 from datetime import date, datetime, timedelta
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 TITLE = "Great Yarmouth Borough Council"
@@ -68,7 +68,7 @@ class Source:
             return None
 
     def fetch(self) -> list[Collection]:
-        session = requests.Session()
+        session = requests.Session(impersonate="chrome")
         session.headers.update(_HEADERS)
 
         # Step 1: GET the form page and extract session tokens.


### PR DESCRIPTION
## Summary

- The `great_yarmouth_gov_uk` source returns 403 on the initial GET because Cloudflare blocks standard Python `requests`.
- Switches the HTTP client to `curl_cffi` with `impersonate="chrome"`, matching the same fix applied to `swale_gov_uk` in #6431.

Closes #6452

## Test plan
- [x] Live test: `python test_sources.py -s great_yarmouth_gov_uk -l` returns collections (verified locally).
- [x] Structural test: `python -m pytest tests/test_source_components.py -q` passes.