### PR TITLE
fix(northumberland_gov_uk): switch to curl_cffi to bypass Barracuda WAF

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/northumberland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/northumberland_gov_uk.py
@@ -2,8 +2,8 @@ import logging
 import re
 from datetime import datetime
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
@@ -54,12 +54,7 @@ class Source:
         self._uprn = str(uprn)
 
     def fetch(self) -> list[Collection]:
-        session = requests.Session()
-        session.headers.update(
-            {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-            }
-        )
+        session = requests.Session(impersonate="chrome")
 
         # Step 1: GET the postcode page to establish a session and retrieve the CSRF token
         r1 = session.get(f"{BASE_URL}/postcode")


### PR DESCRIPTION
## Summary

- Switches `northumberland_gov_uk` from `requests` to `curl_cffi` (Chrome impersonation) to bypass the Barracuda Networks WAF on `bincollection.northumberland.gov.uk`.
- Drops the now-redundant manual `User-Agent` header (curl_cffi supplies browser headers automatically).
- Same pattern as the `preston_gov_uk` fix.

## Root cause

The site uses a Barracuda Networks WAF that blocks requests by TLS fingerprint. Real browsers pass; Python `requests` does not, and the source then falls through to `SourceArgumentNotFound` on the empty "Blocked" page.

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `python test_sources.py -s northumberland_gov_uk -l` — requires UK network access (site is geo-blocked outside the UK)

Closes #6434