### PR TITLE
south_norfolk_and_broadland: Add food, edit existing entries.

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/south_norfolk_and_broadland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/south_norfolk_and_broadland_gov_uk.py
@@ -24,7 +24,7 @@ EXTRA_INFO = [
     },
 ]
 TEST_CASES = {
-    "Random address": {
+    "Random Broadland address": {
         "address_payload": {
             "Uprn": "010014355477",
             "Address": "29 Mallard Way, Sprowston, Norwich, Norfolk, NR7 8DN",
@@ -37,9 +37,26 @@ TEST_CASES = {
             "Authority": "2610",
         }
     },
-    "Random address new Method": {
+    "Random Broadland address new Method": {
         "postcode": "NR7 8DN",
         "address": "29 Mallard Way, Sprowston, Norfolk, NR7 8DN",
+    },
+    "Random South Norfolk address": {
+        "address_payload": {
+            "Uprn": "002630130840",
+            "Address": "1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX",
+            "X": "619142.00000",
+            "Y": "300585.00000",
+            "Ward": "Mulbarton And Stoke Holy Cross",
+            "Parish": "Mulbarton",
+            "Village": "Mulbarton",
+            "Street": "Brindle Drive",
+            "Authority": "2630",
+        }
+    },
+    "Random South Norfolk address new Method": {
+        "postcode": "NR14 8BX",
+        "address": "1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX",
     },
     "Big Tesco": {
         "address_payload": {
@@ -60,6 +77,8 @@ ICON_MAP = {
     "Rubbish": Icons.GENERAL_WASTE,
     "Recycling": Icons.RECYCLING,
     "Garden (if applicable)": Icons.GARDEN,
+    "Garden": Icons.GARDEN,
+    "Food": Icons.BIO_KITCHEN,
 }
 
 matcher = re.compile(r"^([A-Z][a-z]+) (\d{1,2}) ([A-Z][a-z]+) (\d{4})$")

--- a/doc/source/south_norfolk_and_broadland_gov_uk.md
+++ b/doc/source/south_norfolk_and_broadland_gov_uk.md
@@ -105,14 +105,15 @@ waste_collection_schedule:
   sources:
     - name: south_norfolk_and_broadland_gov_uk
       args:
-        "address_payload": {
-          "Uprn": "002630130840",
-          "Address": "1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX",
-          "X": "619142.00000",
-          "Y": "300585.00000",
-          "Ward": "Mulbarton And Stoke Holy Cross",
-          "Parish": "Mulbarton",
-          "Village": "Mulbarton",
-          "Street": "Brindle Drive",
-          "Authority": "2630",
+        address_payload: {
+            "Uprn": "002630130840",
+            "Address": "1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX",
+            "X": "619142.00000",
+            "Y": "300585.00000",
+            "Ward": "Mulbarton And Stoke Holy Cross",
+            "Parish": "Mulbarton",
+            "Village": "Mulbarton",
+            "Street": "Brindle Drive",
+            "Authority": "2630"
+          }
 ```

--- a/doc/source/south_norfolk_and_broadland_gov_uk.md
+++ b/doc/source/south_norfolk_and_broadland_gov_uk.md
@@ -27,7 +27,7 @@ Full examples for both council areas are given at the bottom of the documentatio
 **address_payload**  
 *(dict) (optional) (deprecated)*  
 
-Either address_payload or postcode and address are needed (address_payload will be used if both are present).
+Either address_payload alone or both postcode and address are needed (address_payload will be used if both are present).
 
 ## Get the arguments
 
@@ -94,8 +94,8 @@ waste_collection_schedule:
   sources:
     - name: south_norfolk_and_broadland_gov_uk
       args:
-        address: 14 Fairland Street, Wymondham, Norfolk, NR18 0AW
-        postcode: NR18 0AW
+        address: 1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX
+        postcode: NR14 8BX
 ```
 
 or
@@ -105,15 +105,14 @@ waste_collection_schedule:
   sources:
     - name: south_norfolk_and_broadland_gov_uk
       args:
-        address_payload: {
-            "Uprn": "002630148121",
-            "Address": "14 Fairland Street, Wymondham, Norfolk, NR18 0AW",
-            "X": "611129.00000",
-            "Y": "301398.00000",
-            "Ward": "Central Wymondham",
-            "Parish": "Wymondham",
-            "Village": "Wymondham",
-            "Street": "Fairland Street",
-            "Authority": "2630"
-          }
+        "address_payload": {
+          "Uprn": "002630130840",
+          "Address": "1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX",
+          "X": "619142.00000",
+          "Y": "300585.00000",
+          "Ward": "Mulbarton And Stoke Holy Cross",
+          "Parish": "Mulbarton",
+          "Village": "Mulbarton",
+          "Street": "Brindle Drive",
+          "Authority": "2630",
 ```


### PR DESCRIPTION
## Changes to `south_norfolk_and_broadland_gov_uk.py`

### Updated test cases
The service availability and format of names and labels can vary between BDC and SNDC. To that end I have:
- Renamed existing random address case (both old and new format) to specify they are for Broadland.
- Added new random address case in South Norfolk.
- Tested test cases pass correctly and sufficiently cover expected service outputs

### New `Food` service
BDC already offers food waste collection as standard. SNDC will start offering it from July.
- Added `"Food": Icons.BIO_KITCHEN,` as an entry to the main parser list.
- Tested working for BDC.
- Cannot test working for SNDC as yet, but it does not break for SNDC.

Full rollout in SNDC isn't expected until September, but I will retest the source when it goes live at my home address.

### Explicitly specify `Garden` service
The Garden waste service is handled differently in BDC and SNDC, with different labelling. BDC's "Garden (if applicable)" entry was fine, but SNDC's "Garden" entry was not explicitly handled.
- Added `"Garden": Icons.GARDEN,` as a separate explicit entry to the list
- DID NOT alter the way the parser actually works, as it skips missing entries and does not duplicate.
- Tested working for SNDC. Tested non-breaking for BDC.

This WAS populating into HA before, but without the correct icon. I did not notice until doing cleanup on this PR because I had set custom icons anyway, but just tested on a fresh integration and it populated the default bin icon instead of a leaf.

## Not Done / Query
I have not updated the `/doc/source/south_norfolk_and_broadland_gov_uk.md` file, as I was unclear if the docs are automatically re-generated for existing sources or not. I know I ran afoul of something to do with this in a past contribution so am steering clear for now.

I'm happy to clean up the documentation for this source if you point me in the right direction, though.
In particular, the test case I added for SNDC is different from the one in the documentation.

## `test_sources.py` Output:

`test_sources.py -s south_norfolk_and_broadland_gov_uk -i -l` outputs:

```
Testing source south_norfolk_and_broadland_gov_uk ...
  found 4 entries for Random Broadland address
    2026-06-02 : Food [mdi:food-apple]
    2026-06-02 : Rubbish [mdi:trash-can]
    2026-06-09 : Garden (if applicable) [mdi:flower]
    2026-06-09 : Recycling [mdi:recycle]
  found 4 entries for Random Broadland address new Method
    2026-06-02 : Food [mdi:food-apple]
    2026-06-02 : Rubbish [mdi:trash-can]
    2026-06-09 : Garden (if applicable) [mdi:flower]
    2026-06-09 : Recycling [mdi:recycle]
  found 3 entries for Random South Norfolk address
    2026-05-27 : Rubbish [mdi:trash-can]
    2026-05-29 : Garden [mdi:flower]
    2026-06-03 : Recycling [mdi:recycle]
  found 3 entries for Random South Norfolk address new Method
    2026-05-27 : Rubbish [mdi:trash-can]
    2026-05-29 : Garden [mdi:flower]
    2026-06-03 : Recycling [mdi:recycle]
  found 1 entries for Big Tesco
    2026-06-09 : Garden (if applicable) [mdi:flower]
```