### PR TITLE
fix(colchester_gov_uk): handle renamed waste types in calendar feed

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
@@ -13,17 +13,25 @@ TEST_CASES = {
     "The Lane, Colchester": {"llpgid": "7cd96a3d-6027-e711-80fa-5065f38b56d1"},
 }
 
-# Colchester's API still emits "Paper/card" for the combined mixed-recycling
-# stream (paper/card, plastics, tins and cans) that replaced the separate
-# rounds.
+# The provider's calendar feed renamed two streams in mid-2026:
+#   "Black bags" -> "Non-recyclable rubbish"
+#   "Paper/card" -> "Mixed recycling"
+# Map both legacy and current names to a single canonical label so the source
+# is stable across the rollout, and (for the two renamed streams) bypass the
+# default .title() casing so labels match the provider's sentence-case feed.
 NAME_MAP = {
+    "Black bags": "Non-recyclable rubbish",
+    "Non-recyclable rubbish": "Non-recyclable rubbish",
     "Paper/card": "Mixed recycling",
+    "Mixed recycling": "Mixed recycling",
 }
 
 ICON_MAP = {
     "Black bags": Icons.GENERAL_WASTE,
+    "Non-recyclable rubbish": Icons.GENERAL_WASTE,
     "Glass": Icons.GLASS,
     "Paper/card": Icons.RECYCLING,
+    "Mixed recycling": Icons.RECYCLING,
     "Garden waste": Icons.GARDEN,
     "Food waste": Icons.BIO_KITCHEN,
 }

--- a/tests/test_colchester_gov_uk.py
+++ b/tests/test_colchester_gov_uk.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for Colchester City Council waste collection source.
+
+Note: This test file is not auto-discovered by pytest due to pytest.ini configuration
+(python_files = test_source_components.py). Run it explicitly:
+
+    pytest tests/test_colchester_gov_uk.py
+    pytest tests/test_colchester_gov_uk.py -v
+"""
+
+import json
+import os
+import sys
+from datetime import date as real_date
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule import Icons  # noqa: E402
+from waste_collection_schedule.source import colchester_gov_uk  # noqa: E402
+
+
+class MockResponse:
+    """Minimal requests.Response stand-in (the source reads .text)."""
+
+    def __init__(self, payload):
+        self.text = json.dumps(payload)
+        self.status_code = 200
+
+
+class FrozenDatetime(datetime):
+    """Subclass datetime so .now() is deterministic but .strptime() still works."""
+
+    _now = datetime(2026, 5, 25, 12, 0, 0)
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls._now
+
+
+# A Tuesday before the first collection in the sample (2026-05-26), so the
+# initial-week entries are always in the future.
+FROZEN_NOW = datetime(2026, 5, 25, 12, 0, 0)
+
+
+def _payload(
+    week_one_names, week_two_names, day="Tuesday", first_date="2026-05-26T00:00:00"
+):
+    """Build a minimal calendar payload in the new (post-2026-06) feed shape."""
+    return {
+        "Weeks": [
+            {
+                "Rows": {
+                    day: [
+                        {"Name": n, "ReportableBecauseWeeklyExemption": False}
+                        for n in week_one_names
+                    ]
+                },
+                "WeekOne": True,
+            },
+            {
+                "Rows": {
+                    day: [
+                        {"Name": n, "ReportableBecauseWeeklyExemption": False}
+                        for n in week_two_names
+                    ]
+                },
+                "WeekOne": False,
+            },
+        ],
+        "DatesOfFirstCollectionDays": {day: first_date},
+        "Today": "2026-05-25T12:00:00",
+        "AddressName": "Test Address",
+        "PostCode": "CO1 1AA",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Current (post-rename) feed: waste-type names must round-trip with correct icons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "feed_name,expected_name,expected_icon",
+    [
+        # The two newly-renamed waste types must round-trip in sentence case
+        # so the label stays consistent with the previous fix's "Mixed recycling".
+        ("Non-recyclable rubbish", "Non-recyclable rubbish", Icons.GENERAL_WASTE),
+        ("Mixed recycling", "Mixed recycling", Icons.RECYCLING),
+        # Unchanged categories: existing .title() behaviour is preserved.
+        ("Glass", "Glass", Icons.GLASS),
+        ("Food waste", "Food Waste", Icons.BIO_KITCHEN),
+        ("Garden waste", "Garden Waste", Icons.GARDEN),
+    ],
+)
+@patch("waste_collection_schedule.source.colchester_gov_uk.datetime", FrozenDatetime)
+@patch("waste_collection_schedule.source.colchester_gov_uk.requests")
+def test_new_feed_name_and_icon(mock_requests, feed_name, expected_name, expected_icon):
+    mock_requests.get.return_value = MockResponse(_payload([feed_name], []))
+    entries = colchester_gov_uk.Source(llpgid="test").fetch()
+    assert entries, f"Expected at least one Collection for {feed_name!r}"
+    for e in entries:
+        assert e.type == expected_name, f"Name {e.type!r} != {expected_name!r}"
+        assert e.icon == expected_icon, f"Icon {e.icon!r} != {expected_icon!r}"
+
+
+# ---------------------------------------------------------------------------
+# Legacy (pre-rename) feed: defensive mapping during the provider's rollout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "legacy_name,expected_name,expected_icon",
+    [
+        ("Black bags", "Non-recyclable rubbish", Icons.GENERAL_WASTE),
+        ("Paper/card", "Mixed recycling", Icons.RECYCLING),
+    ],
+)
+@patch("waste_collection_schedule.source.colchester_gov_uk.datetime", FrozenDatetime)
+@patch("waste_collection_schedule.source.colchester_gov_uk.requests")
+def test_legacy_feed_name_and_icon(
+    mock_requests, legacy_name, expected_name, expected_icon
+):
+    mock_requests.get.return_value = MockResponse(_payload([legacy_name], []))
+    entries = colchester_gov_uk.Source(llpgid="test").fetch()
+    assert entries, f"Expected at least one Collection for legacy {legacy_name!r}"
+    for e in entries:
+        assert e.type == expected_name
+        assert e.icon == expected_icon
+
+
+# ---------------------------------------------------------------------------
+# Integration: the exact response shape reported by the live API on 2026-05-29
+# ---------------------------------------------------------------------------
+
+
+@patch("waste_collection_schedule.source.colchester_gov_uk.datetime", FrozenDatetime)
+@patch("waste_collection_schedule.source.colchester_gov_uk.requests")
+def test_full_response_produces_expected_collections(mock_requests):
+    payload = {
+        "Weeks": [
+            {
+                "Rows": {
+                    "Tuesday": [
+                        {
+                            "Name": "Non-recyclable rubbish",
+                            "ReportableBecauseWeeklyExemption": False,
+                        },
+                        {
+                            "Name": "Food waste",
+                            "ReportableBecauseWeeklyExemption": False,
+                        },
+                    ]
+                },
+                "WeekOne": True,
+            },
+            {
+                "Rows": {
+                    "Tuesday": [
+                        {"Name": "Glass", "ReportableBecauseWeeklyExemption": False},
+                        {
+                            "Name": "Mixed recycling",
+                            "ReportableBecauseWeeklyExemption": False,
+                        },
+                        {
+                            "Name": "Food waste",
+                            "ReportableBecauseWeeklyExemption": False,
+                        },
+                    ]
+                },
+                "WeekOne": False,
+            },
+        ],
+        "DatesOfFirstCollectionDays": {"Tuesday": "2026-05-26T00:00:00"},
+        "Today": "2026-05-25T12:00:00",
+        "AddressName": "Test",
+        "PostCode": "CO1 1AA",
+    }
+    mock_requests.get.return_value = MockResponse(payload)
+
+    entries = colchester_gov_uk.Source(llpgid="test").fetch()
+
+    # Each waste-type entry produces (initial-if-future, +14 days) = 2 dates.
+    # Five waste-type slots total -> 10 Collections.
+    assert len(entries) == 10
+
+    actual = sorted({(e.date, e.type) for e in entries})
+    expected = sorted(
+        [
+            # Week 1 (WeekOne=True) on 2026-05-26
+            (real_date(2026, 5, 26), "Non-recyclable rubbish"),
+            (real_date(2026, 5, 26), "Food Waste"),
+            (real_date(2026, 6, 9), "Non-recyclable rubbish"),  # +14 days
+            (real_date(2026, 6, 9), "Food Waste"),
+            # Week 2 (WeekOne=False) on 2026-06-02
+            (real_date(2026, 6, 2), "Glass"),
+            (real_date(2026, 6, 2), "Mixed recycling"),
+            (real_date(2026, 6, 2), "Food Waste"),
+            (real_date(2026, 6, 16), "Glass"),  # +14 days
+            (real_date(2026, 6, 16), "Mixed recycling"),
+            (real_date(2026, 6, 16), "Food Waste"),
+        ]
+    )
+    assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# Date filtering: past collections in the current cycle drop the initial entry
+# but keep the +14 day extrapolation.
+# ---------------------------------------------------------------------------
+
+
+@patch("waste_collection_schedule.source.colchester_gov_uk.datetime", FrozenDatetime)
+@patch("waste_collection_schedule.source.colchester_gov_uk.requests")
+def test_past_initial_collection_is_dropped_but_extrapolation_kept(mock_requests):
+    # Frozen "now" is 2026-05-25. First collection is 2026-05-19 (in the past).
+    payload = _payload(["Glass"], [], first_date="2026-05-19T00:00:00")
+    mock_requests.get.return_value = MockResponse(payload)
+
+    entries = colchester_gov_uk.Source(llpgid="test").fetch()
+
+    dates = sorted(e.date for e in entries)
+    assert real_date(2026, 5, 19) not in dates
+    assert real_date(2026, 6, 2) in dates  # +14 days, kept unconditionally


### PR DESCRIPTION
  ## Summary

  Colchester's calendar API has renamed two of its waste streams:

  - `Black bags` -> `Non-recyclable rubbish`
  - `Paper/card` -> `Mixed recycling`

  Verified live against both `TEST_CASES` (`Church Road` and `The Lane`) on 2026-05-29 - both addresses now return the new names.

  Without this change `ICON_MAP.get("Non-recyclable rubbish")` and `ICON_MAP.get("Mixed recycling")` both miss, so those collections lose their icons. The
  new `Mixed recycling` label also gets mangled by the default `.title()` casing into `Mixed Recycling`, regressing the label that the previous fix (#6420)
  deliberately set.

  ## Changes

  - `ICON_MAP` gains entries for the two new names so icons resolve correctly.
  - `NAME_MAP` maps each new name to itself, bypassing the default `.title()` casing so `Mixed recycling` stays sentence case (matching #6420).
  - `NAME_MAP` keeps the legacy `Paper/card` mapping and adds `Black bags -> Non-recyclable rubbish` so users mid-rollout see the same canonical labels
  regardless of which feed version their address is on.
  - Adds `tests/test_colchester_gov_uk.py` covering the new and legacy feed shapes, an integration test with the exact JSON returned by the live API, and a
  date-filter regression test.ter / extrapolation behaviour.