### PR TITLE
fix(app_abfallplus_de): send client/app_id as HTTP headers for API_BASE requests

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -504,6 +504,8 @@ class AppAbfallplusDe:
             headers["User-Agent"] = USER_AGENT.format(
                 MAP_APP_USERAGENTS.get(self._app_id, "%")
             )
+            headers["x-abfallplus-client"] = self._client
+            headers["x-abfallplus-appid"] = self._app_id
 
         if "config.xml" in url_ending:
             headers["Accept-Encoding"] = "gzip, deflate, br"


### PR DESCRIPTION
## Summary
- Fixes #6462
- The Abfall+ API changed its authentication scheme on 2026-05-29: `client` and `app_id` must now be sent as `x-abfallplus-client` / `x-abfallplus-appid` HTTP headers (the server confirms this via `access-control-allow-headers`).
- Added both headers in the `else` branch of `AppAbfallplusDe._request()`, where non-`API_ASSISTANT` (i.e. `API_BASE`) requests are configured. No other changes required.

## Test plan
- [ ] Run `python test_sources.py -s app_abfallplus_de -l` against a live `app_id` (e.g. `de.k4systems.abfallapp`) and confirm collections are returned without 401/connection-reset errors.
- [ ] Confirm `python -m pytest tests/test_source_components.py -q` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)