### PR TITLE
fix(init_yaml): await initial fetch before calendar platform setup

### DIFF
--- a/custom_components/waste_collection_schedule/init_yaml.py
+++ b/custom_components/waste_collection_schedule/init_yaml.py
@@ -144,6 +144,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     # store api object
     hass.data.setdefault(const.DOMAIN, {})["YAML_CONFIG"] = api
 
+    # perform initial fetch so collection types are known before platform setup
+    await hass.async_add_executor_job(api._fetch)
+
     # load calendar platform
     await async_load_platform(hass, "calendar", const.DOMAIN, {"api": api}, config)
 
@@ -156,9 +159,6 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             {"api": api, "sensor_config": sensor_config},
             config,
         )
-
-    # initial fetch of all data
-    hass.add_job(api._fetch)
 
     # Register new Service fetch_data
     hass.services.async_register(


### PR DESCRIPTION
## Summary

- Fixes a race condition in the YAML setup path where `hass.add_job(api._fetch)` was dispatched after `async_load_platform("calendar", ...)` had already completed, meaning `create_calendar_entries` always saw empty collection data.
- The guard `aggregator.types != dedicated_calendar_types` evaluates to `False` when both sets are empty (no data yet), so the main calendar entity was silently skipped and never retried.
- Fix: move the initial fetch to before the calendar platform load, using `await hass.async_add_executor_job(api._fetch)` so the call is properly awaited and data is present when entity creation runs.
- Sensor entities are unaffected (they read data lazily). Config-entry (UI) path is unaffected (already awaits coordinator refresh first).

## Test plan

- [ ] Configure any network-backed source via YAML (e.g. `reading_gov_uk` with a valid UPRN)
- [ ] Restart Home Assistant
- [ ] Verify `calendar.<source>` is created and populated (not `unavailable`/`restored`)
- [ ] Verify sensor entities still work as before
- [ ] Verify a source with `use_dedicated_calendar: true` still creates dedicated + main calendar correctly

Fixes #6458

🤖 Generated with [Claude Code](https://claude.com/claude-code)