### PR TITLE
fix(valeofglamorgan_gov_uk): switch to curl_cffi to bypass WAF (#6468)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/valeofglamorgan_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/valeofglamorgan_gov_uk.py
@@ -2,8 +2,8 @@ import json
 import random
 from datetime import date, datetime, timedelta
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 TITLE = "Vale of Glamorgan Council"
@@ -40,8 +40,10 @@ class Source:
     def __init__(self, uprn: str | int):
         self._uprn: str | int = uprn
 
-    def __get_colltion(self, calendar_url: str, bin_type: str) -> list[Collection]:
-        r = requests.get(calendar_url)
+    def __get_collection(
+        self, session: requests.Session, calendar_url: str, bin_type: str
+    ) -> list[Collection]:
+        r = session.get(calendar_url)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
         entries = []
@@ -56,13 +58,13 @@ class Source:
                 day = day.strip()
                 if not day.isdigit():
                     continue
-                date = datetime.strptime(f"{day} {months}", "%d %B %Y").date()
-                entries.append(
-                    Collection(date=date, t=bin_type, icon=ICON_MAP[bin_type])
-                )
+                dt = datetime.strptime(f"{day} {months}", "%d %B %Y").date()
+                entries.append(Collection(date=dt, t=bin_type, icon=ICON_MAP[bin_type]))
         return entries
 
     def fetch(self) -> list[Collection]:
+        session = requests.Session(impersonate="chrome")
+
         timestamp = str(int(datetime.now().timestamp() * 1000))
         random_callback_number = str(
             random.randint(10000000000000000000, 99999999999999999999)
@@ -79,7 +81,7 @@ class Source:
         }
 
         # get json file
-        r = requests.get(API_URL, params=params)
+        r = session.get(API_URL, params=params)
         r.raise_for_status()
         text = r.text
         text = text.replace("AddressInfoCallback(", "").rstrip(");")
@@ -111,7 +113,11 @@ class Source:
             for i in range(10)
         )
 
-        entries.extend(self.__get_colltion(data["residual_calendar_url"], "Trash"))
-        entries.extend(self.__get_colltion(data["green_calendar_url"], "Garden"))
+        entries.extend(
+            self.__get_collection(session, data["residual_calendar_url"], "Trash")
+        )
+        entries.extend(
+            self.__get_collection(session, data["green_calendar_url"], "Garden")
+        )
 
         return entries


### PR DESCRIPTION
## Summary
- The provider's CDN now returns 403 to Python `requests` user-agent on both the JSONP API endpoint and the calendar HTML pages.
- Replace `import requests` with `from curl_cffi import requests`, create a shared session with `impersonate="chrome"`, and pass it into `__get_collection`.
- Tested live against both TEST_CASES — all returning schedule data as expected.

Fixes #6468.

## Test plan
- [ ] Live test: `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s valeofglamorgan_gov_uk -l`
- [ ] Structural test: `python -m pytest tests/test_source_components.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)