### PR TITLE
fix: add Coquitlam, BC to ReCollect ICS source (#6461)

### DIFF
--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -185,6 +185,9 @@ extra_info:
     country: ca
     default_params:
       service_url: https://api.recollect.net/r/area/OxfordCounty
+  - title: City of Coquitlam, BC
+    url: https://www.coquitlam.ca/157/Collection-Calendar-and-Guidelines
+    country: ca
 
 howto:
   en: |
@@ -237,6 +240,7 @@ howto:
     |City of Beaumont, AB|Canada|[beaumont.ab.ca](https://www.beaumont.ab.ca/1159/Waste-and-Recycling)|
     |Bassetlaw District Council|UK|[bassetlaw.gov.uk](https://www.bassetlaw.gov.uk/bins-recycling-and-waste/bins-for-recycling-and-waste/bin-collection-days/)|
     |Oxford County, ON|Canada|[oxfordcounty.ca](https://www.oxfordcounty.ca/services-for-you/garbage-and-recycling/curbside-collection/)|
+    |City of Coquitlam, BC|Canada|[coquitlam.ca](https://www.coquitlam.ca/157/Collection-Calendar-and-Guidelines)|
 
     and probably a lot more.
 
@@ -292,4 +296,7 @@ test_cases:
     split_at: '\, (?:and )?|(?: and )'
   Denver, CO, USA:
     url: https://recollect-us.global.ssl.fastly.net/api/places/464342A6-3CBF-11E5-9D27-D51A47A8A7C0/services/248/events.en-US.ics
+    split_at: '\, (?:and )?|(?: and )'
+  1402 Lansdowne Dr, Coquitlam, BC, Canada:
+    url: https://recollect-us.global.ssl.fastly.net/api/places/60B07F16-912F-11E2-91C6-912BB3DE4739/services/202/events.en.ics
     split_at: '\, (?:and )?|(?: and )'


### PR DESCRIPTION
## Summary

- Adds City of Coquitlam, BC, Canada to the ReCollect shared ICS platform (`doc/ics/yaml/recollect.yaml`)
- Verified the ICS endpoint is publicly accessible without login and returns valid iCal data
- Adds entry to `extra_info`, `howto.en` table, and `test_cases`

Closes #6461

## Test plan

- [ ] ICS URL fetches valid calendar data for 1402 Lansdowne Dr, Coquitlam
- [ ] CI passes (yamlfmt + structural tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)