### PR TITLE
fix(kiertokapula_fi): switch to curl_cffi to bypass Azure Application Gateway WAF (#6405)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiertokapula_fi.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiertokapula_fi.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import date, datetime
 
-import requests
+from curl_cffi import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 TITLE = "Kiertokapula Finland"
@@ -16,6 +16,7 @@ TEST_CASES = {
 }
 
 API_URL = "https://asiakasnetti.kiertokapula.fi/api/customers"
+PORTAL_URL = "https://asiakasnetti.kiertokapula.fi/e-services/kiertokapula/login"
 TENANT_ID = "493c3a57-70d8-4515-aa94-05dd1185b986"
 
 PARAM_TRANSLATIONS = {
@@ -39,18 +40,25 @@ class Source:
         self._password = password
 
     def fetch(self) -> list[Collection]:
-        session = requests.Session()
+        session = requests.Session(impersonate="chrome")
+
+        # Prime Azure Application Gateway affinity cookies by visiting the portal first.
+        # Without this the gateway returns 403 on the login POST.
+        session.get(PORTAL_URL, timeout=30)
 
         # Authenticate against new Vingo 2.0 API
         login_headers = {
             "Content-Type": "application/json;charset=utf-8",
             "Accept-Language": "fi",
             "Tenant-Id": TENANT_ID,
+            "Origin": "https://asiakasnetti.kiertokapula.fi",
+            "Referer": PORTAL_URL,
         }
         r = session.post(
             f"{API_URL}/Users/login",
             json={"userName": self._username, "password": self._password},
             headers=login_headers,
+            timeout=30,
         )
         r.raise_for_status()
         token_data = r.json()
@@ -67,6 +75,7 @@ class Source:
         r = session.get(
             f"{API_URL}/Customers/emptying-infos",
             headers=auth_headers,
+            timeout=30,
         )
         r.raise_for_status()
         emptying_infos = r.json() or []
@@ -82,6 +91,7 @@ class Source:
             r = session.get(
                 f"{API_URL}/Customers/emptying-infos/{emptying_id}/contracts",
                 headers=auth_headers,
+                timeout=30,
             )
             r.raise_for_status()
             contracts = r.json() or []


### PR DESCRIPTION
## Summary

Fixes #6405. After PR #6408 updated the source for the Vingo 2.0 portal migration, users were still getting a 403 on the login endpoint.

Root cause: the portal sits behind an Azure Application Gateway that performs a cookie challenge on first contact. The gateway sets `ApplicationGatewayAffinity` and `ApplicationGatewayAffinityCORS` cookies when a browser-like client hits the login page; subsequent requests from that session are allowed through. Plain `requests` never passes the challenge (confirmed: `requests` → 403, `curl_cffi(impersonate="chrome")` → 200).

Changes:
- Switch from `requests` to `curl_cffi` with `impersonate="chrome"`
- Add a cookie-priming GET to the portal login page before the login POST
- Add `Origin` and `Referer` headers to the login POST (matching browser behaviour)
- Add explicit `timeout=30` on all requests

## Test plan

- [ ] Verify the login endpoint now returns 401 (wrong credentials) rather than 403 (WAF block) for invalid credentials
- [ ] Test with real Kiertokapula e-services credentials — should return collection entries
- [ ] Verify backward compatibility: existing configs using `bill_number` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)