### PR TITLE
fix(eastcambs_gov_uk): migrate to new AchieveForms bin collection API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastcambs_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastcambs_gov_uk.py
@@ -1,57 +1,197 @@
 import datetime
+import re
+import time
 
 import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "East Cambridgeshire District Council"
 DESCRIPTION = "Source for eastcambs.gov.uk, East Cambridgeshire District Council, UK"
 URL = "https://www.eastcambs.gov.uk"
 TEST_CASES = {
-    "East Cambridgeshire District Council, CB7 4EE": {"uprn": 10002597178},
+    "14 Meadow Way Ely": {"uprn": 10002601730},
+    "20 Forehill Ely": {"uprn": "10002597181"},
 }
 
-API_URL = "https://eastcambs-self.achieveservice.com/appshost/firmstep/self/apps/custompage/bincollections?uprn={uprn}"
+COUNTRY = "uk"
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Find your UPRN by visiting "
+        "https://eastcambs-self.achieveservice.com/service/Check_your_waste_collection_day "
+        "and searching for your address. Your UPRN can also be found at https://www.findmyaddress.co.uk/."
+    )
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number (UPRN) for your address.",
+    }
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number",
+    }
+}
+
+HOSTNAME = "eastcambs-self.achieveservice.com"
+PROCESS_ID = "2c7575a6-0139-4555-9d8a-ab504a44d989"
+STAGE_ID = "94ee5097-94db-474d-bc7a-d1796e3ab83a"
+INITIAL_URL = f"https://{HOSTNAME}/AchieveForms/"
+AUTH_LOOKUP_ID = "69d8f92eea3cf"
+COLLECTIONS_LOOKUP_ID = "6784e74793b68"
+API_URL = f"https://{HOSTNAME}/apibroker/runLookup"
 
 ICON_MAP = {
-    "Black Bag": Icons.GENERAL_WASTE,
-    "Blue Bin": Icons.RECYCLING,
-    "Green or Brown Bin": Icons.BIO_KITCHEN,
+    "RECYCLING BIN": Icons.RECYCLING,
+    "OUTDOOR FOOD CADDY": Icons.BIO_KITCHEN,
+    "INDOOR FOOD CADDY": Icons.BIO_KITCHEN,
+    "RUBBISH BIN": Icons.GENERAL_WASTE,
+    "GARDEN WASTE BIN": Icons.GARDEN,
+    "BROWN BAGS": Icons.GENERAL_WASTE,
+    "PURPLE BAGS": Icons.RECYCLING,
+    "CLEAR BAGS": Icons.RECYCLING,
+    "BLACK BAG": Icons.GENERAL_WASTE,
+    "BLUE BIN": Icons.RECYCLING,
+    "GREEN": Icons.GARDEN,
 }
+
+
+def _get_icon(collection_type: str) -> str | None:
+    upper = collection_type.upper()
+    for key, icon in ICON_MAP.items():
+        if key in upper:
+            return icon
+    return None
 
 
 class Source:
-    def __init__(self, uprn=None):
-        self._uprn = uprn
+    def __init__(self, uprn: str | int):
+        self._uprn = str(uprn).strip()
 
-    def fetch(self):
-        q = str(API_URL).format(uprn=self._uprn)
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update({"user-agent": "Mozilla/5.0"})
 
-        r = requests.get(q)
+        # Step 1: Load the AchieveForms page to get a session
+        r = session.get(
+            INITIAL_URL,
+            params={
+                "mode": "fill",
+                "consentMessage": "yes",
+                "form_uri": f"sandbox-publish://AF-Process-{PROCESS_ID}/AF-Stage-{STAGE_ID}/definition.json",
+                "process": "1",
+                "process_uri": f"sandbox-processes://AF-Process-{PROCESS_ID}",
+                "process_id": f"AF-Process-{PROCESS_ID}",
+            },
+            timeout=30,
+        )
         r.raise_for_status()
 
-        responseContent = r.text
+        sid_match = re.search(r'"auth-session":"([^"]+)"', r.text)
+        if not sid_match:
+            raise ValueError("Could not obtain session ID from East Cambs service")
+        sid = sid_match.group(1)
 
-        entries = []
+        # Step 2: Obtain authentication token
+        timestamp = int(time.time() * 1000)
+        r_auth = session.post(
+            API_URL,
+            params={
+                "id": AUTH_LOOKUP_ID,
+                "repeat_against": "",
+                "noRetry": "false",
+                "getOnlyTokens": "undefined",
+                "log_id": "",
+                "app_name": "AchieveForms",
+                "_": timestamp,
+                "sid": sid,
+            },
+            json={"formValues": {"Section 1": {}}},
+            timeout=30,
+        )
+        r_auth.raise_for_status()
+        auth_data = r_auth.json()
+        auth_token = (
+            auth_data.get("integration", {})
+            .get("transformed", {})
+            .get("rows_data", {})
+            .get("0", {})
+            .get("AuthenticateResponse", "")
+        )
 
-        soup = BeautifulSoup(responseContent, "html.parser")
-        x = soup.findAll("div", {"class": "row collectionsrow"})
+        # Step 3: Fetch upcoming bin collections
+        today = datetime.date.today()
+        # The new service started June 1 2026; use that as the earliest start date
+        service_start = datetime.date(2026, 6, 1)
+        start_date = max(today, service_start)
+        end_date = today + datetime.timedelta(days=90)
 
-        for row in x:
-            fields = row.findChildren()
-            if (
-                fields[0].text.strip()
-                == "Please select an address to view the upcoming collections."
-            ):
+        timestamp = int(time.time() * 1000)
+        r_col = session.post(
+            API_URL,
+            params={
+                "id": COLLECTIONS_LOOKUP_ID,
+                "repeat_against": "",
+                "noRetry": "false",
+                "getOnlyTokens": "undefined",
+                "log_id": "",
+                "app_name": "AchieveForms",
+                "_": timestamp,
+                "sid": sid,
+            },
+            json={
+                "formValues": {
+                    "Section 1": {
+                        "AuthenticateResponse": {"value": auth_token},
+                        "selected_uprn": {"value": self._uprn},
+                        "MinimumDateForNextDates": {
+                            "value": start_date.strftime("%Y-%m-%d")
+                        },
+                        "MaximumDateFormattedNext": {
+                            "value": end_date.strftime("%Y-%m-%d")
+                        },
+                    }
+                }
+            },
+            timeout=30,
+        )
+        r_col.raise_for_status()
+        col_data = r_col.json()
+
+        # select_data contains all collection occurrences in chronological order
+        # Each entry: {"label": "BIN TYPE - DD/MM/YYYY", "value": "BIN TYPE"}
+        select_data = (
+            col_data.get("integration", {})
+            .get("transformed", {})
+            .get("select_data", [])
+        )
+
+        if not select_data:
+            raise SourceArgumentNotFound("uprn", self._uprn)
+
+        entries: list[Collection] = []
+        for item in select_data:
+            label = item.get("label", "")
+            # Label format: "BIN TYPE - DD/MM/YYYY"
+            parts = label.rsplit(" - ", 1)
+            if len(parts) != 2:
+                continue
+            bin_type, date_str = parts
+            try:
+                collection_date = datetime.datetime.strptime(
+                    date_str, "%d/%m/%Y"
+                ).date()
+            except ValueError:
                 continue
 
             entries.append(
                 Collection(
-                    date=datetime.datetime.strptime(
-                        fields[3].text, "%a - %d %b %Y"
-                    ).date(),
-                    t=fields[2].text,
-                    icon=ICON_MAP.get(fields[2].text),
+                    date=collection_date,
+                    t=bin_type.strip(),
+                    icon=_get_icon(bin_type.strip()),
                 )
             )
 

--- a/doc/source/eastcambs_gov_uk.md
+++ b/doc/source/eastcambs_gov_uk.md
@@ -1,6 +1,6 @@
 # East Cambridgeshire District Council
 
-Support for schedules provided by [East Cambridgeshire District Council](https://www.eastcambs.gov.uk/), serving East Cambridgeshrire district, UK.
+Support for schedules provided by [East Cambridgeshire District Council](https://www.eastcambs.gov.uk/), serving East Cambridgeshire district, UK.
 
 ## Configuration via configuration.yaml
 
@@ -14,21 +14,21 @@ waste_collection_schedule:
 
 ### Configuration Variables
 
-### Configuration Variables
-
 **uprn**<br>
 *(string) (required)*
 
-
 #### How to find your `UPRN`
-An easy way to discover your Unique Property Reference Number (UPRN) is by going to https://www.findmyaddress.co.uk/ and entering in your address details.
-Otherwise you can inspect the web requests the East Cambridgeshire District Council website makes when entering in your postcode and then selecting your address.
+
+Visit the [East Cambridgeshire bin collection checker](https://eastcambs-self.achieveservice.com/service/Check_your_waste_collection_day) and search for your address. Your UPRN will appear as part of the address lookup.
+
+Alternatively, go to <https://www.findmyaddress.co.uk/> and enter your address details.
 
 ## Example
+
 ```yaml
 waste_collection_schedule:
     sources:
     - name: eastcambs_gov_uk
       args:
-        uprn: 10002597178
+        uprn: 10002601730
 ```


### PR DESCRIPTION
## Summary

East Cambridgeshire District Council launched a new bin collection service on 1 June 2026.
The old Firmstep custom-page API stopped returning future dates under the new scheme,
and all bin types were renamed.

This PR rewrites the source to use the new AchieveForms portal:

- Implements a three-step session/auth/lookup flow via `apibroker/runLookup`
- Updates `ICON_MAP` for the new bin names (RECYCLING BIN - 240L, RUBBISH BIN - 180L, OUTDOOR FOOD CADDY, etc.)
- Replaces the old TEST_CASES UPRN (council offices) with two residential UPRNs that have data in the new system
- Updates `doc/source/eastcambs_gov_uk.md` with the new service URL and example UPRN

Fixes #6464

## Test plan

- [x] Live test: `python test_sources.py -s eastcambs_gov_uk -l` — both TEST_CASES return 30 entries each for June–August 2026
- [x] Structural test: `python -m pytest tests/test_source_components.py -q` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)