### PR TITLE
Add Glashütten to mymuell service list (jumomind_de)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -142,6 +142,7 @@ SERVICE_MAP = {
             "Esens",
             "Flensburg",
             "Gelnhausen",
+            "Glashütten",
             "Grävenwiesbach",
             "Großkrotzenburg",
             "Hainburg",


### PR DESCRIPTION
## Summary

- Adds `Glashütten` to the `SERVICE_MAP["mymuell"]["list"]` in `jumomind_de.py`
- The mymuell API confirms city id 18531 exists with street-level resolution
- No code changes required — the dynamic city lookup already handles it

Closes #3216

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>