### PR TITLE
fix(abfalltermine_forchheim_de): use HTTPS endpoint directly

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
@@ -26,7 +26,7 @@ class Source:
     def fetch(self):
         place = urllib.parse.quote(self._city + " - " + self._area)
         r = requests.get(
-            f"http://www.abfalltermine-forchheim.de/Forchheim/Landkreis/{place}/ics?RESTMUELL=true&RESTMUELL_SINGLE=true&BIO=true&YELLOW_SACK=true&PAPER=true"
+            f"https://www.abfalltermine-forchheim.de/Forchheim/Landkreis/{place}/ics?RESTMUELL=true&RESTMUELL_SINGLE=true&BIO=true&YELLOW_SACK=true&PAPER=true"
         )
         r.encoding = "utf-8"
         dates = self._ics.convert(r.text)


### PR DESCRIPTION
## Summary
- Closes #3341
- The abfalltermine-forchheim.de server now enforces HTTPS, returning a 301 redirect on HTTP requests. Update the hardcoded URL in `fetch()` from `http://` to `https://` to hit the correct endpoint directly.
- The `icalevents` module-not-found error reported in the issue is a stale HACS installation issue (unrelated to the source code) — `icalevents` is correctly listed in `manifest.json` requirements. A "Redownload" from HACS resolves it.

## Test plan
- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] Live test: `python test_sources.py -s abfalltermine_forchheim_de -l` returns schedule entries for all three TEST_CASES

🤖 Generated with [Claude Code](https://claude.com/claude-code)