### PR TITLE
fix: bump icalevents minimum to >=0.2.1 to resolve windows_to_olson import error

### DIFF
--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -10,7 +10,7 @@
   "requirements": [
     "pdfminer.six",
     "icalendar",
-    "icalevents>=0.1.26,!=0.1.28",
+    "icalevents>=0.2.1",
     "beautifulsoup4",
     "lxml",
     "pycryptodome",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4>=4.12.2
 curl_cffi
 DateTime>=4.9
 icalendar>=4.0.9
-icalevents>=0.1.29
+icalevents>=0.2.1
 python-dateutil>=2.8.2
 pytz>=2021.3
 PyYAML>=6.0.1


### PR DESCRIPTION
## Summary

- Bumps `icalevents` minimum version from `>=0.1.26,!=0.1.28` to `>=0.2.1` in `manifest.json` (and `requirements.txt`)
- `icalevents` 0.1.x imports `icalendar.windows_to_olson`, which was removed in `icalendar` v6.0; installations with a newer `icalendar` (installed by another HA integration such as `ics_calendar`) fail with `ModuleNotFoundError: No module named 'icalendar.windows_to_olson'`, surfacing as "Unknown error occurred" in the config UI
- `icalevents` 0.2.0 (2025-01-17) was the first version to drop this import; current latest is 0.3.1

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] Install on a HA instance with `icalendar` v6+ present; confirm ICS-based sources load without error and the config flow no longer shows "Unknown error occurred"

Closes #3489
Closes #3445
Related: #3390, #3259, #3426, #3465, #3511

🤖 Generated with [Claude Code](https://claude.com/claude-code)