### PR TITLE
Fix: place Generic country first in config flow dropdown

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -384,9 +384,11 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
             {
                 vol.Required(CONF_COUNTRY_NAME): SelectSelector(
                     SelectSelectorConfig(
-                        options=[""] + list(self._sources.keys()),
+                        options=[""]
+                        + (["Generic"] if "Generic" in self._sources else [])
+                        + sorted(k for k in self._sources if k != "Generic"),
                         mode=SelectSelectorMode.DROPDOWN,
-                        sort=True,
+                        sort=False,
                     )
                 )
             }

--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -616,7 +616,7 @@ def update_sources_json(countries: dict[str, list[SourceInfo]]) -> None:
     output: dict[str, list[dict[str, str | dict[str, Any]]]] = {}
     source_metadata_by_module: dict[str, dict[str, Any]] = {}
 
-    for country in sorted(countries):
+    for country in ["Generic"] + sorted(c for c in countries if c != "Generic"):
         output[country] = []
         for e in sorted(
             countries[country],


### PR DESCRIPTION
## Summary

Fixes #3442 — "Generic" appeared mid-alphabet between Finland and Germany in the country-selection dropdown.

- `update_sources_json` in `update_docu_links.py` now writes the `"Generic"` key first in `sources.json` before iterating sorted country names.
- The config flow country selector now sorts countries explicitly in Python (Generic first, then alphabetical), replacing the frontend `sort=True` which ignored insertion order.

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` passes.
- [ ] In HA UI, verify "Generic" appears first in the country dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)