### PR TITLE
Fix day_switch_time timezone handling in sensor.py

### DIFF
--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -1,6 +1,5 @@
 """Sensor platform support for Waste Collection Schedule."""
 
-import datetime
 import logging
 from enum import Enum
 from typing import Any

--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Any
 
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -276,9 +277,9 @@ class ScheduleSensor(SensorEntity):
     def _include_today(self):
         """Return true if collections for today shall be included in the results."""
         if self._api:
-            return datetime.datetime.now().time() < self._api._day_switch_time
+            return dt_util.now().time() < self._api._day_switch_time
         else:
-            return datetime.datetime.now().time() < self._coordinator.day_switch_time
+            return dt_util.now().time() < self._coordinator.day_switch_time
 
     def _add_refreshtime(self):
         """Add refresh-time (= last fetch time) to device-state-attributes."""


### PR DESCRIPTION
## Summary

- `sensor.py`'s `_include_today` property compared `datetime.datetime.now().time()` against `day_switch_time`, which uses the OS/system clock timezone.
- On UTC-system deployments (Docker, HA OS), this causes the comparison to fire at the wrong local time, making sensors behave as if `day_switch_time` had already passed after a restart mid-day.
- Fixed by replacing both occurrences with `dt_util.now().time()`, the standard HA pattern for timezone-aware time comparisons.

## Test plan

- [ ] Restart HA on a UTC-system deployment with `day_switch_time` set later in the day; confirm today's collections are included as expected.
- [ ] Confirm sensors switch at `day_switch_time` in the user's local HA timezone (not UTC).

Fixes #3395

🤖 Generated with [Claude Code](https://claude.com/claude-code)