### PR TITLE
fix: newcastle_gov_uk — pick rescheduled date on bank-holiday substitutions

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_gov_uk.py
@@ -14,7 +14,21 @@ TEST_CASES = {"Test_001": {"uprn": "004510053797"}, "Test_002": {"uprn": 4510053
 
 
 API_URL = "https://community.newcastle.gov.uk/my-neighbourhood/ajax/getBinsNew.php"
-REGEX = r"[Green|Blue|Brown] [Bb]in \(([A-Za-z]+)( Waste)?\) .*? ([0-9]{2}-[A-Za-z]+-[0-9]{4})"
+
+# Match each bin-type section in the HTML response.
+# Group 1: waste type (e.g. "Domestic", "Recycling", "Garden")
+# Group 2: remainder of that bin's section up to the next bin heading
+SECTION_RE = re.compile(
+    r"(?:Green|Blue|Brown) [Bb]in \(([A-Za-z]+)(?: Waste)?\)(.*?)(?=(?:Green|Blue|Brown) [Bb]in|\Z)",
+    re.DOTALL,
+)
+
+# Match the "Next collection :" text portion of a section (up to the next HTML tag).
+# Taking the LAST date on that line correctly handles the "was DD-Mon-YYYY, now DD-Mon-YYYY"
+# phrasing used by the council during public-holiday substitutions.
+NEXT_COLLECTION_RE = re.compile(r"Next collection\s*:[^<]*")
+DATE_RE = re.compile(r"\d{2}-[A-Za-z]+-\d{4}")
+
 ICON_MAP = {
     "DOMESTIC": Icons.GENERAL_WASTE,
     "RECYCLING": Icons.RECYCLING,
@@ -25,16 +39,28 @@ ICON_MAP = {
 class Source:
     def __init__(self, uprn):
         self._uprn = str(uprn).zfill(12)
-        self._session = requests.Session()
 
     def fetch(self):
         entries = []
         res = requests.get(f"{API_URL}?uprn={self._uprn}")
-        collections = re.findall(REGEX, res.text)
 
-        for collection in collections:
-            collection_type = collection[0]
-            collection_date = collection[2]
+        for section_match in SECTION_RE.finditer(res.text):
+            collection_type = section_match.group(1)
+            section_text = section_match.group(2)
+
+            nc_line = NEXT_COLLECTION_RE.search(section_text)
+            if not nc_line:
+                continue
+
+            dates = DATE_RE.findall(nc_line.group(0))
+            if not dates:
+                continue
+
+            # When a collection is shifted due to a public holiday the council
+            # displays "was <original-date>, now <rescheduled-date>".  The
+            # rescheduled date is always the last date on that line.
+            collection_date = dates[-1]
+
             entries.append(
                 Collection(
                     date=datetime.strptime(collection_date, "%d-%b-%Y").date(),


### PR DESCRIPTION
## Summary

Fixes #3388.

When Newcastle City Council rearranges a bin collection due to a public holiday, the API response changes the "Next collection" line to `Next collection : was 02-Jan-2025, now 03-Jan-2025`. The previous single-regex approach used a non-greedy `.*?` which captured the **first** date — the old, now-wrong date — instead of the rescheduled one.

**Changes:**
- Rewrites `fetch()` to parse per-bin sections, then takes the **last** date on the "Next collection :" line (the effective rescheduled date).
- Fixes the `[Green|Blue|Brown]` character-class bug (should be `(?:Green|Blue|Brown)` alternation).
- Removes unused `self._session` attribute.

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 6 passed
- [x] Live test: `python test_sources.py -s newcastle_gov_uk -l` — 2 entries for both TEST_CASES with correct forward dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)