### PR TITLE
fix(avfallsor_no): accept addresses entered without a city suffix (#3467)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsor_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsor_no.py
@@ -8,7 +8,10 @@ from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSugge
 TITLE = "Avfall Sør, Kristiansand"
 DESCRIPTION = "Source for Avfall Sør, Kristiansand."
 URL = "https://avfallsor.no/"
-TEST_CASES = {"Auglandslia 1, Kristiansand": {"address": "Auglandslia 1, Kristiansand"}}
+TEST_CASES = {
+    "Auglandslia 1, Kristiansand": {"address": "Auglandslia 1, Kristiansand"},
+    "Auglandslia 1 (without city)": {"address": "Auglandslia 1"},
+}
 
 # Maps fraksjonId to English waste type names
 # fraksjonId is the stable provider identifier
@@ -39,32 +42,36 @@ ICON_MAP = {
 API_URL = "https://avfallsor.no/wp-json/addresses/v1/address"
 
 
+def _normalize(s: str) -> str:
+    return s.lower().replace(" ", "").replace(",", "").replace(".", "").casefold()
+
+
 class Source:
     def __init__(self, address: str):
         self._address: str = address
 
     def fetch(self) -> list[Collection]:
-        args = {"lookup_term": self._address.split(",")[0].strip()}
+        # The API does prefix matching on the street+number part; strip any city suffix
+        # before the first comma so the lookup works regardless of whether the user
+        # included a city name (e.g. "Auglandslia 1" vs "Auglandslia 1, Kristiansand").
+        lookup_term = self._address.split(",")[0].strip()
+        args = {"lookup_term": lookup_term}
 
         r = requests.get(API_URL, params=args)
         r.raise_for_status()
         matches = r.json()
         href: str | None = None
 
+        addr_norm = _normalize(self._address)
         for match in matches:
-            if (
-                match["label"]
-                .lower()
-                .replace(" ", "")
-                .replace(",", "")
-                .replace(".", "")
-                .casefold()
-                == self._address.lower()
-                .replace(" ", "")
-                .replace(",", "")
-                .replace(".", "")
-                .casefold()
-            ):
+            # Primary: exact match on the full label (includes city) — handles the case
+            # where the user supplied the city in their address string.
+            if _normalize(match["label"]) == addr_norm:
+                href = match["href"]
+                break
+            # Fallback: match on the value field (street + number only, no city) —
+            # handles the case where the user omitted the city name.
+            if _normalize(match.get("value", "")) == addr_norm:
                 href = match["href"]
                 break
 


### PR DESCRIPTION
## Summary

Fixes #3467 — users who enter their address without the city name (e.g. `Auglandslia 1` instead of `Auglandslia 1, Kristiansand`) receive a "no address found" error.

### Root cause

The address lookup compared the user-supplied string against the `label` field from the Avfall Sør API, which always includes the city. If the city was omitted, the normalised strings never matched.

### Fix

Add a fallback comparison against the API's `value` field (street + number only, no city). Whichever format the user enters is now accepted.

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 6 passed
- [x] `python test_sources.py -s avfallsor_no -l` — both test cases return 36 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)