### PR TITLE
fix(republicservices_com): apply holiday delay to all service types (#3359)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -86,7 +86,7 @@ class Source:
                 "Contact Republic Services directly for your collection schedule.",
             )
 
-        service = ""
+        services: set = set()
         schedule = []
         today = date.today()
         end_date = today + timedelta(days=182)
@@ -97,6 +97,7 @@ class Source:
                     period_length = item.get("numberOfPickupsPeriodLength", 1)
                     period_unit = item.get("numberOfPickupsPeriodUnit", "")
                     service = item["containerCategory"]
+                    services.add(service)
 
                     if (
                         period_unit
@@ -137,10 +138,10 @@ class Source:
             params={"latitude": latitude, "longitude": longitude},
         )
         r2_data = r2.json().get("data", [])
-        day_offset = 0
         holidays = []
         for item in r2_data:
-            if item and item["serviceImpacted"] is True and item["LOB"] == service:
+            if item and item["serviceImpacted"] is True and item["LOB"] in services:
+                day_offset = 0
                 for delay in DELAYS:
                     if delay in item["description"]:
                         day_offset = DELAYS[delay]


### PR DESCRIPTION
## Summary

- Fixes holiday date offsets being silently skipped for addresses with multiple collection service types (e.g. solid waste + recycling).
- The `service` variable was overwritten on each iteration of the schedule-building loop; the holiday filter `item["LOB"] == service` then only matched the very last service processed, so holiday delays were never applied to earlier services.
- Fix: collect all `containerCategory` values into a `services` set and check `item["LOB"] in services`.
- Also resets `day_offset` to `0` per holiday item to prevent delay values bleeding between unrelated holidays.

## Test plan
- [ ] `python test_sources.py -s republicservices_com -l` returns results for all TEST_CASES.
- [ ] `python -m pytest tests/test_source_components.py -q` passes.

Fixes #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)