### PR TITLE
Add ICS support for Atlantic Waste Services, GA (ReCollect)

### DIFF
--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -188,6 +188,9 @@ extra_info:
   - title: City of Coquitlam, BC
     url: https://www.coquitlam.ca/157/Collection-Calendar-and-Guidelines
     country: ca
+  - title: Atlantic Waste Services, GA
+    url: https://atlanticwaste.com
+    country: us
 
 howto:
   en: |
@@ -241,6 +244,7 @@ howto:
     |Bassetlaw District Council|UK|[bassetlaw.gov.uk](https://www.bassetlaw.gov.uk/bins-recycling-and-waste/bins-for-recycling-and-waste/bin-collection-days/)|
     |Oxford County, ON|Canada|[oxfordcounty.ca](https://www.oxfordcounty.ca/services-for-you/garbage-and-recycling/curbside-collection/)|
     |City of Coquitlam, BC|Canada|[coquitlam.ca](https://www.coquitlam.ca/157/Collection-Calendar-and-Guidelines)|
+    |Atlantic Waste Services, GA|USA|[atlanticwaste.com](https://atlanticwaste.com)|
 
     and probably a lot more.
 


### PR DESCRIPTION
## Summary

Adds Atlantic Waste Services (coastal Georgia, USA) to the ReCollect ICS platform entry.

The provider uses ReCollect (area: `AtlanticWasteSvcGA`) — users can search their address at https://api.recollect.net/r/area/AtlanticWasteSvcGA (or via the embedded widget on the Atlantic Waste website), click "Get a calendar", and use the resulting ICS URL with the existing `ics` source.

Closes #3389

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` passes (YAML only)
- [ ] Confirm the ReCollect widget at https://api.recollect.net/r/area/AtlanticWasteSvcGA returns a valid address lookup widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)