### PR TITLE
Fix stadtreinigung_dresden_de UI setup and invalid-standort error handling

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_dresden_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_dresden_de.py
@@ -2,23 +2,47 @@ import datetime
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ICS import ICS
 
 TITLE = "Stadtreinigung Dresden"
 DESCRIPTION = "Source for Stadtreinigung Dresden waste collection."
 URL = "https://www.dresden.de"
+COUNTRY = "de"
 TEST_CASES = {
     "Neumarkt 6": {"standort": 80542},
 }
 
+PARAM_TRANSLATIONS = {
+    "en": {
+        "standort": "Location ID",
+    },
+    "de": {
+        "standort": "Standort-ID",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "standort": "Numeric location ID from the Dresden waste calendar URL (e.g. 80542 for Neumarkt 6).",
+    },
+    "de": {
+        "standort": "Numerische Standort-ID aus der URL des Dresdner Abfallkalenders (z.B. 80542 für Neumarkt 6).",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Open https://www.dresden.de/apps_ext/AbfallApp/wastebins and search for your address. Then download the PDF calendar — the URL will contain '?STANDORT=<number>'. Use that number as the Location ID.",
+    "de": "Öffne https://www.dresden.de/apps_ext/AbfallApp/wastebins und suche deine Adresse. Lade den PDF-Kalender herunter — die URL enthält '?STANDORT=<Zahl>'. Diese Zahl ist die Standort-ID.",
+}
+
 
 class Source:
-    def __init__(self, standort):
+    def __init__(self, standort: int):
         self._standort = standort
         self._ics = ICS()
 
-    def fetch(self):
-
+    def fetch(self) -> list[Collection]:
         now = datetime.datetime.now().date()
 
         r = requests.get(
@@ -29,6 +53,12 @@ class Source:
                 "DATUM_BIS": (now + datetime.timedelta(days=365)).strftime("%d.%m.%Y"),
             },
         )
+
+        if not r.text.startswith("BEGIN:VCALENDAR"):
+            raise SourceArgumentNotFound(
+                "standort",
+                self._standort,
+            )
 
         dates = self._ics.convert(r.text)
 


### PR DESCRIPTION
## Summary

Fixes #3362. The source worked fine programmatically but failed in the HA UI config flow because:

- `standort` had no type annotation, so the config flow presented an unlabelled free-text field with no hint that a numeric ID was needed
- An invalid standort caused the API to return HTML, which made `ICS.convert()` raise a bare exception that the config flow surfaced as "unknown error occurred"

Changes:
- Added `standort: int` annotation so the config flow renders a numeric input field
- Added `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` (en/de) for a clearer label and description
- Added `HOW_TO_GET_ARGUMENTS_DESCRIPTION` (en/de) explaining how to find the standort ID from the PDF download URL
- Added `COUNTRY = "de"` constant
- Added `SourceArgumentNotFound` guard when the API returns HTML instead of valid ICS

## Test plan
- [x] `python test_sources.py -s stadtreinigung_dresden_de -l` returns entries for Neumarkt 6
- [x] `python -m pytest tests/test_source_components.py -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)