### PR TITLE
fix(c_trace_de): extend default abfall ID range to fix missing waste types (#3535)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
@@ -227,7 +227,7 @@ class Source:
         self.ical_url_file = ical_url_file
         self._ics = ICS(regex=r"Abfuhr: (.*)")
         if not abfall:
-            abfall = "|".join(str(i) for i in range(0, 99))
+            abfall = "|".join(str(i) for i in range(0, 300))
         self._abfall = abfall
 
     def fetch(self):


### PR DESCRIPTION
## Summary

- The default `Abfall` parameter was built from `range(0, 99)`, capping waste-type IDs at 98.
- The WZV Kreis Segeberg portal has container IDs up to 173; addresses mapped to IDs >= 99 returned incomplete schedules (in the reporter's case, only "Wertstoff").
- Fix: extend the default range to `range(0, 300)`, which the server accepts without issue.

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` passes (6/6)
- [x] Manual check against the WZV Segeberg portal with IDs 99–173 confirms "Saubere Landschaft", "Strauchgut", "Trödelmarkt" are now included
- [x] Existing TEST_CASES continue to return correct results

Fixes #3535

🤖 Generated with [Claude Code](https://claude.com/claude-code)