### PR TITLE
fix(solihull_gov_uk): correct typo in display URL

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/solihull_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/solihull_gov_uk.py
@@ -9,7 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 TITLE = "Solihull Council"
 DESCRIPTION = "Source for Solihull Council."
-URL = "https://www.solihul.gov.uk/"
+URL = "https://www.solihull.gov.uk/"
 TEST_CASES = {
     "100070994046": {"uprn": 100070994046},
     "200003821723, Predict": {"uprn": 200003821723, "predict": True},


### PR DESCRIPTION
Corrects a one-character typo in the `solihull_gov_uk` source's display `URL` (`solihul.gov.uk` → `solihull.gov.uk`). Data fetching uses `API_URL`, which was already correct, so this is display-only.

Closes #3740

🤖 Generated with [Claude Code](https://claude.com/claude-code)