### PR TITLE
feat(infeo_at): add Abfallverband Schwechat (av-schwechat)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/infeo_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/infeo_at.py
@@ -29,6 +29,12 @@ EXTRA_INFO = [
         "country": "at",
         "default_params": {"customer": "salzburg"},
     },
+    {
+        "title": "Abfallverband Schwechat",
+        "url": "https://schwechat.umweltverbaende.at/",
+        "country": "at",
+        "default_params": {"customer": "av-schwechat"},
+    },
 ]
 TEST_CASES = {
     "Bogeschütz": {"customer": "bogenschütz", "zone": "Dettenhausen"},
@@ -43,6 +49,12 @@ TEST_CASES = {
         "city": "Salzburg",
         "street": "Adolf-Schemel-Straße",
         "housenumber": "13",
+    },
+    "Schwechat": {
+        "customer": "av-schwechat",
+        "city": "Fischamend",
+        "street": "Am Damm",
+        "housenumber": "2",
     },
 }
 


### PR DESCRIPTION
## Summary

Adds **Abfallverband Schwechat** to the `infeo_at` source (`customer: av-schwechat`), plus a test case.

The Schwechat district migrated from umweltverbaende.at to the Infeo platform (abfallkalender.infeo.at). PR #6205 commented it out of `umweltverbaende_at.py` but never added it to `infeo_at`'s EXTRA_INFO, so it dropped out of the UI picker/docs.

Closes #3810

## Test plan
- `python test_sources.py -s infeo_at -l` — all test cases (incl. new Schwechat / Fischamend) return collections
- `python -m pytest tests/test_source_components.py -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)