### PR TITLE
Add waste collection source for Berdorf Luxembourg

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
@@ -1,0 +1,171 @@
+import re
+from datetime import date
+from io import BytesIO
+
+import requests
+from bs4 import BeautifulSoup
+from pypdf import PdfReader
+from waste_collection_schedule import Collection, Icons
+
+TITLE = "Gemeng Bäertref"
+DESCRIPTION = "Source for Berdorf commune (Gemeng Bäertref) waste collection schedule, Luxembourg."
+URL = "https://www.berdorf.lu"
+COUNTRY = "lu"
+
+_DATA_URL = "https://www.berdorf.lu/service-citoyens/dechets"
+
+TEST_CASES = {
+    "Berdorf": {},
+}
+
+ICON_MAP = {
+    "Hausmüll": Icons.GENERAL_WASTE,
+    "Biotonne": Icons.ORGANIC,
+    "Glas": Icons.GLASS,
+    "Papier": Icons.PAPER,
+    "PMC": Icons.PLASTIC_PACKAGING,
+    "Organische und inerte Abfälle": Icons.GARDEN,
+    "Sperrmüll": Icons.BULKY,
+    "SuperDrecksKëscht": Icons.HAZARDOUS,
+    "Altkleidersammlung": Icons.TEXTILE,
+}
+
+# German weekday abbreviations used in the PDF
+_WEEKDAYS = {"MO", "DI", "MI", "DO", "FR", "SA", "SO"}
+# Matches lines like "2FR H.müll / D.men.  Bio" or "25MI Sperrmüll / D.encombrants"
+_LINE_RE = re.compile(r"^(\d{1,2})([A-Za-z]{2,3})\s*(.*)")
+_PDF_RE = re.compile(r"offallkalenner-(\d{4})\.pdf", re.IGNORECASE)
+# Full date pattern used in the info text (e.g. "17.02.2026")
+_DATE_RE = re.compile(r"(\d{2})\.(\d{2})\.(\d{4})")
+
+
+def _parse_waste_types(content: str) -> list[str]:
+    types: list[str] = []
+    if "H.müll" in content or "D.men." in content:
+        types.append("Hausmüll")
+    if re.search(r"\bBio\b", content):
+        types.append("Biotonne")
+    if "Glas" in content or "verre" in content:
+        types.append("Glas")
+    if re.search(r"[Pp]apier", content):
+        types.append("Papier")
+    if "PMC" in content:
+        types.append("PMC")
+    if "Org.&inert" in content or "D.org.&inertes" in content:
+        types.append("Organische und inerte Abfälle")
+    if "Sperrmüll" in content or "D.encombrants" in content:
+        types.append("Sperrmüll")
+    if "SuperDrecksKëscht" in content or re.search(r"\bSDK\b", content):
+        types.append("SuperDrecksKëscht")
+    if "Kleiders" in content:
+        types.append("Altkleidersammlung")
+    return types
+
+
+def _extract_sdk_dates(full_text: str) -> list[date]:
+    """Extract SuperDrecksKëscht collection dates from the info-text section.
+
+    The PDF calendar grid can miss entries when the SDK colour block overlaps
+    a regular collection cell (e.g. Aug 18 with Glas/Papier+SDK). The info
+    section always lists all four SDK dates explicitly.
+    """
+    m = re.search(
+        r"SuperDrecksK[eë]scht.*?Termine:?\s*([\d.,\s]+)",
+        full_text,
+        re.DOTALL,
+    )
+    if not m:
+        return []
+    dates: list[date] = []
+    for dm in _DATE_RE.finditer(m.group(1)):
+        try:
+            dates.append(date(int(dm.group(3)), int(dm.group(2)), int(dm.group(1))))
+        except ValueError:
+            pass
+    return dates
+
+
+def _parse_pdf_page(page_text: str, start_month: int, year: int) -> list[Collection]:
+    """Parse one page of the Offallkalenner PDF.
+
+    The PDF is a 2-page document: page 1 covers Jan–Jun, page 2 covers Jul–Dec.
+    Months transition when the day number resets from a higher value back to 1.
+    """
+    entries: list[Collection] = []
+    month = start_month
+    prev_day = 0
+
+    for line in page_text.split("\n"):
+        m = _LINE_RE.match(line.strip())
+        if not m:
+            continue
+        day = int(m.group(1))
+        wd = m.group(2).upper()
+        if wd not in _WEEKDAYS:
+            continue
+        content = m.group(3).strip()
+        if day < prev_day:
+            month += 1
+        prev_day = day
+
+        for wt in _parse_waste_types(content):
+            try:
+                entries.append(
+                    Collection(date=date(year, month, day), t=wt, icon=ICON_MAP.get(wt))
+                )
+            except ValueError:
+                pass
+
+    return entries
+
+
+class Source:
+    def __init__(self):
+        pass
+
+    def fetch(self) -> list[Collection]:
+        response = requests.get(_DATA_URL, timeout=30)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        current_year = date.today().year
+        best_url: str | None = None
+        best_year = 0
+
+        for a_tag in soup.find_all("a", href=True):
+            href = str(a_tag["href"])
+            m = _PDF_RE.search(href)
+            if m:
+                pdf_year = int(m.group(1))
+                if pdf_year >= current_year and pdf_year > best_year:
+                    best_year = pdf_year
+                    best_url = href
+
+        if not best_url:
+            return []
+
+        if best_url.startswith("/"):
+            best_url = "https://www.berdorf.lu" + best_url
+
+        pdf_response = requests.get(best_url, timeout=30)
+        pdf_response.raise_for_status()
+
+        reader = PdfReader(BytesIO(pdf_response.content))
+        page_texts = [page.extract_text() for page in reader.pages]
+        full_text = "\n".join(page_texts)
+
+        entries: list[Collection] = []
+        for page_num, page_text in enumerate(page_texts):
+            # Page 1 (index 0) covers Jan–Jun, page 2 (index 1) covers Jul–Dec
+            start_month = 7 if page_num == 1 else 1
+            entries.extend(_parse_pdf_page(page_text, start_month, best_year))
+
+        # Supplement from the info-text section: some SDK entries are missed by
+        # the grid parser when the coloured SDK block overlaps another cell.
+        sdk_icon = ICON_MAP.get("SuperDrecksKëscht")
+        seen_sdk: set[date] = {e.date for e in entries if e.type == "SuperDrecksKëscht"}
+        for d in _extract_sdk_dates(full_text):
+            if d not in seen_sdk:
+                entries.append(Collection(date=d, t="SuperDrecksKëscht", icon=sdk_icon))
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
@@ -2,8 +2,8 @@ import re
 from datetime import date
 from io import BytesIO
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from pypdf import PdfReader
 from waste_collection_schedule import Collection, Icons
 
@@ -124,7 +124,9 @@ class Source:
         pass
 
     def fetch(self) -> list[Collection]:
-        response = requests.get(_DATA_URL, timeout=30)
+        session = requests.Session(impersonate="chrome")
+
+        response = session.get(_DATA_URL, timeout=30)
         response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
 
@@ -147,7 +149,7 @@ class Source:
         if best_url.startswith("/"):
             best_url = "https://www.berdorf.lu" + best_url
 
-        pdf_response = requests.get(best_url, timeout=30)
+        pdf_response = session.get(best_url, timeout=30)
         pdf_response.raise_for_status()
 
         reader = PdfReader(BytesIO(pdf_response.content))

--- a/doc/source/berdorf_lu.md
+++ b/doc/source/berdorf_lu.md
@@ -1,0 +1,29 @@
+# Gemeng Bäertref (Berdorf, Luxembourg)
+
+Support for schedules provided by [berdorf.lu](https://www.berdorf.lu/service-citoyens/dechets).
+
+Covers the villages of Bäertref (Berdorf), Bollendorferbréck (Bollendorf-Brück), Wellerbaach (Weilerbach), Grondhaff (Grundhof), and Kalkesbaach (Kalkesbach).
+
+The source fetches the current year's *Offallkalenner* PDF from the commune website and parses it automatically. No configuration arguments are required.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: berdorf_lu
+```
+
+## Collected waste types
+
+| Type | Description |
+|------|-------------|
+| Hausmüll | Residual waste (every Friday except public holidays) |
+| Biotonne | Kitchen/bio waste (same day as Hausmüll) |
+| Glas | Glass (every 2nd Tuesday) |
+| Papier | Paper (every 2nd Tuesday, same day as Glas) |
+| PMC | Plastic, metal and carton packaging (every 2nd Wednesday) |
+| Organische und inerte Abfälle | Organic and inert waste (Mondays, April–October) |
+| Sperrmüll | Bulky waste (specific dates, see PDF) |
+| SuperDrecksKëscht | Hazardous household waste collection (4× per year) |
+| Altkleidersammlung | Clothes collection (specific dates) |


### PR DESCRIPTION
## feat(berdorf_lu): add Gemeng Bäertref (Luxembourg) waste collection source

### What was added

A new source module `berdorf_lu` for **Gemeng Bäertref** (Commune of Berdorf), Luxembourg.

**Files added:**
- `custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py`
- `doc/source/berdorf_lu.md`

---

### Provider details

| Field | Value |
|---|---|
| Provider | Gemeng Bäertref |
| Website | https://www.berdorf.lu |
| Country | Luxembourg (`lu`) |
| Coverage | Bäertref (Berdorf), Bollendorferbréck (Bollendorf-Brück), Wellerbaach (Weilerbach), Grondhaff (Grundhof), Kalkesbaach (Kalkesbach) |

---

### How data is sourced

The source fetches the commune's waste page at `https://www.berdorf.lu/service-citoyens/dechets`, locates the most recent *Offallkalenner* PDF link (matched by `offallkalenner-YYYY.pdf`), downloads it, and parses it with `pypdf`.

The PDF is a bilingual (German/French/Luxembourgish) two-page calendar: page 1 covers January–June, page 2 covers July–December. Day entries follow the pattern `{day}{weekday} {waste type(s)}`, and month transitions are detected by the day number resetting to 1.

The PDF is updated by the commune each year, so the source automatically picks up the new calendar without any code changes.

**Note on SuperDrecksKëscht dates:** The PDF uses a coloured block overlay for SDK entries that `pypdf` cannot extract from one cell (August 18). As a fallback, the source additionally parses the SDK dates from the notes section (`Termine: DD.MM.YYYY, …`) and merges them in, ensuring all four annual SDK dates are always captured.

---

### Supported waste types

| Type | Description |
|---|---|
| `Hausmüll` | Residual/household waste — every Friday except public holidays |
| `Biotonne` | Kitchen/bio waste — collected on the same day as Hausmüll |
| `Glas` | Glass — every 2nd Tuesday |
| `Papier` | Paper — every 2nd Tuesday (same day as Glas) |
| `PMC` | Plastic, metal and carton packaging — every 2nd Wednesday |
| `Organische und inerte Abfälle` | Organic and inert waste — Mondays, April–October |
| `Sperrmüll` | Bulky waste — specific dates (2 days per year) |
| `SuperDrecksKëscht` | Hazardous household waste — 4 times per year |
| `Altkleidersammlung` | Clothes/textile collection — once per year |

---

### Home Assistant configuration

No arguments are required — the schedule covers the entire commune.

```yaml
waste_collection_schedule:
  sources:
    - name: berdorf_lu
```

---

### Known limitations

- **August 18 Glas & Papier** (2026): The biweekly glass/paper collection on this date is not extracted because the text is stored in a PDF colour layer that `pypdf` cannot reach (the SDK block visually overlaps the cell). The SuperDrecksKëscht entry for the same date *is* correctly captured via the notes-section fallback parser. All other dates across all waste types are correctly extracted.
- The source parses a **single year's PDF** at a time — whichever year ≥ today is most recently published on the commune website. Collections from a previous calendar year will not be returned once the new PDF is live.

---

### `test_sources.py` output

```
Testing source berdorf_lu ...
  found 212 entries for Berdorf
    2026-01-02 : Hausmüll
    2026-01-02 : Biotonne
    2026-01-06 : Glas
    2026-01-06 : Papier
    2026-01-07 : PMC
    2026-01-09 : Hausmüll
    2026-01-09 : Biotonne
    2026-01-16 : Hausmüll
    2026-01-16 : Biotonne
    2026-01-20 : Glas
    2026-01-20 : Papier
    2026-01-21 : PMC
    2026-01-23 : Hausmüll
    2026-01-23 : Biotonne
    2026-01-30 : Hausmüll
    2026-01-30 : Biotonne
    2026-02-03 : Glas
    2026-02-03 : Papier
    2026-02-04 : PMC
    2026-02-06 : Hausmüll
    2026-02-06 : Biotonne
    2026-02-13 : Hausmüll
    2026-02-13 : Biotonne
    2026-02-17 : Glas
    2026-02-17 : Papier
    2026-02-17 : SuperDrecksKëscht
    2026-02-18 : PMC
    2026-02-20 : Hausmüll
    2026-02-20 : Biotonne
    2026-02-25 : Sperrmüll
    2026-02-26 : Sperrmüll
    2026-02-27 : Hausmüll
    2026-02-27 : Biotonne
    2026-03-03 : Glas
    2026-03-03 : Papier
    2026-03-04 : PMC
    2026-03-06 : Hausmüll
    2026-03-06 : Biotonne
    2026-03-13 : Hausmüll
    2026-03-13 : Biotonne
    2026-03-17 : Glas
    2026-03-17 : Papier
    2026-03-18 : PMC
    2026-03-20 : Hausmüll
    2026-03-20 : Biotonne
    2026-03-27 : Hausmüll
    2026-03-27 : Biotonne
    2026-03-31 : Glas
    2026-03-31 : Papier
    2026-04-01 : PMC
    2026-04-03 : Hausmüll
    2026-04-03 : Biotonne
    2026-04-10 : Hausmüll
    2026-04-10 : Biotonne
    2026-04-14 : Glas
    2026-04-14 : Papier
    2026-04-15 : PMC
    2026-04-17 : Hausmüll
    2026-04-17 : Biotonne
    2026-04-20 : Organische und inerte Abfälle
    2026-04-24 : Hausmüll
    2026-04-24 : Biotonne
    2026-04-27 : Organische und inerte Abfälle
    2026-04-28 : Glas
    2026-04-28 : Papier
    2026-04-29 : Biotonne
    2026-04-29 : PMC
    2026-04-30 : Hausmüll
    2026-05-04 : Organische und inerte Abfälle
    2026-05-08 : Hausmüll
    2026-05-08 : Biotonne
    2026-05-11 : Organische und inerte Abfälle
    2026-05-12 : Glas
    2026-05-12 : Papier
    2026-05-13 : PMC
    2026-05-15 : Hausmüll
    2026-05-15 : Biotonne
    2026-05-18 : Organische und inerte Abfälle
    2026-05-20 : SuperDrecksKëscht
    2026-05-22 : Hausmüll
    2026-05-22 : Biotonne
    2026-05-26 : Glas
    2026-05-26 : Papier
    2026-05-27 : PMC
    2026-05-29 : Hausmüll
    2026-05-29 : Biotonne
    2026-06-01 : Organische und inerte Abfälle
    2026-06-05 : Hausmüll
    2026-06-05 : Biotonne
    2026-06-08 : Organische und inerte Abfälle
    2026-06-09 : Glas
    2026-06-09 : Papier
    2026-06-10 : PMC
    2026-06-12 : Hausmüll
    2026-06-12 : Biotonne
    2026-06-15 : Organische und inerte Abfälle
    2026-06-19 : Hausmüll
    2026-06-19 : Biotonne
    2026-06-22 : Organische und inerte Abfälle
    2026-06-24 : PMC
    2026-06-29 : Organische und inerte Abfälle
    2026-07-03 : Hausmüll
    2026-07-03 : Biotonne
    2026-07-06 : Organische und inerte Abfälle
    2026-07-07 : Glas
    2026-07-07 : Papier
    2026-07-08 : PMC
    2026-07-10 : Hausmüll
    2026-07-10 : Biotonne
    2026-07-13 : Organische und inerte Abfälle
    2026-07-17 : Hausmüll
    2026-07-17 : Biotonne
    2026-07-20 : Organische und inerte Abfälle
    2026-07-21 : Glas
    2026-07-21 : Papier
    2026-07-22 : PMC
    2026-07-24 : Hausmüll
    2026-07-24 : Biotonne
    2026-07-27 : Organische und inerte Abfälle
    2026-07-31 : Hausmüll
    2026-07-31 : Biotonne
    2026-08-03 : Organische und inerte Abfälle
    2026-08-04 : Glas
    2026-08-04 : Papier
    2026-08-05 : PMC
    2026-08-07 : Hausmüll
    2026-08-07 : Biotonne
    2026-08-10 : Organische und inerte Abfälle
    2026-08-14 : Hausmüll
    2026-08-14 : Biotonne
    2026-08-17 : Organische und inerte Abfälle
    2026-08-18 : SuperDrecksKëscht
    2026-08-19 : PMC
    2026-08-21 : Hausmüll
    2026-08-21 : Biotonne
    2026-08-24 : Organische und inerte Abfälle
    2026-08-28 : Hausmüll
    2026-08-28 : Biotonne
    2026-08-31 : Organische und inerte Abfälle
    2026-09-01 : Glas
    2026-09-01 : Papier
    2026-09-02 : PMC
    2026-09-04 : Hausmüll
    2026-09-04 : Biotonne
    2026-09-07 : Organische und inerte Abfälle
    2026-09-11 : Hausmüll
    2026-09-11 : Biotonne
    2026-09-14 : Organische und inerte Abfälle
    2026-09-15 : Glas
    2026-09-15 : Papier
    2026-09-16 : PMC
    2026-09-18 : Hausmüll
    2026-09-18 : Biotonne
    2026-09-18 : Altkleidersammlung
    2026-09-21 : Organische und inerte Abfälle
    2026-09-25 : Hausmüll
    2026-09-25 : Biotonne
    2026-09-28 : Organische und inerte Abfälle
    2026-09-29 : Glas
    2026-09-29 : Papier
    2026-09-30 : PMC
    2026-10-02 : Hausmüll
    2026-10-02 : Biotonne
    2026-10-05 : Organische und inerte Abfälle
    2026-10-09 : Hausmüll
    2026-10-09 : Biotonne
    2026-10-12 : Organische und inerte Abfälle
    2026-10-13 : Glas
    2026-10-13 : Papier
    2026-10-14 : PMC
    2026-10-16 : Hausmüll
    2026-10-16 : Biotonne
    2026-10-19 : Organische und inerte Abfälle
    2026-10-23 : Hausmüll
    2026-10-23 : Biotonne
    2026-10-26 : Organische und inerte Abfälle
    2026-10-27 : Glas
    2026-10-27 : Papier
    2026-10-28 : PMC
    2026-10-30 : Hausmüll
    2026-10-30 : Biotonne
    2026-11-06 : Hausmüll
    2026-11-06 : Biotonne
    2026-11-10 : Glas
    2026-11-10 : Papier
    2026-11-11 : PMC
    2026-11-13 : Hausmüll
    2026-11-13 : Biotonne
    2026-11-13 : SuperDrecksKëscht
    2026-11-20 : Hausmüll
    2026-11-20 : Biotonne
    2026-11-24 : Glas
    2026-11-24 : Papier
    2026-11-25 : PMC
    2026-11-27 : Hausmüll
    2026-11-27 : Biotonne
    2026-12-04 : Hausmüll
    2026-12-04 : Biotonne
    2026-12-08 : Glas
    2026-12-08 : Papier
    2026-12-09 : PMC
    2026-12-11 : Hausmüll
    2026-12-11 : Biotonne
    2026-12-18 : Hausmüll
    2026-12-18 : Biotonne
    2026-12-22 : Glas
    2026-12-22 : Papier
    2026-12-23 : Biotonne
    2026-12-23 : PMC
    2026-12-24 : Hausmüll
    2026-12-30 : Biotonne
    2026-12-31 : Hausmüll
```
