### PR TITLE
feat(junker_app): add Novara to SERVICE_PROVIDERS

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -274,6 +274,7 @@ SERVICE_PROVIDERS = {
     "Cooperativa Trasforma",
     "Patti - Pizzo Pippo",
     "Noventa di Piave",
+    "Novara",
     "Palata",
     "Monte di Procida - DM Technology Srl",
     "Tricase",


### PR DESCRIPTION
Adds Novara (served via the Junker app) to `SERVICE_PROVIDERS` so it's discoverable in the UI config flow. The existing source already handles all 13 Novara quartieri via the `area` arg. Closes #3987

🤖 Generated with [Claude Code](https://claude.com/claude-code)