### PR TITLE
Colchester postcode lookup

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
@@ -1,17 +1,52 @@
 import json
 from datetime import datetime, timedelta
+from typing import Optional
 
 import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequired,
+)
 
 TITLE = "Colchester City Council"
 DESCRIPTION = "Source for Colchester.gov.uk services for the borough of Colchester, UK."
 URL = "https://colchester.gov.uk"
 COUNTRY = "uk"
 TEST_CASES = {
-    # "High Street, Colchester": {"llpgid": "1197e725-3c27-e711-80fa-5065f38b5681"},  # Should be 0
-    "Church Road, Colchester": {"llpgid": "30213e07-6027-e711-80fa-5065f38b56d1"},
-    "The Lane, Colchester": {"llpgid": "7cd96a3d-6027-e711-80fa-5065f38b56d1"},
+    "Church Road, Colchester (llpgid)": {
+        "llpgid": "30213e07-6027-e711-80fa-5065f38b56d1"
+    },
+    "The Lane, Colchester (llpgid)": {"llpgid": "7cd96a3d-6027-e711-80fa-5065f38b56d1"},
+    "16 The Lane, CO5 8NT": {"postcode": "CO5 8NT", "house": "16"},
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "postcode": "Postcode",
+        "house": "House number or name",
+        "llpgid": "LLPG ID",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "postcode": "UK postcode for the address, e.g. 'CO5 8NT'.",
+        "house": "House number or name as shown in the council's address picker, e.g. '16' or 'The Old Forge'.",
+        "llpgid": "(Advanced) Direct LLPG GUID taken from the recycling calendar URL. Provide this OR postcode + house.",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Enter your UK postcode and the house number or name as it appears in the "
+        "Colchester recycling calendar address picker at "
+        "https://www.colchester.gov.uk/your-recycling-calendar/. "
+        "Advanced users may instead supply 'llpgid' (the GUID from the calendar URL "
+        "after selecting an address)."
+    ),
 }
 
 # Colchester's API still emits "Paper/card" for the combined mixed-recycling
@@ -29,18 +64,48 @@ ICON_MAP = {
     "Food waste": Icons.BIO_KITCHEN,
 }
 
+CALENDAR_API = "https://new-llpg-app.azurewebsites.net/api/calendar/{llpgid}"
+ADDRESS_API = "https://www.colchester.gov.uk/_api/new_llpgs"
+
+
+def _normalise_postcode(postcode: str) -> str:
+    # The address API matches on the postcode in "OUTWARD INWARD" form (single
+    # space before the last three characters). Any other spacing returns no
+    # results, even though the picker on the website tolerates it.
+    compact = "".join(str(postcode).split()).upper()
+    if len(compact) < 4:
+        return compact
+    return f"{compact[:-3]} {compact[-3:]}"
+
 
 class Source:
-    def __init__(self, llpgid):
-        self._llpgid = llpgid
+    def __init__(
+        self,
+        llpgid: Optional[str] = None,
+        postcode: Optional[str] = None,
+        house: Optional[str] = None,
+    ):
+        if llpgid:
+            self._llpgid: Optional[str] = llpgid
+            self._postcode: Optional[str] = None
+            self._house: Optional[str] = None
+        elif postcode and house is not None and str(house).strip():
+            self._llpgid = None
+            self._postcode = _normalise_postcode(postcode)
+            self._house = str(house).strip()
+        else:
+            raise SourceArgumentRequired(
+                "postcode/house",
+                "Provide either 'llpgid', or both 'postcode' and 'house'.",
+            )
 
     def fetch(self):
-        # get json file
-        r = requests.get(
-            f"https://new-llpg-app.azurewebsites.net/api/calendar/{self._llpgid}"
-        )
+        if self._llpgid is None:
+            # Resolve once and cache so subsequent polls only hit the calendar API.
+            self._llpgid = self._resolve_llpgid()
 
-        # extract data from json
+        r = requests.get(CALENDAR_API.format(llpgid=self._llpgid))
+        r.raise_for_status()
         data = json.loads(r.text)
 
         entries = []
@@ -87,3 +152,55 @@ class Source:
                         pass  # ignore date conversion failure for not scheduled collections
 
         return entries
+
+    def _resolve_llpgid(self) -> str:
+        assert self._postcode is not None and self._house is not None
+        r = requests.get(
+            ADDRESS_API,
+            params={
+                "$select": "new_llpgid,new_paon,new_street,new_postcoide,new_name",
+                "$filter": f"(new_postcoide eq '{self._postcode}')",
+            },
+            headers={"Accept": "application/json"},
+            timeout=30,
+        )
+        r.raise_for_status()
+        addresses = r.json().get("value", [])
+        if not addresses:
+            raise SourceArgumentNotFound("postcode", self._postcode)
+
+        target = self._house.casefold()
+
+        exact = [
+            a
+            for a in addresses
+            if (a.get("new_paon") or "").strip().casefold() == target
+        ]
+        if len(exact) == 1:
+            return exact[0]["new_llpgid"]
+        if len(exact) > 1:
+            raise SourceArgAmbiguousWithSuggestions(
+                "house",
+                self._house,
+                sorted({(a.get("new_name") or "").strip() for a in exact}),
+            )
+
+        substr = [
+            a
+            for a in addresses
+            if target in (a.get("new_paon") or "").casefold()
+            or target in (a.get("new_name") or "").casefold()
+        ]
+        if len(substr) == 1:
+            return substr[0]["new_llpgid"]
+        if len(substr) > 1:
+            raise SourceArgAmbiguousWithSuggestions(
+                "house",
+                self._house,
+                sorted({(a.get("new_name") or "").strip() for a in substr}),
+            )
+
+        suggestions = sorted(
+            {(a.get("new_name") or "").strip() for a in addresses if a.get("new_name")}
+        )
+        raise SourceArgumentNotFoundWithSuggestions("house", self._house, suggestions)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
@@ -7,6 +7,7 @@ from waste_collection_schedule import Collection, Icons  # type: ignore[attr-def
 TITLE = "Colchester City Council"
 DESCRIPTION = "Source for Colchester.gov.uk services for the borough of Colchester, UK."
 URL = "https://colchester.gov.uk"
+COUNTRY = "uk"
 TEST_CASES = {
     # "High Street, Colchester": {"llpgid": "1197e725-3c27-e711-80fa-5065f38b5681"},  # Should be 0
     "Church Road, Colchester": {"llpgid": "30213e07-6027-e711-80fa-5065f38b56d1"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/colchester_gov_uk.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -6,9 +5,9 @@ import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgAmbiguousWithSuggestions,
+    SourceArgumentExceptionMultiple,
     SourceArgumentNotFound,
     SourceArgumentNotFoundWithSuggestions,
-    SourceArgumentRequired,
 )
 
 TITLE = "Colchester City Council"
@@ -94,8 +93,8 @@ class Source:
             self._postcode = _normalise_postcode(postcode)
             self._house = str(house).strip()
         else:
-            raise SourceArgumentRequired(
-                "postcode/house",
+            raise SourceArgumentExceptionMultiple(
+                ["postcode", "house"],
                 "Provide either 'llpgid', or both 'postcode' and 'house'.",
             )
 
@@ -104,9 +103,9 @@ class Source:
             # Resolve once and cache so subsequent polls only hit the calendar API.
             self._llpgid = self._resolve_llpgid()
 
-        r = requests.get(CALENDAR_API.format(llpgid=self._llpgid))
+        r = requests.get(CALENDAR_API.format(llpgid=self._llpgid), timeout=30)
         r.raise_for_status()
-        data = json.loads(r.text)
+        data = r.json()
 
         entries = []
 
@@ -175,6 +174,7 @@ class Source:
             a
             for a in addresses
             if (a.get("new_paon") or "").strip().casefold() == target
+            or (a.get("new_name") or "").strip().casefold() == target
         ]
         if len(exact) == 1:
             return exact[0]["new_llpgid"]

--- a/doc/source/colchester_gov_uk.md
+++ b/doc/source/colchester_gov_uk.md
@@ -4,24 +4,55 @@ Support for schedules provided by [Colchester Council](https://www.colchester.go
 
 ## Configuration via configuration.yaml
 
+The recommended setup uses your postcode and house number/name:
+
 ```yaml
 waste_collection_schedule:
     sources:
     - name: colchester_gov_uk
       args:
-        llpgid: LLPDID_CODE
+        postcode: POSTCODE
+        house: HOUSE_NUMBER_OR_NAME
+```
+
+Advanced users may instead provide the LLPG ID directly:
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: colchester_gov_uk
+      args:
+        llpgid: LLPGID_CODE
 ```
 
 ### Configuration Variables
 
+**postcode**  
+*(string) (required when llpgid is not set)*  
+UK postcode for the address, e.g. `CO5 8NT`. Whitespace and case are normalised.
+
+**house**  
+*(string) (required when llpgid is not set)*  
+House number or name as it appears in the council's address picker, e.g. `16` or `The Old Forge`. Matched case-insensitively, falling back to a substring match when no exact match is found.
+
 **llpgid**  
-*(string) (required)*
+*(string) (advanced, optional)*  
+LLPG GUID for the address. Provide this OR `postcode` + `house`. The LLPG ID can be found in the URL after entering your postcode and selecting your address on the [Colchester Your recycling calendar page](https://www.colchester.gov.uk/your-recycling-calendar/). The URL in your browser URL bar should look like `https://www.colchester.gov.uk/your-recycling-calendar/?start=true&step=1&llpgid=1197e725-3c27-e711-80fa-5065f38b5681`.
 
-#### How to find your `llpgid` code
+## Examples
 
-The LLPDID code can be found in the URL after entering your postcode and selecting your address on the [Colchester Your recycling calendar page](https://www.colchester.gov.uk/your-recycling-calendar/). The URL in your browser URL bar should look like `https://www.colchester.gov.uk/your-recycling-calendar/?start=true&step=1&llpgid=1197e725-3c27-e711-80fa-5065f38b5681`.
+Using postcode and house:
 
-## Example
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: colchester_gov_uk
+      args:
+        postcode: "CO5 8NT"
+        house: "16"
+```
+
+Using LLPG ID:
 
 ```yaml
 waste_collection_schedule:


### PR DESCRIPTION
## Summary

  Lets users set up the Colchester source with their postcode and house number/name
  instead of having to navigate the council site and copy a GUID. The existing
  `llpgid` argument continues to work unchanged — existing configs are untouched.

  The recycling calendar page already chains two anonymous endpoints:
  postcode -> address list (Dynamics 365 portal OData at `/_api/new_llpgs`) and
  then llpgid -> calendar. This PR teaches the source module to walk that chain
  itself when the user provides `postcode` + `house` instead of `llpgid`. The
  resolved llpgid is cached on the `Source` instance so subsequent polls still
  only hit the calendar endpoint.

  Also adds the missing `COUNTRY = "uk"` field as a separate prerequisite commit.

  ## Commits

  - `Add COUNTRY field to colchester_gov_uk source` — single-line prerequisite,
    avoids relying on the `*_gov_uk` filename fallback in `update_docu_links.py`.
  - `Add postcode/house lookup to colchester_gov_uk` — the feature.