### PR TITLE
Add Mid Suffolk District Council source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
@@ -4,7 +4,6 @@ import time
 
 import requests
 from bs4 import BeautifulSoup
-
 from waste_collection_schedule import Collection
 from waste_collection_schedule.exceptions import SourceArgumentExceptionMultiple
 
@@ -45,14 +44,14 @@ PARAM_DESCRIPTIONS = {
 }
 
 _BASE_URL = "https://www.midsuffolk.gov.uk/check-your-collection-day"
-_PORTLET  = "_com_placecube_digitalplace_local_waste_portlet_CollectionDayFinderPortlet_"
+_PORTLET = "_com_placecube_digitalplace_local_waste_portlet_CollectionDayFinderPortlet_"
 
 ICON_MAP = {
-    "refuse":    "mdi:trash-can",
+    "refuse": "mdi:trash-can",
     "recycling": "mdi:recycle",
-    "paper":     "mdi:newspaper",
-    "food":      "mdi:food-apple",
-    "garden":    "mdi:leaf",
+    "paper": "mdi:newspaper",
+    "food": "mdi:food-apple",
+    "garden": "mdi:leaf",
 }
 
 
@@ -84,9 +83,9 @@ class Source:
 
         # Form data fields
         data = {
-            _PORTLET + "formDate":    str(int(time.time() * 1000)),
-            _PORTLET + "postcode":    self._postcode,
-            _PORTLET + "uprn":        self._uprn,
+            _PORTLET + "formDate": str(int(time.time() * 1000)),
+            _PORTLET + "postcode": self._postcode,
+            _PORTLET + "uprn": self._uprn,
             _PORTLET + "fullAddress": "",
         }
 
@@ -107,7 +106,7 @@ class Source:
                 continue
 
             waste_type = cells[0].get_text(strip=True)
-            date_text  = cells[1].get_text(strip=True)
+            date_text = cells[1].get_text(strip=True)
 
             if not waste_type or not date_text:
                 continue
@@ -133,8 +132,8 @@ class Source:
 
 
 _DATE_FORMATS = (
-    "%A %d %B %Y",   # Thursday 04 Jun 2026 — note: need %b not %B for abbrev
-    "%A %d %b %Y",   # Thursday 04 Jun 2026
+    "%A %d %B %Y",   # Thursday 04 June 2026 (full month name)
+    "%A %d %b %Y",   # Thursday 04 Jun 2026 (abbreviated month name)
     "%d %B %Y",
     "%d %b %Y",
     "%d/%m/%Y",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
@@ -1,0 +1,154 @@
+import datetime
+import re
+import time
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "Mid Suffolk District Council"
+DESCRIPTION = "Source for Mid Suffolk District Council waste collection."
+URL = "https://www.midsuffolk.gov.uk"
+TEST_CASES = {
+    "1 School Meadow Stowmarket": {
+        "postcode": "IP14 2SA",
+        "uprn": "10012168792",
+    },
+    "2 School Meadow Stowmarket": {
+        "postcode": "IP14 2SA",
+        "uprn": "10012168793",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "You need your postcode and UPRN. To find your UPRN, visit "
+        "https://www.findmyaddress.co.uk or https://uprn.uk and search "
+        "for your address. The UPRN is a unique number identifying your property."
+    )
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "postcode": "Postcode",
+        "uprn": "UPRN (Unique Property Reference Number)",
+    }
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "postcode": "Your full postcode, e.g. IP14 2SA",
+        "uprn": "Your property's UPRN, e.g. 10012168792. Find it at https://uprn.uk",
+    }
+}
+
+_BASE_URL = "https://www.midsuffolk.gov.uk/check-your-collection-day"
+_PORTLET  = "_com_placecube_digitalplace_local_waste_portlet_CollectionDayFinderPortlet_"
+
+ICON_MAP = {
+    "refuse":    "mdi:trash-can",
+    "recycling": "mdi:recycle",
+    "paper":     "mdi:newspaper",
+    "food":      "mdi:food-apple",
+    "garden":    "mdi:leaf",
+}
+
+
+def _icon(waste_type: str) -> str:
+    t = waste_type.lower()
+    for key, icon in ICON_MAP.items():
+        if key in t:
+            return icon
+    return "mdi:trash-can"
+
+
+class Source:
+    def __init__(self, postcode: str, uprn: str):
+        self._postcode = postcode.strip().lower()
+        self._uprn = str(uprn).strip()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update({"User-Agent": "Mozilla/5.0"})
+
+        # Build the query string exactly as the browser does
+        params = {
+            "p_p_id": "com_placecube_digitalplace_local_waste_portlet_CollectionDayFinderPortlet",
+            "p_p_lifecycle": "0",
+            "p_p_state": "normal",
+            "p_p_mode": "view",
+            _PORTLET + "mvcRenderCommandName": "/collection_day_finder/get_days",
+        }
+
+        # Form data fields
+        data = {
+            _PORTLET + "formDate":    str(int(time.time() * 1000)),
+            _PORTLET + "postcode":    self._postcode,
+            _PORTLET + "uprn":        self._uprn,
+            _PORTLET + "fullAddress": "",
+        }
+
+        response = session.post(_BASE_URL, params=params, data=data, timeout=30)
+        response.raise_for_status()
+
+        return self._parse(response.text)
+
+    def _parse(self, html: str) -> list[Collection]:
+        soup = BeautifulSoup(html, "html.parser")
+        entries: list[Collection] = []
+
+        # The page returns a table with columns:
+        # Collection type | Next collection | Frequency
+        for row in soup.select("table tr"):
+            cells = row.find_all("td")
+            if len(cells) < 2:
+                continue
+
+            waste_type = cells[0].get_text(strip=True)
+            date_text  = cells[1].get_text(strip=True)
+
+            if not waste_type or not date_text:
+                continue
+
+            date = _parse_date(date_text)
+            if date:
+                entries.append(
+                    Collection(
+                        date=date,
+                        t=waste_type,
+                        icon=_icon(waste_type),
+                    )
+                )
+
+        if not entries:
+            raise Exception(
+                "No collection dates found. Check your UPRN and postcode are correct. "
+                f"postcode={self._postcode}, uprn={self._uprn}"
+            )
+
+        return entries
+
+
+_DATE_FORMATS = (
+    "%A %d %B %Y",   # Thursday 04 Jun 2026 — note: need %b not %B for abbrev
+    "%A %d %b %Y",   # Thursday 04 Jun 2026
+    "%d %B %Y",
+    "%d %b %Y",
+    "%d/%m/%Y",
+    "%Y-%m-%d",
+)
+
+
+def _parse_date(text: str) -> datetime.date | None:
+    text = text.strip()
+    # Remove ordinal suffixes: 1st, 2nd, 3rd, 4th etc
+    text = re.sub(r"(\d+)(st|nd|rd|th)", r"\1", text)
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.datetime.strptime(text, fmt).date()
+        except ValueError:
+            pass
+    return None

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
@@ -1,13 +1,12 @@
 import datetime
 import re
 import time
+
 import requests
 from bs4 import BeautifulSoup
+
 from waste_collection_schedule import Collection
-from waste_collection_schedule.exceptions import (
-    SourceArgumentNotFound,
-    SourceArgumentNotFoundWithSuggestions,
-)
+from waste_collection_schedule.exceptions import SourceArgumentExceptionMultiple
 
 TITLE = "Mid Suffolk District Council"
 DESCRIPTION = "Source for Mid Suffolk District Council waste collection."
@@ -17,9 +16,9 @@ TEST_CASES = {
         "postcode": "IP14 2SA",
         "uprn": "10012168792",
     },
-    "1 Laurel Way Claydon": {
-        "postcode": "IP6 0DD",
-        "uprn": "200003809007",
+    "2 School Meadow Stowmarket": {
+        "postcode": "IP14 2SA",
+        "uprn": "10012168793",
     },
 }
 
@@ -124,9 +123,10 @@ class Source:
                 )
 
         if not entries:
-            raise Exception(
+            raise SourceArgumentExceptionMultiple(
+                ["postcode", "uprn"],
                 "No collection dates found. Check your UPRN and postcode are correct. "
-                f"postcode={self._postcode}, uprn={self._uprn}"
+                f"postcode={self._postcode}, uprn={self._uprn}",
             )
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsuffolk_gov_uk.py
@@ -17,9 +17,9 @@ TEST_CASES = {
         "postcode": "IP14 2SA",
         "uprn": "10012168792",
     },
-    "2 School Meadow Stowmarket": {
-        "postcode": "IP14 2SA",
-        "uprn": "10012168793",
+    "1 Laurel Way Claydon": {
+        "postcode": "IP6 0DD",
+        "uprn": "200003809007",
     },
 }
 

--- a/doc/source/midsuffolk_gov_uk.md
+++ b/doc/source/midsuffolk_gov_uk.md
@@ -1,0 +1,55 @@
+# Mid Suffolk District Council
+
+Support for bin collection schedules from [Mid Suffolk District Council](https://www.midsuffolk.gov.uk).
+
+> **Note:** From June 2026, Mid Suffolk moved to a three-weekly collection cycle for refuse, recycling, and paper & card, with a separate weekly food-waste collection.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: midsuffolk_gov_uk
+      args:
+        postcode: "IP14 2SA"
+        uprn: "10012168792"
+```
+
+### Configuration Variables
+
+| Variable | Type | Required | Description |
+|----------|------|----------|-------------|
+| `postcode` | string | **yes** | Your full postcode, e.g. `IP14 2SA` |
+| `uprn` | string | **yes** | Your property's Unique Property Reference Number |
+
+## Finding your UPRN
+
+Visit [https://uprn.uk](https://uprn.uk) or [https://www.findmyaddress.co.uk](https://www.findmyaddress.co.uk) and search for your address. The UPRN is a unique number that identifies your property — for example `10012168792`.
+
+## Examples
+
+### Standard house
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: midsuffolk_gov_uk
+      args:
+        postcode: "IP14 2SA"
+        uprn: "10012168792"
+```
+
+## Collection types returned
+
+| Type | Icon |
+|------|------|
+| Refuse Collection (General Rubbish) | `mdi:trash-can` |
+| Recycling Collection | `mdi:recycle` |
+| Paper & Card Collection | `mdi:newspaper` |
+| Food Waste Collection | `mdi:food-apple` |
+| Garden Waste Collection (Brown Bin) | `mdi:leaf` |
+
+## Notes
+
+- Garden waste is an optional chargeable subscription — if you are not subscribed it will not appear.
+- Bank holiday collection changes are reflected automatically once the council updates their website.


### PR DESCRIPTION
Adds support for Mid Suffolk District Council waste collection.
Closes #3824, closes #4081
The source POSTs directly to the Placecube/Liferay portlet endpoint using the user's postcode and UPRN. Returns collection type and next date for all services (refuse, recycling, food waste, garden waste).
Test cases use addresses in IP14 2SA, Stowmarket