### PR TITLE
fix: updated Bedford UK API endpoint

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bedford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bedford_gov_uk.py
@@ -32,7 +32,7 @@ class Source:
 
         s = requests.Session()
         r = s.get(
-            f"https://bbaz-as-prod-bartecapi.azurewebsites.net/api/bincollections/residential/getbyuprn/{self._uprn}/35",
+            f"https://bbaz-as-prod-bartecapi.azurewebsites.net/api/bincollections/residential/getbyuprn/{self._uprn}",
             headers=HEADERS,
         )
         json_data = json.loads(r.text)["BinCollections"]


### PR DESCRIPTION
Fixes #6520

Bedford Borough Council has changed the endpoint used to retrieve collection data.

The previous endpoint:

/api/bincollections/residential/getbyuprn/<UPRN>/35

Updated endpoint:

/api/bincollections/residential/getbyuprn/<UPRN>

This change updates the provider to use the current endpoint.

Credit to @siandco for identifying the updated endpoint in the issue discussion.

Verification:

<img width="1802" height="534" alt="Screenshot_2026-06-04_00-15-50" src="https://github.com/user-attachments/assets/1dc9f65e-9a0f-45ee-bfca-d3708eb7b459" />

The updated endpoint was tested with a valid <UPRN> and returns the expected collection data.

I also verified the change through the Bedford Borough Council waste collection application, which is currently using the updated endpoint.