### PR TITLE
fix(avfallsapp_se): add Teknik i Väst (Arvika/Eda) provider

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsapp_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/avfallsapp_se.py
@@ -25,6 +25,11 @@ TEST_CASES = {
         "api_key": "!secret avfallsapp_se_api_key",
         "service_provider": "soderkoping",
     },
+    "Teknik i Väst - Arvika/Eda": {
+        "api_key": "!secret avfallsapp_se_teknikivast_api_key",
+        "token": "!secret avfallsapp_se_teknikivast_token",
+        "service_provider": "teknikivast",
+    },
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
@@ -66,6 +71,9 @@ ICON_MAP = {
     "Plast": Icons.PLASTIC_PACKAGING,
     "Tidning": Icons.NEWSPAPER,
     "Deponi": Icons.GENERAL_WASTE,
+    # Teknik i Väst (Arvika/Eda)
+    "Mat- och restavfall": Icons.GENERAL_WASTE,
+    "Papp och plast": Icons.RECYCLING,
 }
 
 SERVICE_PROVIDERS = {
@@ -98,6 +106,14 @@ SERVICE_PROVIDERS = {
         "supports_registration": True,
         "requires_token": False,
         "app_version": "2.1.3",
+    },
+    "teknikivast": {
+        "title": "Teknik i Väst (Arvika/Eda)",
+        "url": "https://teknikivast.se",
+        "api_url": "https://teknikivast.avfallsapp.se/api/nova/v1/",
+        "supports_registration": False,
+        "requires_token": True,
+        "app_version": "1.0.1.0",
     },
 }
 
@@ -366,7 +382,7 @@ class Source:
                     )
                     continue
 
-                icon = ICON_MAP.get(waste_type, "mdi:trash-can")
+                icon = ICON_MAP.get(waste_type, Icons.GENERAL_WASTE)
 
                 if multi_config and address:
                     waste_type = f"{address} {waste_type}"

--- a/doc/source/avfallsapp_se.md
+++ b/doc/source/avfallsapp_se.md
@@ -8,6 +8,7 @@ This is a waste collection schedule integration for the Avfallsapp API. Avfallsa
 - `motala`: Motala
 - `vanersborg`: Vänersborg
 - `upplands-bro`: Upplands-Bro
+- `teknikivast`: Teknik i Väst (Arvika/Eda)
 <!--End of service section-->
 
 ## Current un-supported service providers (Cities)


### PR DESCRIPTION
## Summary

Adds support for Teknik i Väst (serving Arvika and Eda municipalities) to the existing `avfallsapp_se` source.

- New `teknikivast` entry in `SERVICE_PROVIDERS` using `https://teknikivast.avfallsapp.se/api/nova/v1/` with `requires_token: True` (same pattern as Vänersborg)
- Two new waste-type entries in `ICON_MAP` for the types returned by this provider (`Mat- och restavfall`, `Papp och plast`)
- Bug fix: raw `"mdi:trash-can"` fallback string in `fetch()` replaced with `Icons.GENERAL_WASTE` (would fail CI if any unmapped type was encountered)
- `doc/source/avfallsapp_se.md` updated to list the new provider

API endpoint and credentials confirmed live by community member @CiruxiaSWE in issue #6310.

Closes #6310

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` passes (6/6)
- [ ] Live test with valid device ID and bearer token against `teknikivast.avfallsapp.se/api/nova/v1/next-pickup/list`