### PR TITLE
feat(ajl_mbh_de): add source for AJL Abfallwirtschaftsgesellschaft Jerichower Land mbH

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ajl_mbh_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ajl_mbh_de.py
@@ -1,0 +1,198 @@
+import re
+from datetime import date
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "AJL - Abfallwirtschaftsgesellschaft Jerichower Land mbH"
+DESCRIPTION = (
+    "Source for AJL - Abfallwirtschaftsgesellschaft Jerichower Land mbH, Germany."
+)
+URL = "https://www.ajl-mbh.de"
+COUNTRY = "de"
+
+TEST_CASES = {
+    "Biederitz (no street)": {"town": "Biederitz"},
+    "Burg, Fliederweg": {"town": "Burg", "street": "Fliederweg"},
+    "Biederitz by ID": {"town": 98},
+    "Burg by ID with street ID": {"town": 154, "street": 313},
+}
+
+ICON_MAP = {
+    "Gelbe Tonne": Icons.PLASTIC_PACKAGING,
+    "Papier": Icons.PAPER,
+    "Biomüll": Icons.ORGANIC,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Sperrmüll": Icons.BULKY,
+    "Schadstoffmobil": Icons.HAZARDOUS,
+    "Weihnachtsbaum": Icons.CHRISTMAS_TREE,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "town": "Town",
+        "street": "Street (only needed for towns with multiple collection zones)",
+    },
+    "de": {
+        "town": "Ort",
+        "street": "Straße (nur bei Orten mit mehreren Abholbereichen nötig)",
+    },
+}
+
+BASE_URL = "https://www.ajl-mbh.de/abfallkalender/entsorgungstermine"
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
+
+
+def _fetch_towns() -> dict[str, int]:
+    """Return a mapping of town name → town ID from the base page."""
+    r = requests.get(BASE_URL, headers=HEADERS, timeout=30)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    towns: dict[str, int] = {}
+    for a in soup.find_all("a", class_="stadtbutton"):
+        href = a.get("href", "")
+        m = re.search(r"town=(\d+)", href)
+        name = a.get("name", "").strip()
+        if m and name:
+            towns[name] = int(m.group(1))
+    return towns
+
+
+def _fetch_streets(town_id: int, year: int) -> dict[str, int]:
+    """Return a mapping of street name → street ID for the given town."""
+    r = requests.get(
+        BASE_URL,
+        params={"year": year, "town": town_id},
+        headers=HEADERS,
+        timeout=30,
+    )
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    streets: dict[str, int] = {}
+    select = soup.find("select", id="street")
+    if select:
+        for option in select.find_all("option"):
+            val = option.get("value", "")
+            label = option.get_text(strip=True)
+            if val and val != "-1" and label:
+                try:
+                    streets[label] = int(val)
+                except ValueError:
+                    pass
+    return streets
+
+
+class Source:
+    def __init__(
+        self,
+        town: str | int,
+        street: str | int | None = None,
+    ):
+        self._town = town
+        self._street = street
+
+    def fetch(self) -> list[Collection]:
+        today = date.today()
+        year = today.year
+
+        # Resolve town ID
+        if isinstance(self._town, int):
+            town_id = self._town
+        else:
+            towns = _fetch_towns()
+            # Case-insensitive fallback
+            match = towns.get(self._town)
+            if match is None:
+                # Try case-insensitive
+                lower_map = {k.lower(): v for k, v in towns.items()}
+                match = lower_map.get(self._town.lower())
+            if match is None:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "town",
+                    self._town,
+                    list(towns.keys()),
+                )
+            town_id = match
+
+        # Resolve street ID (if provided)
+        street_id: int | None = None
+        if self._street is not None:
+            if isinstance(self._street, int):
+                street_id = self._street
+            else:
+                streets = _fetch_streets(town_id, year)
+                match_s = streets.get(self._street)
+                if match_s is None:
+                    lower_map_s = {k.lower(): v for k, v in streets.items()}
+                    match_s = lower_map_s.get(self._street.lower())
+                if match_s is None:
+                    raise SourceArgumentNotFoundWithSuggestions(
+                        "street",
+                        self._street,
+                        list(streets.keys()),
+                    )
+                street_id = match_s
+
+        # Fetch calendar page
+        params: dict[str, int | str] = {"year": year, "town": town_id}
+        if street_id is not None:
+            params["street"] = street_id
+
+        r = requests.get(BASE_URL, params=params, headers=HEADERS, timeout=30)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        # Extract year from heading (e.g. "Abholtermine 2026 für …")
+        cal_year = year
+        heading = soup.find("h2", class_="ajl-green")
+        if heading:
+            m = re.search(r"(\d{4})", heading.get_text())
+            if m:
+                cal_year = int(m.group(1))
+
+        # Find the calenderview div
+        cal_div = soup.find("div", id="calenderview")
+        if cal_div is None:
+            # Town requires a street selection — no data available at town level
+            streets = _fetch_streets(town_id, year)
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street",
+                str(self._street),
+                list(streets.keys()),
+            )
+
+        entries: list[Collection] = []
+        for cat_div in cal_div.find_all("div", class_="cat"):
+            # The inner div has a class like cat-gelb, cat-papier, etc.
+            inner = cat_div.find("div", class_=re.compile(r"^cat-"))
+            if inner is None:
+                continue
+            h3 = inner.find("h3")
+            if h3 is None:
+                continue
+            waste_type = h3.get_text(strip=True)
+            icon = ICON_MAP.get(waste_type)
+
+            for day_div in inner.find_all("div", class_="dayprint"):
+                text = day_div.get_text(strip=True)
+                # Format: "Mo 19.01." → day=19, month=01
+                dm = re.search(r"(\d{1,2})\.(\d{2})\.", text)
+                if dm:
+                    try:
+                        d = date(cal_year, int(dm.group(2)), int(dm.group(1)))
+                        entries.append(Collection(d, waste_type, icon=icon))
+                    except ValueError:
+                        pass
+
+        return entries

--- a/doc/source/ajl_mbh_de.md
+++ b/doc/source/ajl_mbh_de.md
@@ -1,0 +1,54 @@
+# AJL - Abfallwirtschaftsgesellschaft Jerichower Land mbH
+
+Support for schedules provided by [AJL - Abfallwirtschaftsgesellschaft Jerichower Land mbH](https://www.ajl-mbh.de), serving the Jerichower Land district in Saxony-Anhalt, Germany.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: ajl_mbh_de
+      args:
+        town: TOWN
+        street: STREET  # optional — only required for towns with multiple collection zones
+```
+
+### Configuration Variables
+
+**town**  
+*(String | Integer) (required)*
+
+The name of your town (e.g. `Biederitz`) or its numeric ID as shown in the URL on the collection calendar page.
+
+**street**  
+*(String | Integer) (optional)*
+
+The street name (e.g. `Fliederweg`) or its numeric ID. Only required for larger towns where the collection schedule differs by street. If omitted and the town has multiple collection zones, an error listing the available streets will be raised.
+
+## Example — town without street filter
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: ajl_mbh_de
+      args:
+        town: Biederitz
+```
+
+## Example — town with street filter
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: ajl_mbh_de
+      args:
+        town: Burg
+        street: Fliederweg
+```
+
+## How to get the source arguments
+
+1. Open the [AJL collection calendar](https://www.ajl-mbh.de/abfallkalender/entsorgungstermine).
+2. Click your town from the alphabetical list. The URL will contain `town=<ID>`.
+3. If a street dropdown appears, select your street. The URL will then also contain `street=<ID>`.
+4. Use the town and street names (or numeric IDs) as the `town` and `street` arguments.


### PR DESCRIPTION
## Summary

- Adds a new source for AJL - Abfallwirtschaftsgesellschaft Jerichower Land mbH (https://www.ajl-mbh.de), covering 176 towns in the Jerichower Land district of Saxony-Anhalt, Germany.
- Scrapes the HTML calendar page (`div#calenderview`) which cleanly renders waste types and collection dates.
- Supports town-level data (most small towns) and street-level filtering (larger towns like Burg that have multiple collection zones).
- Resolves town/street by name (with case-insensitive matching and suggestions on error) or directly by numeric ID.

Closes #6225

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 6/6 passed
- [x] `python test_sources.py -s ajl_mbh_de -l` — all 4 TEST_CASES returned entries
- [x] `python -m black` and `python -m isort --profile black` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)