### PR TITLE
fix(tonnenticker_pro_de): casefold matching for ß/ss + fix raw mdi fallback icon

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tonnenticker_pro_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tonnenticker_pro_de.py
@@ -63,7 +63,9 @@ class Source:
 
     def fetch(self) -> list[Collection]:
         orte = requests.get(f"{API_BASE}/orte", timeout=30).json()
-        ort = next((o for o in orte if o["name"].lower() == self._city.lower()), None)
+        ort = next(
+            (o for o in orte if o["name"].casefold() == self._city.casefold()), None
+        )
         if ort is None:
             raise SourceArgumentNotFoundWithSuggestions(
                 "city", self._city, [o["name"] for o in orte]
@@ -73,7 +75,8 @@ class Source:
             f"{API_BASE}/orte/{ort['id']}/strassen", timeout=30
         ).json()
         strasse = next(
-            (s for s in strassen if s["name"].lower() == self._street.lower()), None
+            (s for s in strassen if s["name"].casefold() == self._street.casefold()),
+            None,
         )
         if strasse is None:
             raise SourceArgumentNotFoundWithSuggestions(
@@ -96,7 +99,7 @@ class Source:
             waste_type = fraktion_map.get(fraktion_id, f"Fraktion {fraktion_id}")
             icon = next(
                 (v for k, v in ICON_MAP.items() if k in waste_type.lower()),
-                "mdi:trash-can",
+                Icons.GENERAL_WASTE,
             )
             entries.append(Collection(date=date, t=waste_type, icon=icon))
 


### PR DESCRIPTION
## Summary

- Switch city and street name comparisons from `.lower()` to `.casefold()` so that user input using `ss` (e.g. "Schloss Holte-Stukenbrock") correctly matches API entries using `ß` (e.g. "Schloß Holte-Stukenbrock"). Python's `.casefold()` converts `ß → ss` per Unicode rules; `.lower()` does not.
- Replace the raw `"mdi:trash-can"` fallback icon string in `fetch()` with `Icons.GENERAL_WASTE` to comply with the canonical icons policy.

## Test plan

- [ ] Existing TEST_CASES continue to pass via test_sources.py -s tonnenticker_pro_de -l
- [x] python -m pytest tests/test_source_components.py -q passes
- [ ] Manually verify: city Schloss Holte-Stukenbrock (ss spelling) now resolves against the API's Schloß Holte-Stukenbrock

Closes #6521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)