### PR TITLE
fix(innerwest_nsw_gov_au): preserve weekday when recurring start_date is past

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
@@ -127,9 +127,11 @@ class Source:
                 if "start_date" not in item:
                     continue
                 collection_date = date.fromisoformat(item["start_date"])
-                # Ensure we start from today or later
-                if collection_date < today:
-                    collection_date = today
+                # Advance weekly until we reach today or later, preserving the
+                # correct day-of-week (simple clamping to today would shift the
+                # weekday and produce wrong dates).
+                while collection_date < today:
+                    collection_date += timedelta(7)
                 while collection_date <= nextmonth:
                     entries.append(
                         Collection(


### PR DESCRIPTION
## Summary

- The waste-info API returns organic collections as a single recurring entry with a `start_date` that may be earlier than today.
- The previous fix (#1284) clamped `collection_date = today` when `start_date < today`, which shifted the collection onto the wrong weekday and caused it to appear every day.
- Replace the one-line clamp with a `while collection_date < today: collection_date += timedelta(7)` loop, advancing by full 7-day steps to preserve the original day-of-week.

Fixes #1361
Reported by @nosaj-au in a comment on the closed issue.

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` — 6 passed
- [x] `python test_sources.py -s innerwest_nsw_gov_au -l` — all three test cases return dates on the correct weekday across the 30-day window

🤖 Generated with [Claude Code](https://claude.com/claude-code)