### PR TITLE
fix(abfallnavi_de): add Porta Westfalica to SERVICE_DOMAINS

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -159,6 +159,11 @@ SERVICE_DOMAINS = [
         "url": "https://www.kranenburg.de/",
         "service_id": "kranenburg",
     },
+    {
+        "title": "Stadt Porta Westfalica",
+        "url": "https://www.portawestfalica.de/",
+        "service_id": "portawestfalica",
+    },
 ]
 
 DEFAULT_TIMEOUT = 20


### PR DESCRIPTION
## Summary

- Adds `Stadt Porta Westfalica` (`service_id: portawestfalica`) to the AbfallNavi SERVICE_DOMAINS list.
- The city's "Abfall-Navi" page at https://www.portawestfalica.de/rathaus/verwaltung/baubetriebshof/abfall/abfall-navi/ embeds an iframe pointing to `https://abfallnavi.de/portawestfalica/`, confirming it runs on the regioit.de AbfallNavi platform.
- API verified: `https://portawestfalica-abfallapp.regioit.de/abfall-app-portawestfalica/rest/orte` returns `[{"id":927793,"name":"Porta Westfalica"}]`.

Closes #3168

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] Manual test: `service=portawestfalica`, `ort=Porta Westfalica`, `strasse=Portastraße` returns collection entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)