### PR TITLE
fix(abfall_io): add AWG Abfallwirtschaft Landkreis Calw

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -162,4 +162,9 @@ SERVICE_MAP = [
         "url": "https://www.avr-kommunal.de/",
         "service_id": "914fb9d000a9a05af4fd54cfba478860",
     },
+    {
+        "title": "AWG Abfallwirtschaft Landkreis Calw",
+        "url": "https://www.awg-info.de/",
+        "service_id": "0813ea99f520c462373386564a99a51e",
+    },
 ]


### PR DESCRIPTION
## Summary

- Adds AWG Abfallwirtschaft Landkreis Calw GmbH to the `abfall_io` shared platform service map
- Covers Neuweiler and other municipalities in Landkreis Calw served by awg-info.de
- Service key: `0813ea99f520c462373386564a99a51e` (distinct from the existing "Landkreis Calw" / kreis-calw.de entry)

Closes #3220

## Test plan

- [ ] Configure `abfall_io` source with `key: 0813ea99f520c462373386564a99a51e` and select Neuweiler via the wizard
- [ ] Verify collection dates are returned for the current year
- [ ] Confirm "AWG Abfallwirtschaft Landkreis Calw" appears in the source picker UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)