### PR TITLE
fix(abfall_io_graphql): add Holding Graz (Austria) to service map

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -1,7 +1,13 @@
 SERVICE_MAP = [
     {
-        "title": "Landkreis M\u00e4rkisch-Oderland",
+        "title": "Landkreis Märkisch-Oderland",
         "url": "https://www.maerkisch-oderland.de/",
         "service_id": "efb75cbd1f08fae1d4e47ae72a85c655",
+    },
+    {
+        "title": "Holding Graz",
+        "url": "https://www.holding-graz.at/",
+        "service_id": "1c230a689579b6d3ddb9ceb5a56c6072",
+        "country": "at",
     },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -31,14 +31,17 @@ query Query($idHouseNumber: ID!, $wasteTypes: [ID], $dateMin: Date, $dateMax: Da
 
 
 def EXTRA_INFO():
-    return [
-        {
+    result = []
+    for s in SERVICE_MAP:
+        entry = {
             "title": s["title"],
             "url": s["url"],
             "default_params": {"key": s["service_id"]},
         }
-        for s in SERVICE_MAP
-    ]
+        if "country" in s:
+            entry["country"] = s["country"]
+        result.append(entry)
+    return result
 
 
 TEST_CASES = {
@@ -49,6 +52,10 @@ TEST_CASES = {
     "Strausberg": {
         "key": "efb75cbd1f08fae1d4e47ae72a85c655",
         "idHouseNumber": 5985,
+    },
+    "Graz (Rudersdorfer Straße 60)": {
+        "key": "1c230a689579b6d3ddb9ceb5a56c6072",
+        "idHouseNumber": 31972,
     },
 }
 


### PR DESCRIPTION
## Summary

- Adds **Holding Graz** (https://www.holding-graz.at/) to the `abfall_io_graphql` source via the existing abfall.io v3 GraphQL platform
- Service key: `1c230a689579b6d3ddb9ceb5a56c6072` (found in the `<abfallplus-publisher>` widget on the calendar page)
- Updates `EXTRA_INFO` builder to propagate the `country` field from the service map, so Graz appears correctly as `"at"` rather than inheriting the module-level `"de"`
- Adds a test case for Rudersdorfer Straße 60, Graz (`idHouseNumber: 31972`)

Closes #5618

## Test plan

- [ ] `python test_sources.py -s abfall_io_graphql -l` passes with the new Graz test case
- [ ] `python -m pytest tests/test_source_components.py -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)