### PR TITLE
fix(awido_de): add Gotha test cases for new OT city naming format

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
@@ -454,6 +454,16 @@ TEST_CASES = {
         "street": "Karwendelweg",
     },
     "Gießen": {"customer": "lkgi", "city": "Langgöns", "street": "Hauptstraße"},
+    "Gotha, Ahornweg": {
+        "customer": "gotha",
+        "city": "Gotha",
+        "street": "Ahornweg",
+    },
+    "Gotha, Drei Gleichen OT Günthersleben, Mittelstr": {
+        "customer": "gotha",
+        "city": "Drei Gleichen OT Günthersleben",
+        "street": "Mittelstr",
+    },
 }
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

- Landkreis Gotha changed their AWIDO city names from short form (e.g. `Günthersleben`) to compound OT form (e.g. `Drei Gleichen OT Günthersleben`) as of 2025-01-01.
- The `awido_de` source code already handles this correctly via live API lookup and `SourceArgumentNotFoundWithSuggestions`.
- This PR adds two working Gotha `TEST_CASES` to validate coverage of the new naming format.

## Test plan
- [ ] `python -m pytest tests/test_source_components.py -q` — passes
- [ ] `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s awido_de -l` — Gotha cases return results

Fixes #5116

🤖 Generated with [Claude Code](https://claude.com/claude-code)