### PR TITLE
fix(source): handle null firstDate in bracknell_forest_gov_uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
@@ -84,7 +84,7 @@ class Source:
             try:
                 coll_day = parser.parse(collection_entry["firstDate"]["date"]).date()
             except (KeyError, TypeError):
-                # Záchyt KeyError pre chýbajúce kľúče a TypeError pre null/None hodnoty
+                # KeyError for missing keys, TypeError for null/None firstDate
                 continue
             entries.append(
                 Collection(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bracknell_forest_gov_uk.py
@@ -83,7 +83,8 @@ class Source:
         for collection_entry in collections:
             try:
                 coll_day = parser.parse(collection_entry["firstDate"]["date"]).date()
-            except KeyError:
+            except (KeyError, TypeError):
+                # Záchyt KeyError pre chýbajúce kľúče a TypeError pre null/None hodnoty
                 continue
             entries.append(
                 Collection(


### PR DESCRIPTION

## Summary

Fixes a `TypeError: 'NoneType' object is not subscriptable` crash that occurs when the API returns `null` for `firstDate` (e.g., for off-season waste types). Added `TypeError` to the exception handling to safely skip these entries.

Fixes #6568

## Type of change

- [ ] New source
- [x ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x ] `python -m pytest tests/test_source_components.py -q` passes
- [ x] `python -m black` and `python -m isort --profile black` run on changed source files
- [x ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [x ] TEST_CASES use real, publicly accessible addresses (not my own)
