### PR TITLE
Docs update for Norfolk councils (UK) and Dartford Council (UK)

### DIFF
--- a/doc/source/breckland_gov_uk.md
+++ b/doc/source/breckland_gov_uk.md
@@ -1,6 +1,6 @@
 # Breckland Council
 
-Support for schedules provided by [Breckland Council](https://www.breckland.gov.uk/mybreckland), serving the district of Breckland, UK.
+Support for schedules provided by [Breckland Council](https://www.breckland.gov.uk/mybreckland), serving the district of Breckland, in Norfolk, UK.
 
 ## Local Government Reorganisation note
 During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk council are not expected to be live until at least April 2028, when the council itself officially comes into being.

--- a/doc/source/breckland_gov_uk.md
+++ b/doc/source/breckland_gov_uk.md
@@ -1,6 +1,9 @@
 # Breckland Council
 
-Support for schedules provided by [Breckland Council](https://www.breckland.gov.uk/mybreckland)
+Support for schedules provided by [Breckland Council](https://www.breckland.gov.uk/mybreckland), serving the district of Breckland, UK.
+
+## Local Government Reorganisation note
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk council are not expected to be live until at least April 2028, when the council itself officially comes into being.
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/dartford_gov_uk.md
+++ b/doc/source/dartford_gov_uk.md
@@ -1,6 +1,6 @@
-# North Norfolk District Council
+# Dartford Borough Council
 
-Support for schedules provided by [Dartford Borough Council](https://www.dartford.gov.uk/waste-recycling/collection-day), serving Darford, UK.
+Support for schedules provided by [Dartford Borough Council](https://www.dartford.gov.uk/waste-recycling/collection-day), serving Dartford, UK.
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/great_yarmouth_gov_uk.md
+++ b/doc/source/great_yarmouth_gov_uk.md
@@ -3,7 +3,7 @@
 Support for schedules provided by [Great Yarmouth Borough Council](https://myaccount.great-yarmouth.gov.uk), serving the Borough of Great Yarmouth, Norfolk, UK.
 
 ## Local Government Reorganisation note
-During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new East Norfolk council are not expected to be live until at least April 2028, when the council itself officially comes into being.
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/great_yarmouth_gov_uk.md
+++ b/doc/source/great_yarmouth_gov_uk.md
@@ -2,6 +2,9 @@
 
 Support for schedules provided by [Great Yarmouth Borough Council](https://myaccount.great-yarmouth.gov.uk), serving the Borough of Great Yarmouth, Norfolk, UK.
 
+## Local Government Reorganisation note
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+
 ## Configuration via configuration.yaml
 
 ```yaml

--- a/doc/source/north_norfolk_gov_uk.md
+++ b/doc/source/north_norfolk_gov_uk.md
@@ -2,6 +2,9 @@
 
 Support for schedules provided by [North Norfolk District Council](https://forms.north-norfolk.gov.uk/xforms/Address/Show/CollectionAddress), serving North Norfolk, UK.
 
+## Local Government Reorganisation note
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+
 ## Configuration via configuration.yaml
 
 ```yaml

--- a/doc/source/north_norfolk_gov_uk.md
+++ b/doc/source/north_norfolk_gov_uk.md
@@ -3,7 +3,7 @@
 Support for schedules provided by [North Norfolk District Council](https://forms.north-norfolk.gov.uk/xforms/Address/Show/CollectionAddress), serving North Norfolk, UK.
 
 ## Local Government Reorganisation note
-During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new East Norfolk council are not expected to be live until at least April 2028, when the council itself officially comes into being.
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/norwich_gov_uk.md
+++ b/doc/source/norwich_gov_uk.md
@@ -3,7 +3,7 @@
 Support for the next collection day provided by [Norwich City Council](https://www.norwich.gov.uk/bins-and-recycling), serving Norwich, UK.
 
 ## Local Government Reorganisation note
-During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new Greater Norwich council are not expected to be live until at least April 2028, when the council itself officially comes into being.
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/norwich_gov_uk.md
+++ b/doc/source/norwich_gov_uk.md
@@ -2,6 +2,9 @@
 
 Support for the next collection day provided by [Norwich City Council](https://www.norwich.gov.uk/bins-and-recycling), serving Norwich, UK.
 
+## Local Government Reorganisation note
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+
 ## Configuration via configuration.yaml
 
 ```yaml

--- a/doc/source/norwich_gov_uk.md
+++ b/doc/source/norwich_gov_uk.md
@@ -1,6 +1,6 @@
 # Norwich City Council
 
-Support for the next collection day provided by [Norwich City Council](https://www.norwich.gov.uk/bins-and-recycling), serving Norwich, UK.
+Support for the next collection day provided by [Norwich City Council](https://www.norwich.gov.uk/bins-and-recycling), serving Norwich, Norfolk, UK.
 
 ## Local Government Reorganisation note
 During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new Greater Norwich council are not expected to be live until at least April 2028, when the council itself officially comes into being.

--- a/doc/source/south_norfolk_and_broadland_gov_uk.md
+++ b/doc/source/south_norfolk_and_broadland_gov_uk.md
@@ -1,6 +1,16 @@
-# South Norfolk and Broadland Council
+# South Norfolk Council and Broadland District Council
 
-Support for schedules provided by [South Norfolk and Broadland Council](https://www.southnorfolkandbroadland.gov.uk/rubbish/find-bin-collection-day) (the joint operations of South Norfolk Council and Broadland District Council).
+Support for schedules provided by [South Norfolk and Broadland District Councils](https://www.southnorfolkandbroadland.gov.uk/rubbish/find-bin-collection-day) (the joint operations of South Norfolk Council and Broadland District Council).
+
+## Local Government Reorganisation note
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+
+## Bin calendar information
+This source uses different methods to fetch information for areas in the two districts, and as a result gives different levels of detail:
+
+For addresses in Broadland, this source only fetches the next collection day for each type of bin, as that is all the information provided by the councils' website.
+
+For addresses in South Norfolk, this source fetches a full list of future collection days, as the councils' website provides access to a full dynamic calendar for future collections.
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/west_norfolk_gov_uk.md
+++ b/doc/source/west_norfolk_gov_uk.md
@@ -1,6 +1,9 @@
 # Borough Council of King's Lynn & West Norfolk
 
-Support for schedules provided by [Borough Council of King's Lynn & West Norfolk](https://www.west-norfolk.gov.uk), serving Borough Council of King's Lynn & West Norfolk, UK.
+Support for schedules provided by [Borough Council of King's Lynn & West Norfolk](https://www.west-norfolk.gov.uk), serving the Borough of King's Lynn & West Norfolk, UK.
+
+## Local Government Reorganisation note
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
 
 ## Configuration via configuration.yaml
 

--- a/doc/source/west_norfolk_gov_uk.md
+++ b/doc/source/west_norfolk_gov_uk.md
@@ -3,7 +3,7 @@
 Support for schedules provided by [Borough Council of King's Lynn & West Norfolk](https://www.west-norfolk.gov.uk), serving the Borough of King's Lynn & West Norfolk, UK.
 
 ## Local Government Reorganisation note
-During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk, Greater Norwich, and East Norfolk councils are not expected to be live until at least April 2028, when the councils themselves officially come into being.
+During the ongoing local government reorganisation (LGR) in Norfolk, please continue to use the source for your current area as long as it's still working. New sources for the new West Norfolk council are not expected to be live until at least April 2028, when the council itself officially comes into being.
 
 ## Configuration via configuration.yaml
 


### PR DESCRIPTION
## Summary

Update the documentation for councils in Norfolk, UK; also fix a documentation error for Dartford Council.

### `dartford_gov_uk.md`
Fix the heading on this. Documentation accidentally referenced North Norfolk

### {`great_yarmouth`, `north_norfolk`, `norwich`, and `west_norfolk`} `_gov_uk.md`
Add a note about local government reorganisation and continuing to use the current sources until new sources are available.
This is not a current problem in the INTEGRATION, but there are already people in real life confused as to whether their council has changed, and this will only become more of a problem over the next 2 years. It is best to have this documentation ready to point people towards.
I also made minor wording adjustments to the geographic text at the top of the source files. Current wording was occasionally conflating council and geographic terminology.

### `south_norfolk_and_broadland_gov_uk.md`
Same as with the other Norfolk councils above. In addition, clarified the difference in data level between Broadland and South Norfolk addresses, both for the information of users and for maintainers who may not be familiar with the local context.

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Checklist

[Not applicable - docs only update]
