### PR TITLE
Add support for Geovest source in IT

### DIFF
--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -831,6 +831,11 @@
     },
     "urls": {}
   },
+  "dienten_gv_at": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/dienten_gv_at.md",
+    "howto": {},
+    "urls": {}
+  },
   "bad_eisenkappel_info": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/bad_eisenkappel_info.md",
     "howto": {},
@@ -880,6 +885,11 @@
   },
   "hausmannstaetten_gv_at": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/hausmannstaetten_gv_at.md",
+    "howto": {},
+    "urls": {}
+  },
+  "abfall_io_graphql": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abfall_io_graphql.md",
     "howto": {},
     "urls": {}
   },
@@ -1419,6 +1429,14 @@
       "url_sictom_lons_le_saunier_fr_quand_passe_le_camion_benne_html": "https://sictom-lons-le-saunier.fr/quand-passe-le-camion-benne.html."
     }
   },
+  "sivom_com": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/sivom_com.md",
+    "howto": {
+      "en": "Go to https://www.sivom.com/mesjoursdecollectes/?v=YOUR_COMMUNE to find your commune name and street name.",
+      "fr": "Allez sur https://www.sivom.com/mesjoursdecollectes/?v=VOTRE_COMMUNE pour trouver le nom de votre commune et de votre rue."
+    },
+    "urls": {}
+  },
   "sivom_rivedroite_fr": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/sivom_rivedroite_fr.md",
     "howto": {},
@@ -1489,11 +1507,6 @@
   },
   "abfall_io": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abfall_io.md",
-    "howto": {},
-    "urls": {}
-  },
-  "abfall_io_graphql": {
-    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abfall_io_graphql.md",
     "howto": {},
     "urls": {}
   },
@@ -2598,6 +2611,14 @@
     },
     "urls": {}
   },
+  "rsag_de": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rsag_de.md",
+    "howto": {
+      "de": "Besuchen Sie [https://www.rsag.de/abfallkalender/abfuhrtermine](https://www.rsag.de/abfallkalender/abfuhrtermine) und wählen Sie Ihren Ort und Ihre Straße. Verwenden Sie die genauen Namen wie in der Auswahlliste.",
+      "en": "Visit [https://www.rsag.de/abfallkalender/abfuhrtermine](https://www.rsag.de/abfallkalender/abfuhrtermine) and select your city and street. Use the exact city and street names shown in the form."
+    },
+    "urls": {}
+  },
   "magdeburg_de": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/magdeburg_de.md",
     "howto": {
@@ -3039,6 +3060,14 @@
     "howto": {},
     "urls": {}
   },
+  "comune_digital_it": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/comune_digital_it.md",
+    "howto": {
+      "en": "The city identifier is the subdomain of your municipality's Comune.Digital website. For example, if the website is https://santostefanodicamastra.comune.digital, the city identifier is \"santostefanodicamastra\".",
+      "it": "L'identificatore della città è il sottodominio del sito web Comune.Digital del tuo comune. Ad esempio, se il sito è https://santostefanodicamastra.comune.digital, l'identificatore è \"santostefanodicamastra\"."
+    },
+    "urls": {}
+  },
   "ics_contarina_it": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/ics/contarina_it.md",
     "howto": {
@@ -3050,14 +3079,6 @@
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/ics/ecolan_it.md",
     "howto": {
       "en": "Use the Google Calendar ICS feed URL below. This calendar covers the Lanciano area served by Ecolan.\n"
-    },
-    "urls": {}
-  },
-  "geovest_it": {
-    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/geovest_it.md",
-    "howto": {
-      "en": "Choose your town from the Geovest source menu, then search for your street name. `numbers` is optional and defaults to 1.",
-      "it": "Scegli il tuo comune dal menu di Geovest, poi cerca il tuo nome di strada. `numbers` è opzionale e assume il valore 1."
     },
     "urls": {}
   },
@@ -3331,6 +3352,11 @@
     "howto": {},
     "urls": {}
   },
+  "npdc_govt_nz": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/npdc_govt_nz.md",
+    "howto": {},
+    "urls": {}
+  },
   "poriruacity_govt_nz": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/poriruacity_govt_nz.md",
     "howto": {},
@@ -3414,6 +3440,13 @@
   "remidt_no": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/remidt_no.md",
     "howto": {},
+    "urls": {}
+  },
+  "rfd_no": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/rfd_no.md",
+    "howto": {
+      "en": "Search for your address at rfd.no/avfallshenting. Use the address exactly as shown in the result list, for example 'Grønland 1, Drammen'."
+    },
     "urls": {}
   },
   "sandnes_no": {
@@ -6098,6 +6131,11 @@
   },
   "wyreforestdc_gov_uk": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/wyreforestdc_gov_uk.md",
+    "howto": {},
+    "urls": {}
+  },
+  "abilene_tx_us": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abilene_tx_us.md",
     "howto": {},
     "urls": {}
   },

--- a/custom_components/waste_collection_schedule/source_metadata.json
+++ b/custom_components/waste_collection_schedule/source_metadata.json
@@ -3053,6 +3053,14 @@
     },
     "urls": {}
   },
+  "geovest_it": {
+    "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/geovest_it.md",
+    "howto": {
+      "en": "Choose your town from the Geovest source menu, then search for your street name. `numbers` is optional and defaults to 1.",
+      "it": "Scegli il tuo comune dal menu di Geovest, poi cerca il tuo nome di strada. `numbers` è opzionale e assume il valore 1."
+    },
+    "urls": {}
+  },
   "gruppoveritas_it": {
     "docs_url": "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/gruppoveritas_it.md",
     "howto": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
@@ -1,12 +1,11 @@
 """Source for Geovest, Italy."""
 
 import re
+import uuid
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
 
 import requests
-import uuid
-
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgAmbiguousWithSuggestions,
@@ -62,7 +61,7 @@ EXTRA_INFO = [
     {
         "title": "Sant'Agata Bolognese",
         "default_params": {"town_id": "13"},
-    }
+    },
 ]
 
 TEST_CASES = {
@@ -196,8 +195,12 @@ class Source:
         self._town_id = self._normalize_town_id(town_id)
         self._numbers = str(numbers or "1").strip()
         self._calendar_type_id = str(calendar_type_id).strip()
-        self._device_id = str(device_id).strip() if device_id else self._generate_device_id()
-        self._authorization = str(authorization).strip() if authorization else AUTHORIZATION
+        self._device_id = (
+            str(device_id).strip() if device_id else self._generate_device_id()
+        )
+        self._authorization = (
+            str(authorization).strip() if authorization else AUTHORIZATION
+        )
         try:
             self._days = int(days)
         except (TypeError, ValueError):
@@ -249,7 +252,9 @@ class Source:
             "filter[town_id]": self._town_id,
         }
 
-        response = requests.get(url, params=params, headers=self._get_headers(), timeout=30)
+        response = requests.get(
+            url, params=params, headers=self._get_headers(), timeout=30
+        )
         response.raise_for_status()
 
         data = response.json()
@@ -264,14 +269,18 @@ class Source:
         return addresses
 
     def _choose_address_id(self, addresses: list[dict[str, Any]]) -> int:
-        suggestions = [address.get("label") for address in addresses if address.get("label")]
+        suggestions = [
+            address.get("label") for address in addresses if address.get("label")
+        ]
         if len(addresses) == 1:
             return int(addresses[0]["value"])
 
         normalized_number = self._numbers.strip()
         for address in addresses:
             label = (address.get("label") or "").lower()
-            if normalized_number and re.search(rf"\b{re.escape(normalized_number)}\b", label):
+            if normalized_number and re.search(
+                rf"\b{re.escape(normalized_number)}\b", label
+            ):
                 return int(address["value"])
 
         raise SourceArgAmbiguousWithSuggestions(
@@ -502,6 +511,10 @@ class Source:
             current_date += timedelta(days=7)
 
         return sorted(
-            [collection for collection in collections if collection.date <= end_date_date],
+            [
+                collection
+                for collection in collections
+                if collection.date <= end_date_date
+            ],
             key=lambda item: item.date,
         )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
@@ -1,0 +1,507 @@
+"""Source for Geovest, Italy."""
+
+import re
+from datetime import datetime, timedelta
+from typing import Any, List, Optional
+
+import requests
+import uuid
+
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+)
+
+TITLE = "Geovest"
+DESCRIPTION = "Source for Geovest, Italy."
+URL = "https://geovest.bluemilk.dev"
+COUNTRY = "it"
+
+EXTRA_INFO = [
+    {
+        "title": "Anzola dell'Emilia",
+        "default_params": {"town_id": "7"},
+    },
+    {
+        "title": "Argelato",
+        "default_params": {"town_id": "12"},
+    },
+    {
+        "title": "Calderara di Reno",
+        "default_params": {"town_id": "8"},
+    },
+    {
+        "title": "Castel Maggiore",
+        "default_params": {"town_id": "10"},
+    },
+    {
+        "title": "Crevalcore",
+        "default_params": {"town_id": "2"},
+    },
+    {
+        "title": "Finale Emilia",
+        "default_params": {"town_id": "1"},
+    },
+    {
+        "title": "Nonantola",
+        "default_params": {"town_id": "6"},
+    },
+    {
+        "title": "Ravarino",
+        "default_params": {"town_id": "9"},
+    },
+    {
+        "title": "Sala Bolognese",
+        "default_params": {"town_id": "4"},
+    },
+    {
+        "title": "San Giovanni in Persiceto",
+        "default_params": {"town_id": "5"},
+    },
+    {
+        "title": "Sant'Agata Bolognese",
+        "default_params": {"town_id": "13"},
+    }
+]
+
+TEST_CASES = {
+    "Via Antonio Gramsci 228": {
+        "town_id": "7",
+        "numbers": "228",
+        "address_name": "via antonio gramsci",
+    },
+    "Via Oreste Vancini 3": {
+        "town_id": "7",
+        "numbers": "3",
+        "address_name": "via oreste vancini",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "numbers": "Street Number",
+        "address_name": "Street Name",
+        "calendar_type_id": "Calendar Type",
+        "days": "Days to fetch",
+        "device_id": "Device ID (optional)",
+        "authorization": "Authorization token (optional)",
+    },
+    "de": {
+        "numbers": "Hausnummer",
+        "address_name": "Straßenname",
+        "calendar_type_id": "Kalendertyp",
+        "days": "Tage zum Abrufen",
+        "device_id": "Geräte-ID (optional)",
+        "authorization": "Autorisierungstoken (optional)",
+    },
+    "it": {
+        "numbers": "Numero Civico",
+        "address_name": "Nome Strada",
+        "calendar_type_id": "Tipo di calendario",
+        "days": "Giorni da recuperare",
+        "device_id": "ID dispositivo (opzionale)",
+        "authorization": "Token di autorizzazione (opzionale)",
+    },
+    "fr": {
+        "numbers": "Numéro de rue",
+        "address_name": "Nom de la rue",
+        "calendar_type_id": "Type de calendrier",
+        "days": "Jours à récupérer",
+        "device_id": "ID du dispositif (optionnel)",
+        "authorization": "Jeton d'autorisation (optionnel)",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "numbers": "Street number or house number. Defaults to 1.",
+        "address_name": "Street name or address.",
+        "calendar_type_id": "1 for private addresses, 2 for businesses.",
+        "days": "Number of days ahead to fetch. Defaults to 30.",
+        "device_id": "Optional device identifier. If omitted, a random device id is generated.",
+        "authorization": "Optional Bearer token. Use this if the default token stops working.",
+    },
+    "de": {
+        "numbers": "Hausnummer. Standardmäßig 1.",
+        "address_name": "Straßenname.",
+        "calendar_type_id": "1 für Privathaushalte, 2 für Unternehmen.",
+        "days": "Anzahl der Tage, die abgerufen werden sollen. Standard ist 30.",
+        "device_id": "Optionale Gerätekennung. Wenn sie fehlt, wird eine zufällige Geräte-ID generiert.",
+        "authorization": "Optionales Bearer-Token. Verwenden Sie dies, wenn das Standard-Token nicht mehr funktioniert.",
+    },
+    "it": {
+        "numbers": "Numero civico. Impostato su 1 per default.",
+        "address_name": "Nome della strada.",
+        "calendar_type_id": "1 per privati, 2 per aziende.",
+        "days": "Numero di giorni da recuperare. Il valore predefinito è 30.",
+        "device_id": "Identificatore dispositivo opzionale. Se omesso, viene generato un ID dispositivo casuale.",
+        "authorization": "Token Bearer opzionale. Usalo se il token predefinito smette di funzionare.",
+    },
+    "fr": {
+        "numbers": "Numéro civique. Par défaut 1.",
+        "address_name": "Nom de la rue.",
+        "calendar_type_id": "1 pour privé, 2 pour entreprise.",
+        "days": "Nombre de jours à récupérer. La valeur par défaut est 30.",
+        "device_id": "Identifiant d'appareil optionnel. Si omis, un identifiant aléatoire est généré.",
+        "authorization": "Jeton Bearer optionnel. Utilisez-le si le jeton par défaut cesse de fonctionner.",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Choose your town from the Geovest source menu, then search your street name. `numbers` is optional and defaults to 1 when not provided. A random `device_id` is generated automatically; enter `authorization` only if the default token stops working.",
+    "it": "Scegli il tuo comune dal menu di Geovest, poi cerca il nome della strada. `numbers` è opzionale e assume il valore 1 se non fornito. Un `device_id` casuale viene generato automaticamente; inserisci `authorization` solo se il token predefinito smette di funzionare.",
+}
+
+CONFIG_FLOW_TYPES = {
+    "calendar_type_id": {
+        "type": "SELECT",
+        "values": ["1", "2"],
+        "multiple": False,
+    },
+}
+
+ICON_MAP = {
+    "Verde leggero": Icons.GARDEN,
+    "Verde": Icons.GARDEN,
+    "Organico": Icons.BIO_KITCHEN,
+    "Umido": Icons.BIO_KITCHEN,
+    "Indifferenziato": Icons.GENERAL_WASTE,
+    "Rifiuti indifferenziati": Icons.GENERAL_WASTE,
+    "Carta": Icons.PAPER,
+    "Cartone": Icons.PAPER,
+    "Imballaggi in plastica": Icons.PLASTIC_PACKAGING,
+    "Plastica": Icons.PLASTIC_PACKAGING,
+    "Metalli": Icons.METAL,
+    "Vetro": Icons.GLASS,
+}
+
+AUTHORIZATION = "Bearer MTga45Xm8YAK"
+USER_AGENT = "okhttp/4.9.2"
+CALENDAR_TYPE_ID = "1"
+
+
+class Source:
+    def __init__(
+        self,
+        address_name: str,
+        town_id: str,
+        numbers: Optional[str] = None,
+        calendar_type_id: str = CALENDAR_TYPE_ID,
+        days: int = 30,
+        device_id: Optional[str] = None,
+        authorization: Optional[str] = None,
+    ):
+        self._address_name = address_name.strip()
+        self._town_id = self._normalize_town_id(town_id)
+        self._numbers = str(numbers or "1").strip()
+        self._calendar_type_id = str(calendar_type_id).strip()
+        self._device_id = str(device_id).strip() if device_id else self._generate_device_id()
+        self._authorization = str(authorization).strip() if authorization else AUTHORIZATION
+        try:
+            self._days = int(days)
+        except (TypeError, ValueError):
+            raise SourceArgumentNotFound(
+                "days",
+                days,
+                "Enter a positive number of days to fetch.",
+            )
+        self._calendar_id = None
+
+        if self._calendar_type_id not in {"1", "2"}:
+            raise SourceArgumentNotFound(
+                "calendar_type_id",
+                calendar_type_id,
+                "Use 1 for private addresses or 2 for businesses.",
+            )
+        if self._days < 1:
+            raise SourceArgumentNotFound(
+                "days",
+                days,
+                "Enter a positive number of days to fetch.",
+            )
+
+    def _generate_device_id(self) -> str:
+        return uuid.uuid4().hex[:16]
+
+    def _get_headers(self) -> dict[str, str]:
+        headers = {
+            "user-agent": USER_AGENT,
+        }
+        if self._authorization:
+            headers["authorization"] = self._authorization
+        return headers
+
+    def _get_json_headers(self) -> dict[str, str]:
+        headers = {
+            "user-agent": USER_AGENT,
+            "accept": "application/json",
+            "content-type": "application/json",
+        }
+        if self._authorization:
+            headers["authorization"] = self._authorization
+        return headers
+
+    def _search_addresses(self) -> list[dict[str, Any]]:
+        url = f"{URL}/api/addresses"
+        params = {
+            "filter[name]": self._address_name,
+            "filter[town_id]": self._town_id,
+        }
+
+        response = requests.get(url, params=params, headers=self._get_headers(), timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+        addresses = data.get("addresses") or []
+
+        if not addresses:
+            raise SourceArgumentNotFound(
+                "address_name",
+                self._address_name,
+            )
+
+        return addresses
+
+    def _choose_address_id(self, addresses: list[dict[str, Any]]) -> int:
+        suggestions = [address.get("label") for address in addresses if address.get("label")]
+        if len(addresses) == 1:
+            return int(addresses[0]["value"])
+
+        normalized_number = self._numbers.strip()
+        for address in addresses:
+            label = (address.get("label") or "").lower()
+            if normalized_number and re.search(rf"\b{re.escape(normalized_number)}\b", label):
+                return int(address["value"])
+
+        raise SourceArgAmbiguousWithSuggestions(
+            "address_name",
+            self._address_name,
+            suggestions,
+        )
+
+    def _clear_favourites(self) -> None:
+        url = f"{URL}/api/favourites"
+        response = requests.get(
+            url,
+            params={"device_id": self._device_id},
+            headers=self._get_json_headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        for fav in data.get("favs", []):
+            fav_id = fav.get("key")
+            if fav_id is None:
+                continue
+
+            delete_url = f"{URL}/api/favourites/delete"
+            delete_response = requests.post(
+                delete_url,
+                params={"id": fav_id, "device_id": self._device_id},
+                headers=self._get_json_headers(),
+                data="",
+                timeout=30,
+            )
+            delete_response.raise_for_status()
+
+    def _store_favourite(self, address_id: int) -> dict[str, Any]:
+        url = f"{URL}/api/favourites/store"
+        payload = {
+            "town_id": self._town_id,
+            "address_id": address_id,
+            "calendar_type_id": self._calendar_type_id,
+            "user_id": None,
+            "device_id": self._device_id,
+        }
+
+        response = requests.post(
+            url,
+            json=payload,
+            headers=self._get_json_headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        if data.get("status") != "ok":
+            raise Exception("Unable to create Geovest favourite entry.")
+
+        return data
+
+    def _get_calendar_id_from_favs(self, fav_data: dict[str, Any]) -> int | None:
+        for fav in fav_data.get("favs", []):
+            value = fav.get("value") or {}
+            calendar_id = value.get("calendar_id")
+            if calendar_id is not None:
+                return int(calendar_id)
+        return None
+
+    def _fetch_favourites(self) -> dict[str, Any]:
+        url = f"{URL}/api/favourites"
+        response = requests.get(
+            url,
+            params={"device_id": self._device_id},
+            headers=self._get_json_headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _normalize_town_id(self, town_id: str) -> str:
+        normalized = str(town_id).strip()
+        if "-" in normalized:
+            normalized = normalized.split("-", 1)[0].strip()
+        if not normalized.isdigit():
+            raise SourceArgumentNotFound(
+                "town_id",
+                town_id,
+                "Select the town ID from the dropdown.",
+            )
+        return normalized
+
+    def _get_calendar_id(self) -> int:
+        if self._calendar_id is not None:
+            return self._calendar_id
+
+        addresses = self._search_addresses()
+        address_id = self._choose_address_id(addresses)
+
+        self._clear_favourites()
+        favorite_data = self._store_favourite(address_id)
+
+        calendar_id = self._get_calendar_id_from_favs(favorite_data)
+        if calendar_id is None:
+            favourite_data = self._fetch_favourites()
+            calendar_id = self._get_calendar_id_from_favs(favourite_data)
+
+        if calendar_id is None:
+            raise Exception("Failed to determine Geovest calendar ID.")
+
+        self._calendar_id = calendar_id
+        return calendar_id
+
+    def _resolve_date_from_day_of_month(
+        self,
+        week_start: datetime,
+        day_of_month: int,
+        weekday_code: str,
+        weekday_map: dict[str, int],
+    ) -> Optional[datetime.date]:
+        possible_dates = []
+        for month_offset in (-1, 0, 1):
+            month = week_start.month + month_offset
+            year = week_start.year
+            if month < 1:
+                month += 12
+                year -= 1
+            elif month > 12:
+                month -= 12
+                year += 1
+
+            try:
+                candidate = datetime(year, month, day_of_month)
+            except ValueError:
+                continue
+
+            if abs((candidate - week_start).days) <= 10:
+                possible_dates.append(candidate.date())
+
+        if not possible_dates:
+            # Fallback to weekday-based resolution within the same week
+            weekday_target = weekday_map.get(weekday_code)
+            if weekday_target is None:
+                return None
+            delta_days = (weekday_target - week_start.weekday()) % 7
+            return (week_start + timedelta(days=delta_days)).date()
+
+        if len(possible_dates) == 1:
+            return possible_dates[0]
+
+        weekday_target = weekday_map.get(weekday_code)
+        if weekday_target is not None:
+            for candidate in possible_dates:
+                if candidate.weekday() == weekday_target:
+                    return candidate
+
+        return possible_dates[0]
+
+    def _fetch_week(self, calendar_id: int, date: datetime) -> list[Collection]:
+        date_str = f"{date.year}-{date.month}-{date.day}"
+        url = f"{URL}/api/calendar/{calendar_id}/week/{date_str}"
+
+        response = requests.get(url, headers=self._get_headers(), timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+        wastes = data.get("wastes", {})
+        week_start_raw = data.get("from")
+        if not week_start_raw:
+            return []
+
+        try:
+            week_start = datetime.strptime(week_start_raw.split(" ")[0], "%Y-%m-%d")
+        except ValueError:
+            return []
+
+        collections: list[Collection] = []
+        weekday_map = {
+            "LUN": 0,
+            "MAR": 1,
+            "MER": 2,
+            "GIO": 3,
+            "VEN": 4,
+            "SAB": 5,
+            "DOM": 6,
+        }
+
+        for day_key, day_wastes in wastes.items():
+            if not day_wastes:
+                continue
+
+            parts = day_key.split("_", 1)
+            if len(parts) != 2:
+                continue
+
+            try:
+                day_of_month = int(parts[0])
+            except ValueError:
+                continue
+
+            weekday_code = parts[1]
+            collection_date = self._resolve_date_from_day_of_month(
+                week_start, day_of_month, weekday_code, weekday_map
+            )
+            if collection_date is None:
+                continue
+
+            for waste in day_wastes:
+                waste_type = waste.get("category_name", "")
+                collections.append(
+                    Collection(
+                        date=collection_date,
+                        t=waste_type,
+                        icon=ICON_MAP.get(waste_type, Icons.GENERAL_WASTE),
+                    )
+                )
+
+        return collections
+
+    def fetch(self) -> List[Collection]:
+        calendar_id = self._get_calendar_id()
+
+        today = datetime.now()
+        end_date = today + timedelta(days=self._days)
+        end_date_date = end_date.date()
+
+        collections: list[Collection] = []
+        current_date = today
+        while current_date <= end_date:
+            collections.extend(self._fetch_week(calendar_id, current_date))
+            current_date += timedelta(days=7)
+
+        return sorted(
+            [collection for collection in collections if collection.date <= end_date_date],
+            key=lambda item: item.date,
+        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
@@ -2,7 +2,7 @@
 
 import re
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any, List, Optional
 
 import requests
@@ -335,7 +335,11 @@ class Source:
 
         data = response.json()
         if data.get("status") != "ok":
-            raise Exception("Unable to create Geovest favourite entry.")
+            raise SourceArgumentNotFound(
+                "address_name",
+                self._address_name,
+                "Unable to create a Geovest schedule entry for this address.",
+            )
 
         return data
 
@@ -386,7 +390,11 @@ class Source:
             calendar_id = self._get_calendar_id_from_favs(favourite_data)
 
         if calendar_id is None:
-            raise Exception("Failed to determine Geovest calendar ID.")
+            raise SourceArgumentNotFound(
+                "address_name",
+                self._address_name,
+                "Could not determine a Geovest collection calendar for this address.",
+            )
 
         self._calendar_id = calendar_id
         return calendar_id
@@ -397,7 +405,7 @@ class Source:
         day_of_month: int,
         weekday_code: str,
         weekday_map: dict[str, int],
-    ) -> Optional[datetime.date]:
+    ) -> Optional[date]:
         possible_dates = []
         for month_offset in (-1, 0, 1):
             month = week_start.month + month_offset
@@ -418,7 +426,6 @@ class Source:
                 possible_dates.append(candidate.date())
 
         if not possible_dates:
-            # Fallback to weekday-based resolution within the same week
             weekday_target = weekday_map.get(weekday_code)
             if weekday_target is None:
                 return None

--- a/doc/source/geovest_it.md
+++ b/doc/source/geovest_it.md
@@ -1,0 +1,71 @@
+# Geovest
+
+Support for waste collection schedules provided by [Geovest](https://geovest.bluemilk.dev), Italy.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: geovest_it
+      args:
+        address_name: "via antonio gramsci"
+        calendar_type_id: "1"
+```
+
+### Configuration Variables
+
+**address_name**
+*(string) (required)*
+
+Street name or address.
+
+**numbers**
+*(string) (optional)*
+
+Street number or house number. Defaults to `1` when omitted.
+
+**calendar_type_id**
+*(string) (required)*
+
+Use `1` for private addresses or `2` for businesses.
+
+**days**
+*(integer) (optional)*
+
+Number of days ahead to fetch. Defaults to `30`.
+
+## How to find your address
+
+1. Choose your town from the Geovest source menu.
+2. Search your street name.
+3. Leave `numbers` empty to use the default value `1`, or enter a house number if multiple addresses are returned.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: geovest_it
+      args:
+        address_name: "via oreste vancini"
+        calendar_type_id: "1"
+        days: 30
+```
+
+## Bin types returned
+
+| Provider description | Returned type | Icon |
+|---------------------|---------------|------|
+| Verde leggero | Verde leggero | `Icons.GARDEN` |
+| Verde | Verde | `Icons.GARDEN` |
+| Organico | Organico | `Icons.BIO_KITCHEN` |
+| Umido | Umido | `Icons.BIO_KITCHEN` |
+| Indifferenziato | Indifferenziato | `Icons.GENERAL_WASTE` |
+| Rifiuti indifferenziati | Rifiuti indifferenziati | `Icons.GENERAL_WASTE` |
+| Carta | Carta | `Icons.PAPER` |
+| Cartone | Cartone | `Icons.PAPER` |
+| Imballaggi in plastica | Imballaggi in plastica | `Icons.PLASTIC_PACKAGING` |
+| Plastica | Plastica | `Icons.PLASTIC_PACKAGING` |
+| Metalli | Metalli | `Icons.METAL` |
+| Vetro | Vetro | `Icons.GLASS` |

--- a/doc/source/geovest_it.md
+++ b/doc/source/geovest_it.md
@@ -9,11 +9,17 @@ waste_collection_schedule:
   sources:
     - name: geovest_it
       args:
+        town_id: "7"
         address_name: "via antonio gramsci"
-        calendar_type_id: "1"
+        numbers: "228"
 ```
 
 ### Configuration Variables
+
+**town_id**
+*(string) (required)*
+
+Identifier of the town. When configuring via the UI, this is set automatically by choosing your town from the source menu. For YAML, use the `town_id` listed for your town (see the Geovest source menu).
 
 **address_name**
 *(string) (required)*
@@ -26,9 +32,9 @@ Street name or address.
 Street number or house number. Defaults to `1` when omitted.
 
 **calendar_type_id**
-*(string) (required)*
+*(string) (optional)*
 
-Use `1` for private addresses or `2` for businesses.
+Use `1` for private addresses or `2` for businesses. Defaults to `1`.
 
 **days**
 *(integer) (optional)*
@@ -48,8 +54,9 @@ waste_collection_schedule:
   sources:
     - name: geovest_it
       args:
+        town_id: "7"
         address_name: "via oreste vancini"
-        calendar_type_id: "1"
+        numbers: "3"
         days: 30
 ```
 


### PR DESCRIPTION
## Summary

Adds support for the Geovest provider in Italy via a new source module geovest.py. The module defines TITLE, DESCRIPTION, URL, COUNTRY, TEST_CASES and a Source class that fetches collection data from Geovest's public schedule endpoint and maps waste types to the canonical Icons enum. Includes test cases in TEST_CASES.
Geovest only provides weekly calendar, therefore it is implemented with a dedicated source.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python -m black` and `python -m isort --profile black` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
