### PR TITLE
Update darlington_gov_uk.py

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darlington_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darlington_gov_uk.py
@@ -48,10 +48,9 @@ class Source:
 
             date_str = date_element.get_text(strip=True).split("(")[0].strip()
             collection_date = datetime.strptime(
-            date_str,
-            "%A %d %B %Y",
+                date_str,
+                "%A %d %B %Y",
             ).date()
-
 
             waste_types = [
                 x.get_text(strip=True) for x in card.select(".collection-result-text")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darlington_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darlington_gov_uk.py
@@ -46,10 +46,12 @@ class Source:
             if not date_element:
                 continue
 
+            date_str = date_element.get_text(strip=True).split("(")[0].strip()
             collection_date = datetime.strptime(
-                date_element.get_text(strip=True),
-                "%A %d %B %Y",
+            date_str,
+            "%A %d %B %Y",
             ).date()
+
 
             waste_types = [
                 x.get_text(strip=True) for x in card.select(".collection-result-text")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darlington_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darlington_gov_uk.py
@@ -51,7 +51,6 @@ class Source:
                 date_str,
                 "%A %d %B %Y",
             ).date()
-
             waste_types = [
                 x.get_text(strip=True) for x in card.select(".collection-result-text")
             ]


### PR DESCRIPTION
the darlington borough council webpage now appends relative time indicators like (Tomorrow) or (Today) to the date string (e.g., "Wednesday 10 June 2026 (Tomorrow)").

If I change the below starting at line 49

collection_date = datetime.strptime(
date_element.get_text(strip=True),
"%A %d %B %Y",
).date()

to the below it and reload it works,

date_str = date_element.get_text(strip=True).split("(")[0].strip() collection_date = datetime.strptime(
date_str,
"%A %d %B %Y",
).date()

## Summary

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `python -m black` and `python -m isort --profile black` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
