### PR TITLE
fix(south_norfolk_and_broadland_gov_uk): correct SOAP calendar day offset when past days are cleared (#6576)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/south_norfolk_and_broadland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/south_norfolk_and_broadland_gov_uk.py
@@ -101,8 +101,6 @@ _SNC_BIN_TYPE_PREFIXES = {
     "Gar": "Garden",
 }
 
-# CSS classes that mark non-calendar (padding) cells in the SNC SOAP calendar grid
-_SNC_NON_CALENDAR_CLASSES = {"tdWhiteLightGrey", "colourWhite", "tdWhiteDarkGrey"}
 
 matcher = re.compile(r"^([A-Z][a-z]+) (\d{1,2}) ([A-Z][a-z]+) (\d{4})$")
 
@@ -202,19 +200,23 @@ def _fetch_snc_soap_calendar(uprn: str) -> List[Collection]:
         except (ValueError, IndexError):
             continue
 
-        day = 0
-        for row in table.find_all("tr")[2:]:  # skip month-header and day-name rows
-            for cell in row.find_all("td")[1:]:  # skip leading empty td
-                cls_set = set(cell.get("class", []))
-                if cls_set & _SNC_NON_CALENDAR_CLASSES:
-                    continue  # padding / out-of-month cell
-
-                # Valid calendar cell — advance the day counter
-                day += 1
+        first_weekday, days_in_month = calendar.monthrange(year, month_num)
+        for row_idx, row in enumerate(
+            table.find_all("tr")[2:]
+        ):  # skip month-header and day-name rows
+            for col_idx, cell in enumerate(
+                row.find_all("td")[1:]
+            ):  # skip leading empty td
+                # Calculate the actual day-of-month from grid position.
+                # The calendar is a Mon-Sun grid; first_weekday (Mon=0) tells us
+                # how many leading padding cells appear before day 1.
+                day = row_idx * 7 + col_idx - first_weekday + 1
+                if day < 1 or day > days_in_month:
+                    continue  # padding cell before or after month
 
                 svg = cell.find("svg")
                 if not svg:
-                    continue  # other rounds collect today, not this property
+                    continue  # no collection for this property on this day
 
                 title_el = svg.find("title")
                 if not title_el:


### PR DESCRIPTION
## Summary

- The SNC SOAP calendar endpoint clears past days in the current month to blank `colourWhite` cells (empty, no day number). The sequential `day` counter introduced in #6478 skipped those cells without incrementing, causing all subsequent dates to be shifted back by the number of elapsed days — wrong collection dates and end-of-month gaps.
- Fix replaces the sequential counter with a grid-position formula: `day = row_idx * 7 + col_idx - first_weekday + 1`, using `calendar.monthrange()` to find the first weekday of the month. Cells with `day < 1` or `day > days_in_month` are skipped as padding.
- Removes the now-unnecessary `_SNC_NON_CALENDAR_CLASSES` constant.

Fixes #6576.

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `python test_sources.py -s south_norfolk_and_broadland_gov_uk -l` — all 5 test cases return entries; South Norfolk cases return 56 entries with Rubbish/Recycling/Garden correctly alternating on separate days across 9 months; no date skipping at month boundaries
- [x] Broadland addresses (no SOAP path) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)