### PR TITLE
fix(gastrikeatervinnare_se): add icons for new plastic, paper and garden waste bins (#6570)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gastrikeatervinnare_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gastrikeatervinnare_se.py
@@ -11,17 +11,25 @@ from waste_collection_schedule.exceptions import (
 TITLE = "Gästrike Återvinnare"
 DESCRIPTION = "Source for Gästrike Återvinnare waste collection"
 URL = "https://gastrikeatervinnare.se/"
+COUNTRY = "se"
 API_URL = "https://gastrikeatervinnare.se/wp-admin/admin-ajax.php"
 TEST_CASES = {
     "Groceries Årsunda": {"street": "Nedre Vägen 52", "city": "Årsunda"},
     "Police Sandviken": {"street": "Bryggargatan 6", "city": "Sandviken"},
     "Police Gävle": {"street": "Södra Centralgatan 1", "city": "Gävle"},
     "Library Ockelbo": {"street": "Södra Åsgatan 30D", "city": "Ockelbo"},
+    "Storgatan Gävle (plastic and paper bins)": {
+        "street": "Storgatan 10",
+        "city": "Gävle",
+    },
 }
 ICON_MAP = {
     "Restavfall": Icons.GENERAL_WASTE,
     "Matavfall": Icons.BIO_KITCHEN,
     "Blandat": Icons.GENERAL_WASTE,
+    "Pappersförpackningar": Icons.PAPER,
+    "Plastförpackningar": Icons.PLASTIC_PACKAGING,
+    "Trädgårdsavfall": Icons.GARDEN,
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `Pappersförpackningar` (paper packaging), `Plastförpackningar` (plastic packaging) and `Trädgårdsavfall` (garden waste) to `ICON_MAP` with the appropriate `Icons` enum values.
- Adds `COUNTRY = "se"` (previously missing; filename fallback was masking this).
- Adds a fifth TEST_CASE at Storgatan 10, Gävle to cover addresses that have the new bin types.

Fixes #6570.

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` passes (9/9)
- [ ] `python test_sources.py -s gastrikeatervinnare_se -l` — all 5 cases return entries including `Pappersförpackningar` and `Plastförpackningar` for the Gävle test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)