### PR TITLE
Add Selwyn District Council (selwyn_govt_nz) source (New Zealand)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -11,8 +11,16 @@ DESCRIPTION = (
 )
 URL = "https://www.selwyn.govt.nz/"
 TEST_CASES = {
+    # schedule 1 (Friday), with organics
     "30 Tennyson Street Rolleston": {"address": "30 Tennyson Street Rolleston"},
+    # schedule 2 (Monday), with organics
     "77 Gerald Street Lincoln": {"address": "77 Gerald Street Lincoln"},
+    # schedule 1 (Tuesday), with organics
+    "15 Meijer Drive Lincoln": {"address": "15 Meijer Drive Lincoln"},
+    # schedule 1 (Thursday), with organics
+    "22 Mclaughlins Road Darfield": {"address": "22 Mclaughlins Road Darfield"},
+    # schedule 2 (Monday), no organics service
+    "156 Leeston Road Springston": {"address": "156 Leeston Road Springston"},
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -3,13 +3,17 @@ from datetime import date, timedelta
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule import Icons
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+)
 
 TITLE = "Selwyn District Council"
 DESCRIPTION = (
     "Source for Selwyn District Council kerbside waste collection, New Zealand."
 )
 URL = "https://www.selwyn.govt.nz/"
+COUNTRY = "nz"
 TEST_CASES = {
     # schedule 1 (Friday), with organics
     "30 Tennyson Street Rolleston": {"address": "30 Tennyson Street Rolleston"},
@@ -83,7 +87,7 @@ def _label_for_charge(charge_type: str) -> str:
     "rubbish 80 litre", "rubbish 240 litre", ...). They are all the same weekly
     rubbish collection, so they collapse to a single label.
     """
-    charge = charge_type.lower()
+    charge = charge_type.strip().lower()
     if charge == "recycling":
         return RECYCLING
     if charge == "organic":
@@ -117,15 +121,20 @@ class Source:
             "returnGeometry": "false",
         }
 
-        r = requests.get(API_URL, params=params)
+        r = requests.get(API_URL, params=params, timeout=30)
         r.raise_for_status()
         features = r.json().get("features", [])
         if not features:
             raise SourceArgumentNotFound("address", self._address)
 
-        # A short fragment can match several properties; keep only the rows that
-        # belong to the first (closest) matched address.
-        target = features[0]["attributes"]["Address_full"]
+        # A short fragment can match several distinct properties. ArcGIS result
+        # ordering is not guaranteed, so don't silently pick one -- if the query
+        # is ambiguous, ask the user to disambiguate with the matching addresses.
+        matched = sorted({f["attributes"]["Address_full"] for f in features})
+        if len(matched) > 1:
+            raise SourceArgAmbiguousWithSuggestions("address", self._address, matched)
+
+        target = matched[0]
         features = [
             f for f in features if f["attributes"].get("Address_full") == target
         ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -6,6 +6,7 @@ from waste_collection_schedule import Icons
 from waste_collection_schedule.exceptions import (
     SourceArgAmbiguousWithSuggestions,
     SourceArgumentNotFound,
+    SourceArgumentRequired,
 )
 
 TITLE = "Selwyn District Council"
@@ -114,6 +115,11 @@ class Source:
         self._address: str = address.strip()
 
     def fetch(self) -> list[Collection]:
+        if not self._address:
+            raise SourceArgumentRequired(
+                "address", "a street address within the Selwyn District is required"
+            )
+
         # Case-insensitive prefix match on the full address. Escape single
         # quotes for the ArcGIS SQL-style ``where`` clause.
         escaped = self._address.lower().replace("'", "''")
@@ -122,6 +128,9 @@ class Source:
             "where": f"LOWER(Address_full) LIKE '{escaped}%'",
             "outFields": "ChargeType,COLLECTION_SCHEDULE,COLLECTION_DAY,Address_full",
             "returnGeometry": "false",
+            # Cap the response: a short prefix can match many properties. We rely
+            # on the ambiguity error below to prompt the user for a longer prefix.
+            "resultRecordCount": 200,
         }
 
         r = requests.get(API_URL, params=params, timeout=30)
@@ -131,15 +140,20 @@ class Source:
             raise SourceArgumentNotFound("address", self._address)
 
         # A short fragment can match several distinct properties. ArcGIS result
-        # ordering is not guaranteed, so don't silently pick one -- if the query
-        # is ambiguous, ask the user to disambiguate with the matching addresses.
+        # ordering is not guaranteed, so don't silently pick one. If the user's
+        # input is itself an exact (case-insensitive) full address, use it even
+        # when other properties share it as a prefix; otherwise ask the user to
+        # disambiguate with the matching addresses.
         matched = sorted({f["attributes"]["Address_full"] for f in features})
         if len(matched) > 1:
-            raise SourceArgAmbiguousWithSuggestions(
-                "address", self._address, matched[:MAX_SUGGESTIONS]
-            )
-
-        target = matched[0]
+            exact = [a for a in matched if a.lower() == self._address.lower()]
+            if not exact:
+                raise SourceArgAmbiguousWithSuggestions(
+                    "address", self._address, matched[:MAX_SUGGESTIONS]
+                )
+            target = exact[0]
+        else:
+            target = matched[0]
         features = [
             f for f in features if f["attributes"].get("Address_full") == target
         ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -159,7 +159,7 @@ class Source:
 
         today = date.today()
         entries: list[Collection] = []
-        for offset in range((WEEKS_AHEAD * 7) + 1):
+        for offset in range(WEEKS_AHEAD * 7):
             day = today + timedelta(days=offset)
             for label, info in bins.items():
                 if day.weekday() != info["weekday"]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -1,0 +1,170 @@
+from datetime import date, timedelta
+
+import requests
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule import Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+TITLE = "Selwyn District Council"
+DESCRIPTION = (
+    "Source for Selwyn District Council kerbside waste collection, New Zealand."
+)
+URL = "https://www.selwyn.govt.nz/"
+TEST_CASES = {
+    "30 Tennyson Street Rolleston": {"address": "30 Tennyson Street Rolleston"},
+    "77 Gerald Street Lincoln": {"address": "77 Gerald Street Lincoln"},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter your address exactly as it appears in the address search on "
+    "Selwyn District Council's collection days and routes page, e.g. "
+    "'30 Tennyson Street Rolleston'."
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Address",
+    }
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Street address within the Selwyn District, e.g. "
+        "'30 Tennyson Street Rolleston'.",
+    }
+}
+
+API_URL = (
+    "https://gis.selwyn.govt.nz/arcgis/rest/services/SDC_Public/"
+    "Refuse_address/MapServer/0/query"
+)
+
+# Waste-type labels.
+RUBBISH = "Rubbish"
+RECYCLING = "Recycling"
+ORGANIC = "Organics"
+
+ICON_MAP = {
+    RUBBISH: Icons.GENERAL_WASTE,
+    RECYCLING: Icons.RECYCLING,
+    ORGANIC: Icons.ORGANIC,
+}
+
+# Number of weeks of collections to generate.
+WEEKS_AHEAD = 8
+
+WEEKDAYS = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+
+def _label_for_charge(charge_type: str) -> str:
+    """Map a raw ``ChargeType`` value to a collapsed waste-type label.
+
+    Selwyn bills several weekly red-bin variants ("refuse uniform charge",
+    "rubbish 80 litre", "rubbish 240 litre", ...). They are all the same weekly
+    rubbish collection, so they collapse to a single label.
+    """
+    charge = charge_type.lower()
+    if charge == "recycling":
+        return RECYCLING
+    if charge == "organic":
+        return ORGANIC
+    return RUBBISH
+
+
+def _fortnight_parity(d: date) -> int:
+    """Return a stable, Monday-aligned fortnight parity (0/1) for a date.
+
+    Anchored to the proleptic-Gregorian epoch (ordinal 1 is a Monday), so the
+    parity is continuous across year boundaries. This avoids the off-by-one that
+    raw ISO week numbers introduce in 53-week ISO years (e.g. 2026), where the
+    week number would otherwise repeat its parity across the New Year.
+    """
+    return ((d.toordinal() - 1) // 7) % 2
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address: str = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        # Case-insensitive prefix match on the full address. Escape single
+        # quotes for the ArcGIS SQL-style ``where`` clause.
+        escaped = self._address.lower().replace("'", "''")
+        params = {
+            "f": "json",
+            "where": f"LOWER(Address_full) LIKE '{escaped}%'",
+            "outFields": "ChargeType,COLLECTION_FREQUENCY,COLLECTION_SCHEDULE,"
+            "COLLECTION_DAY,Address_full",
+            "returnGeometry": "false",
+        }
+
+        r = requests.get(API_URL, params=params)
+        r.raise_for_status()
+        features = r.json().get("features", [])
+        if not features:
+            raise SourceArgumentNotFound("address", self._address)
+
+        # A short fragment can match several properties; keep only the rows that
+        # belong to the first (closest) matched address.
+        target = features[0]["attributes"]["Address_full"]
+        features = [
+            f for f in features if f["attributes"].get("Address_full") == target
+        ]
+
+        # Collapse the feature rows into one entry per waste-type label.
+        bins: dict[str, dict] = {}
+        for feature in features:
+            attrs = feature["attributes"]
+            day = (attrs.get("COLLECTION_DAY") or "").strip().lower()
+            if day not in WEEKDAYS:
+                continue
+            label = _label_for_charge(attrs.get("ChargeType", ""))
+            frequency = (attrs.get("COLLECTION_FREQUENCY") or "").strip().lower()
+            schedule = (attrs.get("COLLECTION_SCHEDULE") or "").strip()
+            bins[label] = {
+                "weekday": WEEKDAYS[day],
+                "fortnightly": frequency.startswith("fortnight"),
+                "schedule": schedule,
+            }
+
+        if not bins:
+            raise SourceArgumentNotFound("address", self._address)
+
+        today = date.today()
+        entries: list[Collection] = []
+        for offset in range((WEEKS_AHEAD * 7) + 1):
+            day = today + timedelta(days=offset)
+            for label, info in bins.items():
+                if day.weekday() != info["weekday"]:
+                    continue
+                if info["fortnightly"]:
+                    if not self._collected_this_fortnight(label, info["schedule"], day):
+                        continue
+                entries.append(Collection(day, label, ICON_MAP[label]))
+
+        return entries
+
+    @staticmethod
+    def _collected_this_fortnight(label: str, schedule: str, day: date) -> bool:
+        """Resolve whether a fortnightly bin is collected on ``day``.
+
+        Recycling and organics alternate on the same weekday. ``COLLECTION_SCHEDULE``
+        ("1" or "2") selects which of the two master calendars a property follows;
+        the absolute phase is anchored from the council's published calendar
+        (verified: a schedule-"2" property collects organics in even fortnights).
+        """
+        if schedule not in ("1", "2"):
+            # Phase cannot be determined for this property; emit nothing rather
+            # than guess. (Residential properties always carry "1" or "2".)
+            return False
+        even = _fortnight_parity(day) == 0
+        organics_week = even if schedule == "2" else not even
+        return organics_week if label == ORGANIC else not organics_week

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -65,6 +65,9 @@ ICON_MAP = {
 # Number of weeks of collections to generate.
 WEEKS_AHEAD = 8
 
+# Cap the disambiguation suggestions: a prefix match can return many properties.
+MAX_SUGGESTIONS = 10
+
 WEEKDAYS = {
     "monday": 0,
     "tuesday": 1,
@@ -132,7 +135,9 @@ class Source:
         # is ambiguous, ask the user to disambiguate with the matching addresses.
         matched = sorted({f["attributes"]["Address_full"] for f in features})
         if len(matched) > 1:
-            raise SourceArgAmbiguousWithSuggestions("address", self._address, matched)
+            raise SourceArgAmbiguousWithSuggestions(
+                "address", self._address, matched[:MAX_SUGGESTIONS]
+            )
 
         target = matched[0]
         features = [

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -63,6 +63,10 @@ WEEKDAYS = {
     "sunday": 6,
 }
 
+# Reference date for the council's two-weekly recycling cycle: a "week 1" Sunday.
+# Matches the anchor used by the council's own collection-day look-up widget.
+RECYCLING_ANCHOR = date(2024, 3, 17)
+
 
 def _label_for_charge(charge_type: str) -> str:
     """Map a raw ``ChargeType`` value to a collapsed waste-type label.
@@ -79,15 +83,15 @@ def _label_for_charge(charge_type: str) -> str:
     return RUBBISH
 
 
-def _fortnight_parity(d: date) -> int:
-    """Return a stable, Monday-aligned fortnight parity (0/1) for a date.
+def _recycling_week(d: date) -> int:
+    """Return the council's recycling-cycle week number (1 or 2) for a date.
 
-    Anchored to the proleptic-Gregorian epoch (ordinal 1 is a Monday), so the
-    parity is continuous across year boundaries. This avoids the off-by-one that
-    raw ISO week numbers introduce in 53-week ISO years (e.g. 2026), where the
-    week number would otherwise repeat its parity across the New Year.
+    Rubbish and organics are collected weekly; only recycling is fortnightly. A
+    property's recycling is collected in the weeks whose number equals its
+    ``COLLECTION_SCHEDULE``. The week number alternates every 7 days from
+    ``RECYCLING_ANCHOR`` -- the same calculation the council's website performs.
     """
-    return ((d.toordinal() - 1) // 7) % 2
+    return ((d - RECYCLING_ANCHOR).days // 7) % 2 + 1
 
 
 class Source:
@@ -101,8 +105,7 @@ class Source:
         params = {
             "f": "json",
             "where": f"LOWER(Address_full) LIKE '{escaped}%'",
-            "outFields": "ChargeType,COLLECTION_FREQUENCY,COLLECTION_SCHEDULE,"
-            "COLLECTION_DAY,Address_full",
+            "outFields": "ChargeType,COLLECTION_SCHEDULE,COLLECTION_DAY,Address_full",
             "returnGeometry": "false",
         }
 
@@ -119,7 +122,8 @@ class Source:
             f for f in features if f["attributes"].get("Address_full") == target
         ]
 
-        # Collapse the feature rows into one entry per waste-type label.
+        # Collapse the feature rows into one entry per waste-type label. Each
+        # property has at most one rubbish, one recycling and one organics charge.
         bins: dict[str, dict] = {}
         for feature in features:
             attrs = feature["attributes"]
@@ -127,13 +131,11 @@ class Source:
             if day not in WEEKDAYS:
                 continue
             label = _label_for_charge(attrs.get("ChargeType", ""))
-            frequency = (attrs.get("COLLECTION_FREQUENCY") or "").strip().lower()
             schedule = (attrs.get("COLLECTION_SCHEDULE") or "").strip()
-            bins[label] = {
-                "weekday": WEEKDAYS[day],
-                "fortnightly": frequency.startswith("fortnight"),
-                "schedule": schedule,
-            }
+            info = bins.setdefault(label, {"weekday": WEEKDAYS[day], "schedule": ""})
+            # Only the recycling row carries a meaningful schedule ("1"/"2").
+            if schedule in ("1", "2"):
+                info["schedule"] = schedule
 
         if not bins:
             raise SourceArgumentNotFound("address", self._address)
@@ -145,26 +147,14 @@ class Source:
             for label, info in bins.items():
                 if day.weekday() != info["weekday"]:
                     continue
-                if info["fortnightly"]:
-                    if not self._collected_this_fortnight(label, info["schedule"], day):
+                # Rubbish and organics are weekly; recycling is fortnightly and
+                # only falls in the weeks matching the property's schedule.
+                if label == RECYCLING:
+                    schedule = info["schedule"]
+                    if schedule not in ("1", "2"):
+                        continue
+                    if _recycling_week(day) != int(schedule):
                         continue
                 entries.append(Collection(day, label, ICON_MAP[label]))
 
         return entries
-
-    @staticmethod
-    def _collected_this_fortnight(label: str, schedule: str, day: date) -> bool:
-        """Resolve whether a fortnightly bin is collected on ``day``.
-
-        Recycling and organics alternate on the same weekday. ``COLLECTION_SCHEDULE``
-        ("1" or "2") selects which of the two master calendars a property follows;
-        the absolute phase is anchored from the council's published calendar
-        (verified: a schedule-"2" property collects organics in even fortnights).
-        """
-        if schedule not in ("1", "2"):
-            # Phase cannot be determined for this property; emit nothing rather
-            # than guess. (Residential properties always carry "1" or "2".)
-            return False
-        even = _fortnight_parity(day) == 0
-        organics_week = even if schedule == "2" else not even
-        return organics_week if label == ORGANIC else not organics_week

--- a/doc/source/selwyn_govt_nz.md
+++ b/doc/source/selwyn_govt_nz.md
@@ -2,7 +2,7 @@
 
 Support for schedules provided by [Selwyn District Council](https://www.selwyn.govt.nz/), serving the Selwyn District, New Zealand.
 
-The source queries the council's public ArcGIS property service and returns the weekly rubbish and organics collections together with the fortnightly recycling collection for the next eight weeks.
+The source queries the council's public ArcGIS property service and returns the next eight weeks of collections for the property: weekly rubbish, fortnightly recycling, and (where the property has an organics service) weekly organics.
 
 ## Configuration via configuration.yaml
 
@@ -36,5 +36,5 @@ Visit the council's [collection days and routes](https://www.selwyn.govt.nz/serv
 
 ## Notes / Limitations
 
-- Rubbish and organics are collected weekly; recycling is collected fortnightly, on the weeks matching the property's recycling schedule. All bins share the same weekday.
+- Rubbish is collected weekly and recycling fortnightly (on the weeks matching the property's recycling schedule). Organics is collected weekly **where the property has an organics service** — some areas (e.g. a number of rural properties) have no kerbside organics, in which case no organics collections are returned. All of a property's bins share the same weekday.
 - The council's data does not encode public-holiday adjustments, so collections that are shifted around New Zealand public holidays are not reflected. This limitation is shared with other New Zealand sources.

--- a/doc/source/selwyn_govt_nz.md
+++ b/doc/source/selwyn_govt_nz.md
@@ -2,7 +2,7 @@
 
 Support for schedules provided by [Selwyn District Council](https://www.selwyn.govt.nz/), serving the Selwyn District, New Zealand.
 
-The source queries the council's public ArcGIS property service and returns the weekly rubbish collection together with the alternating fortnightly recycling and organics collections for the next eight weeks.
+The source queries the council's public ArcGIS property service and returns the weekly rubbish and organics collections together with the fortnightly recycling collection for the next eight weeks.
 
 ## Configuration via configuration.yaml
 
@@ -36,5 +36,5 @@ Visit the council's [collection days and routes](https://www.selwyn.govt.nz/serv
 
 ## Notes / Limitations
 
-- Rubbish is collected weekly; recycling and organics are collected fortnightly on the same weekday, alternating week-to-week.
+- Rubbish and organics are collected weekly; recycling is collected fortnightly, on the weeks matching the property's recycling schedule. All bins share the same weekday.
 - The council's data does not encode public-holiday adjustments, so collections that are shifted around New Zealand public holidays are not reflected. This limitation is shared with other New Zealand sources.

--- a/doc/source/selwyn_govt_nz.md
+++ b/doc/source/selwyn_govt_nz.md
@@ -9,9 +9,9 @@ The source queries the council's public ArcGIS property service and returns the 
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: selwyn_govt_nz
-      args:
-        address: ADDRESS
+        - name: selwyn_govt_nz
+          args:
+            address: ADDRESS
 ```
 
 ### Configuration Variables
@@ -25,9 +25,9 @@ Your street address within the Selwyn District, including the town, exactly as i
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: selwyn_govt_nz
-      args:
-        address: 30 Tennyson Street Rolleston
+        - name: selwyn_govt_nz
+          args:
+            address: 30 Tennyson Street Rolleston
 ```
 
 ## How to get the source argument

--- a/doc/source/selwyn_govt_nz.md
+++ b/doc/source/selwyn_govt_nz.md
@@ -1,0 +1,40 @@
+# Selwyn District Council
+
+Support for schedules provided by [Selwyn District Council](https://www.selwyn.govt.nz/), serving the Selwyn District, New Zealand.
+
+The source queries the council's public ArcGIS property service and returns the weekly rubbish collection together with the alternating fortnightly recycling and organics collections for the next eight weeks.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: selwyn_govt_nz
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**  
+*(String) (required)*  
+Your street address within the Selwyn District, including the town, exactly as it appears in the council's address search (e.g. `30 Tennyson Street Rolleston`).
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: selwyn_govt_nz
+      args:
+        address: 30 Tennyson Street Rolleston
+```
+
+## How to get the source argument
+
+Visit the council's [collection days and routes](https://www.selwyn.govt.nz/services/rubbish-and-recycling/collection-days-and-routes) page and search for your property. Copy the address as shown in the search result and use it as the `address` argument. A partial address is matched as a prefix; include the town to avoid matching multiple properties.
+
+## Notes / Limitations
+
+- Rubbish is collected weekly; recycling and organics are collected fortnightly on the same weekday, alternating week-to-week.
+- The council's data does not encode public-holiday adjustments, so collections that are shifted around New Zealand public holidays are not reflected. This limitation is shared with other New Zealand sources.

--- a/doc/source/selwyn_govt_nz.md
+++ b/doc/source/selwyn_govt_nz.md
@@ -36,5 +36,5 @@ Visit the council's [collection days and routes](https://www.selwyn.govt.nz/serv
 
 ## Notes / Limitations
 
-- Rubbish is collected weekly and recycling fortnightly (on the weeks matching the property's recycling schedule). Organics is collected weekly **where the property has an organics service** — some areas (e.g. a number of rural properties) have no kerbside organics, in which case no organics collections are returned. All of a property's bins share the same weekday.
+- Rubbish is collected weekly and recycling fortnightly (on the weeks matching the property's recycling schedule). Organics is collected weekly **where the property has an organics service** — some areas (e.g. a number of rural properties) have no kerbside organics, in which case no organics collections are returned. See the council's [organic collection](https://www.selwyn.govt.nz/services/rubbish-recycling-And-organics/kerbside-collections/organic-collection) page for which areas are covered. All of a property's bins share the same weekday.
 - The council's data does not encode public-holiday adjustments, so collections that are shifted around New Zealand public holidays are not reflected. This limitation is shared with other New Zealand sources.


### PR DESCRIPTION
## New source: Selwyn District Council

Adds a dedicated source for [Selwyn District Council](https://www.selwyn.govt.nz/), serving the Selwyn District, New Zealand.

### Data source
Queries the council's **public** ArcGIS property service (no auth): `SDC_Public/Refuse_address/MapServer/0` — a case-insensitive prefix `LIKE` query on the full address returns one feature per bin charge for the property. This is the same endpoint the council's own collection-day look-up widget uses.

### Collection model
- **Rubbish** — weekly (the several billing variants `refuse uniform charge` / `rubbish 80 litre` / `rubbish 240 litre` collapse to one label).
- **Recycling** — fortnightly, collected in the weeks whose number matches the property's `COLLECTION_SCHEDULE` (1 or 2). The week number alternates every 7 days from a fixed anchor (2024-03-17), reproducing the exact calculation in the council website's JavaScript.
- **Organics** — weekly, **where the property has an organics service**. Not all areas have kerbside organics (e.g. a number of rural properties); those properties have no `organic` charge row and the source returns no organics collections for them.

> Note: the GIS `COLLECTION_FREQUENCY` field labels the organics row "Fortnightly", but the council's widget collects organics **weekly** (it appears on every collection day alongside rubbish, where the service exists). The source follows the widget's behaviour, not that flag.

### Files
- ✅ `custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py`
- ✅ `doc/source/selwyn_govt_nz.md`
- No edits to `README.md` / `info.md` (auto-generated by CI after merge).

### Checks
- `python -m pytest tests/test_source_components.py` → **9 passed**
- `black`, `isort --profile black`, `flake8` → clean
- `COUNTRY = "nz"`, `ICON_MAP` uses canonical `Icons` enum members, English-only `PARAM_TRANSLATIONS` / `PARAM_DESCRIPTIONS`.

### `test_sources.py` output
The test cases cover both recycling schedules, four collection weekdays, and both organics and no-organics areas:

```
Testing source selwyn_govt_nz ...
  found 20 entries for 30 Tennyson Street Rolleston   (Friday,   schedule 1, organics)
  found 20 entries for 77 Gerald Street Lincoln       (Monday,   schedule 2, organics)
  found 20 entries for 15 Meijer Drive Lincoln        (Tuesday,  schedule 1, organics)
  found 20 entries for 22 Mclaughlins Road Darfield   (Thursday, schedule 1, organics)
  found 12 entries for 156 Leeston Road Springston    (Monday,   schedule 2, no organics)
```

Example breakdown (schedule 2, Monday — matches the council widget exactly):
```
  77 Gerald Street Lincoln
    2026-06-15 : Rubbish / Recycling / Organics
    2026-06-22 : Rubbish / Organics
    2026-06-29 : Rubbish / Recycling / Organics
    ... (8 weeks) ...
  156 Leeston Road Springston   (no organics service)
    2026-06-15 : Rubbish / Recycling
    2026-06-22 : Rubbish
    2026-06-29 : Rubbish / Recycling
    ... (8 weeks) ...
```

Each address was reconciled against the council's live collection-day widget, including across a year boundary.

### Known limitation
The council data does not encode public-holiday adjustments, so collections shifted around NZ public holidays are not reflected — a limitation shared with other NZ sources. Documented on the source's doc page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)