### PR TITLE
fix(edpevent_se): remove nodra provider (endpoint now login-protected)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edpevent_se.py
@@ -94,10 +94,6 @@ TEST_CASES = {
         "street_address": "Olofsgatan 9 / Kommunhuset, Ljungby",
         "service_provider": "ljungby-kommun",
     },
-    "Nodra - Norrköping": {
-        "street_address": "Erikslund 3, Kolmården",
-        "service_provider": "nodra",
-    },
     "Örebro - Kommunstyrelsen": {
         "street_address": "Ringgatan 32",
         "service_provider": "orebro-kommun",
@@ -225,11 +221,6 @@ SERVICE_PROVIDERS = {
         "title": "Ljungby kommun",
         "url": "https://ljungby.se/",
         "api_url": "https://edpwebb.ljungby.se/FutureWeb/SimpleWastePickup",
-    },
-    "nodra": {
-        "title": "Nodra",
-        "url": "https://www.nodra.se",
-        "api_url": "https://futureweb.nodra.se/FutureWeb/SimpleWastePickup",
     },
     "orebro-kommun": {
         "title": "Örebro kommun",


### PR DESCRIPTION
## Summary

- Nodra's FutureWeb endpoint (`futureweb.nodra.se/FutureWeb/`) now redirects to SAML login for all requests, making it unavailable to unauthenticated clients.
- The `SearchAdress` endpoint returns `{"Succeeded":true,"Buildings":[]}` for all queries without a valid session — silently failing rather than 401/403.
- Since the project only supports publicly accessible endpoints, Nodra is removed from `edpevent_se`'s `SERVICE_PROVIDERS` and `TEST_CASES`.

## Test plan

- [ ] `python test_sources.py -s edpevent_se -l` — all remaining TEST_CASES pass
- [ ] `python -m pytest tests/test_source_components.py -q` — no regressions

Fixes #6590

🤖 Generated with [Claude Code](https://claude.com/claude-code)