### PR TITLE
fix(publidata_fr): add CC Pévèle Carembault to EXTRA_INFO

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -277,6 +277,11 @@ EXTRA_INFO = [
         "url": "https://tripratik.lehavreseinemetropole.fr/",
         "default_params": {"instance_id": 1408},
     },
+    {
+        "title": "Communauté de Communes Pévèle Carembault",
+        "url": "https://www.pevelecarembault.fr/",
+        "default_params": {"instance_id": 1141},
+    },
 ]
 
 _CALENDAR_DAY_VERY_ABBR = {


### PR DESCRIPTION
## Summary

- Adds Communauté de Communes Pévèle Carembault (instance_id 1141) to the `EXTRA_INFO` list in `publidata_fr.py` so it appears in the sources list, README, and the HA config flow provider picker.
- The source already supports this provider; this change makes it discoverable. No functional changes.

Closes #5598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>