### PR TITLE
fix(preston_gov_uk): require street for UPRN lookup; clarify parameter docs

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/preston_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/preston_gov_uk.py
@@ -20,7 +20,25 @@ SRV_URL = (
 
 TEST_CASES = {
     "Test_001": {"street": "town hall, lancaster road"},
-    "Test_002": {"street": "", "uprn": "10002220003"},
+    "Test_002": {"street": "PR1 2RL", "uprn": "10002220003"},
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "street": "Street / Postcode",
+        "uprn": "UPRN (optional)",
+    }
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street": "Your street name or postcode (required). Used to search for your address.",
+        "uprn": "Your Unique Property Reference Number (optional). When provided alongside street/postcode, it picks the exact matching property from the search results. Leave blank if you are unsure.",
+    }
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter your postcode or street name in the 'Street / Postcode' field. If your postcode returns multiple properties, find your UPRN at https://www.findmyaddress.co.uk/ and enter it in the optional 'UPRN' field to select the exact property."
 }
 
 ICON_MAP = {
@@ -67,6 +85,12 @@ class Source:
         self._uprn = str(uprn)
 
     def fetch(self) -> list:
+        if not self._street:
+            raise SourceArgumentNotFound(
+                argument="street",
+                value=self._street,
+            )
+
         session = requests.Session(impersonate="chrome")
 
         # Step 1: GET the initial page to obtain session cookies and hidden ASP.NET fields
@@ -74,14 +98,12 @@ class Source:
         r0.raise_for_status()
         soup0 = BeautifulSoup(r0.text, features="html.parser")
 
-        # Step 2: POST the search request with address/UPRN
+        # Step 2: POST the search request with address/postcode
         params1 = _extract_hidden_inputs(soup0)
         params1["__EVENTTARGET"] = "ctl00$MainContent$btnSearch"
         params1["__EVENTARGUMENT"] = ""
         params1["ctl00$MainContent$hdnService"] = "bins"
-        params1["ctl00$MainContent$txtAddress"] = (
-            self._street if self._street else self._uprn
-        )
+        params1["ctl00$MainContent$txtAddress"] = self._street
         params1["ctl00$MainContent$hdnUPRN"] = self._uprn
 
         r1 = session.post(SRV_URL, data=params1)
@@ -97,8 +119,8 @@ class Source:
         select_el = soup1.find("select", {"name": "ctl00$MainContent$ddlSearchResults"})
         if not select_el:
             raise SourceArgumentNotFound(
-                argument="street" if self._street else "uprn",
-                value=self._street if self._street else self._uprn,
+                argument="street",
+                value=self._street,
             )
 
         options = [
@@ -115,12 +137,6 @@ class Source:
                 for opt in select_el.find_all("option")
                 if opt.get("value", "") not in ("Make a selection from the list", "")
             ]
-            if self._uprn:
-                raise SourceArgumentNotFoundWithSuggestions(
-                    argument="uprn",
-                    value=self._uprn,
-                    suggestions=all_opts,
-                )
             raise SourceArgumentNotFoundWithSuggestions(
                 argument="street",
                 value=self._street,
@@ -148,9 +164,7 @@ class Source:
         params2["__EVENTTARGET"] = "ctl00$MainContent$ddlSearchResults"
         params2["__EVENTARGUMENT"] = ""
         params2["ctl00$MainContent$hdnService"] = "bins"
-        params2["ctl00$MainContent$txtAddress"] = (
-            self._street if self._street else self._uprn
-        )
+        params2["ctl00$MainContent$txtAddress"] = self._street
         params2["ctl00$MainContent$ddlSearchResults"] = selected_value
 
         r2 = session.post(SRV_URL, data=params2)
@@ -160,8 +174,8 @@ class Source:
         cnt = soup2.select_one("span#MainContent_lblMoreCollectionDates")
         if not cnt or not cnt.find_all("div", {"id": "container"}):
             raise SourceArgumentNotFound(
-                argument="street" if self._street else "uprn",
-                value=self._street if self._street else self._uprn,
+                argument="street",
+                value=self._street,
             )
 
         return self._parse(cnt)


### PR DESCRIPTION
## Summary

Partial follow-up to #6419 — fixes the residual UPRN-only regression reported in #6337 (comment 2026-06-10).

- Add early validation: when `street` is empty, raise `SourceArgumentNotFound` with the `street` argument immediately, rather than sending the UPRN as an address search string and silently failing
- Update `TEST_CASES`: `Test_002` now provides both `street` (postcode `PR1 2RL`) and `uprn`, matching realistic usage
- Add `PARAM_TRANSLATIONS` / `PARAM_DESCRIPTIONS` (en) making it clear that `street` is required and `uprn` is an optional disambiguator
- Add `HOW_TO_GET_ARGUMENTS_DESCRIPTION` with a link to findmyaddress.co.uk for UPRN lookup

**Root cause:** The Preston self-service form's `txtAddress` field requires a postcode or street name. Passing a raw UPRN number here yields no dropdown, so `select_el` is `None` and `SourceArgumentNotFound` is thrown.

**Note:** I could not test this against the live Preston site (it geo-restricts non-UK IPs), so the live TEST_CASES are unverified from my environment. Asking the original reporter to validate from master once merged.

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `python test_sources.py -s preston_gov_uk -l` passes both TEST_CASES (requires UK network access to selfservice.preston.gov.uk)

Closes #6337 (residual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>