### PR TITLE
[RFC PoC] Image-PDF calendar parsing (amarsul_pt) — see #6607

### DIFF
--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -15,6 +15,7 @@
     "lxml",
     "pycryptodome",
     "pypdf",
+    "Pillow>=10.0.0",
     "curl_cffi>=0.7.0"
   ],
   "version": "2.27.0"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/PdfImageCalendar.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/PdfImageCalendar.py
@@ -1,0 +1,319 @@
+"""Parse a yearly waste calendar published as a single embedded PDF image.
+
+Some providers publish their collection calendar only as a PDF whose page is one
+raster image (``pypdf`` text extraction returns nothing). This service reads such
+calendars without OCR by detecting the colour-filled day cells of a grid of
+monthly mini-calendars.
+
+It is provider-agnostic: a source configures it with the header-bar colour, the
+set of colour-to-waste-type bins, and the page layout, then calls ``fetch(url)``.
+Grid geometry is detected at runtime from the coloured month-header bands (the
+four header tops give the vertical row pitch; the teal runs within each band give
+the month-box columns), with calibrated fallbacks for when detection cannot find
+the expected structure. The parsed result is validated (minimum count, per-type
+weekday consistency, per-month plausibility) so a future layout change fails
+loudly instead of returning a handful of silently-wrong dates.
+"""
+
+import calendar
+import re
+from collections import Counter, defaultdict
+from datetime import date
+from io import BytesIO
+from statistics import median
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
+
+import requests
+from PIL import Image
+from pypdf import PdfReader
+
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentException
+
+RGBMatcher = Callable[[int, int, int], bool]
+
+
+class ColourBin(NamedTuple):
+    """Maps a fill colour to a waste type (and optional icon)."""
+
+    name: str
+    icon: Optional[str]
+    matches: RGBMatcher
+
+
+class PdfImageCalendar:
+    def __init__(
+        self,
+        *,
+        header_matches: RGBMatcher,
+        bins: List[ColourBin],
+        box_cols: int = 3,
+        grid_cols: int = 7,
+        grid_rows: int = 6,
+        ref_width: int = 1240,
+        fallback_box_x: Tuple[int, ...] = (73, 449, 824),
+        fallback_box_w: int = 353,
+        row1_ratio: float = 71.0 / 267.0,
+        row_pitch_ratio: float = 29.4 / 267.0,
+        sample_half_x: int = 11,
+        sample_half_y: int = 13,
+        fill_threshold: int = 50,
+        min_collections: int = 12,
+        min_weekday_share: float = 0.5,
+        max_per_month: int = 6,
+    ):
+        self._header_matches = header_matches
+        self._bins = bins
+        self._box_cols = box_cols
+        self._grid_cols = grid_cols
+        self._grid_rows = grid_rows
+        self._ref_width = ref_width
+        self._fallback_box_x = fallback_box_x
+        self._fallback_box_w = fallback_box_w
+        self._row1_ratio = row1_ratio
+        self._row_pitch_ratio = row_pitch_ratio
+        self._sample_half_x = sample_half_x
+        self._sample_half_y = sample_half_y
+        self._fill_threshold = fill_threshold
+        self._min_collections = min_collections
+        self._min_weekday_share = min_weekday_share
+        self._max_per_month = max_per_month
+
+    # -- image / metadata ---------------------------------------------------
+
+    def _extract_image(self, url: str) -> Image.Image:
+        try:
+            resp = requests.get(url, timeout=60)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise SourceArgumentException(
+                "calendar_url", f"could not download the calendar PDF: {exc}"
+            ) from exc
+
+        try:
+            reader = PdfReader(BytesIO(resp.content))
+            page = reader.pages[0]
+            images = page.images
+            if not images:
+                raise SourceArgumentException(
+                    "calendar_url", "the PDF page contains no embedded image"
+                )
+            img = images[0].image
+        except SourceArgumentException:
+            raise
+        except Exception as exc:
+            raise SourceArgumentException(
+                "calendar_url", f"could not read the calendar PDF: {exc}"
+            ) from exc
+
+        return img.convert("RGB")
+
+    @staticmethod
+    def year_from_url(url: str) -> int:
+        """Best-effort year for date mapping: a 20xx in the URL, else today."""
+        match = re.search(r"20\d\d", url)
+        return int(match.group(0)) if match else date.today().year
+
+    # -- geometry detection -------------------------------------------------
+
+    def _header_bands(self, img: Image.Image) -> List[Tuple[int, int]]:
+        """Locate the coloured month-header bands (one per box-row)."""
+        width, height = img.size
+        px = img.load()
+        rows = []
+        for y in range(height):
+            rows.append(
+                sum(1 for x in range(0, width, 2) if self._header_matches(*px[x, y]))
+            )
+
+        threshold = max(rows) * 0.4
+        bands: List[Tuple[int, int]] = []
+        start = None
+        for y, count in enumerate(rows):
+            if count > threshold and start is None:
+                start = y
+            elif count <= threshold and start is not None:
+                if y - start >= 15:  # full header bars are ~28px tall
+                    bands.append((start, y))
+                start = None
+        if start is not None and height - start >= 15:
+            bands.append((start, height))
+
+        box_rows = -(-12 // self._box_cols)  # ceil(12 / box_cols)
+        if len(bands) != box_rows:
+            raise SourceArgumentException(
+                "calendar_url",
+                f"expected {box_rows} month-header rows in the calendar image, "
+                f"found {len(bands)}",
+            )
+        return bands
+
+    def _box_columns(
+        self, img: Image.Image, top: int, bot: int
+    ) -> Optional[List[Tuple[int, int]]]:
+        """Detect each month-box's (left, width) from a header band.
+
+        A box header is split by its white month name, so a box shows up as two
+        or more coloured runs. Runs are grouped into ``box_cols`` boxes by
+        cutting at the inter-run gaps nearest the evenly-spaced column
+        boundaries. Returns None if the expected structure is not found.
+        """
+        width, _ = img.size
+        px = img.load()
+        band_h = bot - top
+        threshold = band_h * 0.3
+        runs: List[Tuple[int, int]] = []
+        start = None
+        for x in range(width):
+            count = sum(1 for y in range(top, bot) if self._header_matches(*px[x, y]))
+            if count > threshold and start is None:
+                start = x
+            elif count <= threshold and start is not None:
+                if x - start >= 25:
+                    runs.append((start, x))
+                start = None
+        if start is not None and width - start >= 25:
+            runs.append((start, width))
+
+        if len(runs) < self._box_cols:
+            return None
+
+        left, right = runs[0][0], runs[-1][1]
+        gap_mids = [(runs[i][1] + runs[i + 1][0]) / 2 for i in range(len(runs) - 1)]
+        cuts = set()
+        for k in range(1, self._box_cols):
+            boundary = left + (right - left) * k / self._box_cols
+            cuts.add(
+                min(range(len(gap_mids)), key=lambda i: abs(gap_mids[i] - boundary))
+            )
+        if len(cuts) != self._box_cols - 1:
+            return None  # two boundaries collapsed onto one gap -> ambiguous
+
+        boxes: List[Tuple[int, int]] = []
+        prev = 0
+        for cut in sorted(cuts) + [len(runs) - 1]:
+            group = runs[prev : cut + 1]
+            box_left = group[0][0]
+            boxes.append((box_left, group[-1][1] - box_left))
+            prev = cut + 1
+        return boxes if len(boxes) == self._box_cols else None
+
+    # -- validation ---------------------------------------------------------
+
+    def _validate(self, raw: List[Tuple[date, str]]) -> None:
+        """Guard against a misread layout producing plausible-but-wrong dates."""
+        if len(raw) < self._min_collections:
+            raise SourceArgumentException(
+                "calendar_url",
+                f"only {len(raw)} collection(s) detected; the calendar layout "
+                "may have changed",
+            )
+
+        by_type: Dict[str, List[date]] = defaultdict(list)
+        for collection_date, waste_type in raw:
+            by_type[waste_type].append(collection_date)
+
+        for waste_type, dates in by_type.items():
+            weekdays = Counter(d.weekday() for d in dates)
+            _, modal = weekdays.most_common(1)[0]
+            if modal / len(dates) < self._min_weekday_share:
+                raise SourceArgumentException(
+                    "calendar_url",
+                    f"detected '{waste_type}' collections fall on inconsistent "
+                    "weekdays; the calendar may not have been read correctly",
+                )
+
+        per_month = Counter((d.year, d.month, t) for d, t in raw)
+        if max(per_month.values()) > self._max_per_month:
+            raise SourceArgumentException(
+                "calendar_url",
+                "implausible number of collections detected in a single month; "
+                "the calendar image may have been misread",
+            )
+
+    # -- public API ---------------------------------------------------------
+
+    def fetch(self, url: str, year: Optional[int] = None) -> List[Collection]:
+        img = self._extract_image(url)
+        width, height = img.size
+        px = img.load()
+        scale = width / self._ref_width
+        if year is None:
+            year = self.year_from_url(url)
+
+        bands = self._header_bands(img)
+        header_tops = [b[0] for b in bands]
+
+        # Vertical row geometry from the measured header-to-header pitch, so it
+        # tracks the page layout rather than assuming a fixed pixel spacing.
+        box_pitch = median(
+            header_tops[i + 1] - header_tops[i] for i in range(len(header_tops) - 1)
+        )
+        row1_offset = self._row1_ratio * box_pitch
+        row_pitch = self._row_pitch_ratio * box_pitch
+
+        # Horizontal box geometry, detected per box-row, with a width-scaled
+        # calibrated fallback.
+        fallback_boxes = [
+            (int(x * scale), int(self._fallback_box_w * scale))
+            for x in self._fallback_box_x
+        ]
+        columns = [
+            self._box_columns(img, top, bot) or fallback_boxes for top, bot in bands
+        ]
+
+        half_x = max(4, int(self._sample_half_x * scale))
+        half_y = max(5, int(self._sample_half_y * scale))
+        fill_threshold = max(40, int(self._fill_threshold * scale * scale))
+
+        def cell_bin(cx: int, cy: int) -> Optional[ColourBin]:
+            counts = [0] * len(self._bins)
+            for x in range(cx - half_x, cx + half_x + 1):
+                if x < 0 or x >= width:
+                    continue
+                for y in range(cy - half_y, cy + half_y + 1):
+                    if y < 0 or y >= height:
+                        continue
+                    rgb = px[x, y]
+                    for i, colour_bin in enumerate(self._bins):
+                        if colour_bin.matches(*rgb):
+                            counts[i] += 1
+                            break
+            best = max(range(len(counts)), key=lambda i: counts[i])
+            if counts[best] > fill_threshold:
+                return self._bins[best]
+            return None
+
+        raw: List[Tuple[date, str]] = []
+        bin_by_name = {b.name: b for b in self._bins}
+        for month in range(1, 13):
+            box_row = (month - 1) // self._box_cols
+            box_col = (month - 1) % self._box_cols
+            htop = header_tops[box_row]
+            box_left, box_w = columns[box_row][box_col]
+            first_weekday, days_in_month = calendar.monthrange(year, month)
+
+            for week in range(self._grid_rows):
+                cy = int(htop + row1_offset + week * row_pitch)
+                for col in range(self._grid_cols):
+                    cx = int(box_left + (col + 0.5) * box_w / self._grid_cols)
+                    colour_bin = cell_bin(cx, cy)
+                    if colour_bin is None:
+                        continue
+                    day = week * self._grid_cols + col - first_weekday + 1
+                    if not 1 <= day <= days_in_month:
+                        # Geometry sanity guard: skip impossible mappings.
+                        continue
+                    raw.append((date(year, month, day), colour_bin.name))
+
+        if not raw:
+            raise SourceArgumentException(
+                "calendar_url",
+                "no collection days could be detected in the calendar image",
+            )
+
+        self._validate(raw)
+
+        return [
+            Collection(date=d, t=name, icon=bin_by_name[name].icon) for d, name in raw
+        ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
@@ -1,31 +1,24 @@
 """Source for Amarsul, Portugal.
 
 Amarsul publishes its selective-collection calendars as single-page PDFs whose
-page is one embedded JPEG image (no extractable text). This source downloads the
-PDF, extracts the embedded image, and reads the yearly grid by detecting the
-colour-filled day cells:
+page is one embedded JPEG image (no extractable text). The generic
+``PdfImageCalendar`` service does the work of extracting the image, detecting the
+month grid and reading the colour-filled day cells; this module only supplies the
+Amarsul specifics:
 
-* blue cells  -> "Papel/Cartão" (paper / cardboard)
-* yellow cells -> "Embalagens"  (lightweight packaging)
+* teal month-header bars (used to detect the grid),
+* blue cells  -> "Papel/Cartão" (paper / cardboard),
+* yellow cells -> "Embalagens"  (lightweight packaging).
 
-The grid geometry is derived from the teal month-header bars, so the parser does
-not depend on any hardcoded schedule -- only the year (read from the PDF URL) is
-needed to map each (weekday-column, week-row) position to a real date.
+The year is read from the PDF URL, so the schedule is parsed live rather than
+hardcoded.
 """
 
-import calendar
-import re
-from datetime import date
-from io import BytesIO
-from typing import List, Optional
-
-import requests
-from PIL import Image
-from pypdf import PdfReader
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import (
-    SourceArgumentException,
-    SourceArgumentRequired,
+from waste_collection_schedule.exceptions import SourceArgumentRequired
+from waste_collection_schedule.service.PdfImageCalendar import (
+    ColourBin,
+    PdfImageCalendar,
 )
 
 TITLE = "Amarsul"
@@ -34,13 +27,13 @@ URL = "https://www.amarsul.pt"
 COUNTRY = "pt"
 
 # A real, confirmed circuit calendar (circuits D230A/D231A/D249A-D254A, 2026).
-DEFAULT_CALENDAR_URL = (
+EXAMPLE_CALENDAR_URL = (
     "https://www.amarsul.pt/media/orllbvsf/"
     "calend%C3%A1rio-recolhas-2026-d230a-d231a-d249a-d250a-d251a-d252a-d253a-e-d254a.pdf"
 )
 
 TEST_CASES = {
-    "Circuits D230A-D254A (2026)": {"calendar_url": DEFAULT_CALENDAR_URL},
+    "Circuits D230A-D254A (2026)": {"calendar_url": EXAMPLE_CALENDAR_URL},
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
@@ -71,17 +64,6 @@ ICON_MAP = {
     TYPE_PACKAGING: Icons.PLASTIC_PACKAGING,
 }
 
-# --- Image-grid calibration (relative to the 1240x1744 extracted JPEG) ------
-# The calendar is a 3-column x 4-row arrangement of month mini-calendars,
-# laid out row-major: Jan-Mar (top row) ... Oct-Dec (bottom row).
-_BOX_X = (73, 449, 824)  # left edge of each month-box column
-_BOX_W = 353  # month-box width (7 weekday columns)
-_N_COLS = 7  # SEG TER QUA QUI SEX SAB DOM (Mon..Sun)
-_N_ROWS = 6  # up to 6 week-rows per month
-_ROW1_OFFSET = 71.0  # header-bar top -> centre of first week-row
-_ROW_PITCH = 29.4  # vertical spacing between week-rows
-_REF_WIDTH = 1240  # reference image width the calibration was measured on
-
 
 def _is_blue(r: int, g: int, b: int) -> bool:
     return b > 120 and b > r + 40 and b > g + 20 and r < 120
@@ -97,147 +79,19 @@ def _is_teal(r: int, g: int, b: int) -> bool:
 
 
 class Source:
-    def __init__(self, calendar_url: Optional[str] = None):
-        self._url = calendar_url or DEFAULT_CALENDAR_URL
-
-    def _extract_image(self) -> Image.Image:
-        try:
-            resp = requests.get(self._url, timeout=60)
-            resp.raise_for_status()
-        except requests.RequestException as exc:
-            raise SourceArgumentException(
-                "calendar_url", f"could not download the calendar PDF: {exc}"
-            ) from exc
-
-        try:
-            reader = PdfReader(BytesIO(resp.content))
-            page = reader.pages[0]
-            images = page.images
-            if not images:
-                raise SourceArgumentException(
-                    "calendar_url", "the PDF page contains no embedded image"
-                )
-            img = images[0].image
-        except SourceArgumentException:
-            raise
-        except Exception as exc:
-            raise SourceArgumentException(
-                "calendar_url", f"could not read the calendar PDF: {exc}"
-            ) from exc
-
-        return img.convert("RGB")
-
-    def _year(self) -> int:
-        match = re.search(r"20\d\d", self._url)
-        if match:
-            return int(match.group(0))
-        return date.today().year
-
-    def _header_tops(self, img: Image.Image) -> List[int]:
-        """Locate the 4 teal month-header bands (one per box-row)."""
-        width, height = img.size
-        px = img.load()
-        teal_rows = []
-        for y in range(height):
-            count = 0
-            for x in range(0, width, 2):
-                if _is_teal(*px[x, y]):
-                    count += 1
-            teal_rows.append(count)
-
-        threshold = max(teal_rows) * 0.4
-        bands: List[tuple] = []
-        start = None
-        for y, count in enumerate(teal_rows):
-            if count > threshold and start is None:
-                start = y
-            elif count <= threshold and start is not None:
-                if y - start >= 15:  # full header bars are ~28px tall
-                    bands.append((start, y))
-                start = None
-        if start is not None and height - start >= 15:
-            bands.append((start, height))
-
-        tops = [b[0] for b in bands]
-        if len(tops) != 4:
-            raise SourceArgumentException(
-                "calendar_url",
-                f"expected 4 month-header rows in the calendar image, found {len(tops)}",
-            )
-        return tops
-
-    def fetch(self) -> List[Collection]:
-        if not self._url:
+    def __init__(self, calendar_url: str):
+        if not calendar_url:
             raise SourceArgumentRequired(
                 "calendar_url", "a calendar PDF URL is required"
             )
+        self._url = calendar_url
+        self._calendar = PdfImageCalendar(
+            header_matches=_is_teal,
+            bins=[
+                ColourBin(TYPE_PAPER, ICON_MAP[TYPE_PAPER], _is_blue),
+                ColourBin(TYPE_PACKAGING, ICON_MAP[TYPE_PACKAGING], _is_yellow),
+            ],
+        )
 
-        img = self._extract_image()
-        width, height = img.size
-        px = img.load()
-        scale = width / _REF_WIDTH
-
-        header_tops = self._header_tops(img)
-        year = self._year()
-
-        box_x = [int(x * scale) for x in _BOX_X]
-        box_w = _BOX_W * scale
-        row1_offset = _ROW1_OFFSET * scale
-        row_pitch = _ROW_PITCH * scale
-        # Sampling half-window scaled from the reference cell size.
-        half_x = max(4, int(11 * scale))
-        half_y = max(5, int(13 * scale))
-
-        def cell_colour(cx: int, cy: int) -> Optional[str]:
-            n_blue = n_yellow = 0
-            for x in range(cx - half_x, cx + half_x + 1):
-                if x < 0 or x >= width:
-                    continue
-                for y in range(cy - half_y, cy + half_y + 1):
-                    if y < 0 or y >= height:
-                        continue
-                    r, g, b = px[x, y]
-                    if _is_blue(r, g, b):
-                        n_blue += 1
-                    elif _is_yellow(r, g, b):
-                        n_yellow += 1
-            # Require a clearly filled cell, not anti-aliasing noise.
-            threshold = max(40, int(50 * scale * scale))
-            if n_blue > threshold or n_yellow > threshold:
-                return TYPE_PAPER if n_blue >= n_yellow else TYPE_PACKAGING
-            return None
-
-        entries: List[Collection] = []
-        for month in range(1, 13):
-            box_row = (month - 1) // 3
-            box_col = (month - 1) % 3
-            htop = header_tops[box_row]
-            bx = box_x[box_col]
-            first_weekday, days_in_month = calendar.monthrange(year, month)
-
-            for week in range(_N_ROWS):
-                cy = int(htop + row1_offset + week * row_pitch)
-                for col in range(_N_COLS):
-                    cx = int(bx + (col + 0.5) * box_w / _N_COLS)
-                    waste_type = cell_colour(cx, cy)
-                    if waste_type is None:
-                        continue
-                    day = week * _N_COLS + col - first_weekday + 1
-                    if not 1 <= day <= days_in_month:
-                        # Geometry sanity guard: skip impossible mappings.
-                        continue
-                    entries.append(
-                        Collection(
-                            date=date(year, month, day),
-                            t=waste_type,
-                            icon=ICON_MAP[waste_type],
-                        )
-                    )
-
-        if not entries:
-            raise SourceArgumentException(
-                "calendar_url",
-                "no collection days could be detected in the calendar image",
-            )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._calendar.fetch(self._url)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
@@ -1,0 +1,243 @@
+"""Source for Amarsul, Portugal.
+
+Amarsul publishes its selective-collection calendars as single-page PDFs whose
+page is one embedded JPEG image (no extractable text). This source downloads the
+PDF, extracts the embedded image, and reads the yearly grid by detecting the
+colour-filled day cells:
+
+* blue cells  -> "Papel/Cartão" (paper / cardboard)
+* yellow cells -> "Embalagens"  (lightweight packaging)
+
+The grid geometry is derived from the teal month-header bars, so the parser does
+not depend on any hardcoded schedule -- only the year (read from the PDF URL) is
+needed to map each (weekday-column, week-row) position to a real date.
+"""
+
+import calendar
+import re
+from datetime import date
+from io import BytesIO
+from typing import List, Optional
+
+import requests
+from PIL import Image
+from pypdf import PdfReader
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentException,
+    SourceArgumentRequired,
+)
+
+TITLE = "Amarsul"
+DESCRIPTION = "Source for Amarsul selective-collection calendars, Portugal."
+URL = "https://www.amarsul.pt"
+COUNTRY = "pt"
+
+# A real, confirmed circuit calendar (circuits D230A/D231A/D249A-D254A, 2026).
+DEFAULT_CALENDAR_URL = (
+    "https://www.amarsul.pt/media/orllbvsf/"
+    "calend%C3%A1rio-recolhas-2026-d230a-d231a-d249a-d250a-d251a-d252a-d253a-e-d254a.pdf"
+)
+
+TEST_CASES = {
+    "Circuits D230A-D254A (2026)": {"calendar_url": DEFAULT_CALENDAR_URL},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Find the collection calendar (PDF) for your circuit on the Amarsul "
+        "website (https://www.amarsul.pt) and copy the direct link to the PDF "
+        "file. Each circuit has its own calendar PDF."
+    ),
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {"calendar_url": "Calendar PDF URL"},
+}
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "calendar_url": (
+            "Direct link to the Amarsul collection-calendar PDF for your circuit."
+        ),
+    },
+}
+
+# Blue = paper/cardboard, Yellow = lightweight packaging.
+TYPE_PAPER = "Papel/Cartão"
+TYPE_PACKAGING = "Embalagens"
+
+ICON_MAP = {
+    TYPE_PAPER: Icons.PAPER,
+    TYPE_PACKAGING: Icons.PLASTIC_PACKAGING,
+}
+
+# --- Image-grid calibration (relative to the 1240x1744 extracted JPEG) ------
+# The calendar is a 3-column x 4-row arrangement of month mini-calendars,
+# laid out row-major: Jan-Mar (top row) ... Oct-Dec (bottom row).
+_BOX_X = (73, 449, 824)  # left edge of each month-box column
+_BOX_W = 353  # month-box width (7 weekday columns)
+_N_COLS = 7  # SEG TER QUA QUI SEX SAB DOM (Mon..Sun)
+_N_ROWS = 6  # up to 6 week-rows per month
+_ROW1_OFFSET = 71.0  # header-bar top -> centre of first week-row
+_ROW_PITCH = 29.4  # vertical spacing between week-rows
+_REF_WIDTH = 1240  # reference image width the calibration was measured on
+
+
+def _is_blue(r: int, g: int, b: int) -> bool:
+    return b > 120 and b > r + 40 and b > g + 20 and r < 120
+
+
+def _is_yellow(r: int, g: int, b: int) -> bool:
+    return r > 180 and g > 150 and b < 120
+
+
+def _is_teal(r: int, g: int, b: int) -> bool:
+    # Dark-teal month-header bar, RGB ~= (3, 74, 96).
+    return abs(r - 3) < 45 and abs(g - 74) < 45 and abs(b - 96) < 45
+
+
+class Source:
+    def __init__(self, calendar_url: Optional[str] = None):
+        self._url = calendar_url or DEFAULT_CALENDAR_URL
+
+    def _extract_image(self) -> Image.Image:
+        try:
+            resp = requests.get(self._url, timeout=60)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise SourceArgumentException(
+                "calendar_url", f"could not download the calendar PDF: {exc}"
+            ) from exc
+
+        try:
+            reader = PdfReader(BytesIO(resp.content))
+            page = reader.pages[0]
+            images = page.images
+            if not images:
+                raise SourceArgumentException(
+                    "calendar_url", "the PDF page contains no embedded image"
+                )
+            img = images[0].image
+        except SourceArgumentException:
+            raise
+        except Exception as exc:
+            raise SourceArgumentException(
+                "calendar_url", f"could not read the calendar PDF: {exc}"
+            ) from exc
+
+        return img.convert("RGB")
+
+    def _year(self) -> int:
+        match = re.search(r"20\d\d", self._url)
+        if match:
+            return int(match.group(0))
+        return date.today().year
+
+    def _header_tops(self, img: Image.Image) -> List[int]:
+        """Locate the 4 teal month-header bands (one per box-row)."""
+        width, height = img.size
+        px = img.load()
+        teal_rows = []
+        for y in range(height):
+            count = 0
+            for x in range(0, width, 2):
+                if _is_teal(*px[x, y]):
+                    count += 1
+            teal_rows.append(count)
+
+        threshold = max(teal_rows) * 0.4
+        bands: List[tuple] = []
+        start = None
+        for y, count in enumerate(teal_rows):
+            if count > threshold and start is None:
+                start = y
+            elif count <= threshold and start is not None:
+                if y - start >= 15:  # full header bars are ~28px tall
+                    bands.append((start, y))
+                start = None
+        if start is not None and height - start >= 15:
+            bands.append((start, height))
+
+        tops = [b[0] for b in bands]
+        if len(tops) != 4:
+            raise SourceArgumentException(
+                "calendar_url",
+                f"expected 4 month-header rows in the calendar image, found {len(tops)}",
+            )
+        return tops
+
+    def fetch(self) -> List[Collection]:
+        if not self._url:
+            raise SourceArgumentRequired(
+                "calendar_url", "a calendar PDF URL is required"
+            )
+
+        img = self._extract_image()
+        width, height = img.size
+        px = img.load()
+        scale = width / _REF_WIDTH
+
+        header_tops = self._header_tops(img)
+        year = self._year()
+
+        box_x = [int(x * scale) for x in _BOX_X]
+        box_w = _BOX_W * scale
+        row1_offset = _ROW1_OFFSET * scale
+        row_pitch = _ROW_PITCH * scale
+        # Sampling half-window scaled from the reference cell size.
+        half_x = max(4, int(11 * scale))
+        half_y = max(5, int(13 * scale))
+
+        def cell_colour(cx: int, cy: int) -> Optional[str]:
+            n_blue = n_yellow = 0
+            for x in range(cx - half_x, cx + half_x + 1):
+                if x < 0 or x >= width:
+                    continue
+                for y in range(cy - half_y, cy + half_y + 1):
+                    if y < 0 or y >= height:
+                        continue
+                    r, g, b = px[x, y]
+                    if _is_blue(r, g, b):
+                        n_blue += 1
+                    elif _is_yellow(r, g, b):
+                        n_yellow += 1
+            # Require a clearly filled cell, not anti-aliasing noise.
+            threshold = max(40, int(50 * scale * scale))
+            if n_blue > threshold or n_yellow > threshold:
+                return TYPE_PAPER if n_blue >= n_yellow else TYPE_PACKAGING
+            return None
+
+        entries: List[Collection] = []
+        for month in range(1, 13):
+            box_row = (month - 1) // 3
+            box_col = (month - 1) % 3
+            htop = header_tops[box_row]
+            bx = box_x[box_col]
+            first_weekday, days_in_month = calendar.monthrange(year, month)
+
+            for week in range(_N_ROWS):
+                cy = int(htop + row1_offset + week * row_pitch)
+                for col in range(_N_COLS):
+                    cx = int(bx + (col + 0.5) * box_w / _N_COLS)
+                    waste_type = cell_colour(cx, cy)
+                    if waste_type is None:
+                        continue
+                    day = week * _N_COLS + col - first_weekday + 1
+                    if not 1 <= day <= days_in_month:
+                        # Geometry sanity guard: skip impossible mappings.
+                        continue
+                    entries.append(
+                        Collection(
+                            date=date(year, month, day),
+                            t=waste_type,
+                            icon=ICON_MAP[waste_type],
+                        )
+                    )
+
+        if not entries:
+            raise SourceArgumentException(
+                "calendar_url",
+                "no collection days could be detected in the calendar image",
+            )
+
+        return entries

--- a/doc/source/amarsul_pt.md
+++ b/doc/source/amarsul_pt.md
@@ -1,0 +1,46 @@
+# Amarsul
+
+Support for waste collection schedules provided by [Amarsul](https://www.amarsul.pt), Portugal.
+
+Amarsul publishes its selective-collection calendars as single-page PDF files whose page is one embedded image. This source downloads the PDF, extracts the embedded image, and reads the yearly grid by detecting the colour-filled day cells (blue = paper/cardboard, yellow = lightweight packaging). The year is read from the PDF link, so the schedule is parsed live rather than hardcoded.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: amarsul_pt
+      args:
+        calendar_url: CALENDAR_PDF_URL
+```
+
+### Configuration Variables
+
+**calendar_url**
+*(string) (required)*
+
+Direct link to the Amarsul collection-calendar PDF for your circuit. Each circuit (e.g. D230A, D249A, ...) has its own calendar PDF.
+
+## How to find your `calendar_url`
+
+1. Go to [https://www.amarsul.pt](https://www.amarsul.pt) and open the collection-calendar page for your municipality / circuit.
+2. Open the calendar PDF for your circuit.
+3. Copy the direct link to the PDF file (it ends in `.pdf`).
+4. Use that link as the `calendar_url` argument.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: amarsul_pt
+      args:
+        calendar_url: "https://www.amarsul.pt/media/orllbvsf/calend%C3%A1rio-recolhas-2026-d230a-d231a-d249a-d250a-d251a-d252a-d253a-e-d254a.pdf"
+```
+
+## Bin types returned
+
+| Provider description (legend) | Returned type   | Icon                    |
+|-------------------------------|-----------------|-------------------------|
+| Contentor Papel/Cartão (blue) | `Papel/Cartão`  | `Icons.PAPER`           |
+| Contentor Embalagens (yellow) | `Embalagens`    | `Icons.PLASTIC_PACKAGING` |

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ pycryptodome>=3.20.0
 typing_extensions>=4.12.2
 pypdf>=5.1.0
 pdfminer.six>=20221105
+Pillow>=10.0.0
 homeassistant


### PR DESCRIPTION
**Draft / not for merge** — proof-of-concept supporting RFC #6607.

This demonstrates that "image-only" PDF calendars (a single embedded raster image; `pypdf` text extraction returns nothing) can be parsed without OCR:
- Extract the embedded JPEG via `pypdf`, locate the 12 month blocks by their teal header bands, sample the 7×6 day grid, and map coloured cells to dates using Python `calendar` + the year parsed from the PDF URL.
- For Amarsul / Almada (PT) — the PDF assessed as "nearly impossible" in #6451 — it extracts **53 validated collections** for 2026 (0 invalid dates, no colour collisions), correctly capturing the New Year's Day holiday shift.

The point of discussion is the **Pillow dependency** this requires (added here to `requirements.txt` and `manifest.json`). Please see #6607 for the decision and weigh in there.

Refs #6607, #6451.