### PR TITLE
fix(npdc_govt_nz): fix SSL certificate verification (mismatched chain)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/npdc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/npdc_govt_nz.py
@@ -1,6 +1,9 @@
 import datetime
+import ssl
 
+import certifi
 import requests
+from requests.adapters import HTTPAdapter
 from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFound,
@@ -43,6 +46,71 @@ COLLECTION_URL = (
     "https://gissearchwebapiproxy.npdcapps.co.nz/api/rubbishdays/ratedrefuseproperties/"
 )
 
+# The NPDC API host (gissearchwebapiproxy.npdcapps.co.nz) serves an incomplete /
+# mismatched certificate chain: its leaf certificate (CN=*.npdcapps.co.nz) is issued
+# by "Sectigo Public Server Authentication CA DV R36", but the server staples a
+# stale, unrelated intermediate ("Sectigo RSA Domain Validation Secure Server CA")
+# whose subject key identifier does not match the leaf's authority key identifier.
+# As a result clients cannot build a trust path to the certifi-trusted Sectigo root,
+# and the handshake fails with CERTIFICATE_VERIFY_FAILED (unable to get local issuer
+# certificate). We supply the correct R36 intermediate ourselves, alongside the
+# standard certifi trust store, so the chain can be validated without disabling
+# verification. The intermediate below was fetched from the leaf's AIA caIssuers URL:
+# http://crt.sectigo.com/SectigoPublicServerAuthenticationCADVR36.crt
+_NPDC_INTERMEDIATE_CERT = """\
+-----BEGIN CERTIFICATE-----
+MIIGTDCCBDSgAwIBAgIQOXpmzCdWNi4NqofKbqvjsTANBgkqhkiG9w0BAQwFADBf
+MQswCQYDVQQGEwJHQjEYMBYGA1UEChMPU2VjdGlnbyBMaW1pdGVkMTYwNAYDVQQD
+Ey1TZWN0aWdvIFB1YmxpYyBTZXJ2ZXIgQXV0aGVudGljYXRpb24gUm9vdCBSNDYw
+HhcNMjEwMzIyMDAwMDAwWhcNMzYwMzIxMjM1OTU5WjBgMQswCQYDVQQGEwJHQjEY
+MBYGA1UEChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQDEy5TZWN0aWdvIFB1Ymxp
+YyBTZXJ2ZXIgQXV0aGVudGljYXRpb24gQ0EgRFYgUjM2MIIBojANBgkqhkiG9w0B
+AQEFAAOCAY8AMIIBigKCAYEAljZf2HIz7+SPUPQCQObZYcrxLTHYdf1ZtMRe7Yeq
+RPSwygz16qJ9cAWtWNTcuICc++p8Dct7zNGxCpqmEtqifO7NvuB5dEVexXn9RFFH
+12Hm+NtPRQgXIFjx6MSJcNWuVO3XGE57L1mHlcQYj+g4hny90aFh2SCZCDEVkAja
+EMMfYPKuCjHuuF+bzHFb/9gV8P9+ekcHENF2nR1efGWSKwnfG5RawlkaQDpRtZTm
+M64TIsv/r7cyFO4nSjs1jLdXYdz5q3a4L0NoabZfbdxVb+CUEHfB0bpulZQtH1Rv
+38e/lIdP7OTTIlZh6OYL6NhxP8So0/sht/4J9mqIGxRFc0/pC8suja+wcIUna0HB
+pXKfXTKpzgis+zmXDL06ASJf5E4A2/m+Hp6b84sfPAwQ766rI65mh50S0Di9E3Pn
+2WcaJc+PILsBmYpgtmgWTR9eV9otfKRUBfzHUHcVgarub/XluEpRlTtZudU5xbFN
+xx/DgMrXLUAPaI60fZ6wA+PTAgMBAAGjggGBMIIBfTAfBgNVHSMEGDAWgBRWc1hk
+lfmSGrASKgRieaFAFYghSTAdBgNVHQ4EFgQUaMASFhgOr872h6YyV6NGUV3LBycw
+DgYDVR0PAQH/BAQDAgGGMBIGA1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0lBBYwFAYI
+KwYBBQUHAwEGCCsGAQUFBwMCMBsGA1UdIAQUMBIwBgYEVR0gADAIBgZngQwBAgEw
+VAYDVR0fBE0wSzBJoEegRYZDaHR0cDovL2NybC5zZWN0aWdvLmNvbS9TZWN0aWdv
+UHVibGljU2VydmVyQXV0aGVudGljYXRpb25Sb290UjQ2LmNybDCBhAYIKwYBBQUH
+AQEEeDB2ME8GCCsGAQUFBzAChkNodHRwOi8vY3J0LnNlY3RpZ28uY29tL1NlY3Rp
+Z29QdWJsaWNTZXJ2ZXJBdXRoZW50aWNhdGlvblJvb3RSNDYucDdjMCMGCCsGAQUF
+BzABhhdodHRwOi8vb2NzcC5zZWN0aWdvLmNvbTANBgkqhkiG9w0BAQwFAAOCAgEA
+YtOC9Fy+TqECFw40IospI92kLGgoSZGPOSQXMBqmsGWZUQ7rux7cj1du6d9rD6C8
+ze1B2eQjkrGkIL/OF1s7vSmgYVafsRoZd/IHUrkoQvX8FZwUsmPu7amgBfaY3g+d
+q1x0jNGKb6I6Bzdl6LgMD9qxp+3i7GQOnd9J8LFSietY6Z4jUBzVoOoz8iAU84OF
+h2HhAuiPw1ai0VnY38RTI+8kepGWVfGxfBWzwH9uIjeooIeaosVFvE8cmYUB4TSH
+5dUyD0jHct2+8ceKEtIoFU/FfHq/mDaVnvcDCZXtIgitdMFQdMZaVehmObyhRdDD
+4NQCs0gaI9AAgFj4L9QtkARzhQLNyRf87Kln+YU0lgCGr9HLg3rGO8q+Y4ppLsOd
+unQZ6ZxPNGIfOApbPVf5hCe58EZwiWdHIMn9lPP6+F404y8NNugbQixBber+x536
+WrZhFZLjEkhp7fFXf9r32rNPfb74X/U90Bdy4lzp3+X1ukh1BuMxA/EEhDoTOS3l
+7ABvc7BYSQubQ2490OcdkIzUh3ZwDrakMVrbaTxUM2p24N6dB+ns2zptWCva6jzW
+r8IWKIMxzxLPv5Kt3ePKcUdvkBU/smqujSczTzzSjIoR5QqQA6lN1ZRSnuHIWCvh
+JEltkYnTAH41QJ6SAWO66GrrUESwN/cgZzL4JLEqz1Y=
+-----END CERTIFICATE-----
+"""
+
+
+class _NPDCChainAdapter(HTTPAdapter):
+    """HTTPAdapter that adds the correct Sectigo R36 intermediate to the trust store.
+
+    NPDC's API host serves a mismatched certificate chain, so we build an SSL context
+    seeded with certifi's roots plus the missing intermediate, allowing certificate
+    verification to succeed without disabling it.
+    """
+
+    def init_poolmanager(self, *args, **kwargs):
+        ctx = ssl.create_default_context(cafile=certifi.where())
+        ctx.load_verify_locations(cadata=_NPDC_INTERMEDIATE_CERT)
+        kwargs["ssl_context"] = ctx
+        return super().init_poolmanager(*args, **kwargs)
+
 
 def _weeks_since_anchor(d: datetime.date) -> int:
     return (d - _ANCHOR).days // 7
@@ -64,8 +132,11 @@ class Source:
         self._address = address.strip()
 
     def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.mount("https://", _NPDCChainAdapter())
+
         # Step 1: Search for the parcel matching the address
-        r = requests.get(SEARCH_URL, params={"q": self._address}, timeout=30)
+        r = session.get(SEARCH_URL, params={"q": self._address}, timeout=30)
         r.raise_for_status()
         results = r.json()
 
@@ -79,7 +150,7 @@ class Source:
             raise SourceArgumentNotFound("address", self._address)
 
         # Step 2: Fetch collection information for the parcel
-        r2 = requests.get(COLLECTION_URL, params={"parcelId": parcel_id}, timeout=30)
+        r2 = session.get(COLLECTION_URL, params={"parcelId": parcel_id}, timeout=30)
         r2.raise_for_status()
         collection_data = r2.json()
 


### PR DESCRIPTION
## Problem

`npdc_govt_nz` fails for all users with:

```
SSLError(SSLCertVerificationError ... [SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate)
```

## Root cause

The API host `gissearchwebapiproxy.npdcapps.co.nz` serves a **mismatched certificate chain**. The leaf (`CN=*.npdcapps.co.nz`) is issued by **Sectigo Public Server Authentication CA DV R36**, but the server staples a stale, unrelated intermediate (**Sectigo RSA Domain Validation Secure Server CA**) whose Subject Key Identifier does not match the leaf's Authority Key Identifier. Clients therefore cannot build a trust path to the certifi-trusted **Sectigo Public Server Authentication Root R46** and the handshake fails. `curl_cffi` does not help (this is a chain-building problem, not a TLS-fingerprint/Cloudflare one).

## Fix

Self-contained, no new dependency and no `verify=False`:

- Bundle the correct R36 intermediate (fetched from the leaf's AIA `caIssuers` URL, `http://crt.sectigo.com/SectigoPublicServerAuthenticationCADVR36.crt`).
- Mount a custom `HTTPAdapter` on the `requests.Session` whose `ssl.SSLContext` is seeded with `certifi.where()` **plus** that intermediate via `load_verify_locations(cadata=...)`. This follows the existing `LegacyTLSAdapter` pattern (e.g. `ashford_gov_uk.py`), adapted to add an intermediate rather than downgrade TLS.

Certificate verification stays fully enabled.

## Verification

- `openssl verify -CAfile <certifi> -untrusted <r36> <leaf>` → `OK`
- Before: plain `requests.get(...)` raises `SSLCertVerificationError`. After: handshake succeeds.
- `python -m pytest tests/test_source_components.py -q` → 9 passed.
- Live run against all three `TEST_CASES` now returns data (104–106 entries each), no SSL error.

Fixes #6611

🤖 Generated with [Claude Code](https://claude.com/claude-code)
