### PR TITLE
chore(muellmax_de): deprecate RSAG Rhein-Sieg-Kreis entry in favour of rsag_de

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/MuellmaxDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/MuellmaxDe.py
@@ -7,11 +7,9 @@ SERVICE_MAP = [
         "url": "https://www.awista.de/",
         "service_id": "Dus",
     },
-    {
-        "title": "RSAG Rhein-Sieg-Kreis",
-        "url": "https://www.rsag.de",
-        "service_id": "Rsa",
-    },
+    # RSAG Rhein-Sieg-Kreis ("Rsa") is covered by the dedicated `rsag_de` source
+    # (same Müllmax backend, friendlier city/street config) — see #6553. Entry
+    # removed to avoid two listings for the same provider.
     {
         "title": "USB Bochum",
         "url": "https://www.usb-bochum.de/",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
@@ -23,11 +23,6 @@ def EXTRA_INFO():
 
 
 TEST_CASES = {
-    # "Rhein-Sieg-Kreis, Alfter": {
-    #     "service": "Rsa",
-    #     "mm_frm_ort_sel": "Alfter",
-    #     "mm_frm_str_sel": "Ahrweg (105-Ende/94-Ende)",
-    # },
     # "Münster, Achatiusweg": {"service": "Awm", "mm_frm_str_sel": "Achatiusweg"},
     # "Hal, Postweg": {"service": "Hal", "mm_frm_str_sel": "Postweg"},
     # "giessen": {


### PR DESCRIPTION
Follow-up to #6553 (RSAG via `rsag_de`).

@David-Development pointed out that the new `rsag_de` source overlaps the existing Müllmax `Rsa` listing. Investigation confirmed they hit the **same backend** — RSAG uses Müllmax as its portal vendor and `rsag.de/api` is a JSON/ICS front-end over the same dataset (identical dates and waste types across the same 19 Rhein-Sieg-Kreis municipalities).

To avoid two listings for one provider, this removes the `RSAG Rhein-Sieg-Kreis` (`service_id: "Rsa"`) entry from `MuellmaxDe.SERVICE_MAP` and the corresponding commented-out test case in `muellmax_de.py`. Users are steered to `rsag_de`, which has a friendlier `city`/`street` config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>