### PR TITLE
fix(awb_mainz_bingen_de): add KAW Mainz-Bingen source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_mainz_bingen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_mainz_bingen_de.py
@@ -5,6 +5,7 @@ from waste_collection_schedule.source.kaw_mainz_bingen_de import URL as KAW_URL
 from waste_collection_schedule.source.kaw_mainz_bingen_de import Source as KawSource
 
 _LOGGER = logging.getLogger(__name__)
+_DEPRECATION_WARNING_LOGGED = False
 
 TITLE = "Abfallwirtschaftsbetrieb LK Mainz-Bingen (Deprecated)"
 DESCRIPTION = (
@@ -30,10 +31,14 @@ TEST_CASES = {
 
 class Source(KawSource):
     def __init__(self, bezirk: str, ort: str, strasse: str | None = None):
+        global _DEPRECATION_WARNING_LOGGED
+
         super().__init__(bezirk, ort, strasse)
-        _LOGGER.warning(
-            "awb_mainz_bingen_de is deprecated, please use kaw_mainz_bingen_de instead"
-        )
+        if not _DEPRECATION_WARNING_LOGGED:
+            _LOGGER.warning(
+                "awb_mainz_bingen_de is deprecated, please use kaw_mainz_bingen_de instead"
+            )
+            _DEPRECATION_WARNING_LOGGED = True
 
 
 Source.__init__.__signature__ = Signature(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_mainz_bingen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_mainz_bingen_de.py
@@ -1,191 +1,45 @@
-import re
+import logging
+from inspect import Parameter, Signature
 
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import (
-    SourceArgumentNotFoundWithSuggestions,
-    SourceArgumentRequired,
+from waste_collection_schedule.source.kaw_mainz_bingen_de import URL as KAW_URL
+from waste_collection_schedule.source.kaw_mainz_bingen_de import Source as KawSource
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "Abfallwirtschaftsbetrieb LK Mainz-Bingen (Deprecated)"
+DESCRIPTION = (
+    "Deprecated source for Abfallwirtschaftsbetrieb LK Mainz-Bingen. "
+    "Please use KAW Mainz und Mainz-Bingen AöR instead."
 )
-from waste_collection_schedule.service.ICS import ICS
-
-TITLE = "Abfallwirtschaftsbetrieb LK Mainz-Bingen"
-DESCRIPTION = "Source for Abfallwirtschaftsbetrieb LK Mainz-Bingen."
-URL = "https://www.awb-mainz-bingen.de/"
+URL = KAW_URL
 TEST_CASES = {
-    "Stadt Ingelheim Ingelheim Süd Albert-Schweitzer-Straße": {
+    "Stadt Ingelheim Ingelheim Süd": {
         "bezirk": "Stadt Ingelheim",
         "ort": "Ingelheim Süd",
-        "strasse": "Albert-Schweitzer-Straße",
     },
     "Verbandsgemeinde Rhein-Selz, Mommenheim": {
         "bezirk": "Verbandsgemeinde Rhein-Selz",
         "ort": "mOmMenHeiM",
     },
-    "Stadt Bingen, Bingen-Stadt, Martinstraße (Haus-Nr.: 5 - 11, 10 - 18)": {
+    "Stadt Bingen, Bingen-Stadt": {
         "bezirk": "Stadt Bingen",
         "ort": "Bingen-Stadt",
-        "strasse": "Martinstraße (Haus-Nr.: 5 - 11, 10 - 18)",
     },
 }
 
 
-ICON_MAP = {
-    "Restmüll": Icons.GENERAL_WASTE,
-    "Glass": Icons.GLASS,
-    "Biomüll": Icons.BIO_KITCHEN,
-    "Papier": Icons.PAPER,
-    "Gelbe/r Tonne / Sack": Icons.RECYCLING,
-    "Problemmüll": Icons.HAZARDOUS,
-}
-
-
-API_URL = "https://abfallkalender.awb-mainz-bingen.de/"
-
-
-class Source:
+class Source(KawSource):
     def __init__(self, bezirk: str, ort: str, strasse: str | None = None):
-        self._bezirk: str = bezirk
-        self._ort: str = ort
-        self._strasse: str | None = strasse
-        self._ics = ICS()
-
-    def fetch(self):
-        session = requests.Session()
-
-        # Get bezirk id from main page
-        r = session.get(API_URL)
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, "html.parser")
-        bezirk = soup.find("select", {"id": "Abfuhrbezirk"}).find(
-            "option", text=re.compile(re.escape(self._bezirk), re.IGNORECASE)
+        super().__init__(bezirk, ort, strasse)
+        _LOGGER.warning(
+            "awb_mainz_bingen_de is deprecated, please use kaw_mainz_bingen_de instead"
         )
 
-        if not bezirk:
-            found = [i.text for i in soup.find_all("option")][1:]
-            raise SourceArgumentNotFoundWithSuggestions("bezirk", self._bezirk, found)
 
-        bezirk_id = bezirk.get("value")
-
-        # set arguments to imitate xajax call
-        xjxargs_string = "<xjxobj>"
-        for key, value in {
-            "Abfuhrbezirk": "{bezirk_id}",
-            "Ortschaft": "{ort_id}",
-            "Strasse": "{strasse_id}",
-        }.items():
-            xjxargs_string += "<e><k>" + key + "</k><v>S" + value + "</v></e>"
-        xjxargs_string += "</xjxobj>"
-
-        args = {
-            "xjxfun": "show_ortsteil_dropdown",
-            "xjxargs[]": xjxargs_string.format(
-                bezirk_id=bezirk_id, ort_id=0, strasse_id=0
-            ),
-        }
-
-        # send request to get dropdown with for ort id
-        r = session.post(API_URL, data=args)
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, "xml")
-        teilorte_div = soup.find("cmd", {"id": "divTeilort"})
-
-        if not teilorte_div:
-            raise Exception("invalid response from server", soup)
-
-        teilorte = BeautifulSoup(
-            teilorte_div.text.replace("<![CDATA[", "").replace("]]>", ""), "html.parser"
-        )
-
-        ort = teilorte.find(
-            "option", text=re.compile(re.escape(self._ort), re.IGNORECASE)
-        )
-        if not ort:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "ort", self._ort, [i.text for i in teilorte.find_all("option")][1:]
-            )
-
-        ort_id = ort.get("value")
-
-        args = {
-            "xjxfun": "show_strasse_dropdown_or_abfuhrtermine",
-            "xjxargs[]": xjxargs_string.format(
-                bezirk_id=bezirk_id, ort_id=ort_id, strasse_id=0
-            ),
-        }
-
-        r = session.post(API_URL, data=args)
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, "xml")
-        div_strasse = soup.find("cmd", {"id": "divStrasse"})
-
-        if not div_strasse:
-            raise Exception("invalid response from server")
-
-        strassen_soup = BeautifulSoup(
-            div_strasse.text.replace("<![CDATA[", "").replace("]]>", ""), "html.parser"
-        )
-
-        # If strasse is needed
-        if strassen_soup.find("option"):
-            if not self._strasse:
-                raise SourceArgumentRequired(
-                    "strasse",
-                    "A street (Strasse) must be selected from the available options",
-                )
-
-            # get strasse id
-            strasse_id = strassen_soup.find(
-                "option", text=re.compile(re.escape(self._strasse), re.IGNORECASE)
-            )
-            if not strasse_id:
-                found = [i.text for i in strassen_soup.find_all("option")][1:]
-                raise SourceArgumentNotFoundWithSuggestions(
-                    "strasse", self._strasse, found
-                )
-
-            strasse_id = strasse_id.get("value")
-            xjxargs = {
-                "bezirk_id": bezirk_id,
-                "ort_id": ort_id,
-                "strasse_id": strasse_id,
-            }
-            args = {
-                "xjxfun": "show_abfuhrtermine",
-                "xjxargs[]": xjxargs_string.format(**xjxargs),
-            }
-
-            # get main calendar
-            r = session.post(API_URL, data=args)
-            r.raise_for_status()
-            soup = BeautifulSoup(r.text, "xml")
-
-        cal_wrapper = soup.find("cmd", {"id": "divKalenderWrapper"})
-
-        if not cal_wrapper:
-            raise Exception("No calendar found", r.text)
-        cal_soup = BeautifulSoup(
-            cal_wrapper.text.replace("<![CDATA[", "").replace("]]>", ""), "html.parser"
-        )
-
-        entries = []
-        # get ical file url
-        for ical_path in cal_soup.findAll("a", {"href": re.compile("ical")}):
-            ical_path = ical_path.get("href")
-            # get ical file
-            r = requests.get(API_URL + ical_path)
-            r.raise_for_status()
-            r.encoding = "utf-8"
-
-            # remove DURATION because the returned icalendar has invalid DURATION syntax
-            ical_string = re.sub(r"^DURATION.*\n?", "", r.text, flags=re.MULTILINE)
-
-            dates = self._ics.convert(ical_string)
-            for d in dates:
-                bin_type = d[1].split(" am ")[0].replace("Abfuhrtermin", "").strip()
-                entries.append(Collection(d[0], bin_type, ICON_MAP.get(bin_type)))
-
-        return entries
+Source.__init__.__signature__ = Signature(
+    parameters=[
+        Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter("bezirk", Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+        Parameter("ort", Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+    ]
+)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaw_mainz_bingen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaw_mainz_bingen_de.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import datetime
+from inspect import Parameter, Signature
+from typing import Any
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+TITLE = "KAW Mainz und Mainz-Bingen AöR"
+DESCRIPTION = "Source for KAW Mainz und Mainz-Bingen AöR."
+URL = "https://lk.kaw-mainz-bingen.de/de/Abfallentsorgung/Abfallkalender"
+TEST_CASES = {
+    "Stadt Ingelheim Ingelheim Süd": {
+        "bezirk": "Stadt Ingelheim",
+        "ort": "Ingelheim Süd",
+    },
+    "Verbandsgemeinde Rhein-Selz, Mommenheim": {
+        "bezirk": "Verbandsgemeinde Rhein-Selz",
+        "ort": "mOmMenHeiM",
+    },
+    "Stadt Bingen, Bingen-Stadt": {
+        "bezirk": "Stadt Bingen",
+        "ort": "Bingen-Stadt",
+    },
+}
+
+
+ICON_MAP = {
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Glass": Icons.GLASS,
+    "Biomüll": Icons.BIO_KITCHEN,
+    "Papier": Icons.PAPER,
+    "Papiertonne": Icons.PAPER,
+    "Gelbe/r Tonne / Sack": Icons.RECYCLING,
+    "Gelbe Tonne": Icons.RECYCLING,
+    "Problemmüll": Icons.HAZARDOUS,
+    "Problemmüllbus": Icons.HAZARDOUS,
+}
+
+
+API_URL = "https://abfallkalender-api-lk.kaw-mainz-bingen.de/public/frontend"
+RECORDS_PER_PAGE = 999999
+DATE_FORMAT = "%Y-%m-%d"
+
+
+class Source:
+    def __init__(self, bezirk: str, ort: str, strasse: str | None = None):
+        self._bezirk: str = bezirk
+        self._ort: str = ort
+        # Kept for compatibility with existing configurations. The new KAW API
+        # exposes the public calendar by district and city only.
+        self._strasse: str | None = strasse
+
+    def fetch(self):
+        session = requests.Session()
+
+        settings = self._get_settings(session)
+        bezirk = self._find_bezirk(settings)
+        ort = self._find_ort(settings, bezirk["Id"])
+
+        today = datetime.date.today()
+        date_to = datetime.date(today.year + 1, 12, 31)
+
+        params = {
+            "Filter.SearchTerm": "",
+            "Filter.DistrictId": bezirk["Id"],
+            "Filter.CityId": ort["Id"],
+            "Filter.StreetId": 0,
+            "Filter.DateFrom": today.strftime(DATE_FORMAT),
+            "Filter.DateTo": date_to.strftime(DATE_FORMAT),
+            "Filter.WasteTypeIds": ",".join(
+                str(waste_type["Id"])
+                for waste_type in _active_items(settings["WasteTypes"])
+            ),
+            "Filter.ShowGroupedResults": "false",
+            "Filter.RecordsPerPage": RECORDS_PER_PAGE,
+            "Filter.CurrentPage": 1,
+            "Filter.SortColumn": "Date",
+        }
+
+        r = session.get(f"{API_URL}/collectiondates", params=params, timeout=30)
+        r.raise_for_status()
+        data = r.json()
+        self._raise_for_api_error(data)
+
+        entries = []
+        for item in data.get("DataList", []):
+            date = datetime.datetime.strptime(item["Date"], "%d.%m.%Y").date()
+            bin_type = item["WasteTypeName"]
+            entries.append(
+                Collection(
+                    date,
+                    bin_type,
+                    ICON_MAP.get(bin_type),
+                    location=item.get("Location"),
+                    description=item.get("AdditionalDescription"),
+                )
+            )
+
+        return entries
+
+    def _get_settings(self, session: requests.Session) -> dict[str, Any]:
+        r = session.get(
+            f"{API_URL}/settings",
+            params={"Filter.IncludeStaticObjects": "true"},
+            timeout=30,
+        )
+        r.raise_for_status()
+        data = r.json()
+        self._raise_for_api_error(data)
+        return data["Data"]
+
+    def _find_bezirk(self, settings: dict[str, Any]) -> dict[str, Any]:
+        districts = _active_items(settings["Districts"])
+        district = _find_by_name(districts, self._bezirk)
+        if district is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "bezirk", self._bezirk, _names(districts)
+            )
+        return district
+
+    def _find_ort(self, settings: dict[str, Any], bezirk_id: int) -> dict[str, Any]:
+        cities = [
+            city
+            for city in _active_items(settings["Cities"])
+            if city["DistrictId"] == bezirk_id
+        ]
+        city = _find_by_name(cities, self._ort)
+        if city is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "ort", self._ort, _names(cities)
+            )
+        return city
+
+    @staticmethod
+    def _raise_for_api_error(data: dict[str, Any]) -> None:
+        if data.get("ReturnCode") not in (0, 990):
+            raise Exception(
+                data.get("ErrorMessage")
+                or data.get("Message")
+                or "Invalid response from server"
+            )
+
+
+def _normalize(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def _active_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        item for item in items if item.get("Id", 0) > 0 and item.get("RecordState") == 1
+    ]
+
+
+def _find_by_name(items: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    normalized_name = _normalize(name)
+    return next(
+        (item for item in items if _normalize(item.get("Name", "")) == normalized_name),
+        None,
+    )
+
+
+def _names(items: list[dict[str, Any]]) -> list[str]:
+    return [item["Name"] for item in items]
+
+
+Source.__init__.__signature__ = Signature(
+    parameters=[
+        Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter("bezirk", Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+        Parameter("ort", Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+    ]
+)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaw_mainz_bingen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaw_mainz_bingen_de.py
@@ -5,7 +5,7 @@ from inspect import Parameter, Signature
 from typing import Any
 
 import requests
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 
 TITLE = "KAW Mainz und Mainz-Bingen AöR"
@@ -53,7 +53,7 @@ class Source:
         # exposes the public calendar by district and city only.
         self._strasse: str | None = strasse
 
-    def fetch(self):
+    def fetch(self) -> list[Collection]:
         session = requests.Session()
 
         settings = self._get_settings(session)
@@ -85,7 +85,7 @@ class Source:
         data = r.json()
         self._raise_for_api_error(data)
 
-        entries = []
+        entries: list[Collection] = []
         for item in data.get("DataList", []):
             date = datetime.datetime.strptime(item["Date"], "%d.%m.%Y").date()
             bin_type = item["WasteTypeName"]

--- a/doc/source/awb_mainz_bingen_de.md
+++ b/doc/source/awb_mainz_bingen_de.md
@@ -9,10 +9,10 @@ Existing `awb_mainz_bingen_de` configurations use the current [KAW Abfallkalende
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: awb_mainz_bingen_de
-      args:
-        bezirk: Abfuhrbezirk
-        ort: Ort
+        - name: awb_mainz_bingen_de
+          args:
+            bezirk: Abfuhrbezirk
+            ort: Ort
 
 ```
 
@@ -32,10 +32,10 @@ waste_collection_schedule:
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: awb_mainz_bingen_de
-      args:
-        bezirk: Stadt Ingelheim
-        ort: Ingelheim Süd
+        - name: awb_mainz_bingen_de
+          args:
+            bezirk: Stadt Ingelheim
+            ort: Ingelheim Süd
 
 ```
 

--- a/doc/source/kaw_mainz_bingen_de.md
+++ b/doc/source/kaw_mainz_bingen_de.md
@@ -7,10 +7,10 @@ Support for schedules provided by [KAW Mainz und Mainz-Bingen AöR](https://lk.k
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: kaw_mainz_bingen_de
-      args:
-        bezirk: Abfuhrbezirk
-        ort: Ort
+        - name: kaw_mainz_bingen_de
+          args:
+            bezirk: Abfuhrbezirk
+            ort: Ort
 
 ```
 
@@ -27,10 +27,10 @@ waste_collection_schedule:
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: kaw_mainz_bingen_de
-      args:
-        bezirk: Stadt Ingelheim
-        ort: Ingelheim Süd
+        - name: kaw_mainz_bingen_de
+          args:
+            bezirk: Stadt Ingelheim
+            ort: Ingelheim Süd
 
 ```
 

--- a/doc/source/kaw_mainz_bingen_de.md
+++ b/doc/source/kaw_mainz_bingen_de.md
@@ -1,15 +1,13 @@
-# Abfallwirtschaftsbetrieb LK Mainz-Bingen (Deprecated)
+# KAW Mainz und Mainz-Bingen AöR
 
-This source is deprecated and kept for existing configurations. Please use [KAW Mainz und Mainz-Bingen AöR](./kaw_mainz_bingen_de.md) for new setups.
-
-Existing `awb_mainz_bingen_de` configurations use the current [KAW Abfallkalender](https://lk.kaw-mainz-bingen.de/de/Abfallentsorgung/Abfallkalender) internally.
+Support for schedules provided by [KAW Mainz und Mainz-Bingen AöR](https://lk.kaw-mainz-bingen.de/de/Abfallentsorgung/Abfallkalender), serving Landkreis Mainz-Bingen, Germany.
 
 ## Configuration via configuration.yaml
 
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: awb_mainz_bingen_de
+    - name: kaw_mainz_bingen_de
       args:
         bezirk: Abfuhrbezirk
         ort: Ort
@@ -18,21 +16,18 @@ waste_collection_schedule:
 
 ### Configuration Variables
 
-**bezirk**  
+**bezirk**
 *(String) (required)*
 
-**ort**  
+**ort**
 *(String) (required)*
-
-**strasse**  
-*(String) (optional, legacy parameter; ignored by the current website)*
 
 ## Example
 
 ```yaml
 waste_collection_schedule:
     sources:
-    - name: awb_mainz_bingen_de
+    - name: kaw_mainz_bingen_de
       args:
         bezirk: Stadt Ingelheim
         ort: Ingelheim Süd


### PR DESCRIPTION
## Summary

Adds KAW Mainz und Mainz-Bingen AöR as the current source for Landkreis Mainz-Bingen collection schedules.

The existing `awb_mainz_bingen_de` source is kept as a deprecated compatibility entry so existing configurations continue to work without changing entity IDs. New configurations should use `kaw_mainz_bingen_de`.

This PR also updates the source documentation:

- adds `doc/source/kaw_mainz_bingen_de.md`
- marks `doc/source/awb_mainz_bingen_de.md` as deprecated and points users to KAW

## Type of change

- [x] New source
- [x] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Validation

- `python -m pytest tests/test_source_components.py -q` passes: `9 passed`
- `python test_sources.py -s kaw_mainz_bingen_de -l` passes:
  - Stadt Ingelheim Ingelheim Süd: 78 entries
  - Verbandsgemeinde Rhein-Selz, Mommenheim: 76 entries
  - Stadt Bingen, Bingen-Stadt: 71 entries
- `python test_sources.py -s awb_mainz_bingen_de -l` passes with the deprecated compatibility source
- Existing AWB-style configuration with legacy `strasse` argument was verified to keep returning entries
- `python -m black` and `python -m isort --profile black` were run on changed source files
- `python -m flake8 --extend-ignore=D100,D101,D102,D103,D104,D105,D106,D107,E501,W503,E203` passes for changed source files
- No generated files are included in the diff (`README.md`, `info.md`, `sources.json`, `source_metadata.json`, `translations/*.json`)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python -m black` and `python -m isort --profile black` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
