### PR TITLE
fix republicservices_com: weekly recurrence projection never fired ('W' vs 'week'); bulk waste icon

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta
 
 import requests
-from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "Republic Services"
@@ -180,14 +180,14 @@ class Source:
         if self._method == 1:
             for item in schedule:
                 if "RECYCLE" in item["waste_description"]:
-                    icon = "mdi:recycle"
+                    icon = Icons.RECYCLING
                 elif (
                     "YARD" in item["waste_description"]
                     or "ORGANICS" in item["waste_description"]
                 ):
-                    icon = "mdi:leaf"
+                    icon = Icons.ORGANIC
                 else:
-                    icon = "mdi:trash-can"
+                    icon = Icons.GENERAL_WASTE
                 entries.append(
                     Collection(
                         date=item["date"],
@@ -201,16 +201,16 @@ class Source:
                     "YARD" in item["waste_description"]
                     or "ORGANICS" in item["waste_description"]
                 ):
-                    icon = "mdi:leaf"
+                    icon = Icons.ORGANIC
                     waste_type = "Yard Waste"
                 elif "BULK SERVICE" in item["waste_description"]:
-                    icon = "mdi:sofa"
+                    icon = Icons.BULKY
                     waste_type = "Bulk Waste"
                 elif "RECYCLE" in item["waste_description"]:
-                    icon = "mdi:recycle"
+                    icon = Icons.RECYCLING
                     waste_type = "Recycle"
                 else:
-                    icon = "mdi:trash-can"
+                    icon = Icons.GENERAL_WASTE
                     waste_type = "Solid Waste"
 
                 entries.append(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -101,7 +101,7 @@ class Source:
 
                     if (
                         period_unit
-                        and period_unit.lower() == "week"
+                        and period_unit.lower() in ("w", "week")
                         and item.get("nextServiceDays")
                     ):
                         # Project recurring weekly/fortnightly schedule from seed date
@@ -204,7 +204,7 @@ class Source:
                     icon = "mdi:leaf"
                     waste_type = "Yard Waste"
                 elif "BULK SERVICE" in item["waste_description"]:
-                    icon = "mdi:leaf"
+                    icon = "mdi:sofa"
                     waste_type = "Bulk Waste"
                 elif "RECYCLE" in item["waste_description"]:
                     icon = "mdi:recycle"


### PR DESCRIPTION
## Summary

Two fixes to the `republicservices_com` source:

**1. Weekly recurrence projection never fired (`'W' != 'week'`).** The Republic Services `publicPickup` API returns `numberOfPickupsPeriodUnit: "W"`, but the projection condition compared it against the full word:

```python
period_unit.lower() == "week"   # API sends "W" → always False
```

so the recurring-schedule projection added in the period-fields change was dead code — every weekly container fell through to the `else` branch and emitted only its single `nextServiceDays` date. Users saw exactly one upcoming pickup per cart instead of the projected ~6 months. Fixed by accepting both forms: `period_unit.lower() in ("w", "week")`.

Live-test evidence (`test_sources.py -s republicservices_com`), entries per test case before → after:

| Test case | Before | After |
|---|---|---|
| Scott Country Clerk | 1 | 26 |
| Branch County Clerk | 1 | 26 |
| Residential Collection | 1 | 26 |
| 4420 Oasis Hill Ave, North Las Vegas | bulk dates only | 65 |

(Non-weekly containers, e.g. Las Vegas bulk service, list explicit future dates in `nextServiceDays` and were unaffected.)

**2. Method-2 "Bulk Waste" used the yard-waste icon.** `mdi:leaf` was a copy-paste from the YARD/ORGANICS branch directly above. Changed to `mdi:sofa`, matching the canonical `Icons.BULKY` value used across the project.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (9 passed)
- [x] `python -m black` and `python -m isort --profile black` run on changed source files (no changes needed)
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources (n/a — existing source)
- [x] TEST_CASES use real, publicly accessible addresses (not my own) (no TEST_CASES changes; all existing cases pass live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
