### PR TITLE
fix(config_flow): allow editing sensor value_template when preset was previously set

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -273,15 +273,20 @@ def validate_sensor_user_input(
 
     # validate value_template and date_template against cv.template
     for key in [CONF_VALUE_TEMPLATE, CONF_DATE_TEMPLATE]:
-        if key + "_preset" in sensor_input and sensor_input[key + "_preset"]:
-            if key in sensor_input:
-                errors[key] = "preset_selected"
-                errors[key + "_preset"] = "preset_selected"
-                continue
-            args.pop(key + "_preset", None)
-            args[key] = sensor_input[key + "_preset"]
+        preset_key = key + "_preset"
+        has_preset = preset_key in sensor_input and sensor_input[preset_key]
+        has_custom = key in sensor_input and sensor_input[key]
 
-        if key in sensor_input and key:
+        if has_preset and has_custom:
+            # Both a preset selection and a custom value are present.
+            # The custom value (TemplateSelector) reflects the user's direct
+            # intent, so honour it and discard the stale preset.
+            args.pop(preset_key, None)
+        elif has_preset:
+            args.pop(preset_key, None)
+            args[key] = sensor_input[preset_key]
+
+        if key in args and args[key]:
             try:
                 cv.template(args[key])
             except vol.Invalid:


### PR DESCRIPTION
## Summary

Fixes the unbreakable error loop reported in #3148: once a sensor had a saved `value_template`, opening the sensor edit form and submitting it would always raise "You cannot select a preset and specify custom values at the same time", with no way to dismiss it except deleting and recreating the sensor.

**Root cause:** `validate_sensor_user_input` pre-filled the TemplateSelector from the stored sensor options. If the preset field and the custom template field were both non-empty on submission, the old code set errors on both and `continue`d — skipping the cleanup that clears the `_preset` key. Each re-render passed the same `user_input` back through the schema, reproducing the same combination of filled fields, making the error permanent.

**Fix:** Replace the mutual-exclusion error with a precedence rule: when both fields are present, the custom TemplateSelector value wins and the stale preset is silently dropped. The preset-only path is unchanged.

## Test plan
- [ ] Open an existing sensor that has a saved `value_template`.
- [ ] Submit the sensor edit form without changes — should save cleanly.
- [ ] Change the `value_template` value directly in the TemplateSelector and submit — should save cleanly.
- [ ] Select a preset from the dropdown (with no custom value) — should still work as before.
- [ ] Select a preset AND type in the TemplateSelector — custom value should win, preset is discarded, no error shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)