### PR TITLE
chore(stirling_wa_gov_au): add @markvp as source codeowner

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
@@ -39,6 +39,8 @@ PARAM_TRANSLATIONS = {
     },
 }
 
+SOURCE_CODEOWNERS = ["@markvp"]
+
 ICON_MAP = {
     "red": Icons.GENERAL_WASTE,
     "green": Icons.ORGANIC,


### PR DESCRIPTION
Adds `SOURCE_CODEOWNERS = ["@markvp"]` to the City of Stirling (WA, AU) source so bug reports naming this source ping and assign me via the Notify Source Owners workflow.

`update_docu_links.py` will populate `.github/source_owners.json` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)