### PR TITLE
feat(customize): support fnmatch wildcards in customize type key

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -1,4 +1,5 @@
 import datetime
+import fnmatch
 import importlib
 import logging
 import traceback
@@ -7,6 +8,33 @@ from typing import Dict, Iterable, List, Optional, Protocol
 from .collection import Collection
 
 _LOGGER = logging.getLogger(__name__)
+
+# Characters that mark a customize key as an fnmatch glob pattern.
+_GLOB_CHARS = "*?["
+
+
+def _is_glob(key: str) -> bool:
+    return any(ch in key for ch in _GLOB_CHARS)
+
+
+def match_customize(
+    customize: Dict[str, "Customize"], waste_type: str
+) -> "Customize | None":
+    """Return the Customize entry for a waste type.
+
+    An exact key match always wins. If no exact key exists, the waste type is
+    matched against any customize key that contains an fnmatch glob wildcard
+    (``*``, ``?`` or ``[...]``), e.g. ``"Sonderabfall *"``. The first matching
+    glob key (in definition order) is used. Matching is case-sensitive, like
+    the exact lookup.
+    """
+    c = customize.get(waste_type)
+    if c is not None:
+        return c
+    for key, candidate in customize.items():
+        if _is_glob(key) and fnmatch.fnmatchcase(waste_type, key):
+            return candidate
+    return None
 
 
 class Fetchable(Protocol):
@@ -75,7 +103,7 @@ class Customize:
 
 
 def filter_function(entry: Collection, customize: Dict[str, Customize]):
-    c = customize.get(entry.type)
+    c = match_customize(customize, entry.type)
     if c is None:
         return True
     else:
@@ -83,7 +111,7 @@ def filter_function(entry: Collection, customize: Dict[str, Customize]):
 
 
 def customize_function(entry: Collection, customize: Dict[str, Customize]):
-    c = customize.get(entry.type)
+    c = match_customize(customize, entry.type)
     if c is not None:
         if c.alias is not None:
             entry.set_type(c.alias)
@@ -194,10 +222,17 @@ class SourceShell:
         self._entries = result
 
     def get_dedicated_calendar_types(self) -> set[str]:
-        """Return set of waste types with a dedicated calendar."""
+        """Return set of waste types with a dedicated calendar.
+
+        Dedicated calendars require an exact type key. Glob customize keys are
+        skipped here: a single pattern can match many fetched types, so a
+        per-type dedicated calendar cannot be derived from it.
+        """
         types = set()
 
         for key, customize in self._customize.items():
+            if _is_glob(key):
+                continue
             if customize.show and customize.use_dedicated_calendar:
                 types.add(key)
 
@@ -205,14 +240,14 @@ class SourceShell:
 
     def get_calendar_title_for_type(self, type: str) -> str:
         """Return calendar title for waste type (used for dedicated calendars)."""
-        c = self._customize.get(type)
+        c = match_customize(self._customize, type)
         if c is not None and c.dedicated_calendar_title:
             return c.dedicated_calendar_title
 
         return self.get_collection_type_name(type)
 
     def get_collection_type_name(self, type: str) -> str:
-        c = self._customize.get(type)
+        c = match_customize(self._customize, type)
         if c is not None and c.alias:
             return c.alias
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -121,13 +121,29 @@ waste_collection_schedule:
 
 | Parameter | Type | Requirement | Description |
 |-----|-----|-----|-----|
-| type | string | required | The identity of the waste type as returned from the source  |
+| type | string | required | The identity of the waste type as returned from the source. May contain an [fnmatch](https://docs.python.org/3/library/fnmatch.html) wildcard (`*`, `?`, `[...]`) to match a family of waste types with a single entry, e.g. `Sonderabfall *`. See the note below. |
 | alias | string | optional | A more readable, or user-friendly, name for the type of waste being collected. Default is `None` |
 | show | boolean | optional | Show (`True`) or hide (`False`) collections of this specific waste type. Default is `True` |
 | icon | string | optional | Icon to use for this specific waste type. Any [Material Design Icon](https://pictogrammers.com/library/mdi/) name in the form `mdi:icon-name` is accepted (e.g. `mdi:bottle-soda`). When omitted, the source's default icon is used — defaults follow the canonical [`Icons`](../custom_components/waste_collection_schedule/waste_collection_schedule/icons.py) catalogue so the same logical category looks consistent across sources. Set this to override the default for any single waste type. |
 | picture | string | optional | string representation of the path to a picture used to represent this specific waste type. Default is `None` |
 | use_dedicated_calendar | boolean | optional | Creates a calendar dedicated to this specific waste type. Default is `False` |
 | dedicated_calendar_title | string | optional | A more readable, or user-friendly, name for this specific waste calendar object. If nothing is provided, the name returned by the source will be used |
+
+### Wildcard type matching
+
+The `type` key may be an [fnmatch](https://docs.python.org/3/library/fnmatch.html) glob pattern, so a single `customize` entry can cover a family of waste types. For example, to hide every waste type starting with `Sonderabfall`:
+
+```yaml
+customize:
+  - type: Sonderabfall *
+    show: false
+```
+
+Matching rules:
+
+- An exact `type` match always takes precedence over a wildcard pattern, so you can override a single type while a pattern covers the rest.
+- Patterns are matched case-sensitively against the type returned by the source (after whitespace is stripped). A key counts as a pattern only if it contains `*`, `?`, or `[...]`.
+- Wildcards apply to `alias`, `show`, `icon`, and `picture`. They do **not** apply to `use_dedicated_calendar`: a dedicated calendar still requires an exact `type`, because one pattern can match several types.
 
 ## Configuring Sensor(s)
 

--- a/tests/test_source_shell_customize.py
+++ b/tests/test_source_shell_customize.py
@@ -1,0 +1,82 @@
+import os
+import sys
+from datetime import date
+
+# Make the core library importable as `waste_collection_schedule`.
+sys.path.append(
+    os.path.join(
+        os.path.dirname(__file__), "../custom_components/waste_collection_schedule"
+    )
+)
+
+from waste_collection_schedule.collection import Collection  # noqa: E402
+from waste_collection_schedule.source_shell import (  # noqa: E402
+    Customize,
+    customize_function,
+    filter_function,
+    match_customize,
+)
+
+D = date(2024, 1, 1)
+
+
+def _coll(t: str) -> Collection:
+    return Collection(date=D, t=t)
+
+
+def test_exact_match_takes_precedence_over_wildcard():
+    customize = {
+        "Sonderabfall *": Customize("Sonderabfall *", alias="Hazardous family"),
+        "Sonderabfall Glas": Customize("Sonderabfall Glas", alias="Glass"),
+    }
+    # Exact key wins even though the glob would also match.
+    assert match_customize(customize, "Sonderabfall Glas").alias == "Glass"
+    # No exact key -> falls back to the glob.
+    assert match_customize(customize, "Sonderabfall Metall").alias == "Hazardous family"
+
+
+def test_no_match_returns_none():
+    customize = {"Restmüll": Customize("Restmüll")}
+    assert match_customize(customize, "Bio") is None
+
+
+def test_plain_key_is_not_treated_as_pattern():
+    # A plain (non-glob) key must only match its exact type.
+    customize = {"Bio": Customize("Bio", show=False)}
+    assert match_customize(customize, "Biotonne") is None
+
+
+def test_wildcard_matching_is_case_sensitive():
+    customize = {"Sonderabfall *": Customize("Sonderabfall *", show=False)}
+    assert match_customize(customize, "Sonderabfall Glas") is not None
+    assert match_customize(customize, "sonderabfall glas") is None
+
+
+def test_filter_function_hides_family_via_wildcard():
+    customize = {"Sonderabfall *": Customize("Sonderabfall *", show=False)}
+    assert filter_function(_coll("Sonderabfall Glas"), customize) is False
+    assert filter_function(_coll("Sonderabfall Metall"), customize) is False
+    # Unrelated type is unaffected.
+    assert filter_function(_coll("Restmüll"), customize) is True
+
+
+def test_customize_function_applies_alias_and_icon_via_wildcard():
+    customize = {
+        "Sonderabfall *": Customize(
+            "Sonderabfall *", alias="Hazardous", icon="mdi:biohazard"
+        )
+    }
+    entry = customize_function(_coll("Sonderabfall Glas"), customize)
+    assert entry.type == "Hazardous"
+    assert entry.icon == "mdi:biohazard"
+
+
+def test_question_mark_and_charclass_patterns():
+    customize = {
+        "Bin ?": Customize("Bin ?", show=False),
+        "Recycling [AB]": Customize("Recycling [AB]", alias="Recycling"),
+    }
+    assert filter_function(_coll("Bin 1"), customize) is False
+    assert filter_function(_coll("Bin 12"), customize) is True  # ? matches one char
+    assert match_customize(customize, "Recycling A").alias == "Recycling"
+    assert match_customize(customize, "Recycling C") is None


### PR DESCRIPTION
Closes #4050.

## What

Lets a `customize` `type` be an [fnmatch](https://docs.python.org/3/library/fnmatch.html) glob pattern (`*`, `?`, `[...]`), so one entry can cover a whole family of waste types instead of repeating it per type:

```yaml
customize:
  - type: Sonderabfall *
    show: false
```

## How

A single `match_customize()` helper in `source_shell.py` does an exact-key lookup first and only then falls back to glob keys. All the existing lookup points (`filter_function`, `customize_function`, `get_calendar_title_for_type`, `get_collection_type_name`) route through it, so wildcards work for **show, alias, icon and picture** on both YAML and UI config.

Design choices:

- **Exact wins.** An exact `type` always beats a pattern, so you can special-case one type while a pattern covers the rest.
- **Case-sensitive**, matching the previous exact-dict behaviour (uses `fnmatch.fnmatchcase` so it is host-OS independent).
- **A key is only a pattern if it contains `*`, `?` or `[`**, so plain keys keep their old exact-only behaviour (no risk of `Bio` matching `Biotonne`).
- **Dedicated calendars still require an exact type.** `get_dedicated_calendar_types` skips glob keys, because one pattern can match several fetched types and a per-type calendar cannot be derived from it. Documented as a limitation.

## Tests

Adds `tests/test_source_shell_customize.py` (7 cases): exact-over-wildcard precedence, no-match, plain-key safety, case sensitivity, filter/alias/icon application, and `?`/`[...]` patterns. Full `tests/test_source_components.py` still green.

Docs updated in `doc/installation.md` with a 'Wildcard type matching' note.