### PR TITLE
test(okc_gov): add live Friday recycle zone test case

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/okc_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/okc_gov.py
@@ -19,6 +19,10 @@ TEST_CASES = {
         "recycleObjectID": 1215,
         "recycle_reference_date": "2026-06-15",
     },
+    "Recycle Fri every other week (anchored, live zone)": {
+        "recycleObjectID": 1366,
+        "recycle_reference_date": "2026-06-19",
+    },
     "Trash only": {
         "trashObjectID": 2,
     },


### PR DESCRIPTION
Follow-up to #6421 / #6621. @totallydifferent shared their verified zone OBJECTIDs, so this adds a live test for a **Friday** recycle zone (OBJECTID 1366) anchored to a known pickup date, alongside the existing Monday zone.

Verified against the live FeatureServer and via `test_sources.py -s okc_gov -l`:

```
found 1 entries for Recycle Fri every other week (anchored, live zone)
    2026-06-19 : RECYCLE
```

2026-06-19 is a Friday and matches the contributor's confirmed pickup date, exercising the every-other-week projection on a different weekday than zone 1215.