### PR TITLE
feat(nwrrr_com_au): add source for North West Resource Recovery & Recycling (Tasmania)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nwrrr_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nwrrr_com_au.py
@@ -1,0 +1,202 @@
+import logging
+from datetime import date, timedelta
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "North West Resource Recovery and Recycling"
+DESCRIPTION = "Source for North West Resource Recovery and Recycling (NWRRR), serving 8 councils in north-west Tasmania, Australia."
+URL = "https://www.nwrrr.com.au"
+COUNTRY = "au"
+
+TEST_CASES = {
+    "Devonport (Thursday)": {
+        "municipality": "Devonport",
+        "region": "Devonport (Thursday)",
+    },
+    "Strahan (West Coast)": {
+        "municipality": "West Coast",
+        "region": "Strahan",
+    },
+    "Smithton East (Circular Head)": {
+        "municipality": "Circular Head",
+        "region": "Smithton East",
+    },
+    "Hawley/Shearwater (Latrobe)": {
+        "municipality": "Latrobe",
+        "region": "Hawley/Shearwater",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Visit https://www.nwrrr.com.au/map, click 'Select Location', then choose your council and region from the list. Use the displayed council name as 'municipality' and the region name as 'region'.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "municipality": "Council name (e.g. 'Devonport', 'Burnie', 'Central Coast', 'Circular Head', 'Kentish', 'Latrobe', 'Waratah Wynyard', 'West Coast')",
+        "region": "Region name within the council (e.g. 'Devonport (Thursday)', 'Smithton East', 'Ulverstone')",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "municipality": "Municipality / Council",
+        "region": "Region",
+    },
+}
+
+ICON_MAP = {
+    "General Waste": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "FOGO": Icons.ORGANIC,
+}
+
+GEOJSON_URL = "https://nwrrr.eskspatial.com.au/assets/all_councils.geojson"
+LOOKAHEAD_DAYS = 365
+
+
+class Source:
+    def __init__(self, municipality: str, region: str):
+        self._municipality = municipality.strip()
+        self._region = region.strip()
+
+    def fetch(self) -> list[Collection]:
+        r = requests.get(GEOJSON_URL, timeout=30)
+        r.raise_for_status()
+
+        features = r.json().get("features", [])
+
+        # Find the matching feature (first match wins; duplicates share identical schedules)
+        properties = None
+        for feat in features:
+            p = feat.get("properties", {})
+            if (
+                p.get("municipality", "").strip().lower() == self._municipality.lower()
+                and p.get("region_name", "").strip().lower() == self._region.lower()
+            ):
+                properties = p
+                break
+
+        if properties is None:
+            # Build suggestions for SourceArgumentNotFoundWithSuggestions
+            available_regions = sorted(
+                {
+                    f["properties"]["region_name"]
+                    for f in features
+                    if f.get("properties", {}).get("municipality", "").strip().lower()
+                    == self._municipality.lower()
+                }
+            )
+            if available_regions:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "region",
+                    self._region,
+                    available_regions,
+                )
+            available_municipalities = sorted(
+                {
+                    f["properties"]["municipality"]
+                    for f in features
+                    if f.get("properties", {}).get("municipality")
+                }
+            )
+            raise SourceArgumentNotFoundWithSuggestions(
+                "municipality",
+                self._municipality,
+                available_municipalities,
+            )
+
+        return self._build_collections(properties)
+
+    def _build_collections(self, p: dict) -> list[Collection]:
+        today = date.today()
+        end = today + timedelta(days=LOOKAHEAD_DAYS)
+        entries: list[Collection] = []
+
+        schedule = [
+            ("General Waste", p.get("landfill_date"), p.get("landfill_freq")),
+            ("Recycling", p.get("recycling_date"), p.get("recycling_freq")),
+            ("FOGO", p.get("fogo_date"), p.get("fogo_freq")),
+        ]
+
+        for waste_type, anchor_str, frequency in schedule:
+            if not anchor_str or not frequency:
+                continue
+            try:
+                anchor = date.fromisoformat(anchor_str)
+            except ValueError:
+                _LOGGER.warning(
+                    "Could not parse anchor date %r for %s", anchor_str, waste_type
+                )
+                continue
+
+            icon = ICON_MAP.get(waste_type)
+            current = today
+            while True:
+                next_date = _next_collection(current, anchor, frequency)
+                if next_date is None or next_date > end:
+                    break
+                entries.append(Collection(date=next_date, t=waste_type, icon=icon))
+                current = next_date + timedelta(days=1)
+
+        return entries
+
+
+def _next_collection(from_date: date, anchor: date, frequency: str) -> date | None:
+    """Return the next collection date on or after *from_date*.
+
+    Uses the same algorithm as the nwrrr.eskspatial.com.au Angular app:
+
+    - **weekly**: next occurrence of the anchor's weekday.
+    - **bi-weekly**: next occurrence of the anchor's weekday that falls on an
+      even number of weeks from the anchor date (i.e. ``(candidate - anchor).days
+      % 14 == 0``).
+    - **monthly**: same ordinal weekday of the month (e.g. 2nd Friday).
+    """
+    if frequency == "weekly":
+        return _next_weekday(from_date, anchor.weekday())
+
+    if frequency == "bi-weekly":
+        candidate = _next_weekday(from_date, anchor.weekday())
+        diff = (candidate - anchor).days
+        if diff % 14 == 0:
+            return candidate
+        # Off-week — advance one more week
+        return candidate + timedelta(days=7)
+
+    if frequency == "monthly":
+        weekday = anchor.weekday()
+        nth = (anchor.day - 1) // 7  # 0-indexed ordinal (0 = 1st, 1 = 2nd, …)
+        return _nth_weekday_of_month(from_date, weekday, nth)
+
+    _LOGGER.warning("Unknown frequency %r — skipping", frequency)
+    return None
+
+
+def _next_weekday(from_date: date, weekday: int) -> date:
+    """Return the first date >= *from_date* that falls on *weekday* (0=Mon)."""
+    days_ahead = (weekday - from_date.weekday()) % 7
+    return from_date + timedelta(days=days_ahead)
+
+
+def _nth_weekday_of_month(from_date: date, weekday: int, nth: int) -> date:
+    """Return the (nth+1)-th occurrence of *weekday* in the current month,
+    or the same occurrence in the following month if that date has passed."""
+    first = from_date.replace(day=1)
+    days_to_first = (weekday - first.weekday()) % 7
+    candidate = first + timedelta(days=days_to_first + 7 * nth)
+    if candidate >= from_date:
+        return candidate
+    # Move to next month
+    if first.month == 12:
+        next_first = first.replace(year=first.year + 1, month=1)
+    else:
+        next_first = first.replace(month=first.month + 1)
+    days_to_first = (weekday - next_first.weekday()) % 7
+    return next_first + timedelta(days=days_to_first + 7 * nth)

--- a/doc/source/nwrrr_com_au.md
+++ b/doc/source/nwrrr_com_au.md
@@ -1,0 +1,80 @@
+# North West Resource Recovery and Recycling
+
+Support for schedules provided by [North West Resource Recovery and Recycling](https://www.nwrrr.com.au), covering 8 councils in north-west Tasmania, Australia:
+
+- Burnie
+- Central Coast
+- Circular Head
+- Devonport
+- Kentish
+- Latrobe
+- Waratah Wynyard
+- West Coast
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: nwrrr_com_au
+      args:
+        municipality: MUNICIPALITY
+        region: REGION
+```
+
+### Configuration Variables
+
+**municipality**
+*(String) (required)*
+
+The council name. One of: `Burnie`, `Central Coast`, `Circular Head`, `Devonport`, `Kentish`, `Latrobe`, `Waratah Wynyard`, `West Coast`.
+
+**region**
+*(String) (required)*
+
+The region name within your council. See the table below or visit <https://www.nwrrr.com.au/map> to find your region.
+
+## Examples
+
+### Devonport (Thursday collection day)
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: nwrrr_com_au
+      args:
+        municipality: Devonport
+        region: "Devonport (Thursday)"
+```
+
+### Strahan (West Coast)
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: nwrrr_com_au
+      args:
+        municipality: West Coast
+        region: Strahan
+```
+
+## How to get the source arguments
+
+1. Go to <https://www.nwrrr.com.au/map>.
+2. Click **Select Location** in the side panel.
+3. Choose your council from the dropdown.
+4. Choose your region from the list.
+5. Use the council name as `municipality` and the region name as `region`.
+
+### Available regions by council
+
+| Municipality | Regions |
+|---|---|
+| Burnie | Burnie (Monday), Burnie (Tuesday), Burnie (Wednesday), Burnie (Thursday) |
+| Central Coast | East Ulverstone, Forth, Penguin, Penguin East, Sulphur Creek/Heybridge, Ulverstone, Ulverstone/Gawler, West Ulverstone (Thursday), West Ulverstone (Wednesday) |
+| Circular Head | Rural A (Tuesday), Rural A (Wednesday), Rural B (Monday), Rural B (Tuesday), Rural B (Wednesday), Smithton East, Smithton North, Smithton South, Stanley |
+| Devonport | Devonport (Friday), Devonport (Monday), Devonport (Thursday), Devonport (Tuesday), Devonport (Wednesday) |
+| Kentish | Sheffield/Barrington, South Spreyton/Railton |
+| Latrobe | Hawley/Shearwater, Latrobe North, Latrobe Rural, Latrobe South, Port Sorell |
+| Waratah Wynyard | Lennah Drive, Little Village Lane, Sisters Beach/Boat Harbour, Somerset North, Somerset South, Waratah, Wynyard Central, Wynyard East, Wynyard West |
+| West Coast | Gormanston, Queenstown, Rosebery, Strahan, Tullah, Zeehan |


### PR DESCRIPTION
## Summary

- Adds `nwrrr_com_au` source covering 8 councils in north-west Tasmania: Burnie, Central Coast, Circular Head, Devonport, Kentish, Latrobe, Waratah Wynyard, and West Coast.
- Data is fetched from a publicly accessible GeoJSON endpoint at `nwrrr.eskspatial.com.au/assets/all_councils.geojson`.
- Collection dates (General Waste, Recycling, FOGO) are calculated from anchor date + frequency using the same algorithm as the official Angular app.
- User selects by `municipality` and `region` (no geocoding required).

Closes #4053

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` — passes (9/9)
- [ ] `python test_sources.py -s nwrrr_com_au -l` — all 4 TEST_CASES return collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)