### PR TITLE
feat(toulouse_metropole_fr): add Toulouse Métropole waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/toulouse_metropole_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/toulouse_metropole_fr.py
@@ -1,0 +1,197 @@
+import datetime
+import logging
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "Toulouse Métropole"
+DESCRIPTION = "Source pour la collecte des déchets de Toulouse Métropole (37 communes)."
+URL = "https://data.toulouse-metropole.fr"
+COUNTRY = "fr"
+
+TEST_CASES = {
+    "Colomiers - Avenue Henri Guillaumet": {
+        "street_name": "Avenue Henri Guillaumet",
+    },
+    "Toulouse - Rue de la Paix": {
+        "street_name": "Rue de la Paix",
+    },
+    # Confirmed in dataset: collecte sélective "semaine paire" (bi-weekly)
+    "Chemin Vié (bi-weekly CS)": {
+        "street_name": "Chemin Vié",
+    },
+    # Confirmed in dataset: ordures ménagères "Vendredi"
+    "Route de Fonbeauzard": {
+        "street_name": "Route de Fonbeauzard",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Enter your street name exactly as it appears on the Toulouse Métropole open data portal. "
+        "You can look it up at: "
+        "https://data.toulouse-metropole.fr/explore/dataset/dechets-collecte-des-ordures-menageres/table/"
+    ),
+    "fr": (
+        "Saisissez le nom de votre voie tel qu'il apparaît sur le portail open data de Toulouse Métropole. "
+        "Vous pouvez le retrouver ici : "
+        "https://data.toulouse-metropole.fr/explore/dataset/dechets-collecte-des-ordures-menageres/table/"
+    ),
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street_name": "Name of your street, exactly as in the open data portal (e.g. 'Avenue Henri Guillaumet')",
+    },
+    "fr": {
+        "street_name": "Nom de votre voie, tel qu'il apparaît dans le portail open data (ex : 'Avenue Henri Guillaumet')",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {"street_name": "Street name"},
+    "fr": {"street_name": "Nom de la voie"},
+}
+
+_WASTE_TYPE_MAP = {
+    "Ordure ménagère": "Déchets non recyclables",
+    "Collecte sélective": "Déchets recyclables",
+}
+
+ICON_MAP = {
+    "Déchets non recyclables": Icons.GENERAL_WASTE,
+    "Déchets recyclables": Icons.RECYCLING,
+}
+
+# ── Opendatasoft API v2.1 ──────────────────────────────────────────────────────
+_BASE = "https://data.toulouse-metropole.fr/api/explore/v2.1/catalog/datasets"
+_OM_DATASET = "dechets-collecte-des-ordures-menageres"
+_CS_DATASET = "dechets-collecte-selective"
+
+# French weekday names → Python weekday (Monday=0)
+_DAY_MAP: dict[str, int] = {
+    "lundi": 0,
+    "mardi": 1,
+    "mercredi": 2,
+    "jeudi": 3,
+    "vendredi": 4,
+    "samedi": 5,
+    "dimanche": 6,
+}
+
+# How many weeks ahead to generate dates
+_WEEKS_AHEAD = 8
+
+
+def _parse_schedule(infobulle: str) -> tuple[int | None, str | None]:
+    """
+    Parse the 'infobulle_pdi' field into (weekday, frequency).
+
+    Examples:
+      "Vendredi"               -> (4, None)       every week
+      "Mercredi semaine paire" -> (2, "even")      even ISO weeks
+      "Lundi semaine impaire"  -> (0, "odd")       odd ISO weeks
+
+    Returns (weekday_int, frequency) where frequency is None / "even" / "odd".
+    """
+    value = infobulle.lower().strip()
+
+    frequency = None
+    if "semaine paire" in value:
+        frequency = "even"
+        value = value.replace("semaine paire", "").strip()
+    elif "semaine impaire" in value:
+        frequency = "odd"
+        value = value.replace("semaine impaire", "").strip()
+
+    weekday = _DAY_MAP.get(value)
+    return weekday, frequency
+
+
+def _generate_dates(
+    weekday: int, frequency: str | None, weeks: int = _WEEKS_AHEAD
+) -> list[datetime.date]:
+    """
+    Generate upcoming collection dates for a given weekday + frequency.
+    """
+    today = datetime.date.today()
+    days_ahead = weekday - today.weekday()
+    if days_ahead <= 0:
+        days_ahead += 7
+    first = today + datetime.timedelta(days=days_ahead)
+
+    dates = []
+    for i in range(weeks):
+        candidate = first + datetime.timedelta(weeks=i)
+        iso_week = candidate.isocalendar()[1]
+
+        if frequency is None:
+            dates.append(candidate)
+        elif frequency == "even" and iso_week % 2 == 0:
+            dates.append(candidate)
+        elif frequency == "odd" and iso_week % 2 != 0:
+            dates.append(candidate)
+
+    return dates
+
+
+class Source:
+    def __init__(self, street_name: str):
+        self._street_name = street_name.strip()
+
+    def fetch(self) -> list[Collection]:
+        entries: list[Collection] = []
+
+        for dataset in (_OM_DATASET, _CS_DATASET):
+            entries.extend(self._fetch_dataset(dataset))
+
+        if not entries:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street_name",
+                self._street_name,
+                [],
+            )
+        return entries
+
+    def _fetch_dataset(self, dataset: str) -> list[Collection]:
+        url = f"{_BASE}/{dataset}/records"
+        params = {
+            "limit": 20,
+            "refine": f'libelle_voie:"{self._street_name}"',
+            "select": "libelle_voie,infobulle_pdi,flux",
+        }
+
+        response = requests.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        records = response.json().get("results", [])
+
+        entries: list[Collection] = []
+        seen: set[tuple[int, str | None]] = set()  # deduplicate (weekday, frequency)
+
+        for record in records:
+            infobulle = (record.get("infobulle_pdi") or "").strip()
+            flux = (record.get("flux") or "").strip()
+
+            if not infobulle or not flux:
+                continue
+
+            weekday, frequency = _parse_schedule(infobulle)
+            if weekday is None:
+                _LOGGER.debug("Could not parse day from: %r", infobulle)
+                continue
+
+            key = (weekday, frequency)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            waste_type = _WASTE_TYPE_MAP.get(flux, flux)
+            icon = ICON_MAP.get(waste_type, Icons.GENERAL_WASTE)
+
+            for date in _generate_dates(weekday, frequency):
+                entries.append(Collection(date=date, t=waste_type, icon=icon))
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/toulouse_metropole_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/toulouse_metropole_fr.py
@@ -13,19 +13,29 @@ URL = "https://data.toulouse-metropole.fr"
 COUNTRY = "fr"
 
 TEST_CASES = {
+    # Single-day OM (Lundi + Mardi) + bi-weekly CS (Mercredi semaine paire)
     "Colomiers - Avenue Henri Guillaumet": {
         "street_name": "Avenue Henri Guillaumet",
     },
+    # Multi-day OM "Le lundi, mercredi et vendredi" + single-day OM "Jeudi" + CS "Jeudi"
     "Toulouse - Rue de la Paix": {
         "street_name": "Rue de la Paix",
     },
-    # Confirmed in dataset: collecte sélective "semaine paire" (bi-weekly)
+    # Bi-weekly CS "Mercredi semaine paire" (even ISO weeks)
     "Chemin Vié (bi-weekly CS)": {
         "street_name": "Chemin Vié",
     },
-    # Confirmed in dataset: ordures ménagères "Vendredi"
+    # Single-day OM "Vendredi" + single-day OM "Lundi" + bi-weekly CS "Jeudi semaine impaire"
     "Route de Fonbeauzard": {
         "street_name": "Route de Fonbeauzard",
+    },
+    # 3-day multi-day OM "Le lundi, mercredi et vendredi" + CS "Jeudi"
+    "Toulouse - Rue Sainte-Thérèse": {
+        "street_name": "Rue Sainte-Thérèse",
+    },
+    # Daily OM "7 jours / 7" (every day of the week)
+    "Toulouse - Rue des Lois": {
+        "street_name": "Rue des Lois",
     },
 }
 
@@ -66,6 +76,8 @@ ICON_MAP = {
     "Déchets recyclables": Icons.RECYCLING,
 }
 
+SOURCE_CODEOWNERS = ["@fangedhex"]
+
 # ── Opendatasoft API v2.1 ──────────────────────────────────────────────────────
 _BASE = "https://data.toulouse-metropole.fr/api/explore/v2.1/catalog/datasets"
 _OM_DATASET = "dechets-collecte-des-ordures-menageres"
@@ -86,18 +98,24 @@ _DAY_MAP: dict[str, int] = {
 _WEEKS_AHEAD = 8
 
 
-def _parse_schedule(infobulle: str) -> tuple[int | None, str | None]:
+def _parse_schedule(infobulle: str) -> list[tuple[int, str | None]]:
     """
-    Parse the 'infobulle_pdi' field into (weekday, frequency).
+    Parse the 'infobulle_pdi' field into a list of (weekday, frequency).
 
     Examples:
-      "Vendredi"               -> (4, None)       every week
-      "Mercredi semaine paire" -> (2, "even")      even ISO weeks
-      "Lundi semaine impaire"  -> (0, "odd")       odd ISO weeks
+      "Vendredi"                        -> [(4, None)]
+      "Mercredi semaine paire"          -> [(2, "even")]
+      "Lundi semaine impaire"           -> [(0, "odd")]
+      "Le lundi et jeudi"               -> [(0, None), (3, None)]
+      "Le lundi, mercredi et vendredi"  -> [(0, None), (2, None), (4, None)]
+      "7 jours / 7"                     -> [(0, None), ..., (6, None)]
 
-    Returns (weekday_int, frequency) where frequency is None / "even" / "odd".
+    Returns list of (weekday_int, frequency) where frequency is None / "even" / "odd".
     """
     value = infobulle.lower().strip()
+
+    if "7 jours / 7" in value:
+        return [(d, None) for d in range(7)]
 
     frequency = None
     if "semaine paire" in value:
@@ -107,8 +125,11 @@ def _parse_schedule(infobulle: str) -> tuple[int | None, str | None]:
         frequency = "odd"
         value = value.replace("semaine impaire", "").strip()
 
-    weekday = _DAY_MAP.get(value)
-    return weekday, frequency
+    days: list[tuple[int, str | None]] = []
+    for day_name, day_num in _DAY_MAP.items():
+        if day_name in value:
+            days.append((day_num, frequency))
+    return days
 
 
 def _generate_dates(
@@ -178,20 +199,21 @@ class Source:
             if not infobulle or not flux:
                 continue
 
-            weekday, frequency = _parse_schedule(infobulle)
-            if weekday is None:
+            parsed_days = _parse_schedule(infobulle)
+            if not parsed_days:
                 _LOGGER.debug("Could not parse day from: %r", infobulle)
                 continue
-
-            key = (weekday, frequency)
-            if key in seen:
-                continue
-            seen.add(key)
 
             waste_type = _WASTE_TYPE_MAP.get(flux, flux)
             icon = ICON_MAP.get(waste_type, Icons.GENERAL_WASTE)
 
-            for date in _generate_dates(weekday, frequency):
-                entries.append(Collection(date=date, t=waste_type, icon=icon))
+            for weekday, frequency in parsed_days:
+                key = (weekday, frequency)
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                for date in _generate_dates(weekday, frequency):
+                    entries.append(Collection(date=date, t=waste_type, icon=icon))
 
         return entries

--- a/doc/source/toulouse_metropole_fr.md
+++ b/doc/source/toulouse_metropole_fr.md
@@ -1,0 +1,44 @@
+# Toulouse Métropole
+
+Support for household waste collection schedules in [Toulouse Métropole](https://www.toulouse-metropole.fr/), based on the [open data portal](https://data.toulouse-metropole.fr/).
+
+The dataset covers 37 municipalities in Haute-Garonne (31), France.
+
+## Configuration via `configuration.yaml`
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: toulouse_metropole_fr
+      args:
+        street_name: STREET_NAME
+```
+
+### Configuration Variables
+
+**street_name**  
+*(String) (required)*
+
+Name of your street, exactly as it appears in the open data portal (e.g. `Avenue Henri Guillaumet`).
+
+## Examples
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: toulouse_metropole_fr
+      args:
+        street_name: Avenue Henri Guillaumet
+```
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: toulouse_metropole_fr
+      args:
+        street_name: Rue de la Paix
+```
+
+## How to get the source arguments
+
+Visit the dataset page at [data.toulouse-metropole.fr](https://data.toulouse-metropole.fr/explore/dataset/dechets-collecte-des-ordures-menageres/table/) and look up your street. The `libelle_voie` column gives the value to use for `street_name`.


### PR DESCRIPTION
## Summary

Adds a new source for waste collection schedules from **Toulouse Métropole** open data portal, serving 37 communes in Haute-Garonne (31), France.

- Queries Opendatasoft API v2.1 for two datasets: ordures ménagèères and collecte selective
- Supports weekly and bi-weekly schedules (semaine paire/impaire)
- Street name lookup via libelle_voie field
- Waste types: Dechets non recyclables / Dechets recyclables
- HOW_TO_GET_ARGUMENTS_DESCRIPTION in en + fr
- PARAM_DESCRIPTIONS and PARAM_TRANSLATIONS in en + fr

## Testing

- test_sources.py -s toulouse_metropole_fr -l -i: 72 entries across 4 test cases
- python -m pytest tests/: 9/9 passed
- Formatted with black + isort
- Tested also on my own Home Assistant with my own street name and works without issue

(PR written with help of AI)