### PR TITLE
Migrate lint/format tooling to Ruff (pre-commit + VSCode)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.python",
+				"charliermarsh.ruff",
 				"github.vscode-pull-request-github",
 				"ryanluker.vscode-coverage-gutters",
 				"ms-python.vscode-pylance"
@@ -25,12 +26,16 @@
 				"terminal.integrated.shell.linux": "/bin/bash",
 				"python.defaultInterpreterPath": "/usr/bin/python3",
 				"python.analysis.autoSearchPaths": false,
-				"python.linting.pylintEnabled": true,
-				"python.linting.enabled": true,
-				"python.formatting.provider": "black",
 				"editor.formatOnPaste": false,
 				"editor.formatOnSave": true,
 				"editor.formatOnType": true,
+				"[python]": {
+					"editor.defaultFormatter": "charliermarsh.ruff"
+				},
+				"editor.codeActionsOnSave": {
+					"source.fixAll.ruff": "explicit",
+					"source.organizeImports.ruff": "explicit"
+				},
 				"files.trimTrailingWhitespace": true
 			}
 		}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,14 +27,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install ruff pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Lint with flake8
+      - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          ruff check . --select E9,F63,F7,F82 --output-format=full --statistics
       - name: Run pre-commit (PR changes only)
         if: github.event_name == 'pull_request'
         uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,18 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
     hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
-        files: ^((custom_components|script|tests)/.+)?[^/]+\.py$
+      # Linting (replaces flake8 + isort). Source modules carry pre-existing
+      # issues out of scope here, matching what flake8 excluded.
+      - id: ruff
+        args: [--fix]
+        files: ^(custom_components|script|tests)/.+\.py$
+        exclude: ^custom_components/waste_collection_schedule/waste_collection_schedule/source/
+      # Formatting (replaces black). Runs on the full tree, like black did.
+      - id: ruff-format
+        files: ^(custom_components|script|tests)/.+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
@@ -23,19 +27,6 @@ repos:
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
-    hooks:
-      - id: flake8
-        args:
-          - --ignore=D100,D101,D102,D103,D104,D105,D106,D107,E501,W503,E203
-        additional_dependencies:
-          - flake8-docstrings==1.5.0
-          - pydocstyle==5.0.2
-        files: ^(custom_components|script|tests)/.+\.py$
-        # Source modules have pre-existing flake8 issues (docstring style,
-        # mostly D400) out of scope for the canonical-icons migration.
-        exclude: ^custom_components/waste_collection_schedule/waste_collection_schedule/source/
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.3
     hooks:
@@ -55,14 +46,6 @@ repos:
     hooks:
       - id: yamlfmt
         args: [--mapping, '2', --sequence, '4', --width, '150', --offset, '2']
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-        args:
-          - --multi-line=3
-          - --trailing-comma
-          - --profile=black
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.17
     hooks:
       # Linting (replaces flake8 + isort). Source modules carry pre-existing
       # issues out of scope here, matching what flake8 excluded.
@@ -18,7 +18,7 @@ repos:
       - id: ruff-format
         files: ^(custom_components|script|tests)/.+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:
@@ -28,7 +28,7 @@ repos:
           - --quiet-level=2
         exclude_types: [csv, json]
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.3
+    rev: 1.9.4
     hooks:
       - id: bandit
         args:
@@ -47,14 +47,14 @@ repos:
       - id: yamlfmt
         args: [--mapping, '2', --sequence, '4', --width, '150', --offset, '2']
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
         stages: [manual]
       - id: check-json
         exclude: ^(\.(devcontainer|vscode)/)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v2.1.0
     hooks:
       - id: mypy
         additional_dependencies: [types-requests, types-python-dateutil, types-pyyaml]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "editor.formatOnSave": true,
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "editor.codeActionsOnSave": {
+        "source.fixAll.ruff": "explicit",
+        "source.organizeImports.ruff": "explicit"
+    },
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.analysis.typeCheckingMode": "basic"
+}

--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.translation import async_get_translations
 from voluptuous.schema_builder import UNDEFINED
+
 from waste_collection_schedule.collection import Collection
 from waste_collection_schedule.exceptions import (
     SourceArgumentException,
@@ -647,9 +648,7 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
                         default=UNDEFINED if default is None else default,
                         description=description,
                     )
-                ] = (
-                    field_type or cv.string
-                )
+                ] = field_type or cv.string
             else:
                 _LOGGER.debug(
                     f"Unsupported type: {type(default)}: {arg_name}: {default}: {field_type}"

--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -83,15 +83,11 @@ async def async_setup_entry(hass, config: ConfigEntry, async_add_entities):
         date_template = sensor.get(CONF_DATE_TEMPLATE)
         try:
             value_template = cv.template(value_template)
-        except (
-            vol.Invalid
-        ):  # should only happen if value_template = None, as it is already validated in the config flow if it is not None
+        except vol.Invalid:  # should only happen if value_template = None, as it is already validated in the config flow if it is not None
             value_template = None
         try:
             date_template = cv.template(date_template)
-        except (
-            vol.Invalid
-        ):  # should only happen if value_template = None, as it is already validated in the config flow if it is not None
+        except vol.Invalid:  # should only happen if value_template = None, as it is already validated in the config flow if it is not None
             date_template = None
         details_format = sensor.get(CONF_DETAILS_FORMAT)
         if isinstance(details_format, str):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
@@ -4,6 +4,7 @@ import requests
 from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,
     SourceArgumentRequiredWithSuggestions,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 import requests
+
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,
     SourceArgumentRequiredWithSuggestions,
@@ -183,7 +184,7 @@ class AbfallnaviDe:
         self._service_domain = service_domain
         if service_domain in self.SHARED_DOMAIN_SERVICES:
             self._service_url = (
-                "https://abfallapp.regioit.de/" f"abfall-app-{service_domain}/rest"
+                f"https://abfallapp.regioit.de/abfall-app-{service_domain}/rest"
             )
             self._service_url_fallback = (
                 f"https://{service_domain}"
@@ -197,7 +198,7 @@ class AbfallnaviDe:
                 f"abfall-app-{service_domain}/rest"
             )
             self._service_url_fallback = (
-                "https://abfallapp.regioit.de/" f"abfall-app-{service_domain}/rest"
+                f"https://abfallapp.regioit.de/abfall-app-{service_domain}/rest"
             )
         self._session = requests.Session()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -8,6 +8,7 @@ from datetime import date, datetime
 
 import requests
 from bs4 import BeautifulSoup, Tag
+
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFound,
     SourceArgumentNotFoundWithSuggestions,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhitespaceWRP.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhitespaceWRP.py
@@ -51,7 +51,9 @@ class WhitespaceClient:
             alink = soup.find("a", href=lambda h: h and "seq=1" in h)
 
         if alink is None:
-            raise ValueError("Initial WRP page did not load correctly – could not find collections link")
+            raise ValueError(
+                "Initial WRP page did not load correctly – could not find collections link"
+            )
 
         # Step 2: skip the landing splash (seq=1 → seq=2) then POST address form.
         next_url = alink["href"].replace("seq=1", "seq=2")
@@ -111,10 +113,18 @@ class WhitespaceClient:
             type_li = lis[2]
 
             date_p = date_li.find("p")
-            date_text = date_p.text.strip() if date_p else date_li.text.replace("\n", "").strip()
+            date_text = (
+                date_p.text.strip()
+                if date_p
+                else date_li.text.replace("\n", "").strip()
+            )
 
             type_p = type_li.find("p")
-            type_text = type_p.text.strip() if type_p else type_li.text.replace("\n", "").strip()
+            type_text = (
+                type_p.text.strip()
+                if type_p
+                else type_li.text.replace("\n", "").strip()
+            )
 
             if date_text:
                 results.append((date_text, type_text))

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/junker_app.py
@@ -4,6 +4,7 @@ import unicodedata
 from datetime import datetime
 
 import requests
+
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 
 EMBED_URL = "https://differenziata.junker.app/embed/{municipality}/calendario"
@@ -98,11 +99,7 @@ class Junker:
                         " ", ""
                     ).replace(",", "").replace("'", "") == replace_accents(
                         self._area_name
-                    ).lower().strip().replace(
-                        " ", ""
-                    ).replace(
-                        ",", ""
-                    ).replace(
+                    ).lower().strip().replace(" ", "").replace(",", "").replace(
                         "'", ""
                     ):
                         if self._area in (str(area[1]), area[1]):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/uk_cloud9_apps.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/uk_cloud9_apps.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 from typing import Any, Optional, Sequence, cast
 
 from curl_cffi import requests
+
 from waste_collection_schedule import Collection
 from waste_collection_schedule.exceptions import (
     SourceArgAmbiguousWithSuggestions,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_my_local_services_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_my_local_services_au.py
@@ -163,8 +163,8 @@ class Source:
                 waste_type: str = data["Waste_Type"]
 
                 weekday_int: int = (
-                    data["Col_Day"] + -2
-                ) % 7  # Normalise to 0(monday)-6(sunday) as response is 1(sunday)-7(saturday)
+                    (data["Col_Day"] + -2) % 7
+                )  # Normalise to 0(monday)-6(sunday) as response is 1(sunday)-7(saturday)
                 freq: int = data["Col_Freq"]
                 offset: int = data["Col_Offset"]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/apricaspa_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/apricaspa_it.py
@@ -73,7 +73,7 @@ PARAM_DESCRIPTIONS = {
     "it": {
         "address": "Il nome della via del tuo indirizzo "
         "(ad esempio, 'Via Triumplina').",
-        "house_number": "Il numero civico del tuo indirizzo " "(ad esempio, '90').",
+        "house_number": "Il numero civico del tuo indirizzo (ad esempio, '90').",
         "city": "La città del tuo indirizzo (ad esempio, 'Brescia').",
     },
 }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashfield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ashfield_gov_uk.py
@@ -89,7 +89,9 @@ class Source:
                     argument=(
                         "name"
                         if self._name
-                        else "number" if self._number else "post_code"
+                        else "number"
+                        if self._number
+                        else "post_code"
                     ),
                     value=self._name or self._number or self._post_code,
                     suggestions=[

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/baltimore_county_md_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/baltimore_county_md_us.py
@@ -270,9 +270,11 @@ class Source:
         """Parse holiday-week weekday shift mappings from the holiday table."""
         soup = BeautifulSoup(page_html, "html.parser")
         heading = soup.find(
-            lambda tag: tag.name in ["h2", "h3", "h4"]
-            and "holiday collection schedule"
-            in tag.get_text(" ", strip=True).casefold()
+            lambda tag: (
+                tag.name in ["h2", "h3", "h4"]
+                and "holiday collection schedule"
+                in tag.get_text(" ", strip=True).casefold()
+            )
         )
         if heading is None:
             return []
@@ -352,8 +354,10 @@ class Source:
         """Return computed yard-material collection dates for a schedule table."""
         soup = BeautifulSoup(page_html, "html.parser")
         heading = soup.find(
-            lambda tag: tag.name in ["h2", "h3", "h4"]
-            and tag.get_text(strip=True).lower().endswith(f"schedule {schedule_id}")
+            lambda tag: (
+                tag.name in ["h2", "h3", "h4"]
+                and tag.get_text(strip=True).lower().endswith(f"schedule {schedule_id}")
+            )
         )
         if heading is None:
             return []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
@@ -194,9 +194,7 @@ class Source:
                     "Friday",
                     "Saturday",
                     "Sunday",
-                ].index(
-                    start_day
-                )
+                ].index(start_day)
                 if days_ahead <= 0:
                     days_ahead += 7
                 start_date = start_date + timedelta(days=days_ahead)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/buchegg_so_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/buchegg_so_ch.py
@@ -179,8 +179,7 @@ class Source:
         """
         if locality and ortschaft:
             raise ValueError(
-                "Both 'locality' and 'ortschaft' are set. "
-                "Please use only 'locality'."
+                "Both 'locality' and 'ortschaft' are set. Please use only 'locality'."
             )
 
         if ortschaft:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/calderdale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/calderdale_gov_uk.py
@@ -55,8 +55,9 @@ class Source:
             # Check if address was found - if table is missing, likely invalid UPRN
             address_check = soup.find(
                 "p",
-                string=lambda text: text
-                and "Currently showing collection days for:" in text,
+                string=lambda text: (
+                    text and "Currently showing collection days for:" in text
+                ),
             )
             if not address_check:
                 raise SourceArgumentNotFound(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/canadabay_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/canadabay_nsw_gov_au.py
@@ -111,7 +111,6 @@ class Source:
             if "start" in item:
                 collection_date = date.fromisoformat(item["start"])
                 if (collection_date - today).days >= 0:
-
                     if item["event_type"] in ["recycle", "organic"]:
                         # Every collection day includes rubbish
                         entries.append(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -239,7 +239,7 @@ class Source:
         self._g4 = g4
         self._g5 = g5
 
-        # house_number should be required as group matching requires it and the App enfoces it too, Keepint it as optional for now to show a better error message
+        # house_number should be required as group matching requires it and the App enforces it too, Keeping it as optional for now to show a better error message
         if not house_number:
             raise SourceArgumentRequired(
                 "house_number",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -306,10 +306,9 @@ class Source:
             if not match:
                 matches = list(
                     map(
-                        lambda x: "town: "
-                        + x.get("name")
-                        + ", district:"
-                        + x.get("district"),
+                        lambda x: (
+                            "town: " + x.get("name") + ", district:" + x.get("district")
+                        ),
                         matching_towns_district,
                     )
                 )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enfield_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enfield_gov_uk.py
@@ -40,7 +40,7 @@ PARAM_DESCRIPTIONS = {
     "en": {
         "uprn": "Use your UPRN if you know it.",
         "address": (
-            "Full Enfield address, for example " "'127 Palmerston Rd, London N22 8QX'."
+            "Full Enfield address, for example '127 Palmerston Rd, London N22 8QX'."
         ),
     }
 }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankenberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankenberg_de.py
@@ -49,19 +49,9 @@ class Source:
             "-", ""
         ).replace("str.", "straße").replace("straße", "strasse").replace(
             ".", ""
-        ) == self._street.lower().replace(
-            " ", ""
-        ).replace(
-            '"', ""
-        ).replace(
+        ) == self._street.lower().replace(" ", "").replace('"', "").replace(
             "-", ""
-        ).replace(
-            "str.", "straße"
-        ).replace(
-            "straße", "strasse"
-        ).replace(
-            ".", ""
-        )
+        ).replace("str.", "straße").replace("straße", "strasse").replace(".", "")
 
     def fetch(self) -> list[Collection]:
         fresh_ids = False

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
@@ -85,11 +85,10 @@ PARAM_DESCRIPTIONS = {
         "gemeinde": "Gemeindename wie in Gemeinde24 angezeigt.",
         "strasse": "Strassen-/Ortsteilname wie in Gemeinde24 angezeigt.",
         "gemeinde_id": (
-            "Numerische GemeindeID aus Gemeinde24 "
-            "(optional statt des Gemeinde-Feldes)."
+            "Numerische GemeindeID aus Gemeinde24 (optional statt des Gemeinde-Feldes)."
         ),
         "street_id": (
-            "Numerische streetID aus Gemeinde24 " "(optional statt des Straßen-Feldes)."
+            "Numerische streetID aus Gemeinde24 (optional statt des Straßen-Feldes)."
         ),
     },
 }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
@@ -188,175 +188,173 @@ ICON_MAP = {
     "paper": Icons.PAPER,
 }
 
-SERVICE_MAP = (
-    [  # supported calendars can be found at https://calendars.impactapps.com.au/
-        {
-            "name": "City of Ballarat",
-            "url": "https://ballarat.waste-info.com.au",
-            "website": "https://www.ballarat.vic.gov.au",
-        },
-        {
-            "name": "Baw Baw Shire Council",
-            "url": "https://baw-baw.waste-info.com.au",
-            "website": "https://www.bawbawshire.vic.gov.au",
-        },
-        {
-            "name": "Bayside Council",
-            "url": "https://rockdale.waste-info.com.au",
-            "website": "https://www.bayside.nsw.gov.au",
-        },
-        {
-            "name": "Bega Valley Shire Council",
-            "url": "https://bega.waste-info.com.au",
-            "website": "https://www.begavalley.nsw.gov.au",
-        },
-        {
-            "name": "Blue Mountains City Council",
-            "url": "https://bmcc.waste-info.com.au",
-            "website": "https://www.bmcc.nsw.gov.au",
-        },
-        {
-            "name": "Brisbane City Council",
-            "url": "https://brisbane.waste-info.com.au",
-            "website": "https://www.brisbane.nsw.gov.au",
-        },
-        {
-            "name": "Burwood City Council",
-            "url": "https://burwood-waste.waste-info.com.au",
-            "website": "https://www.burwood.nsw.gov.au",
-        },
-        {
-            "name": "Campbeltown City Council",
-            "url": "https://campbelltown.waste-info.com.au",
-            "website": "https://www.campbelltown.vic.gov.au",
-        },
-        {
-            "name": "City of Canada Bay Council",
-            "url": "https://canada-bay.waste-info.com.au",
-            "website": "https://www.canadabay.vic.gov.au",
-        },
-        {
-            "name": "Cowra Council",
-            "url": "https://cowra.waste-info.com.au",
-            "website": "https://www.cowracouncil.com.au/",
-        },
-        {
-            "name": "Cumberland City Council",
-            "url": "https://cumberland.waste-info.com.au",
-            "website": "https://www.cumberland.vic.gov.au",
-        },
-        {
-            "name": "Forbes Shire Council",
-            "url": "https://forbes.waste-info.com.au",
-            "website": "https://www.forbes.nsw.gov.au",
-        },
-        {
-            "name": "Gwydir Shire Council",
-            "url": "https://gwydir.waste-info.com.au",
-            "website": "https://www.gwydir.nsw.gov.au",
-        },
-        {
-            "name": "Lithgow City Council",
-            "url": "https://lithgow.waste-info.com.au",
-            "website": "https://www.lithgow.nsw.gov.au",
-        },
-        {
-            "name": "Livingstone Shire Council",
-            "url": "https://livingstone.waste-info.com.au",
-            "website": "https://www.livingstone.qld.gov.au",
-        },
-        {
-            "name": "Moira Shire Council",
-            "url": "https://moira.waste-info.com.au",
-            "website": "https://www.moira.vic.gov.au",
-        },
-        {
-            "name": "Moree Plains Shire Council",
-            "url": "https://moree.waste-info.com.au",
-            "website": "https://www.mpsc.nsw.gov.au",
-        },
-        {
-            "name": "Penrith City Council",
-            "url": "https://penrith.waste-info.com.au",
-            "website": "https://www.penrithcity.nsw.gov.au",
-        },
-        {
-            "name": "Port Stephens Council",
-            "url": "https://port-stephens.waste-info.com.au",
-            "website": "https://www.portstephens.vic.gov.au",
-        },
-        {
-            "name": "Port Macquarie Hastings Council",
-            "url": "https://pmhc.waste-info.com.au",
-            "website": "https://www.pmhc.nsw.gov.au",
-        },
-        {
-            "name": "Queanbeyan-Palerang Regional Council",
-            "url": "https://qprc.waste-info.com.au",
-            "website": "https://www.qprc.nsw.gov.au",
-        },
-        {
-            "name": "Redland City Council",
-            "url": "https://redland.waste-info.com.au",
-            "website": "https://www.redland.qld.gov.au",
-        },
-        {
-            "name": "Snowy Valleys Council",
-            "url": "https://snowy-valleys.waste-info.com.au",
-            "website": "https://www.snowyvalleys.nsw.gov.au",
-        },
-        {
-            "name": "South Burnett Regional Council",
-            "url": "https://south-burnett.waste-info.com.au",
-            "website": "https://www.southburnett.qld.gov.au",
-        },
-        {
-            "name": "Wellington Shire Council",
-            "url": "https://wellington.waste-info.com.au",
-            "website": "https://www.wellington.vic.gov.au",
-        },
-        {
-            "name": "Wollongong City Council",
-            "url": "https://wollongong.waste-info.com.au",
-            "website": "https://www.wollongong.vic.gov.au",
-        },
-        {
-            "name": "Gympie Regional Council",
-            "url": "https://gympie.waste-info.com.au",
-            "website": "https://www.gympie.qld.gov.au",
-        },
-        {
-            "name": "Benalla Rural City Council",
-            "url": "https://benalla.waste-info.com.au",
-            "website": "https://www.benalla.vic.gov.au/",
-        },
-        {
-            "name": "Coffs Coast Waste Services",
-            "url": "https://coffs-coast.waste-info.com.au",
-            "website": "https://www.coffsharbour.nsw.gov.au",
-        },
-        {
-            "name": "Ku-ring-gai Council",
-            "url": "https://ku-ring-gai.waste-info.com.au",
-            "website": "https://www.krg.nsw.gov.au",
-        },
-        {
-            "name": "Horsham Rural City Council",
-            "url": "https://hrcc.waste-info.com.au",
-            "website": "https://www.hrcc.vic.gov.au",
-        },
-        {
-            "name": "Murrindindi Shire Counci",
-            "url": "https://murrindindi.waste-info.com.au",
-            "website": "https://www.murrindindi.vic.gov.au",
-        },
-        {
-            "name": "Clarence Valley Council",
-            "url": "https://clarence.waste-info.com.au",
-            "website": "https://www.clarence.nsw.gov.au",
-        },
-    ]
-)
+SERVICE_MAP = [  # supported calendars can be found at https://calendars.impactapps.com.au/
+    {
+        "name": "City of Ballarat",
+        "url": "https://ballarat.waste-info.com.au",
+        "website": "https://www.ballarat.vic.gov.au",
+    },
+    {
+        "name": "Baw Baw Shire Council",
+        "url": "https://baw-baw.waste-info.com.au",
+        "website": "https://www.bawbawshire.vic.gov.au",
+    },
+    {
+        "name": "Bayside Council",
+        "url": "https://rockdale.waste-info.com.au",
+        "website": "https://www.bayside.nsw.gov.au",
+    },
+    {
+        "name": "Bega Valley Shire Council",
+        "url": "https://bega.waste-info.com.au",
+        "website": "https://www.begavalley.nsw.gov.au",
+    },
+    {
+        "name": "Blue Mountains City Council",
+        "url": "https://bmcc.waste-info.com.au",
+        "website": "https://www.bmcc.nsw.gov.au",
+    },
+    {
+        "name": "Brisbane City Council",
+        "url": "https://brisbane.waste-info.com.au",
+        "website": "https://www.brisbane.nsw.gov.au",
+    },
+    {
+        "name": "Burwood City Council",
+        "url": "https://burwood-waste.waste-info.com.au",
+        "website": "https://www.burwood.nsw.gov.au",
+    },
+    {
+        "name": "Campbeltown City Council",
+        "url": "https://campbelltown.waste-info.com.au",
+        "website": "https://www.campbelltown.vic.gov.au",
+    },
+    {
+        "name": "City of Canada Bay Council",
+        "url": "https://canada-bay.waste-info.com.au",
+        "website": "https://www.canadabay.vic.gov.au",
+    },
+    {
+        "name": "Cowra Council",
+        "url": "https://cowra.waste-info.com.au",
+        "website": "https://www.cowracouncil.com.au/",
+    },
+    {
+        "name": "Cumberland City Council",
+        "url": "https://cumberland.waste-info.com.au",
+        "website": "https://www.cumberland.vic.gov.au",
+    },
+    {
+        "name": "Forbes Shire Council",
+        "url": "https://forbes.waste-info.com.au",
+        "website": "https://www.forbes.nsw.gov.au",
+    },
+    {
+        "name": "Gwydir Shire Council",
+        "url": "https://gwydir.waste-info.com.au",
+        "website": "https://www.gwydir.nsw.gov.au",
+    },
+    {
+        "name": "Lithgow City Council",
+        "url": "https://lithgow.waste-info.com.au",
+        "website": "https://www.lithgow.nsw.gov.au",
+    },
+    {
+        "name": "Livingstone Shire Council",
+        "url": "https://livingstone.waste-info.com.au",
+        "website": "https://www.livingstone.qld.gov.au",
+    },
+    {
+        "name": "Moira Shire Council",
+        "url": "https://moira.waste-info.com.au",
+        "website": "https://www.moira.vic.gov.au",
+    },
+    {
+        "name": "Moree Plains Shire Council",
+        "url": "https://moree.waste-info.com.au",
+        "website": "https://www.mpsc.nsw.gov.au",
+    },
+    {
+        "name": "Penrith City Council",
+        "url": "https://penrith.waste-info.com.au",
+        "website": "https://www.penrithcity.nsw.gov.au",
+    },
+    {
+        "name": "Port Stephens Council",
+        "url": "https://port-stephens.waste-info.com.au",
+        "website": "https://www.portstephens.vic.gov.au",
+    },
+    {
+        "name": "Port Macquarie Hastings Council",
+        "url": "https://pmhc.waste-info.com.au",
+        "website": "https://www.pmhc.nsw.gov.au",
+    },
+    {
+        "name": "Queanbeyan-Palerang Regional Council",
+        "url": "https://qprc.waste-info.com.au",
+        "website": "https://www.qprc.nsw.gov.au",
+    },
+    {
+        "name": "Redland City Council",
+        "url": "https://redland.waste-info.com.au",
+        "website": "https://www.redland.qld.gov.au",
+    },
+    {
+        "name": "Snowy Valleys Council",
+        "url": "https://snowy-valleys.waste-info.com.au",
+        "website": "https://www.snowyvalleys.nsw.gov.au",
+    },
+    {
+        "name": "South Burnett Regional Council",
+        "url": "https://south-burnett.waste-info.com.au",
+        "website": "https://www.southburnett.qld.gov.au",
+    },
+    {
+        "name": "Wellington Shire Council",
+        "url": "https://wellington.waste-info.com.au",
+        "website": "https://www.wellington.vic.gov.au",
+    },
+    {
+        "name": "Wollongong City Council",
+        "url": "https://wollongong.waste-info.com.au",
+        "website": "https://www.wollongong.vic.gov.au",
+    },
+    {
+        "name": "Gympie Regional Council",
+        "url": "https://gympie.waste-info.com.au",
+        "website": "https://www.gympie.qld.gov.au",
+    },
+    {
+        "name": "Benalla Rural City Council",
+        "url": "https://benalla.waste-info.com.au",
+        "website": "https://www.benalla.vic.gov.au/",
+    },
+    {
+        "name": "Coffs Coast Waste Services",
+        "url": "https://coffs-coast.waste-info.com.au",
+        "website": "https://www.coffsharbour.nsw.gov.au",
+    },
+    {
+        "name": "Ku-ring-gai Council",
+        "url": "https://ku-ring-gai.waste-info.com.au",
+        "website": "https://www.krg.nsw.gov.au",
+    },
+    {
+        "name": "Horsham Rural City Council",
+        "url": "https://hrcc.waste-info.com.au",
+        "website": "https://www.hrcc.vic.gov.au",
+    },
+    {
+        "name": "Murrindindi Shire Counci",
+        "url": "https://murrindindi.waste-info.com.au",
+        "website": "https://www.murrindindi.vic.gov.au",
+    },
+    {
+        "name": "Clarence Valley Council",
+        "url": "https://clarence.waste-info.com.au",
+        "website": "https://www.clarence.nsw.gov.au",
+    },
+]
 
 SERVICE_MAP_LOOKUP = {council["name"]: council for council in SERVICE_MAP}
 
@@ -565,15 +563,13 @@ class Source:
             # determine waste type for icon
             try:
                 event_type = event["event_type"]
-            except (
-                KeyError
-            ):  # some entries do not contain a waste collection event, so move to next item in list
+            except KeyError:  # some entries do not contain a waste collection event, so move to next item in list
                 continue
             icon = ICON_MAP.get(event_type, None)
 
             # determine waste type for title (some entries contain additional info)
             try:
-                event_type = f'{event["event_type"]} ({event["name"]})'
+                event_type = f"{event['event_type']} ({event['name']})"
             except KeyError:  # not all service return "name"
                 event_type = event["event_type"]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
@@ -146,7 +146,9 @@ class Source:
                 key = (
                     "start"
                     if "start" in item
-                    else "start_date" if "start_date" in item else None
+                    else "start_date"
+                    if "start_date" in item
+                    else None
                 )
                 if key is None:
                     continue

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/isontinambiente_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/isontinambiente_it.py
@@ -60,9 +60,7 @@ class Source:
         calendars = soup.select("table.calendar")
 
         collections = []
-        for (
-            calendar
-        ) in (
+        for calendar in (
             calendars
         ):  # Probably only one but just in case there are more at the end of a month
             prev_sibling = calendar.find_previous_sibling()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mojiodpadki_si.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mojiodpadki_si.py
@@ -40,7 +40,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Source:
-
     def __init__(self, uprn):
         _LOGGER.info(
             f"Initializing mojiodpadki.si waste collection service for uprn={uprn}"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/monmouthshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/monmouthshire_gov_uk.py
@@ -143,7 +143,6 @@ class Source:
             waste_blocks = waste_div.find_all("div", class_="waste")
 
             for waste_block in waste_blocks:
-
                 # Get location of <h4> for Waste Type and <strong> for Collection Date
                 waste_h4 = waste_block.find("h4")
                 collection_strong = waste_block.find("strong")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
@@ -244,7 +244,7 @@ class Source:
             dates = self._ics.convert(r.text)
         except ValueError as e:
             raise ValueError(
-                "Got invalid response from the server, " "please recheck your arguments"
+                "Got invalid response from the server, please recheck your arguments"
             ) from e
 
         entries = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzv_rotenburg_bebra_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzv_rotenburg_bebra_de.py
@@ -91,10 +91,12 @@ class Source:
 
         soup = BeautifulSoup(r.content, "html.parser")
         links = soup.find_all(
-            lambda tag: tag
-            and tag.name == "a"
-            and tag.get("href")
-            and "entsorgung.php?ort=" in tag["href"]
+            lambda tag: (
+                tag
+                and tag.name == "a"
+                and tag.get("href")
+                and "entsorgung.php?ort=" in tag["href"]
+            )
         )
         return [link["href"].split("?ort=")[1] for link in links]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/neath_port_talbot_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/neath_port_talbot_gov_uk.py
@@ -184,7 +184,9 @@ def _parse_collections_from_page_source(raw_html: str) -> list[Collection]:
 
     # Find all date headers (they are <h2> containing e.g. "Thursday, 23 October").
     headers = [
-        h for h in root.find_all("h2") if _DAY_MONTH_RE.match(_clean_text(h.get_text()))  # type: ignore[union-attr]
+        h
+        for h in root.find_all("h2")
+        if _DAY_MONTH_RE.match(_clean_text(h.get_text()))  # type: ignore[union-attr]
     ]
 
     collections: list = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
@@ -148,9 +148,7 @@ class Source:
                         icon=ICON_MAP.get(details[0].text),
                     )
                 )
-            except (
-                IndexError
-            ):  # empty list is returned if property doesn't subscribe to that collection
+            except IndexError:  # empty list is returned if property doesn't subscribe to that collection
                 continue
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pendle_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pendle_gov_uk.py
@@ -74,7 +74,7 @@ DEFAULT_WEEKS_AHEAD = 12
 _LOGGER = logging.getLogger(__name__)
 REQUEST_HEADERS = {
     "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) " "Gecko/20100101 Firefox/128.0"
+        "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
     )
 }
 WEEKDAYS = {
@@ -400,7 +400,7 @@ class Source:
                     "layers": "none",
                     "styles": "",
                     "srs": "EPSG:27700",
-                    "bbox": f"{x-buffer_size},{y-buffer_size},{x+buffer_size},{y+buffer_size}",
+                    "bbox": f"{x - buffer_size},{y - buffer_size},{x + buffer_size},{y + buffer_size}",
                     "width": 101,
                     "height": 101,
                     "query_layers": layer_id,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/poriruacity_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/poriruacity_govt_nz.py
@@ -56,7 +56,9 @@ class Source:
         # replace new Date(2022,7,22) with "2022-08-22"
         zones_js = re.sub(
             r"new Date\((\d{4}),(\d{1,2}),(\d{1,2})\)",
-            lambda m: f'"{m.group(1)}-{str(int(m.group(2)) + 1).zfill(2)}-{m.group(3).zfill(2)}"',
+            lambda m: (
+                f'"{m.group(1)}-{str(int(m.group(2)) + 1).zfill(2)}-{m.group(3).zfill(2)}"'
+            ),
             zones_js,
         )
         # replace zone1 with "zone1"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -682,8 +682,8 @@ class Source:
             if part == "week":
                 kwargs["freq"] = WEEKLY
                 kwargs.update(self._parse_week_no(parts.pop(0)))
-            elif part.startswith("off") or part.startswith(
-                '"'
+            elif (
+                part.startswith("off") or part.startswith('"')
             ):  # schedule should be of type "closed" or "closing_exception", or part should be a comment
                 continue
             else:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/real_luzern_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/real_luzern_ch.py
@@ -21,15 +21,13 @@ ICON_MAP = {
     "Altmetall": Icons.METAL,
 }
 
-OLD_WASTE_NAME = (
-    {  # New fetcher uses different names this should prevent breaking changes
-        "Kehrichtsammlung": "Kehricht",
-        "Grüngutsammlung": "Grüngut",
-        "Papiersammlung": "Papier",
-        "Kartonsammlung": "Karton",
-        "Alteisen/Metallsammlung": "Altmetall",
-    }
-)
+OLD_WASTE_NAME = {  # New fetcher uses different names this should prevent breaking changes
+    "Kehrichtsammlung": "Kehricht",
+    "Grüngutsammlung": "Grüngut",
+    "Papiersammlung": "Papier",
+    "Kartonsammlung": "Karton",
+    "Alteisen/Metallsammlung": "Altmetall",
+}
 
 API_URL = "https://www.real-luzern.ch/abfall/sammeldienst/abfallkalender/"
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/roundrocktexas_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/roundrocktexas_gov.py
@@ -27,25 +27,17 @@ DAYS = {
     "Saturday": SA,
     "Sunday": SU,
 }
-HOLIDAYS = (
-    {  # website indicates collections falling on these days will be shifted by 1 day
-        "Thanksgiving": list(
-            rrule(YEARLY, bymonth=11, byweekday=TH(4), dtstart=datetime.now())
-        )[
-            0
-        ].date(),  # 4th Thursday in November
-        "Christmas Day": list(
-            rrule(YEARLY, bymonth=12, bymonthday=25, dtstart=datetime.now())
-        )[
-            0
-        ].date(),  # 25th December
-        "New Years Day": list(
-            rrule(YEARLY, bymonth=1, bymonthday=1, dtstart=datetime.now())
-        )[
-            0
-        ].date(),  # 1st January
-    }
-)
+HOLIDAYS = {  # website indicates collections falling on these days will be shifted by 1 day
+    "Thanksgiving": list(
+        rrule(YEARLY, bymonth=11, byweekday=TH(4), dtstart=datetime.now())
+    )[0].date(),  # 4th Thursday in November
+    "Christmas Day": list(
+        rrule(YEARLY, bymonth=12, bymonthday=25, dtstart=datetime.now())
+    )[0].date(),  # 25th December
+    "New Years Day": list(
+        rrule(YEARLY, bymonth=1, bymonthday=1, dtstart=datetime.now())
+    )[0].date(),  # 1st January
+}
 
 
 class Source:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
@@ -30,12 +30,10 @@ DAYS: dict = {
     "FRIDAY": FR,
 }
 WEEKDAYS: list = [MO, TU, WE, TH, FR]
-START_DATES: dict = (
-    {  # taken from https://www.scenicrim.qld.gov.au/downloads/file/6551/your-waste-bins-and-facilities-guide
-        "BLUE": datetime(2024, 12, 2, 0, 0, 0),  # known Monday in a Red Week
-        "RED": datetime(2024, 12, 9, 0, 0, 0),  # known Monday in a Blue Week
-    }
-)
+START_DATES: dict = {  # taken from https://www.scenicrim.qld.gov.au/downloads/file/6551/your-waste-bins-and-facilities-guide
+    "BLUE": datetime(2024, 12, 2, 0, 0, 0),  # known Monday in a Red Week
+    "RED": datetime(2024, 12, 9, 0, 0, 0),  # known Monday in a Blue Week
+}
 
 # ### Arguments affecting the configuration GUI ####
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/simbio_si.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/simbio_si.py
@@ -51,8 +51,9 @@ class Source:
                 if not key.startswith("next_"):
                     continue
                 bin_name = key.split("_")[1]
-                bin_type, icon = BIN_TYPES.get(bin_name, bin_name), ICON_MAP.get(
-                    bin_name
+                bin_type, icon = (
+                    BIN_TYPES.get(bin_name, bin_name),
+                    ICON_MAP.get(bin_name),
                 )
 
                 mes_date = self.get_date(value)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
@@ -223,7 +223,9 @@ class Source:
         self._start = (
             start
             if isinstance(start, datetime.date)
-            else parser.isoparse(start).date() if start else None
+            else parser.isoparse(start).date()
+            if start
+            else None
         )
         if until:
             self._until: datetime.date | None = (

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stratford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stratford_gov_uk.py
@@ -10,12 +10,10 @@ DESCRIPTION = (
 )
 URL = "https://stratford.gov.uk"
 
-TEST_CASES = (
-    {  # if you want your address removed, please submit a request and this will be done
-        "Stratford DC": {"uprn": "100071513500"},  # doesn't have food waste
-        "Alscot Estate": {"uprn": 10024633309},
-    }
-)
+TEST_CASES = {  # if you want your address removed, please submit a request and this will be done
+    "Stratford DC": {"uprn": "100071513500"},  # doesn't have food waste
+    "Alscot Estate": {"uprn": 10024633309},
+}
 
 ICON_MAP = {
     "Garden waste": Icons.GARDEN,
@@ -68,7 +66,6 @@ class Source:
             # each bin may be "checked" to show it can be collected on that date
             for idx, cell in enumerate(all_bins):
                 if cell.find("img", class_="check-img"):
-
                     entries.append(
                         Collection(date=date, t=BINS[idx], icon=ICON_MAP.get(BINS[idx]))
                     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swindon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swindon_gov_uk.py
@@ -53,7 +53,6 @@ class Source:
         for results in BeautifulSoup(r.text, "html.parser").find_all(
             "div", class_="bin-collection-content"
         ):
-
             try:
                 recyclingdate = results.find("span", class_="nextCollectionDate")
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tauranga_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tauranga_govt_nz.py
@@ -92,17 +92,17 @@ class Source:
         addr_input = soup.find(
             "input",
             attrs={
-                "id": lambda x: x
-                and "CollectionDaysSAP" in str(x)
-                and "Address" in str(x)
+                "id": lambda x: (
+                    x and "CollectionDaysSAP" in str(x) and "Address" in str(x)
+                )
             },
         )
         hdn_input = soup.find(
             "input",
             attrs={
-                "id": lambda x: x
-                and "CollectionDaysSAP" in str(x)
-                and "hdnValue" in str(x)
+                "id": lambda x: (
+                    x and "CollectionDaysSAP" in str(x) and "hdnValue" in str(x)
+                )
             },
         )
         if not addr_input or not hdn_input:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/warrington_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/warrington_gov_uk.py
@@ -54,9 +54,13 @@ class Source:
             # List contains duplicates, so skip if already added.
             if self.contains(
                 entries,
-                lambda x: x.date
-                == datetime.strptime(job["ScheduledStart"], "%Y-%m-%dT%H:00:00").date()
-                and x.type == bin_type,
+                lambda x: (
+                    x.date
+                    == datetime.strptime(
+                        job["ScheduledStart"], "%Y-%m-%dT%H:00:00"
+                    ).date()
+                    and x.type == bin_type
+                ),
             ):
                 continue
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wokingham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wokingham_gov_uk.py
@@ -70,9 +70,9 @@ class Source:
         }
         # reformat dates to make comparison easier
         revised_schedules = {
-            datetime.strptime(k, "%A %d %B %Y")
-            .strftime("%d/%m/%Y"): datetime.strptime(v, "%A %d %B %Y")
-            .strftime("%d/%m/%Y")
+            datetime.strptime(k, "%A %d %B %Y").strftime("%d/%m/%Y"): datetime.strptime(
+                v, "%A %d %B %Y"
+            ).strftime("%d/%m/%Y")
             for k, v in revised_schedules.items()
         }
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+target-version = "py313"
+line-length = 88
+
+[lint]
+# Mirror the previous flake8 + isort behaviour: pycodestyle (E/W), pyflakes (F)
+# and import sorting (I, equivalent to isort profile=black). E203/E501 were
+# ignored by flake8; E721 is stricter in ruff than pycodestyle, so keep it off
+# to avoid new findings the old tool chain never reported.
+select = ["E", "F", "W", "I"]
+ignore = ["E203", "E501", "E721"]
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/tests/test_darebin_vic_gov_au.py
+++ b/tests/test_darebin_vic_gov_au.py
@@ -96,7 +96,7 @@ def test_get_previous_date_for_day_of_week_monday(monkeypatch):
         darebin_vic_gov_au.WEEKDAY_MAP[collection_day]
     )
     assert results == expected, (
-        f"Expected {expected} for day_of_week={collection_day}, " f"but got {results}"
+        f"Expected {expected} for day_of_week={collection_day}, but got {results}"
     )
 
 
@@ -109,7 +109,7 @@ def test_get_previous_date_for_day_of_week_tuesday(monkeypatch):
         darebin_vic_gov_au.WEEKDAY_MAP[collection_day]
     )
     assert results == expected, (
-        f"Expected {expected} for day_of_week={collection_day}, " f"but got {results}"
+        f"Expected {expected} for day_of_week={collection_day}, but got {results}"
     )
 
 
@@ -122,7 +122,7 @@ def test_get_previous_date_for_day_of_week_wednesday(monkeypatch):
         darebin_vic_gov_au.WEEKDAY_MAP[collection_day]
     )
     assert results == expected, (
-        f"Expected {expected} for day_of_week={collection_day}, " f"but got {results}"
+        f"Expected {expected} for day_of_week={collection_day}, but got {results}"
     )
 
 
@@ -135,7 +135,7 @@ def test_get_previous_date_for_day_of_week_thursday(monkeypatch):
         darebin_vic_gov_au.WEEKDAY_MAP[collection_day]
     )
     assert results == expected, (
-        f"Expected {expected} for day_of_week={collection_day}, " f"but got {results}"
+        f"Expected {expected} for day_of_week={collection_day}, but got {results}"
     )
 
 
@@ -148,7 +148,7 @@ def test_get_previous_date_for_day_of_week_friday(monkeypatch):
         darebin_vic_gov_au.WEEKDAY_MAP[collection_day]
     )
     assert results == expected, (
-        f"Expected {expected} for day_of_week={collection_day}, " f"but got {results}"
+        f"Expected {expected} for day_of_week={collection_day}, but got {results}"
     )
 
 
@@ -161,7 +161,7 @@ def test_get_previous_date_for_day_of_week_saturday(monkeypatch):
         darebin_vic_gov_au.WEEKDAY_MAP[collection_day]
     )
     assert results == expected, (
-        f"Expected {expected} for day_of_week={collection_day}, " f"but got {results}"
+        f"Expected {expected} for day_of_week={collection_day}, but got {results}"
     )
 
 
@@ -174,5 +174,5 @@ def test_get_previous_date_for_day_of_week_sunday(monkeypatch):
         darebin_vic_gov_au.WEEKDAY_MAP[collection_day]
     )
     assert results == expected, (
-        f"Expected {expected} for day_of_week={collection_day},  " f"but got {results}"
+        f"Expected {expected} for day_of_week={collection_day},  but got {results}"
     )

--- a/tests/test_hillingdon_gov_uk.py
+++ b/tests/test_hillingdon_gov_uk.py
@@ -224,9 +224,9 @@ def test_fetch_all_dates_on_correct_weekday(mock_requests, mock_bh):
 
     assert len(entries) == 8
     for entry in entries:
-        assert (
-            entry.date.weekday() == 2
-        ), f"Expected Wednesday (weekday 2), got {entry.date} (weekday {entry.date.weekday()})"
+        assert entry.date.weekday() == 2, (
+            f"Expected Wednesday (weekday 2), got {entry.date} (weekday {entry.date.weekday()})"
+        )
 
 
 @patch(
@@ -265,9 +265,9 @@ def test_fetch_strips_subscription_expiry_suffix(mock_requests, mock_bh):
 
     waste_types = {e.type for e in entries}
     assert "Garden Waste" in waste_types
-    assert not any(
-        "( -" in t for t in waste_types
-    ), "Raw suffix should have been stripped from waste type"
+    assert not any("( -" in t for t in waste_types), (
+        "Raw suffix should have been stripped from waste type"
+    )
 
 
 @patch(

--- a/tests/test_midlothian_gov_uk.py
+++ b/tests/test_midlothian_gov_uk.py
@@ -62,9 +62,9 @@ def test_collection_dates_are_valid(collections):
 
     # Assert all collection dates are valid date objects
     for collection in collections:
-        assert isinstance(
-            collection.date, date
-        ), "Collection date should be a date object"
+        assert isinstance(collection.date, date), (
+            "Collection date should be a date object"
+        )
         assert earliest_allowed <= collection.date <= latest_allowed, (
             f"Collection date {collection.date} is outside reasonable range "
             f"({earliest_allowed} to {latest_allowed})"
@@ -82,9 +82,9 @@ def test_collection_dates_are_valid(collections):
     # so we expect dates >= today, but allow a 1-day grace period for edge cases
     for ctype, dates in type_to_dates.items():
         soonest = min(dates)
-        assert (
-            soonest >= earliest_allowed
-        ), f"Soonest collection date for {ctype} is unexpectedly old: {soonest}"
+        assert soonest >= earliest_allowed, (
+            f"Soonest collection date for {ctype} is unexpectedly old: {soonest}"
+        )
 
 
 def test_collection_types_are_recognized(collections):
@@ -103,18 +103,18 @@ def test_collection_types_are_recognized(collections):
     collection_types = {c.type for c in collections}
 
     # Then
-    assert collection_types.issubset(
-        expected_types
-    ), f"Unexpected collection types found: {collection_types - expected_types}"
+    assert collection_types.issubset(expected_types), (
+        f"Unexpected collection types found: {collection_types - expected_types}"
+    )
 
 
 def test_icons_match_collection_types(collections):
     """Test that icons are correctly mapped to their collection types."""
     for collection in collections:
         expected_icon = midlothian_gov_uk.ICON_MAP.get(collection.type)
-        assert (
-            collection.icon == expected_icon
-        ), f"Icon mismatch for {collection.type}: expected {expected_icon}, got {collection.icon}"
+        assert collection.icon == expected_icon, (
+            f"Icon mismatch for {collection.type}: expected {expected_icon}, got {collection.icon}"
+        )
 
 
 def test_source_initialization():
@@ -132,6 +132,6 @@ def test_source_initialization():
 
 def test_multiple_collections_returned(collections):
     """Test that multiple collections are returned (typically multiple weeks/services)."""
-    assert (
-        len(collections) >= 2
-    ), f"Expected at least 2 collections, but got {len(collections)}"
+    assert len(collections) >= 2, (
+        f"Expected at least 2 collections, but got {len(collections)}"
+    )

--- a/tests/test_olo_sk.py
+++ b/tests/test_olo_sk.py
@@ -350,9 +350,9 @@ def test_waste_types_all_have_display_name_and_icon():
     for waste_type, (display_name, icon) in olo_sk.WASTE_TYPES.items():
         assert display_name, f"Missing display name for {waste_type}"
         assert icon, f"Missing icon for {waste_type}"
-        assert icon.startswith(
-            "mdi:"
-        ), f"Icon should start with 'mdi:' for {waste_type}"
+        assert icon.startswith("mdi:"), (
+            f"Icon should start with 'mdi:' for {waste_type}"
+        )
 
 
 def test_waste_types_expected_count():

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -9,9 +9,7 @@ from unittest.mock import patch
 
 import yaml
 
-sys.path.append(
-    os.path.join(os.path.dirname(__file__), "..")
-)  # isort:skip # noqa: E402
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))  # isort:skip # noqa: E402
 from update_docu_links import (  # isort:skip # noqa: E402
     BLACK_LIST,
     COUNTRYCODES,
@@ -148,26 +146,26 @@ def _param_translation_check(
     init_params_names: Iterable[str],
     source_param_to_test: str = "translations",
 ) -> None:
-    assert isinstance(
-        translations, dict
-    ), f"{source_param_to_test} must be a dictionary in {source}"
+    assert isinstance(translations, dict), (
+        f"{source_param_to_test} must be a dictionary in {source}"
+    )
     for lang, lang_translations in translations.items():
-        assert (
-            lang in LANGUAGES
-        ), f"unknown/unsupported language code {lang} in {source} {source_param_to_test}, must be one of {LANGUAGES}"
-        assert isinstance(
-            lang_translations, dict
-        ), f"{source_param_to_test} must be a dictionary in {source}"
+        assert lang in LANGUAGES, (
+            f"unknown/unsupported language code {lang} in {source} {source_param_to_test}, must be one of {LANGUAGES}"
+        )
+        assert isinstance(lang_translations, dict), (
+            f"{source_param_to_test} must be a dictionary in {source}"
+        )
         for argument, argument_translation in lang_translations.items():
-            assert isinstance(
-                argument, str
-            ), f"{source_param_to_test} keys must be strings in {source} for language {lang}"
-            assert isinstance(
-                argument_translation, str
-            ), f"{source_param_to_test} values must be strings in {source} for language {lang}"
-            assert (
-                argument in init_params_names
-            ), f"{source_param_to_test} key {argument} for language {lang} not a valid parameter in Source class in {source}"
+            assert isinstance(argument, str), (
+                f"{source_param_to_test} keys must be strings in {source} for language {lang}"
+            )
+            assert isinstance(argument_translation, str), (
+                f"{source_param_to_test} values must be strings in {source} for language {lang}"
+            )
+            assert argument in init_params_names, (
+                f"{source_param_to_test} key {argument} for language {lang} not a valid parameter in Source class in {source}"
+            )
 
 
 def _test_case_check(
@@ -178,21 +176,21 @@ def _test_case_check(
     mandatory_init_params_names: Iterable[str],
 ) -> None:
     assert isinstance(name, str), f"test_case key must be a string in source {source}"
-    assert isinstance(
-        test_case, dict
-    ), f"test_case value must be a dictionary in source {source}"
+    assert isinstance(test_case, dict), (
+        f"test_case value must be a dictionary in source {source}"
+    )
     for test_case_param in test_case.keys():
-        assert isinstance(
-            test_case_param, str
-        ), f"test_case keys must be strings in source {source}"
-        assert (
-            test_case_param in init_params_names
-        ), f"test_case key {test_case_param} not a valid parameter in Source class in source {source}"
+        assert isinstance(test_case_param, str), (
+            f"test_case keys must be strings in source {source}"
+        )
+        assert test_case_param in init_params_names, (
+            f"test_case key {test_case_param} not a valid parameter in Source class in source {source}"
+        )
 
     for param in mandatory_init_params_names:
-        assert (
-            param in test_case.keys()
-        ), f"missing mandatory parameter ({param}) in test_case '{name}' in source {source}"
+        assert param in test_case.keys(), (
+            f"missing mandatory parameter ({param}) in test_case '{name}' in source {source}"
+        )
 
 
 def _test_source_has_necessary_parameters_test_cases(
@@ -202,12 +200,12 @@ def _test_source_has_necessary_parameters_test_cases(
     mandatory_init_params_names: Iterable[str],
 ) -> None:
     assert hasattr(module, "TEST_CASES"), f"missing test_cases in source {source}"
-    assert isinstance(
-        module.TEST_CASES, dict
-    ), f"test_cases must be a dictionary in source {source}"
-    assert (
-        len(module.TEST_CASES) > 0
-    ), f"test_cases must not be empty in source {source}"
+    assert isinstance(module.TEST_CASES, dict), (
+        f"test_cases must be a dictionary in source {source}"
+    )
+    assert len(module.TEST_CASES) > 0, (
+        f"test_cases must not be empty in source {source}"
+    )
 
     if source not in SOURCES_EXCLUDE_TEST_CASE_CHECK:
         for name, test_case in module.TEST_CASES.items():
@@ -228,44 +226,44 @@ def _test_source_has_necessary_parameters_extra_info(
             assert False, f"EXTRA_INFO() function in source {source} failed with {e}"
 
         # check if is iterable (list, tupüle, set)
-        assert isinstance(
-            extra_info, (list, tuple, set, GeneratorType)
-        ), f"EXTRA_INFO in source {source}, must be or return an iterable"
+        assert isinstance(extra_info, (list, tuple, set, GeneratorType)), (
+            f"EXTRA_INFO in source {source}, must be or return an iterable"
+        )
         # check if all items are dictionaries
         for item in extra_info:
-            assert isinstance(
-                item, dict
-            ), f"EXTRA_INFO in source {source}, must return a list of dictionaries, but at least one is not a dict"
-            assert (
-                "title" in item
-            ), f"EXTRA_INFO in source {source}, must have a new title key in each dictionary"
-            assert isinstance(
-                item["title"], str
-            ), f"EXTRA_INFO in source {source}, must have a string title key in each dictionary"
+            assert isinstance(item, dict), (
+                f"EXTRA_INFO in source {source}, must return a list of dictionaries, but at least one is not a dict"
+            )
+            assert "title" in item, (
+                f"EXTRA_INFO in source {source}, must have a new title key in each dictionary"
+            )
+            assert isinstance(item["title"], str), (
+                f"EXTRA_INFO in source {source}, must have a string title key in each dictionary"
+            )
 
             for key in item.keys():
-                assert isinstance(
-                    key, str
-                ), f"EXTRA_INFO in source {source}, must only have string keys in each dictionary"
-                assert (
-                    key in EXTRA_INFO_KEYS
-                ), f"Found unknown key {key} in source {source}, must have only the following keys: {EXTRA_INFO_KEYS}"
-                assert isinstance(
-                    item[key], EXTRA_INFO_TYPES[key]
-                ), f"EXTRA_INFO in source {source}, key {key} must have type {EXTRA_INFO_TYPES[key]}"
+                assert isinstance(key, str), (
+                    f"EXTRA_INFO in source {source}, must only have string keys in each dictionary"
+                )
+                assert key in EXTRA_INFO_KEYS, (
+                    f"Found unknown key {key} in source {source}, must have only the following keys: {EXTRA_INFO_KEYS}"
+                )
+                assert isinstance(item[key], EXTRA_INFO_TYPES[key]), (
+                    f"EXTRA_INFO in source {source}, key {key} must have type {EXTRA_INFO_TYPES[key]}"
+                )
 
             if "country" in item:
-                assert _is_supported_country_code(
-                    item["country"]
-                ), f"unsupported country code in source {source} in EXTRA_INFO"
+                assert _is_supported_country_code(item["country"]), (
+                    f"unsupported country code in source {source} in EXTRA_INFO"
+                )
             if "default_params" in item:
                 for key in item["default_params"].keys():
-                    assert isinstance(
-                        key, str
-                    ), f"EXTRA_INFO in source {source}, default_params keys must be strings"
-                    assert (
-                        key in init_params_names
-                    ), f"EXTRA_INFO in source {source}, default_params key {key} not a valid parameter in Source class"
+                    assert isinstance(key, str), (
+                        f"EXTRA_INFO in source {source}, default_params keys must be strings"
+                    )
+                    assert key in init_params_names, (
+                        f"EXTRA_INFO in source {source}, default_params key {key} not a valid parameter in Source class"
+                    )
 
 
 def test_source_has_necessary_parameters() -> None:
@@ -288,21 +286,21 @@ def test_source_has_necessary_parameters() -> None:
             module, source, init_params_names, mandatory_init_params_names
         )
 
-        assert hasattr(
-            module.Source, "fetch"
-        ), f"missing fetch method in Source class of source {source}"
+        assert hasattr(module.Source, "fetch"), (
+            f"missing fetch method in Source class of source {source}"
+        )
 
         # If the module declares COUNTRY it must be a valid code — update_docu_links.py
         # uses this value directly and silently orphans the source if it doesn't match.
         if hasattr(module, "COUNTRY"):
-            assert _is_supported_country_code(
-                module.COUNTRY
-            ), f"unsupported country code {module.COUNTRY!r} in source {source}"
+            assert _is_supported_country_code(module.COUNTRY), (
+                f"unsupported country code {module.COUNTRY!r} in source {source}"
+            )
 
         if source not in SOURCES_NO_COUNTRY and not _has_supported_country_code(source):
-            assert hasattr(
-                module, "COUNTRY"
-            ), f"missing COUNTRY in source {source} or supported countrycode in filename"
+            assert hasattr(module, "COUNTRY"), (
+                f"missing COUNTRY in source {source} or supported countrycode in filename"
+            )
 
         if hasattr(module, "EXTRA_INFO"):
             _test_source_has_necessary_parameters_extra_info(
@@ -310,16 +308,16 @@ def test_source_has_necessary_parameters() -> None:
             )
 
         if hasattr(module, "HOW_TO_GET_ARGUMENTS_DESCRIPTION"):
-            assert isinstance(
-                module.HOW_TO_GET_ARGUMENTS_DESCRIPTION, dict
-            ), f"HOW_TO_GET_ARGUMENTS_DESCRIPTION must be a dictionary in {source}"
+            assert isinstance(module.HOW_TO_GET_ARGUMENTS_DESCRIPTION, dict), (
+                f"HOW_TO_GET_ARGUMENTS_DESCRIPTION must be a dictionary in {source}"
+            )
             for key, value in module.HOW_TO_GET_ARGUMENTS_DESCRIPTION.items():
-                assert (
-                    key in LANGUAGES
-                ), f"HOW_TO_GET_ARGUMENTS_DESCRIPTION key {key} must be a valid/supported language code in {source}, must be one of {LANGUAGES}"
-                assert isinstance(
-                    value, str
-                ), f"HOW_TO_GET_ARGUMENTS_DESCRIPTION values must be strings in {source}"
+                assert key in LANGUAGES, (
+                    f"HOW_TO_GET_ARGUMENTS_DESCRIPTION key {key} must be a valid/supported language code in {source}, must be one of {LANGUAGES}"
+                )
+                assert isinstance(value, str), (
+                    f"HOW_TO_GET_ARGUMENTS_DESCRIPTION values must be strings in {source}"
+                )
 
         if hasattr(module, "PARAM_TRANSLATIONS"):
             _param_translation_check(
@@ -338,13 +336,13 @@ def test_source_has_necessary_parameters() -> None:
 
         if hasattr(module, "SOURCE_CODEOWNERS"):
             owners = module.SOURCE_CODEOWNERS
-            assert isinstance(
-                owners, list
-            ), f"SOURCE_CODEOWNERS must be a list in {source}, got {type(owners).__name__}"
+            assert isinstance(owners, list), (
+                f"SOURCE_CODEOWNERS must be a list in {source}, got {type(owners).__name__}"
+            )
             for i, handle in enumerate(owners):
-                assert (
-                    isinstance(handle, str) and handle.strip()
-                ), f"SOURCE_CODEOWNERS[{i}] in {source} must be a non-empty string"
+                assert isinstance(handle, str) and handle.strip(), (
+                    f"SOURCE_CODEOWNERS[{i}] in {source} must be a non-empty string"
+                )
                 assert handle.strip().startswith("@"), (
                     f"SOURCE_CODEOWNERS[{i}] in {source} must start with '@' "
                     f"(got {handle!r}). Use the canonical @handle format."
@@ -364,25 +362,25 @@ def test_ics_source_has_necessary_parameters():
         assert "title" in data, f"missing title in yaml file {source}.yaml"
         assert "url" in data, f"missing url in yaml file {source}.yaml"
         assert "howto" in data, f"missing howto in yaml file {source}.yaml"
-        assert isinstance(
-            data["howto"], dict
-        ), f"howto must be a dictionary in yaml file {source}.yaml"
-        assert (
-            "en" in data["howto"]
-        ), f"missing english howto translation in {source}.yaml"
+        assert isinstance(data["howto"], dict), (
+            f"howto must be a dictionary in yaml file {source}.yaml"
+        )
+        assert "en" in data["howto"], (
+            f"missing english howto translation in {source}.yaml"
+        )
         for key, value in data["howto"].items():
             assert isinstance(key, str), f"howto keys must be strings in {source}.yaml"
-            assert (
-                key in LANGUAGES
-            ), f"howto key {key} must be a valid/supported language code in {source}.yaml, must be one of {LANGUAGES}"
-            assert isinstance(
-                value, str
-            ), f"howto values must be strings in {source}.yaml"
+            assert key in LANGUAGES, (
+                f"howto key {key} must be a valid/supported language code in {source}.yaml, must be one of {LANGUAGES}"
+            )
+            assert isinstance(value, str), (
+                f"howto values must be strings in {source}.yaml"
+            )
 
         assert "test_cases" in data, f"missing test_cases in yaml file {source}.yaml"
-        assert isinstance(
-            data["test_cases"], dict
-        ), f"test_cases must be a dictionary in yaml file {source}.yaml"
+        assert isinstance(data["test_cases"], dict), (
+            f"test_cases must be a dictionary in yaml file {source}.yaml"
+        )
         for name, test_case in data["test_cases"].items():
             _test_case_check(
                 name,
@@ -398,13 +396,13 @@ def test_ics_source_has_necessary_parameters():
 
         if "codeowners" in data:
             ics_owners = data["codeowners"]
-            assert isinstance(
-                ics_owners, list
-            ), f"codeowners must be a list in ICS yaml {source}.yaml, got {type(ics_owners).__name__}"
+            assert isinstance(ics_owners, list), (
+                f"codeowners must be a list in ICS yaml {source}.yaml, got {type(ics_owners).__name__}"
+            )
             for i, handle in enumerate(ics_owners):
-                assert (
-                    isinstance(handle, str) and handle.strip()
-                ), f"codeowners[{i}] in ICS yaml {source}.yaml must be a non-empty string"
+                assert isinstance(handle, str) and handle.strip(), (
+                    f"codeowners[{i}] in ICS yaml {source}.yaml must be a non-empty string"
+                )
                 assert handle.strip().startswith("@"), (
                     f"codeowners[{i}] in ICS yaml {source}.yaml must start with '@' "
                     f"(got {handle!r}). Use the canonical @handle format."

--- a/tests/test_stockport_gov_uk.py
+++ b/tests/test_stockport_gov_uk.py
@@ -16,7 +16,6 @@ sys.path.append(
     )
 )
 
-from waste_collection_schedule import Collection  # noqa: E402
 from waste_collection_schedule.source import stockport_gov_uk  # noqa: E402
 
 # Sample HTML that mimics the Stockport council website structure


### PR DESCRIPTION
Replace black, flake8 and isort with Ruff in .pre-commit-config.yaml and configure VSCode to use Ruff as formatter / import organiser.

Ruff is configured to mirror the previous tool chain so the diff stays minimal and behaviour is unchanged:
- line-length 88 (black default)
- lint select E,F,W,I (pycodestyle + pyflakes + isort profile=black)
- ignore E203,E501 (as flake8 did) and E721 (stricter in Ruff than pycodestyle, so kept off to avoid new findings)
- ruff-format runs on the full tree like black; the ruff lint hook excludes source/ exactly as the flake8 hook did
- pyupgrade, codespell, bandit, yamlfmt and mypy hooks are unchanged

The .py reformatting in this commit is the irreducible black->ruff formatting difference; no logic changes.


## Summary

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `python -m black` and `python -m isort --profile black` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
