### PR TITLE
fix(fylde_gov_uk): integration changed parameter

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fylde_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fylde_gov_uk.py
@@ -4,7 +4,9 @@ from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+
+# type: ignore[attr-defined]
+from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import SourceArgumentRequired
 
 TITLE = "Fylde Council"
@@ -154,13 +156,15 @@ class Source:
         for event in events:
             # Filter by UPRN if specified
             if self._uprn is not None:
-                event_uprn = event.get("UPRN")
-                if event_uprn != self._uprn and str(event_uprn) != str(self._uprn):
+                try:
+                    if int(float(event.get("UPRN"))) != int(self._uprn):
+                        continue
+                except (TypeError, ValueError):
                     continue
 
-            # Extract bin type from Subject field (e.g., "GREY BIN 240L" -> "Grey Bin")
-            subject = event.get("Subject", "")
-            bin_type_match = re.search(REGEX_BIN_TYPE, subject)
+            # Extract bin type from Description field (e.g., "GREY BIN 240L" -> "Grey Bin")
+            description = event.get("Description", "")
+            bin_type_match = re.search(REGEX_BIN_TYPE, description)
             if not bin_type_match:
                 # Skip entries without a recognised bin type
                 continue

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fylde_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fylde_gov_uk.py
@@ -4,10 +4,12 @@ from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup
-
-# type: ignore[attr-defined]
-from waste_collection_schedule import Collection, Icons
-from waste_collection_schedule.exceptions import SourceArgumentRequired
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentExceptionMultiple,
+    SourceArgumentNotFound,
+    SourceArgumentRequired,
+)
 
 TITLE = "Fylde Council"
 DESCRIPTION = "Source for waste.fylde.gov.uk services for Fylde Council, UK."
@@ -109,8 +111,9 @@ class Source:
             "validation-summary-errors" in response.text
             or "/Identity/Account/Login" in response.url
         ):
-            raise Exception(
-                "Login failed. Please check your email and password credentials."
+            raise SourceArgumentExceptionMultiple(
+                ["email", "password"],
+                "Login failed. Please check your email and password credentials.",
             )
 
     def _extract_schedule_data(self, html: str) -> list:
@@ -183,15 +186,16 @@ class Source:
                 Collection(
                     date=collection_date,
                     t=bin_type,
-                    icon=ICON_MAP.get(bin_type, "mdi:trash-can"),
+                    icon=ICON_MAP.get(bin_type),
                 )
             )
 
         if not entries:
             if self._uprn is not None:
-                raise Exception(
-                    f"No collection events found for UPRN {self._uprn}. "
-                    "Please check that this property is registered on your waste portal account."
+                raise SourceArgumentNotFound(
+                    "uprn",
+                    self._uprn,
+                    "please check that this property is registered on your waste portal account.",
                 )
             else:
                 raise Exception(


### PR DESCRIPTION
## Summary

Fylde Gov integration changed parameter from "Subject" to "Description"
Also added a fix for when UPRN is returned as a `float`

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python -m black` and `python -m isort --profile black` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)