### PR TITLE
feat(ics): add optional impersonate arg to pass TLS-fingerprinting WAFs

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -113,6 +113,7 @@ _LOGGER = logging.getLogger(__name__)
 PARAM_TRANSLATIONS = {
     "en": {
         "version": "(Deprecated) Version, has no effect anymore",
+        "impersonate": "Browser to impersonate (e.g. 'chrome') to pass TLS-fingerprinting WAFs",
     },
     "de": {
         "url": "URL",
@@ -127,6 +128,7 @@ PARAM_TRANSLATIONS = {
         "version": "(Veraltet) Version, hat keine Auswirkung mehr",
         "verify_ssl": "SSL-Verifizierung aktivieren",
         "headers": "Headers",
+        "impersonate": "Zu imitierender Browser (z.B. 'chrome'), um TLS-Fingerprinting-WAFs zu passieren",
     },
 }
 
@@ -146,6 +148,7 @@ class Source:
         version: int | None = None,
         verify_ssl: bool = True,
         headers: dict = {},
+        impersonate: str | None = None,
     ):
         self._url = re.sub("^webcal", "https", url) if url else None
         self._file = file
@@ -170,6 +173,7 @@ class Source:
         self._verify_ssl = verify_ssl
         self._headers = HEADERS
         self._headers.update(headers)
+        self._impersonate = impersonate
 
     def fetch(self):
         if self._url is not None:
@@ -227,6 +231,7 @@ class Source:
                 params=flat_params,
                 headers=self._headers,
                 verify=self._verify_ssl,
+                impersonate=self._impersonate,
             )
         elif self._method == "POST":
             r = requests.post(
@@ -234,6 +239,7 @@ class Source:
                 data=flat_params,
                 headers=self._headers,
                 verify=self._verify_ssl,
+                impersonate=self._impersonate,
             )
         else:
             raise SourceArgumentNotFoundWithSuggestions(

--- a/doc/source/ics.md
+++ b/doc/source/ics.md
@@ -541,6 +541,7 @@ waste_collection_schedule:
         version: 2
         verify_ssl: VERIFY_SSL
         headers: HEADERS
+        impersonate: IMPERSONATE
         title_template: "{{date.summary}}"
 ```
 
@@ -640,6 +641,13 @@ Set this option to `False` if you see the following warning in the logs:
 Add custom headers to HTTP request, e.g. `referer`. By default, the `user-agent` is already set to `Mozilla/5.0 (Windows NT 10.0; Win64; x64)`.
 
 See also [example](#custom-headers) below.
+
+**impersonate**  
+*(string) (optional, default: None)*
+
+Impersonate a real browser so the request matches a browser's TLS/JA3 fingerprint. Some providers sit behind a WAF (e.g. Incapsula/Imperva, Cloudflare) that rejects non-browser clients with an `HTTP 403` even when a browser `user-agent` header is set, because the block is based on the TLS handshake rather than the header. Setting this to a browser name (e.g. `chrome`) makes the underlying `curl_cffi` client mimic that browser and pass the check.
+
+Only set this if you get a `403` that a custom `user-agent` header does not fix. See the [curl_cffi documentation](https://curl-cffi.readthedocs.io/en/latest/impersonate.html) for the list of supported values (e.g. `chrome`, `safari`, `firefox`).
 
 **title_template**  
 *(str) (optional, default: `{{date.summary}}`)*


### PR DESCRIPTION
## Summary

Adds an optional `impersonate` argument to the generic ICS source, passed through to the underlying `curl_cffi` `get`/`post` calls. This lets the client mimic a real browser's TLS/JA3 fingerprint so feeds behind a WAF (Incapsula/Imperva, Cloudflare) that returns `HTTP 403` to non-browser clients can be fetched.

Default is `None`, so existing behaviour is unchanged. It's annotated like the other optional ICS args (`regex`, `split_at`), so the config flow renders it automatically once `sources.json` is regenerated.

This is the generic counterpart to the per-source workaround already used by `banyule_vic_gov_au`, `goldenplains_vic_gov_au`, and `valeofglamorgan_gov_uk`. Motivating case: Moreton Bay QLD (#1391), resolved as a generic-ICS provider and since put behind an Incapsula WAF. See #6645 for the discussion.

Verified against the affected feed:

| call | result |
|------|--------|
| `impersonate=None` (default) | HTTP 403 |
| `impersonate="chrome"` | 200 — 55 collections parsed |

## Type of change

- [x] Bug fix / source fix
- [x] Other (small enhancement to the generic ICS source)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (9 passed)
- [x] `python -m black` and `python -m isort --profile black` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources — n/a (not a new source; updated `doc/source/ics.md`)
- [ ] TEST_CASES use real, publicly accessible addresses — n/a (no new source/test cases)

<sub>Implemented with AI assistance (Claude Code) and reviewed by me before submitting.</sub>
