### PR TITLE
Update templates and agent docs to use Ruff instead of black/flake8/i…

### DIFF
--- a/.claude/agents/issue-executor.md
+++ b/.claude/agents/issue-executor.md
@@ -2,7 +2,7 @@
 name: issue-executor
 description: Executes a pre-approved issue resolution plan for mampfes/hacs_waste_collection_schedule. Receives a verbatim step-by-step plan from the issue-triager and executes it exactly in an isolated worktree. Every listed action is pre-authorised — no confirmation gates.
 model: sonnet
-tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git add *), Bash(git branch *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git push *), Bash(git remote *), Bash(git status *), Bash(python -m black *), Bash(python -m isort *), Bash(python -m pytest *), Bash(python test_sources.py *), Read, Edit, Write, Grep
+tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git add *), Bash(git branch *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git push *), Bash(git remote *), Bash(git status *), Bash(ruff *), Bash(python -m pytest *), Bash(python test_sources.py *), Read, Edit, Write, Grep
 ---
 
 You are an issue execution agent for mampfes/hacs_waste_collection_schedule. You receive a pre-approved execution plan from the issue-triager and carry it out exactly as written in an isolated worktree.

--- a/.claude/agents/issue-triager.md
+++ b/.claude/agents/issue-triager.md
@@ -2,7 +2,7 @@
 name: issue-triager
 description: Triages issues on mampfes/hacs_waste_collection_schedule. Validates labels/title, determines category, implements fixes where feasible (adding locations to shared configs, bug fixes, simple new sources), drafts responses for others. Works in two phases: Phase 1 returns a report without posting/committing anything; Phase 2 executes approved actions when continued via SendMessage.
 model: sonnet
-tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git add *), Bash(git branch *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git push *), Bash(git status *), Bash(python *), Bash(python -m black *), Bash(python -m isort *), Read, Edit, Write, Grep
+tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git add *), Bash(git branch *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git push *), Bash(git status *), Bash(python *), Bash(ruff *), Read, Edit, Write, Grep
 ---
 
 You are a specialised issue triager for mampfes/hacs_waste_collection_schedule, a Home Assistant custom component that fetches waste/bin collection schedules from ~600 providers worldwide.
@@ -23,7 +23,7 @@ You are a specialised issue triager for mampfes/hacs_waste_collection_schedule, 
 - No hardcoded dates, no `if __name__ == "__main__"` block
 - Must create `doc/source/<id>.md` — update_docu_links.py reads but does NOT create this
 - `COUNTRY` must be a lowercase code from `update_docu_links.py`'s `COUNTRYCODES` list. UK = `"uk"` (NOT `"gb"`); Canada = `"ca"` (lowercase). An invalid value silently orphans the source out of README/info/sources.json without failing CI.
-- Lint: `python -m black <file> && python -m isort --profile black <file>`
+- Lint/format: `ruff check --fix <file> && ruff format <file>` (ruff replaces black, flake8 and isort)
 - Test: `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s <id> -l`
 
 ### CI-enforced structural invariants — must validate at design time
@@ -80,10 +80,10 @@ The project requires publicly accessible endpoints. Prepare a polite explanation
 **Category F — Unclear or out of scope**
 Prepare an appropriate info-request or "not planned" comment.
 
-4. Lint any changed files:
+4. Lint/format any changed files:
    ```bash
-   python -m black <file>
-   python -m isort --profile black <file>
+   ruff check --fix <file>
+   ruff format <file>
    ```
 
 5. Return your Phase 1 report in this exact structure, then STOP — do NOT commit, push, post, label, or close anything:
@@ -128,7 +128,7 @@ Prepare an appropriate info-request or "not planned" comment.
    <complete final file content>
    ```
    (Repeat for each file the executor must create or overwrite.)
-3. [format commands: `python -m black <file>` and/or `python -m isort --profile black <file>`]
+3. [format commands: `ruff check --fix <file>` and/or `ruff format <file>`]
 4. [optional live test: `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s <id> -l`]
 5. **Mandatory structural test (do not skip even if live-test was blocked or impossible):** `python -m pytest tests/test_source_components.py -q` — must pass before commit.
 6. `git add <files>`

--- a/.claude/agents/pr-executor.md
+++ b/.claude/agents/pr-executor.md
@@ -2,7 +2,7 @@
 name: pr-executor
 description: Executes a pre-approved PR completion plan for mampfes/hacs_waste_collection_schedule. Receives a verbatim step-by-step plan from the pr-reviewer planner and executes it exactly in an isolated worktree. Every listed action is pre-authorised — no confirmation gates.
 model: sonnet
-tools: Bash(gh pr *), Bash(gh api *), Bash(gh issue *), Bash(git add *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git merge-base *), Bash(git remote *), Bash(git push *), Bash(git status *), Bash(python -m black *), Bash(python -m isort *), Bash(python -m pytest *), Read, Edit, Write, Grep
+tools: Bash(gh pr *), Bash(gh api *), Bash(gh issue *), Bash(git add *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git merge-base *), Bash(git remote *), Bash(git push *), Bash(git status *), Bash(ruff *), Bash(python -m pytest *), Read, Edit, Write, Grep
 ---
 
 You are a PR execution agent for mampfes/hacs_waste_collection_schedule. You receive a pre-approved execution plan from the pr-reviewer planner and carry it out exactly as written in an isolated worktree.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -2,7 +2,7 @@
 name: pr-reviewer
 description: Reviews and completes contributor PRs on mampfes/hacs_waste_collection_schedule. Checks diff for generated files, validates source module structure, applies auto-fixable issues (lint, formatting, missing docs), escalates substantive problems. Works in two phases: Phase 1 returns a report without committing anything; Phase 2 executes approved remote actions when continued via SendMessage.
 model: opus
-tools: Bash(gh pr *), Bash(gh api *), Bash(gh issue *), Bash(git add *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git merge-base *), Bash(git push *), Bash(git status *), Bash(python -m black *), Bash(python -m isort *), Read, Edit, Write, Grep
+tools: Bash(gh pr *), Bash(gh api *), Bash(gh issue *), Bash(git add *), Bash(git checkout *), Bash(git commit *), Bash(git diff *), Bash(git fetch *), Bash(git log *), Bash(git merge-base *), Bash(git push *), Bash(git status *), Bash(ruff *), Read, Edit, Write, Grep
 ---
 
 You are a specialised PR reviewer and completer for mampfes/hacs_waste_collection_schedule, a Home Assistant custom component that fetches waste/bin collection schedules from ~600 providers worldwide.
@@ -68,10 +68,10 @@ These cause CI failure if violated. Check the diff for each:
 
 6. Validate each changed source module per the rules above. Fix what can be fixed automatically.
 
-7. Lint all changed source files:
+7. Lint/format all changed source files:
    ```bash
-   python -m black <file>
-   python -m isort --profile black <file>
+   ruff check --fix <file>
+   ruff format <file>
    ```
 
 8. **Run the structural test suite against the post-fix state** — do not skip even if live-test is impossible:
@@ -110,7 +110,7 @@ These cause CI failure if violated. Check the diff for each:
 ### Execution Plan
 [Numbered list of exact steps for the pr-executor agent to run. Use verbatim bash commands where possible.
 
-**CRITICAL — the executor does not share your worktree.** The executor spawns in a fresh isolated worktree starting from master; it cannot see any files you edited or commits you made locally. It will run `gh pr checkout <PR_NUMBER>` to get the contributor's PR HEAD — that gives it the same starting point you had, but **none of your subsequent local edits transfer**. For every file you modified beyond running deterministic formatters (black/isort), include the **complete final file content** inline in a fenced code block so the executor can use Write to overwrite. Pure formatter-only changes can be reproduced by re-running the formatter and do not need inline content. New files (e.g. a missing `doc/source/<id>.md`) must always include the complete final content inline.]
+**CRITICAL — the executor does not share your worktree.** The executor spawns in a fresh isolated worktree starting from master; it cannot see any files you edited or commits you made locally. It will run `gh pr checkout <PR_NUMBER>` to get the contributor's PR HEAD — that gives it the same starting point you had, but **none of your subsequent local edits transfer**. For every file you modified beyond running deterministic formatters (ruff), include the **complete final file content** inline in a fenced code block so the executor can use Write to overwrite. Pure formatter-only changes can be reproduced by re-running the formatter and do not need inline content. New files (e.g. a missing `doc/source/<id>.md`) must always include the complete final content inline.]
 
 1. `gh pr checkout <PR_NUMBER> --repo mampfes/hacs_waste_collection_schedule`
 2. [revert commands if needed: `git checkout upstream/master -- <file>`]
@@ -122,7 +122,7 @@ These cause CI failure if violated. Check the diff for each:
    ```
    ```
    (Repeat per file. Omit this step if no edits or new files.)
-4. [format commands: `python -m black <file>` and/or `python -m isort --profile black <file>`]
+4. [format commands: `ruff check --fix <file>` and/or `ruff format <file>`]
 5. **Mandatory structural test (do not skip):** `python -m pytest tests/test_source_components.py -q` — must pass before commit.
 6. `git add <files>`
 7. `git commit -m "<exact commit message>"`

--- a/.claude/agents/source-implementer.md
+++ b/.claude/agents/source-implementer.md
@@ -2,7 +2,7 @@
 name: source-implementer
 description: Implements a new waste-collection source module from a recommendation produced by source-investigator. Generates the .py source, the doc/source/<id>.md, lints, and runs the TEST_CASES. Use this after investigation has confirmed the approach.
 model: opus
-tools: Bash(python *), Bash(python -m black *), Bash(python -m isort *), Bash(python -m pytest *), Read, Edit, Write, Grep, Glob, WebFetch
+tools: Bash(python *), Bash(ruff *), Bash(python -m pytest *), Read, Edit, Write, Grep, Glob, WebFetch
 ---
 
 You are an implementation agent that writes a new waste-collection source from a pre-vetted plan. You produce real files in the working tree; you do not commit or push (the contributor does that, after reviewing your output).
@@ -151,10 +151,10 @@ waste_collection_schedule:
 2. Write the source `.py` file using the template. Implement `fetch()` against the data feed described in the recommendation.
 3. Encourage the contributor to add their GitHub handle to `SOURCE_CODEOWNERS` in the source file. Explain that this means they will be automatically notified and assigned on bug reports for their source. If they decline or are not present, leave the commented-out placeholder in the template.
 4. Write the `doc/source/<module>.md` file.
-5. Lint:
+5. Lint/format:
    ```bash
-   python -m black <source.py> <if you touched any other .py>
-   python -m isort --profile black <source.py>
+   ruff check --fix <source.py> <if you touched any other .py>
+   ruff format <source.py>
    ```
 6. Run the structural tests:
    ```bash

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 ## Checklist
 
 - [ ] `python -m pytest tests/test_source_components.py -q` passes
-- [ ] `python -m black` and `python -m isort --profile black` run on changed source files
+- [ ] `ruff check --fix` and `ruff format` run on changed source files
 - [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
 - [ ] `doc/source/<name>.md` created for new sources
 - [ ] TEST_CASES use real, publicly accessible addresses (not my own)

--- a/.github/chatmodes/issue-triager.chatmode.md
+++ b/.github/chatmodes/issue-triager.chatmode.md
@@ -17,7 +17,7 @@ Rules:
 - Do not use unsupported translation language keys (only `en`, `de`, `it`, `fr`).
 - Use `Icons` enum in ICON_MAP.
 - Use lowercase COUNTRY allowlist value.
-- Run black/isort for changed Python files.
+- Run ruff (`ruff check --fix` + `ruff format`) for changed Python files.
 - If source files are touched, run `python -m pytest tests/test_source_components.py -q` before finalizing.
 
 Always output an Issue Triage Report containing label corrections, category, local work, draft comment, recommended action, and an execution plan with exact steps.

--- a/.github/chatmodes/source-implementer.chatmode.md
+++ b/.github/chatmodes/source-implementer.chatmode.md
@@ -23,7 +23,7 @@ Rules:
 - Do not modify generated files (`README.md`, `info.md`, `sources.json`, `source_metadata.json`, `translations/*.json`, `doc/ics/*.md`).
 
 Validation:
-- Format changed Python files with black + isort.
+- Format and lint changed Python files with ruff (`ruff check --fix` + `ruff format`).
 - Run `python -m pytest tests/test_source_components.py -q`.
 - Run `python test_sources.py -s <module> -l` from the test directory when applicable.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,15 +24,14 @@ For the human-facing guide, see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 - Adding language keys to `HOW_TO_GET_ARGUMENTS_DESCRIPTION` that the contributor did not write — it is fine to provide the description in only one language. Reviewers and AI agents must not inject translations for languages the contributor did not include.
 - Committing generated files (`README.md`, `sources.json`, etc.) — CI handles these post-merge.
 - Silent `[]` returns on HTTP errors (masks failures as "no upcoming collections").
-- Unformatted code — always run `python -m black <path> && python -m isort --profile black <path>` before committing.
+- Unformatted code — always run `ruff check --fix <path> && ruff format <path>` before committing.
 
 ## Useful commands
 
 ```bash
 python -m pytest tests/                                          # run automated test suite
 python custom_components/.../test/test_sources.py -s <name> -l  # test one source
-python -m black <path> && python -m isort --profile black <path> # format before committing
-python -m flake8 --extend-ignore=D100,D101,D102,D103,D104,D105,D106,D107,E501,W503,E203 <path>
+ruff check --fix <path> && ruff format <path>                    # lint + format before committing (replaces flake8, isort, black)
 pre-commit install                                               # activate git hook (run once after cloning)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Things the maintainers consistently bounce in code review — avoid these from t
 - **Unsupported language codes in `PARAM_DESCRIPTIONS`, `PARAM_TRANSLATIONS`, or `HOW_TO_GET_ARGUMENTS_DESCRIPTION`.** Only `en`, `de`, `it`, `fr` are valid keys. Including any other code (e.g. `lt`, `nl`, `pl`) fails `test_source_has_necessary_parameters`. If a contributor wrote their `HOW_TO_GET_ARGUMENTS_DESCRIPTION` in only one language (e.g. `{"en": "..."}`) that is fine — do not add translations for the other languages. See the [HOW_TO_GET_ARGUMENTS_DESCRIPTION rules](#how_to_get_arguments_description-rules) section.
 - **Editing files in the "must not hand-edit" list above** — they get overwritten by CI after merge.
 - **Suppressing failures silently.** Returning `[]` on an HTTP error masks problems as "no upcoming collections".
-- **Unformatted code.** Run `black` and `isort` before committing (see Commands below).
+- **Unformatted code.** Run `ruff check --fix` and `ruff format` before committing (see Commands below).
 - **Raw `mdi:*` strings in `ICON_MAP`.** Use the canonical `Icons` enum (`from waste_collection_schedule import Icons`) so icons stay consistent across sources for the same logical waste category. See `custom_components/waste_collection_schedule/waste_collection_schedule/icons.py`.
 
 ## HOW_TO_GET_ARGUMENTS_DESCRIPTION rules
@@ -147,20 +147,18 @@ python -m pytest tests/
 cd custom_components/waste_collection_schedule/waste_collection_schedule/test
 python test_sources.py -s <source_name> -l
 
-# Format before every commit — REQUIRED on every file you change
-python -m black <path>
-python -m isort --profile black <path>
-
-# Lint
-python -m flake8 --extend-ignore=D100,D101,D102,D103,D104,D105,D106,D107,E501,W503,E203 <path>
+# Format + lint before every commit — REQUIRED on every file you change
+# ruff replaces black, flake8 and isort
+ruff check --fix <path>
+ruff format <path>
 
 # Activate the git pre-commit hook (run once after cloning — enforces formatting automatically)
 pre-commit install
 ```
 
-`pre-commit run --all-files` runs the full lint suite (black, flake8, isort, mypy, codespell, bandit, pyupgrade, yamlfmt).
+`pre-commit run --all-files` runs the full lint suite (ruff lint + format, mypy, codespell, bandit, pyupgrade, yamlfmt).
 
-> **AI agents:** Always run `python -m black <path> && python -m isort --profile black <path>` on every changed file before calling `git commit`. The pre-commit hook enforces this for human contributors; agents must do it explicitly.
+> **AI agents:** Always run `ruff check --fix <path> && ruff format <path>` on every changed file before calling `git commit`. The pre-commit hook enforces this for human contributors; agents must do it explicitly.
 
 > **Note:** Do not run `update_docu_links.py` in a PR branch. The `Update Documentation` CI workflow runs it automatically on every push to `master` (post-merge) and commits the generated output.
 
@@ -175,6 +173,6 @@ pre-commit install
 1. Source module passes `test_sources.py -s <name>` against real TEST_CASES.
 2. New `doc/source/<name>.md` exists.
 3. `python -m pytest tests/` passes locally.
-4. Changed files are formatted with `black` and `isort --profile black`.
+4. Changed files are formatted and linted with `ruff format` and `ruff check --fix`.
 5. PR targets `master` of `mampfes/hacs_waste_collection_schedule`.
 6. Do **not** commit changes to `README.md`, `info.md`, `sources.json`, `source_metadata.json`, `translations/*.json`, or `doc/ics/*.md` — CI regenerates these after merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ python -m pytest tests/test_source_components.py -k "test_name"
 cd custom_components/waste_collection_schedule/waste_collection_schedule/test
 python test_sources.py -s <source_name> -l
 
-# All pre-commit hooks (black, flake8, isort, mypy, codespell, bandit, pyupgrade, yamlfmt)
+# All pre-commit hooks (ruff lint + format, mypy, codespell, bandit, pyupgrade, yamlfmt)
 pre-commit run --all-files
 
 # Install dependencies
@@ -76,9 +76,7 @@ pip install -r requirements.txt
 
 ## Linting and formatting
 
-- **black**: `--safe --quiet`
-- **flake8** ignores: D100–D107, E501, W503, E203
-- **isort**: profile=black, multi-line=3, trailing-comma
+- **ruff** (replaces black, flake8 and isort): line-length 88, lint select `E,F,W,I` (pycodestyle + pyflakes + isort, profile=black), ignore `E203,E501,E721`. `ruff format` mirrors black; `ruff check` mirrors flake8 + isort. Config lives in `.pre-commit-config.yaml` / `pyproject.toml`.
 - **mypy**: `--ignore-missing-imports --explicit-package-bases`
 - **bandit**: config at `tests/bandit.yaml`
 - **pyupgrade**: targets Python 3.7+
@@ -87,8 +85,8 @@ pip install -r requirements.txt
 For a single source file edit:
 
 ```bash
-python -m black <file>
-python -m isort --profile black <file>
+ruff check --fix <file>
+ruff format <file>
 ```
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to #6639, which migrated the actual lint/format toolchain to Ruff.
The tooling change was merged, but the **templates and agent/instruction docs
still referenced the old `black` / `flake8` / `isort` commands**. This PR brings
them in line with the current `.pre-commit-config.yaml`.

Docs-only change — no source modules and no generated files are touched.

## Command mapping

| Old | New |
|---|---|
| `python -m black <file>` | `ruff format <file>` |
| `python -m isort --profile black <file>` | `ruff check --fix <file>` (import sorting via Ruff's `I` rules) |
| `python -m flake8 …` | `ruff check` |

## Files changed

- `CLAUDE.md` — "Linting and formatting" section, single-file snippet, pre-commit hook list
- `AGENTS.md` — pitfalls, Commands block, AI-agent note, PR checklist
- `.github/copilot-instructions.md` — pitfalls + commands
- `.github/chatmodes/{issue-triager,source-implementer}.chatmode.md`
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist item
- `.claude/agents/*.md` — replaced `Bash(python -m black *), Bash(python -m isort *)` tool grants with `Bash(ruff *)`, updated prose snippets