### PR TITLE
fix/mypy type annotations 

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -458,7 +458,7 @@ class AppAbfallplusDe:
         bezirk_id="",
         strasse_id=None,
         hnr_id=None,
-    ):
+    ) -> None:
         self._client = str(uuid.uuid4())
 
         self._app_id = app_id

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/Samiljo_se_wastetype_searcher.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/Samiljo_se_wastetype_searcher.py
@@ -77,7 +77,7 @@ retry_codes = [
 ]
 
 
-NEW_NAME_MAP = {}
+NEW_NAME_MAP: dict[str, str] = {}
 
 
 def waste_searcher(arg1):  # sourcery skip: use-fstring-for-concatenation


### PR DESCRIPTION
This pull request makes minor improvements to type annotations and function signatures for better code clarity and type safety.

- Type annotation improvements:
  * Added an explicit return type (`-> None`) to the `__init__` method in `AppAbfallplusDe.py` for clarity and correctness.
  * Added a type annotation (`dict[str, str]`) to `NEW_NAME_MAP` in `Samiljo_se_wastetype_searcher.py` to specify its expected usage.## Summary

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `python -m black` and `python -m isort --profile black` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
