### PR TITLE
fix(ecoharmonogram_pl): add Wodzisław Śląski support via communityId 23

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -203,6 +203,13 @@ TEST_CASES = {
         "house_number": "1",
         "additional_sides_matcher": "Zabudowa jednorodzinna",
     },
+    "Wodzisław Śląski, Mszańska 16 (community 23)": {
+        "town": "Wodzisław Śląski",
+        "district": "Wodzisław Śląski",
+        "community": "23",
+        "street": "Mszańska",
+        "house_number": "16",
+    },
 }
 
 

--- a/doc/source/ecoharmonogram_pl.md
+++ b/doc/source/ecoharmonogram_pl.md
@@ -89,8 +89,9 @@ The `community` argument is a numeric ID that can be found in the plugin URL of 
 
 | Community ID | Town |
 | ------------ | ---- |
-| 108 | Gdańsk |
+| 23 | Wodzisław Śląski |
 | 60 | Rzeszów |
+| 108 | Gdańsk |
 
 ## Keep in mind
 


### PR DESCRIPTION
## Summary

- Adds a `TEST_CASES` entry for Wodzisław Śląski (Mszańska 16) using `community: "23"`
- Documents `community` ID 23 in the `## Towns requiring community argument` table in `doc/source/ecoharmonogram_pl.md`
- No source logic changes needed; the existing `community` parameter already routes through `getTownsForCommunity`

Closes #3872

## Test plan

- [ ] `python test_sources.py -s ecoharmonogram_pl -l` — all existing test cases pass, new Wodzisław Śląski case returns collection dates
- [ ] `python -m pytest tests/test_source_components.py -q` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)