### PR TITLE
fix(app_abfallplus_de): URL-decode HNR IDs before extracting display name

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -5,6 +5,7 @@ import time
 import uuid
 from collections import Counter, OrderedDict
 from datetime import date, datetime
+from urllib.parse import unquote
 
 import requests
 from bs4 import BeautifulSoup, Tag
@@ -820,7 +821,7 @@ class AppAbfallplusDe:
             hnrs.append(
                 {
                     "id": a[0],
-                    "name": a[0].split("|")[0],
+                    "name": unquote(a[0]).split("|")[0],
                     "f_id_strasse": a[6] if len(a) > 6 else None,
                 }
             )


### PR DESCRIPTION
## Summary

- House number display names in `get_hnrs()` were computed by splitting the raw onclick ID on `|`.
- Some apps (confirmed: `de.k4systems.bonnorange`) URL-encode the pipe as `%7C`, so the split had no effect and users saw garbled values like `3%7C%7C174955001` instead of `3`.
- Fix: apply `urllib.parse.unquote()` to the ID before the split. The raw (possibly encoded) ID is preserved as `"id"` so the API call is unchanged.

## Test plan

- [ ] Live-test existing `de.k4systems.bonnorange` TEST_CASE (`app_id=de.k4systems.bonnorange`, `city="A"`, `strasse="Auf dem Hügel"`, `hnr=6`)
- [ ] `python -m pytest tests/test_source_components.py -q` passes

Fixes #6660

🤖 Generated with [Claude Code](https://claude.com/claude-code)