### PR TITLE
Add Torre de' Passeri to Junker APP source (#6661)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -326,6 +326,7 @@ SERVICE_PROVIDERS = {
     "Broni",
     "San Cipriano Po",
     "Stradella",
+    "Torre de' Passeri",
 }
 
 
@@ -349,6 +350,10 @@ TEST_CASES = {
     "Mosciano Sant'Angelo": {"municipality": "Mosciano Sant'Angelo"},
     "Lodè": {"municipality": "Lodè", "area": "Utenze non domestiche"},
     "Udine": {"municipality": "Udine", "area": "Zona 2-4-5-6 - Utenze domestiche"},
+    "Torre de' Passeri": {
+        "municipality": "Torre de' Passeri",
+        "area": "Utenze domestiche",
+    },
 }
 
 


### PR DESCRIPTION
Add the municipality Torre de' Passeri (PE, Italy) to the SERVICE_PROVIDERS set in junker_app.py and include a corresponding TEST_CASE (Utenze domestiche area). The existing Junker platform implementation handles the double-dash slug and multi-zone area selection without any service-layer changes.

## Summary

closes #6661

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
