### PR TITLE
Refactor and add RiSKommunal sources using shared service

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
@@ -1,0 +1,415 @@
+"""Shared service for Austrian municipalities running the RiSKommunal (RIS) CMS.
+
+Many small Austrian municipalities publish their waste-collection calendar on the
+RiSKommunal platform. They all expose the same building blocks:
+
+* an HTML calendar page at ``/system/web/kalender.aspx`` which renders either as a
+  table (``ris_table`` / ``td_kal`` cells) or as a list (``list_style`` div with
+  ``h2`` dates), and
+* an ICS feed at ``/system/web/CalendarService.ashx`` (used by a few sources that
+  rely on hard-coded or scraped calendar IDs).
+
+This module provides a single base class, :class:`RiSKommunalSource`, so that an
+individual municipality source shrinks to a declaration of ``BASE_URL``,
+``ICON_MAP`` and (where the calendar needs them) a few query parameters. The base
+class auto-detects the table vs. list rendering, handles pagination with loop
+detection, resolves address-based ``typids`` from the embedded ``strassenArr``
+JavaScript array, and offers helpers for the ICS feed.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from datetime import date, datetime
+
+import requests
+from bs4 import BeautifulSoup
+
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.ICS import ICS  # type: ignore[attr-defined]
+
+# Assembly-qualified name token required by every RiSKommunal CalendarService.ashx
+# endpoint. It is a platform constant (base64 of
+# "RiSKommunal.Objects.Kalender, RISComponents, Version=1.0.0.0, Culture=neutral,
+# PublicKeyToken=null") and is therefore shared here rather than in each source.
+ICS_AQN = (
+    "UmlTS29tbXVuYWwuT2JqZWN0cy5LYWxlbmRlciwgUklTQ29tcG9uZW50cywgVmVyc2lvbj0xLjAuMC4w"
+    "LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPW51bGw="
+)
+
+CALENDAR_PATH = "/system/web/kalender.aspx"
+ICS_PATH = "/system/web/CalendarService.ashx"
+
+_DATE_RE = re.compile(r"(\d{2}\.\d{2}\.\d{4})")
+_LIST_DIV_ID = "ctl00_ctl00_ctl00_cph_col_a_cph_content_cph_content_list_style"
+
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+class RiSKommunalSource:
+    """Base class for RiSKommunal-based waste-collection sources.
+
+    Subclasses set class attributes:
+
+    * ``BASE_URL`` (required): municipality root URL, e.g. ``https://www.koppl.at``.
+    * ``ICON_MAP``: mapping of waste-type string -> ``Icons`` member.
+    * ``QUERY_PARAMS``: extra query parameters for ``kalender.aspx`` (dict).
+    * ``VDATUM_TODAY``: if True, add ``vdatum`` = today to the request.
+    * ``MAX_PAGES``: pagination upper bound (default 50).
+    * ``SELECTION_URL``: page carrying the street dropdown + ``strassenArr`` array
+      (only needed for address-based sources).
+
+    Address-/zone-based sources override ``__init__`` to expose their config-flow
+    parameters and pass them to :meth:`__init__` of this class.
+    """
+
+    BASE_URL: str = ""
+    ICON_MAP: dict = {}
+    QUERY_PARAMS: dict = {}
+    VDATUM_TODAY: bool = False
+    MAX_PAGES: int = 50
+    SELECTION_URL: str | None = None
+    RAISE_ON_EMPTY: bool = False
+    LOOKAHEAD_DAYS: int | None = None
+
+    def __init__(
+        self,
+        strasse: str | None = None,
+        hausnummer: str | int | None = None,
+        zone: str | None = None,
+    ):
+        self._strasse = str(strasse).strip() if strasse is not None else None
+        self._hausnummer = str(hausnummer).strip() if hausnummer is not None else None
+        self._zone = str(zone).strip() if zone is not None else None
+
+    # ------------------------------------------------------------------ #
+    # Public fetch (HTML path)
+    # ------------------------------------------------------------------ #
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        typids = None
+        if self._strasse is not None:
+            typids = self._resolve_typids(session)
+
+        entries = self._fetch_html(session, typids)
+        if not entries and self.RAISE_ON_EMPTY:
+            raise ValueError("Could not find any collection events.")
+        return entries
+
+    # ------------------------------------------------------------------ #
+    # HTML calendar
+    # ------------------------------------------------------------------ #
+    def _calendar_url(self) -> str:
+        return self.BASE_URL.rstrip("/") + CALENDAR_PATH
+
+    def _get_page(
+        self, session: requests.Session, page: int, typids: str | None
+    ) -> BeautifulSoup:
+        params = dict(self.QUERY_PARAMS)
+        if self.VDATUM_TODAY or self.LOOKAHEAD_DAYS is not None:
+            params["vdatum"] = date.today().strftime("%d.%m.%Y")
+        if self.LOOKAHEAD_DAYS is not None:
+            params["bdatum"] = self._end_date().strftime("%d.%m.%Y")
+        if typids is not None:
+            params["typids"] = typids
+        params["page"] = page
+
+        r = session.get(
+            self._calendar_url(), params=params, headers=HEADERS, timeout=30
+        )
+        r.raise_for_status()
+        r.encoding = r.apparent_encoding or "utf-8"
+        return BeautifulSoup(r.text, "html.parser")
+
+    def _end_date(self) -> date:
+        from datetime import timedelta
+
+        return date.today() + timedelta(days=self.LOOKAHEAD_DAYS or 0)
+
+    def _fetch_html(
+        self, session: requests.Session, typids: str | None
+    ) -> list[Collection]:
+        entries: list[Collection] = []
+        seen: set[tuple[str, str]] = set()
+        seen_first: set[tuple[str, str]] = set()
+        end_date = self._end_date() if self.LOOKAHEAD_DAYS is not None else None
+
+        for page in range(self.MAX_PAGES):
+            soup = self._get_page(session, page, typids)
+
+            rows = self._parse_table(soup)
+            list_mode = rows is None
+            if list_mode:
+                rows = self._parse_list(soup)
+
+            if not rows:
+                break
+
+            first_key = (rows[0][0].isoformat(), rows[0][1])
+            if first_key in seen_first:
+                break
+            seen_first.add(first_key)
+
+            for collection_date, waste_type in rows:
+                if end_date is not None and collection_date > end_date:
+                    continue
+                key = (collection_date.isoformat(), waste_type)
+                if key in seen:
+                    continue
+                seen.add(key)
+                entries.append(
+                    Collection(
+                        date=collection_date,
+                        t=waste_type,
+                        icon=self._icon(waste_type),
+                    )
+                )
+
+            # The list rendering is never paginated.
+            if list_mode:
+                break
+            # Stop once the page has run past the requested look-ahead window.
+            if end_date is not None and rows[-1][0] > end_date:
+                break
+
+        return sorted(entries, key=lambda c: c.date)
+
+    def _parse_table(self, soup: BeautifulSoup) -> list[tuple[date, str]] | None:
+        """Parse the table rendering.
+
+        Prefers the ``ris_table`` calendar; on installs that render a plain table
+        it falls back to the first table that yields date rows. Returns ``None``
+        when no data table is present so the caller can fall back to the list
+        parser.
+        """
+        table = soup.find("table", class_="ris_table")
+        if table is not None:
+            return self._extract_table_rows(table)
+
+        for table in soup.find_all("table"):
+            rows = self._extract_table_rows(table)
+            if rows:
+                return rows
+        return None
+
+    def _extract_table_rows(self, table) -> list[tuple[date, str]]:
+        out: list[tuple[date, str]] = []
+        for row in table.find_all("tr"):
+            tds = row.find_all("td")
+            if len(tds) < 2:
+                continue
+
+            m = _DATE_RE.match(tds[0].get_text(" ", strip=True))
+            if not m:
+                continue
+            collection_date = datetime.strptime(m.group(1), "%d.%m.%Y").date()
+
+            # Optional zone filter (third column, e.g. Eggelsberg).
+            if self._zone is not None and len(tds) >= 3:
+                row_zone = tds[2].get_text(strip=True)
+                if row_zone not in ("Gemeinde Alle", self._zone):
+                    continue
+
+            anchor = tds[1].find("a")
+            raw = (
+                anchor.get_text(strip=True)
+                if anchor
+                else tds[1].get_text(" ", strip=True)
+            )
+            waste_type = re.sub(r"\s*\(.*\)\s*$", "", raw).strip()
+            if not waste_type:
+                continue
+
+            out.append((collection_date, waste_type))
+
+        return out
+
+    def _parse_list(self, soup: BeautifulSoup) -> list[tuple[date, str]]:
+        """Parse the ``list_style`` rendering.
+
+        The list view groups collections under an ``<h2>`` date heading; the waste
+        types follow either as ``<li>`` items in the next ``<ul>`` (each item
+        carries a short ``<span>`` category and/or a descriptive ``<a>`` link) or,
+        on older installs, as a single ``<span>`` after the heading. The short
+        ``<span>`` category is preferred because it matches the ``ICON_MAP`` keys.
+        """
+        div = soup.find(id=_LIST_DIV_ID)
+        if div is None:
+            return []
+
+        out: list[tuple[date, str]] = []
+        for heading in div.find_all("h2"):
+            m = _DATE_RE.match(heading.get_text(" ", strip=True))
+            if not m:
+                continue
+            collection_date = datetime.strptime(m.group(1), "%d.%m.%Y").date()
+
+            ul = heading.find_next_sibling("ul")
+            items = ul.find_all("li") if ul else []
+            if items:
+                for li in items:
+                    out.append((collection_date, self._list_item_type(li)))
+            else:
+                span = heading.find_next_sibling("span")
+                if span is not None:
+                    waste_type = re.sub(
+                        r"^\((.*)\)$", r"\1", span.get_text(strip=True)
+                    ).strip()
+                    if waste_type:
+                        out.append((collection_date, waste_type))
+
+        return [(d, t) for d, t in out if t]
+
+    @staticmethod
+    def _list_item_type(li) -> str:
+        span = li.find("span")
+        if span is not None and span.get_text(strip=True):
+            return re.sub(r"^\((.*)\)$", r"\1", span.get_text(strip=True)).strip()
+        anchor = li.find("a")
+        if anchor is not None:
+            return anchor.get_text(strip=True)
+        return li.get_text(" ", strip=True)
+
+    # ------------------------------------------------------------------ #
+    # Address resolution (strassenArr -> typids)
+    # ------------------------------------------------------------------ #
+    def _resolve_typids(self, session: requests.Session) -> str:
+        url = self.SELECTION_URL or self._calendar_url()
+        r = session.get(url, headers=HEADERS, timeout=30)
+        r.raise_for_status()
+        r.encoding = r.apparent_encoding or "utf-8"
+        html = r.text
+
+        street_map = self._parse_street_dropdown(html)
+        street_id = None
+        target = (self._strasse or "").casefold().replace(" ", "")
+        for name, sid in street_map.items():
+            if name.casefold().replace(" ", "") == target:
+                street_id = sid
+                break
+        if street_id is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "strasse", self._strasse, sorted(street_map)
+            )
+
+        house = (self._hausnummer or "").casefold()
+        labels: list[str] = []
+        for entry in self._parse_strassen_arr(html):
+            if entry[0] != street_id:
+                continue
+            for hnr in entry[1]:
+                label = str(hnr[1])
+                labels.append(label)
+                if label.casefold() == house:
+                    return hnr[2]
+            break
+
+        raise SourceArgumentNotFoundWithSuggestions(
+            "hausnummer", self._hausnummer, labels
+        )
+
+    @staticmethod
+    def _parse_street_dropdown(html: str) -> dict[str, int]:
+        soup = BeautifulSoup(html, "html.parser")
+        select = soup.find(
+            "select",
+            attrs={"name": re.compile(r"boxmuellkalenderstrassedd$")},
+        )
+        if select is None:
+            select = soup.find(
+                "select",
+                attrs={"id": re.compile(r"boxmuellkalenderstrassedd$")},
+            )
+        if select is None:
+            raise ValueError("Could not locate street selector on RiSKommunal page")
+
+        result: dict[str, int] = {}
+        for opt in select.find_all("option"):
+            value = (opt.get("value") or "").strip()
+            text = opt.get_text(strip=True)
+            if value and text:
+                result[text] = int(value)
+        return result
+
+    @staticmethod
+    def _parse_strassen_arr(html: str) -> list:
+        match = re.search(r"strassenArr\s*=\s*", html)
+        if not match:
+            raise ValueError("Could not locate strassenArr in page")
+
+        start = html.find("[", match.end())
+        depth = 0
+        end = start
+        for idx in range(start, len(html)):
+            ch = html[idx]
+            if ch == "[":
+                depth += 1
+            elif ch == "]":
+                depth -= 1
+                if depth == 0:
+                    end = idx + 1
+                    break
+        if depth != 0:
+            raise ValueError("Could not parse strassenArr (unbalanced brackets)")
+
+        return ast.literal_eval(html[start:end])
+
+    # ------------------------------------------------------------------ #
+    # ICS feed helpers
+    # ------------------------------------------------------------------ #
+    def _ics_url(self, gnr: str, do: str, sprache: str = "1") -> str:
+        params = {"aqn": ICS_AQN, "sprache": sprache, "gnr": gnr, "do": do}
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return self.BASE_URL.rstrip("/") + ICS_PATH + "?" + query
+
+    def parse_ics_url(self, url: str) -> list[tuple[date, str]]:
+        """Fetch one ICS URL and return its ``(date, title)`` entries."""
+        r = requests.get(url, headers=HEADERS, timeout=60)
+        r.raise_for_status()
+        r.encoding = r.apparent_encoding or "utf-8"
+        return ICS().convert(r.text)
+
+    def parse_ics_urls(self, urls: list[str]) -> list[Collection]:
+        """Fetch several ICS URLs, using each event's own title as the waste type."""
+        entries: list[Collection] = []
+        for url in urls:
+            for d, title in self.parse_ics_url(url):
+                waste_type = title.strip()
+                entries.append(
+                    Collection(date=d, t=waste_type, icon=self._icon(waste_type))
+                )
+        return entries
+
+    def fetch_ics(self, gnr: str, do_ids: list[str]) -> list[Collection]:
+        """Fetch ICS feeds for the given ``do`` ids; waste type from the event."""
+        return self.parse_ics_urls([self._ics_url(gnr, do) for do in do_ids])
+
+    def fetch_ics_by_label(
+        self, gnr: str, calendars: dict[str, str]
+    ) -> list[Collection]:
+        """Fetch ICS feeds for ``{waste_type: do}``; label by the dict key."""
+        entries: list[Collection] = []
+        for waste_type, do in calendars.items():
+            for d, _title in self.parse_ics_url(self._ics_url(gnr, do)):
+                entries.append(
+                    Collection(date=d, t=waste_type, icon=self._icon(waste_type))
+                )
+        return entries
+
+    # ------------------------------------------------------------------ #
+    # Icons
+    # ------------------------------------------------------------------ #
+    def _icon(self, waste_type: str):
+        icon = self.ICON_MAP.get(waste_type)
+        if icon is not None:
+            return icon
+        lowered = waste_type.casefold()
+        for key, value in self.ICON_MAP.items():
+            if key.casefold() in lowered:
+                return value
+        return None

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
@@ -367,18 +367,22 @@ class RiSKommunalSource:
         query = "&".join(f"{k}={v}" for k, v in params.items())
         return self.BASE_URL.rstrip("/") + ICS_PATH + "?" + query
 
-    def parse_ics_url(self, url: str) -> list[tuple[date, str]]:
-        """Fetch one ICS URL and return its ``(date, title)`` entries."""
-        r = requests.get(url, headers=HEADERS, timeout=60)
+    def parse_ics_url(self, url: str, cookies=None) -> list[tuple[date, str]]:
+        """Fetch one ICS URL and return its ``(date, title)`` entries.
+
+        Optional ``cookies`` are passed per request (no session persistence) for
+        installs that gate the iCal download behind a selection cookie.
+        """
+        r = requests.get(url, headers=HEADERS, cookies=cookies, timeout=60)
         r.raise_for_status()
         r.encoding = r.apparent_encoding or "utf-8"
         return ICS().convert(r.text)
 
-    def parse_ics_urls(self, urls: list[str]) -> list[Collection]:
+    def parse_ics_urls(self, urls: list[str], cookies=None) -> list[Collection]:
         """Fetch several ICS URLs, using each event's own title as the waste type."""
         entries: list[Collection] = []
         for url in urls:
-            for d, title in self.parse_ics_url(url):
+            for d, title in self.parse_ics_url(url, cookies=cookies):
                 waste_type = title.strip()
                 entries.append(
                     Collection(date=d, t=waste_type, icon=self._icon(waste_type))

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
@@ -25,6 +25,7 @@ from datetime import date, datetime
 
 import requests
 from bs4 import BeautifulSoup
+
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
@@ -25,7 +25,6 @@ from datetime import date, datetime
 
 import requests
 from bs4 import BeautifulSoup
-
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/badaussee_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/badaussee_at.py
@@ -1,10 +1,10 @@
-import requests
-from waste_collection_schedule import Collection, Icons
-from waste_collection_schedule.service.ICS import ICS
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Bad Aussee"
 DESCRIPTION = "Source for Bad Aussee, Austria"
 URL = "https://www.badaussee.at"
+COUNTRY = "at"
 TEST_CASES = {
     "Zone 1": {
         "restmuell_zone": "1",
@@ -16,16 +16,6 @@ TEST_CASES = {
         "biomuell_zone": "4",
         "altpapier_zone": "4",
     },
-}
-
-ICS_BASE_URL = "https://www.badaussee.at/system/web/CalendarService.ashx"
-ICS_PARAMS = {
-    "aqn": (
-        "UmlTS29tbXVuYWwuT2JqZWN0cy5LYWxlbmRlciwgUklTQ29tcG9uZW50cywgVmVyc2lvbj0xLjAuMC4w"
-        "LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPW51bGw="
-    ),
-    "sprache": "1",
-    "gnr": "3138",
 }
 
 # Mapping of zone codes to their ICS 'do' parameter values
@@ -87,73 +77,33 @@ PARAM_TRANSLATIONS = {
 }
 
 
-class Source:
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.badaussee.at"
+    ICON_MAP = ICON_MAP
+    GNR = "3138"
+
     def __init__(
         self,
         restmuell_zone: str | int = "",
         biomuell_zone: str | int = "",
         altpapier_zone: str | int = "",
     ):
+        super().__init__()
         self._restmuell_zone = str(restmuell_zone) if restmuell_zone else ""
         self._biomuell_zone = str(biomuell_zone) if biomuell_zone else ""
         self._altpapier_zone = str(altpapier_zone) if altpapier_zone else ""
-        self._ics = ICS()
 
-    def fetch(self) -> list[Collection]:
-        entries = []
+    def fetch(self):
+        # Always include Gelber Sack, then add the configured zone calendars.
+        do_ids = [ICS_ZONE_MAPPING["gelber_sack"]]
 
-        # Always include Gelber Sack
-        gelber_sack_code = ICS_ZONE_MAPPING["gelber_sack"]
-        assert isinstance(gelber_sack_code, str)
-        ics_urls = [self._build_ics_url(gelber_sack_code)]
+        for key, zone in (
+            ("restmuell", self._restmuell_zone),
+            ("biomuell", self._biomuell_zone),
+            ("altpapier", self._altpapier_zone),
+        ):
+            mapping = ICS_ZONE_MAPPING[key]
+            if zone and zone in mapping:
+                do_ids.append(mapping[zone])
 
-        # Add zone-specific URLs based on configured zones
-        restmuell_zones = ICS_ZONE_MAPPING["restmuell"]
-        assert isinstance(restmuell_zones, dict)
-        if self._restmuell_zone and self._restmuell_zone in restmuell_zones:
-            ics_urls.append(self._build_ics_url(restmuell_zones[self._restmuell_zone]))
-
-        biomuell_zones = ICS_ZONE_MAPPING["biomuell"]
-        assert isinstance(biomuell_zones, dict)
-        if self._biomuell_zone and self._biomuell_zone in biomuell_zones:
-            ics_urls.append(self._build_ics_url(biomuell_zones[self._biomuell_zone]))
-
-        altpapier_zones = ICS_ZONE_MAPPING["altpapier"]
-        assert isinstance(altpapier_zones, dict)
-        if self._altpapier_zone and self._altpapier_zone in altpapier_zones:
-            ics_urls.append(self._build_ics_url(altpapier_zones[self._altpapier_zone]))
-
-        # Fetch and parse each ICS feed
-        for ics_url in ics_urls:
-            r = requests.get(ics_url, timeout=60)
-            r.raise_for_status()
-
-            # Parse ICS data
-            dates = self._ics.convert(r.text)
-
-            # Convert to Collection objects
-            for d in dates:
-                waste_type = d[1].strip()
-
-                # Determine icon based on waste type
-                icon = "mdi:trash-can-outline"
-                for key, value in ICON_MAP.items():
-                    if key.lower() in waste_type.lower():
-                        icon = value
-                        break
-
-                entries.append(
-                    Collection(
-                        date=d[0],
-                        t=waste_type,
-                        icon=icon,
-                    )
-                )
-
-        return entries
-
-    def _build_ics_url(self, do_param: str) -> str:
-        """Build ICS URL with the given 'do' parameter."""
-        params = {**ICS_PARAMS, "do": do_param}
-        param_str = "&".join([f"{k}={v}" for k, v in params.items()])
-        return f"{ICS_BASE_URL}?{param_str}"
+        return self.fetch_ics(self.GNR, do_ids)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dienten_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dienten_gv_at.py
@@ -1,25 +1,16 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Dienten am Hochkönig"
 DESCRIPTION = "Waste collection schedule for Dienten am Hochkönig, Austria."
 URL = "https://www.dienten.gv.at"
+COUNTRY = "at"
 
 TEST_CASES = {
-    # no input required as the waste collectoin site (dienten.gv.at) does not have any address specific requirement
+    # no input required as the waste collection site (dienten.gv.at) does not
+    # have any address specific requirement
     "Dorf 53": {},
 }
-
-HEADERS = {
-    "User-Agent": "Mozilla/5.0",
-}
-
-BASE_URL = "https://www.dienten.gv.at/system/web/kalender.aspx?bdatum=31.12.9999&blnr=&gnr_search=0&menuonr=218643352"
-
-MAX_PAGES = 50
 
 ICON_MAP = {
     "Restmüll": Icons.GENERAL_WASTE,
@@ -31,94 +22,13 @@ ICON_MAP = {
 }
 
 
-class Source:
-    def __init__(self):
-        pass
-
-    def _get_page(self, page_number: int):
-        url = f"{BASE_URL}&page={page_number}"
-
-        response = requests.get(
-            url,
-            headers=HEADERS,
-            timeout=30,
-        )
-
-        response.raise_for_status()
-
-        return BeautifulSoup(response.text, "html.parser")
-
-    def fetch(self):
-        entries: list[Collection] = []
-
-        seen_first_row: set[tuple[str, str]] = set()
-
-        for page in range(MAX_PAGES):
-            soup = self._get_page(page)
-
-            table = soup.find("table", class_="ris_table")
-
-            if table is None:
-                break
-
-            rows = table.find_all("tr")
-
-            if len(rows) <= 1:
-                break
-
-            first_cells = rows[1].find_all("td")
-            if len(first_cells) >= 2:
-                first_row_key = (
-                    first_cells[0].get_text(" ", strip=True),
-                    first_cells[1].get_text(" ", strip=True),
-                )
-                if first_row_key in seen_first_row:
-                    break
-                seen_first_row.add(first_row_key)
-
-            for row in rows[1:]:
-                cells = row.find_all("td")
-
-                if len(cells) < 2:
-                    continue
-
-                date_text = cells[0].get_text(" ", strip=True)
-                collection_type = cells[1].get_text(" ", strip=True)
-
-                if not date_text or not collection_type:
-                    continue
-
-                # Examples:
-                # "05.06.2026 (Freitag)"
-                # "11.06.2026 (Donnerstag) 16:00 - 19:00 Uhr"
-                date_text = date_text.split("(")[0].strip()
-
-                try:
-                    collection_date = datetime.strptime(
-                        date_text,
-                        "%d.%m.%Y",
-                    ).date()
-                except ValueError:
-                    continue
-
-                entries.append(
-                    Collection(
-                        date=collection_date,
-                        t=collection_type,
-                        icon=ICON_MAP.get(collection_type),
-                    )
-                )
-
-        if not entries:
-            raise ValueError("Could not find any collection events.")
-
-        # Remove duplicates
-        unique_entries = {}
-        for entry in entries:
-            key = (entry.date, entry.type)
-            unique_entries[key] = entry
-
-        return sorted(
-            unique_entries.values(),
-            key=lambda x: x.date,
-        )
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.dienten.gv.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "bdatum": "31.12.9999",
+        "blnr": "",
+        "gnr_search": "0",
+        "menuonr": "218643352",
+    }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edlitz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edlitz_at.py
@@ -1,13 +1,11 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Marktgemeinde Edlitz"
-DESCRIPTION = "Source for Marktgeneinde Edlitz, AT"
+DESCRIPTION = "Source for Marktgemeinde Edlitz, AT"
 URL = "https://edlitz.at"
-TEST_CASES = {"TestSource": {}, "IgnoredArgument": {"_": ""}}
+COUNTRY = "at"
+TEST_CASES = {"TestSource": {}}
 ICON_MAP = {
     "Biomüllabfuhr": Icons.BIO_KITCHEN,
     "Papier Tonne": Icons.PAPER,
@@ -18,30 +16,6 @@ ICON_MAP = {
 }
 
 
-class Source:
-    def __init__(self, _=None):
-        pass
-
-    def fetch(self):
-        s = requests.Session()
-        r = s.get("https://www.edlitz.at/system/web/kalender.aspx")
-
-        soup = BeautifulSoup(r.text, "html.parser")
-        td = soup.find_all("td", {"class": "td_kal"})
-
-        dts = td[::2]
-        wst = td[1::2]
-
-        entries = []
-        for i in range(0, len(dts)):
-            entries.append(
-                Collection(
-                    date=datetime.strptime(
-                        dts[i].text.split(" ")[0].strip(), "%d.%m.%Y"
-                    ).date(),
-                    t=wst[i].text.strip(),
-                    icon=ICON_MAP.get(wst[i].text.strip()),
-                )
-            )
-
-        return entries
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.edlitz.at"
+    ICON_MAP = ICON_MAP

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
@@ -1,9 +1,6 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Marktgemeinde Eggelsberg"
 DESCRIPTION = "Source for Marktgemeinde Eggelsberg waste collection."
@@ -50,73 +47,25 @@ PARAM_TRANSLATIONS = {
 }
 
 VALID_ZONES = ["A", "B"]
-CALENDAR_URL = "https://www.eggelsberg.at/system/web/kalender.aspx"
-MENU_ONR = "224085238"
-MAX_PAGES = 10
 
 
-class Source:
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.eggelsberg.at"
+    ICON_MAP = ICON_MAP
+    VDATUM_TODAY = True
+    QUERY_PARAMS = {
+        "bdatum": "31.12.9999",
+        "blnr": "",
+        "gnr_search": "0",
+        "menuonr": "224085238",
+        "umkreis": "",
+        "useronr": "0",
+    }
+
     def __init__(self, zone: str):
         zone = zone.strip().upper()
         if zone not in VALID_ZONES:
             raise SourceArgumentNotFoundWithSuggestions(
                 "zone", zone, suggestions=VALID_ZONES
             )
-        self._zone = zone
-
-    def fetch(self) -> list[Collection]:
-        entries: list[Collection] = []
-        seen: set[tuple[str, str, str]] = set()
-        today = datetime.now().strftime("%d.%m.%Y")
-
-        for page in range(MAX_PAGES):
-            params = {
-                "bdatum": "31.12.9999",
-                "blnr": "",
-                "gnr_search": "0",
-                "menuonr": MENU_ONR,
-                "page": str(page),
-                "umkreis": "",
-                "useronr": "0",
-                "vdatum": today,
-            }
-            r = requests.get(CALENDAR_URL, params=params, timeout=30)
-            r.raise_for_status()
-
-            soup = BeautifulSoup(r.text, "html.parser")
-            rows = [
-                tr
-                for tr in soup.find_all("tr")
-                if tr.find_all("td") and len(tr.find_all("td")) >= 3
-            ]
-
-            if not rows:
-                break
-
-            # Detect pagination loop (server repeats page 0 after last page)
-            first_row_key = tuple(
-                td.get_text(strip=True) for td in rows[0].find_all("td")[:3]
-            )
-            if first_row_key in seen:
-                break
-            seen.add(first_row_key)
-
-            for row in rows:
-                tds = row.find_all("td")
-                date_text = tds[0].get_text(strip=True)
-                waste_type = tds[1].get_text(strip=True)
-                zone = tds[2].get_text(strip=True)
-
-                if zone not in ("Gemeinde Alle", self._zone):
-                    continue
-
-                date_part = date_text.split("(")[0].strip()
-                try:
-                    date = datetime.strptime(date_part, "%d.%m.%Y").date()
-                except ValueError:
-                    continue
-
-                icon = ICON_MAP.get(waste_type)
-                entries.append(Collection(date=date, t=waste_type, icon=icon))
-
-        return entries
+        super().__init__(zone=zone)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/goessendorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/goessendorf_at.py
@@ -1,12 +1,10 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Marktgemeinde Gössendorf"
 DESCRIPTION = "Source for Marktgemeinde Gössendorf, AT"
 URL = "https://www.goessendorf.com/"
+COUNTRY = "at"
 TEST_CASES: dict[str, dict[str, str]] = {"TestSource": {}}
 ICON_MAP = {
     "Bioabfall": Icons.BIO_KITCHEN,
@@ -19,35 +17,6 @@ ICON_MAP = {
 }
 
 
-class Source:
-    def __init__(self):
-        pass
-
-    def fetch(self):
-        s = requests.Session()
-        r = s.get("https://www.goessendorf.com/system/web/kalender.aspx")
-
-        soup = BeautifulSoup(r.text, "html.parser")
-        div = soup.find(
-            id="ctl00_ctl00_ctl00_cph_col_a_cph_content_cph_content_list_style"
-        )
-
-        dts = div.find_all("h2")
-        ul = div.find_all("ul")[1::]
-        wst = ""
-
-        entries = []
-        for i in range(0, len(dts)):
-            wst = ul[i].find_all("a")
-            for j in range(0, len(wst)):
-                entries.append(
-                    Collection(
-                        date=datetime.strptime(
-                            dts[i].text.split(" ")[0].strip(), "%d.%m.%Y"
-                        ).date(),
-                        t=wst[j].text.strip(),
-                        icon=ICON_MAP.get(wst[j].text.strip()),
-                    )
-                )
-
-        return entries
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.goessendorf.com"
+    ICON_MAP = ICON_MAP

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kanzian_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kanzian_at.py
@@ -1,0 +1,39 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "St. Kanzian am Klopeiner See"
+DESCRIPTION = "Source for St. Kanzian am Klopeiner See, Austria."
+URL = "https://www.kanzian.at"
+COUNTRY = "at"
+
+TEST_CASES = {
+    "St. Kanzian": {},
+}
+
+ICON_MAP = {
+    "Hausmüll": Icons.GENERAL_WASTE,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Biomüll": Icons.BIO_KITCHEN,
+    "Bioabfall": Icons.BIO_KITCHEN,
+    "Papier": Icons.PAPER,
+    "Altpapier": Icons.PAPER,
+    "Leicht- und Metallverpackungen": Icons.PLASTIC_PACKAGING,
+    "Leichtverpackungen": Icons.PLASTIC_PACKAGING,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Gelbe Tonne": Icons.PLASTIC_PACKAGING,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.kanzian.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "bdatum": "31.12.9999",
+        "detailonr": "225258384",
+        "menuonr": "225275269",
+        "typ": "225258384",
+    }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
@@ -1,13 +1,5 @@
-import ast
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import (
-    SourceArgumentNotFoundWithSuggestions,
-)
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Stadtgemeinde Klosterneuburg"
 DESCRIPTION = "Source for Stadtgemeinde Klosterneuburg waste collection."
@@ -47,110 +39,18 @@ PARAM_DESCRIPTIONS = {
     },
 }
 
-PAGE_URL = "https://www.klosterneuburg.at/Natur_Umwelt/Recycling/Muellabfuhr/Muellabfuhrkalender"
-CALENDAR_URL = "https://www.klosterneuburg.at/system/web/kalender.aspx"
 
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.klosterneuburg.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = (
+        "https://www.klosterneuburg.at/Natur_Umwelt/Recycling/Muellabfuhr/"
+        "Muellabfuhrkalender"
+    )
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "226582740",
+    }
 
-class Source:
-    def __init__(self, street: str, house_number: str | int):
-        self._street = street.strip()
-        self._house_number = str(house_number).strip()
-
-    def fetch(self) -> list[Collection]:
-        session = requests.Session()
-
-        # Step 1: GET the main page to extract street/house/zone data
-        r = session.get(PAGE_URL, timeout=30)
-        r.raise_for_status()
-        r.encoding = "utf-8"
-
-        # Parse strassenArr (street → house numbers → zone IDs)
-        start = r.text.index("strassenArr = [") + len("strassenArr = ")
-        depth = 0
-        for i, c in enumerate(r.text[start:], start):
-            if c == "[":
-                depth += 1
-            elif c == "]":
-                depth -= 1
-            if depth == 0:
-                end = i + 1
-                break
-        street_data = ast.literal_eval(r.text[start:end])
-
-        # Parse street name dropdown
-        select_match = re.search(
-            r'id="\d+_boxmuellkalenderstrassedd"[^>]*>(.*?)</select>',
-            r.text,
-            re.DOTALL,
-        )
-        opts = re.findall(r'value="(\d+)"[^>]*>(.*?)<', select_match.group(1))
-        street_map = {name: int(val) for val, name in opts}
-
-        # Find matching street
-        street_id = None
-        for name, sid in street_map.items():
-            if name.lower().replace(" ", "") == self._street.lower().replace(" ", ""):
-                street_id = sid
-                break
-
-        if street_id is None:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "street", self._street, list(street_map.keys())
-            )
-
-        # Find matching house number and get typIds
-        typ_ids = None
-        house_numbers = []
-        for street in street_data:
-            if street[0] == street_id:
-                for hnr in street[1]:
-                    house_numbers.append(str(hnr[1]))
-                    if str(hnr[1]) == self._house_number:
-                        typ_ids = hnr[2]
-                break
-
-        if typ_ids is None:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "house_number", self._house_number, house_numbers
-            )
-
-        # Extract menuonr from the calendar URL pattern
-        menu_match = re.search(r"menuonr=(\d+)", r.text)
-        menuonr = menu_match.group(1) if menu_match else "226582740"
-
-        # Step 2: GET the calendar page
-        r = session.get(
-            CALENDAR_URL,
-            params={"sprache": 1, "menuonr": menuonr, "typids": typ_ids},
-            timeout=30,
-        )
-        r.raise_for_status()
-        r.encoding = "utf-8"
-
-        # Step 3: Parse the HTML table
-        soup = BeautifulSoup(r.text, "html.parser")
-        table = soup.find("table")
-        if not table:
-            return []
-
-        entries = []
-        for row in table.find_all("tr"):
-            cells = row.find_all("td")
-            if len(cells) < 2:
-                continue
-            date_text = cells[0].get_text(strip=True)
-            waste_type = cells[1].get_text(strip=True)
-
-            # Parse date: "20.04.2026  (Montag)" → extract date part
-            date_match = re.match(r"(\d{2}\.\d{2}\.\d{4})", date_text)
-            if not date_match:
-                continue
-
-            date = datetime.strptime(date_match.group(1), "%d.%m.%Y").date()
-            icon = next(
-                (v for k, v in ICON_MAP.items() if k.lower() in waste_type.lower()),
-                None,
-            )
-            entries.append(Collection(date=date, t=waste_type, icon=icon))
-
-        return entries
+    def __init__(self, street, house_number):
+        super().__init__(strasse=street, hausnummer=house_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/koppl_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/koppl_at.py
@@ -1,8 +1,5 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Koppl"
 DESCRIPTION = "Waste collection schedule for Koppl, Austria."
@@ -12,14 +9,6 @@ COUNTRY = "at"
 TEST_CASES = {
     "Koppl": {},
 }
-
-HEADERS = {
-    "User-Agent": "Mozilla/5.0",
-}
-
-BASE_URL = "https://www.koppl.at/system/web/kalender.aspx?bdatum=31.12.9999&detailonr=225241960&menuonr=225241969&typids=225241960"
-
-MAX_PAGES = 50
 
 ICON_MAP = {
     "Restabfall 14-tägig": Icons.GENERAL_WASTE,
@@ -36,94 +25,13 @@ ICON_MAP = {
 }
 
 
-class Source:
-    def __init__(self):
-        pass
-
-    def _get_page(self, page_number: int):
-        url = f"{BASE_URL}&page={page_number}"
-
-        response = requests.get(
-            url,
-            headers=HEADERS,
-            timeout=30,
-        )
-
-        response.raise_for_status()
-
-        return BeautifulSoup(response.text, "html.parser")
-
-    def fetch(self):
-        entries: list[Collection] = []
-
-        seen_first_row: set[tuple[str, str]] = set()
-
-        for page in range(MAX_PAGES):
-            soup = self._get_page(page)
-
-            table = soup.find("table", class_="ris_table")
-
-            if table is None:
-                break
-
-            rows = table.find_all("tr")
-
-            if len(rows) <= 1:
-                break
-
-            first_cells = rows[1].find_all("td")
-            if len(first_cells) >= 2:
-                first_row_key = (
-                    first_cells[0].get_text(" ", strip=True),
-                    first_cells[1].get_text(" ", strip=True),
-                )
-                if first_row_key in seen_first_row:
-                    break
-                seen_first_row.add(first_row_key)
-
-            for row in rows[1:]:
-                cells = row.find_all("td")
-
-                if len(cells) < 2:
-                    continue
-
-                date_text = cells[0].get_text(" ", strip=True)
-                collection_type = cells[1].get_text(" ", strip=True)
-
-                if not date_text or not collection_type:
-                    continue
-
-                # Examples:
-                # "05.06.2026 (Freitag)"
-                # "11.06.2026 (Donnerstag) 16:00 - 19:00 Uhr"
-                date_text = date_text.split("(")[0].strip()
-
-                try:
-                    collection_date = datetime.strptime(
-                        date_text,
-                        "%d.%m.%Y",
-                    ).date()
-                except ValueError:
-                    continue
-
-                entries.append(
-                    Collection(
-                        date=collection_date,
-                        t=collection_type,
-                        icon=ICON_MAP.get(collection_type),
-                    )
-                )
-
-        if not entries:
-            raise ValueError("Could not find any collection events.")
-
-        # Remove duplicates
-        unique_entries = {}
-        for entry in entries:
-            key = (entry.date, entry.type)
-            unique_entries[key] = entry
-
-        return sorted(
-            unique_entries.values(),
-            key=lambda x: x.date,
-        )
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.koppl.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "bdatum": "31.12.9999",
+        "detailonr": "225241960",
+        "menuonr": "225241969",
+        "typids": "225241960",
+    }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
@@ -3,15 +3,15 @@ from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,
 )
-from waste_collection_schedule.service.ICS import ICS  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Stadtservice Korneuburg"
 DESCRIPTION = "Source for Stadtservice Korneuburg"
 URL = "https://www.korneuburg.gv.at"
+COUNTRY = "at"
 TEST_CASES = {
     "Rathaus": {"street_name": "Hauptplatz", "street_number": 39},  # Teilgebiet 4
     "Rathaus using Teilgebiet": {
@@ -45,8 +45,11 @@ PARAM_TRANSLATIONS = {
 }
 
 
-class Source:
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.korneuburg.gv.at"
+
     def __init__(self, street_name, street_number, teilgebiet=-1):
+        super().__init__()
         self.street_name = street_name
         self.street_number = street_number
         self.teilgebiet = teilgebiet
@@ -56,7 +59,6 @@ class Source:
         self._street_number_id = -1
         self._headers = {"User-Agent": "Mozilla/5.0"}
         self._cookies = {"ris_cookie_setting": "g7750"}  # Accept Cookie Consent
-        self._ics = ICS()
 
     @staticmethod
     def extract_street_numbers(soup):
@@ -169,7 +171,7 @@ class Source:
         return str(region)
 
     def get_region_links(self):
-        """Traverse the pages for different waste types and collect download links for the iCals."""
+        """Traverse the waste-type pages and collect the iCal download links."""
         if self._region is None:
             self._region = self.determine_region()
 
@@ -192,23 +194,6 @@ class Source:
 
         return ical_urls
 
-    def process_waste_type(self, url):
-        """Download one calendar and return list with entries."""
-        r = requests.get(url=url, headers=self._headers, cookies=self._cookies)
-        r.encoding = r.apparent_encoding
-
-        dates = self._ics.convert(r.text)
-
-        entries = [Collection(d[0], d[1]) for d in dates]
-
-        return entries
-
     def fetch(self):
         ical_urls = self.get_region_links()
-        all_entries = []
-
-        for ical in ical_urls:
-            entries = self.process_waste_type(url=ical)
-            all_entries = all_entries + entries
-
-        return all_entries
+        return self.parse_ics_urls(ical_urls, cookies=self._cookies)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/obdach_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/obdach_at.py
@@ -1,12 +1,10 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Marktgemeinde Obdach"
-DESCRIPTION = "Source for Marktgeneinde Obdach, AT"
+DESCRIPTION = "Source for Marktgemeinde Obdach, AT"
 URL = "https://www.obdach.gv.at/"
+COUNTRY = "at"
 TEST_CASES: dict[str, dict[str, str]] = {"TestSource": {}}
 ICON_MAP = {
     "Biomüll": Icons.BIO_KITCHEN,
@@ -17,32 +15,6 @@ ICON_MAP = {
 }
 
 
-class Source:
-    def __init__(self):
-        pass
-
-    def fetch(self):
-        s = requests.Session()
-        r = s.get("https://www.obdach.gv.at/system/web/kalender.aspx")
-
-        soup = BeautifulSoup(r.text, "html.parser")
-        div = soup.find(
-            id="ctl00_ctl00_ctl00_cph_col_a_cph_content_cph_content_list_style"
-        )
-
-        dts = div.find_all("h2")
-        wst = div.find_all("span")
-
-        entries = []
-        for i in range(0, len(dts)):
-            entries.append(
-                Collection(
-                    date=datetime.strptime(
-                        dts[i].text.split(" ")[0].strip(), "%d.%m.%Y"
-                    ).date(),
-                    t=wst[i].text.strip()[1:-1],
-                    icon=ICON_MAP.get(wst[i].text.strip()[1:-1]),
-                )
-            )
-
-        return entries
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.obdach.gv.at"
+    ICON_MAP = ICON_MAP

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/piberbach_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/piberbach_ooe_gv_at.py
@@ -1,8 +1,5 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Piberbach"
 DESCRIPTION = "Source for Piberbach, Austria."
@@ -12,14 +9,6 @@ COUNTRY = "at"
 TEST_CASES = {
     "Piberbacherstraße 20": {},
 }
-
-HEADERS = {
-    "User-Agent": "Mozilla/5.0",
-}
-
-BASE_URL = "https://www.piberbach.ooe.gv.at/system/web/kalender.aspx?bdatum=31.12.9999"
-
-MAX_PAGES = 50
 
 ICON_MAP = {
     "Bioabfall": Icons.ORGANIC,
@@ -31,76 +20,10 @@ ICON_MAP = {
 }
 
 
-class Source:
-    def __init__(self):
-        pass
-
-    def _get_page(self, page_number: int):
-        url = f"{BASE_URL}&page={page_number}"
-        response = requests.get(url, headers=HEADERS, timeout=30)
-        response.raise_for_status()
-        return BeautifulSoup(response.text, "html.parser")
-
-    def fetch(self):
-        entries: list[Collection] = []
-        seen_first_row: set[tuple[str, str]] = set()
-
-        for page in range(MAX_PAGES):
-            soup = self._get_page(page)
-            table = soup.find("table", class_="ris_table")
-
-            if table is None:
-                break
-
-            rows = table.find_all("tr")
-
-            if len(rows) <= 1:
-                break
-
-            first_cells = rows[1].find_all("td")
-            if len(first_cells) >= 2:
-                first_row_key = (
-                    first_cells[0].get_text(" ", strip=True),
-                    first_cells[1].get_text(" ", strip=True),
-                )
-                if first_row_key in seen_first_row:
-                    break
-                seen_first_row.add(first_row_key)
-
-            for row in rows[1:]:
-                cells = row.find_all("td")
-                if len(cells) < 2:
-                    continue
-
-                date_text = cells[0].get_text(" ", strip=True)
-                collection_type = cells[1].get_text(" ", strip=True)
-
-                if not date_text or not collection_type:
-                    continue
-
-                # Date format: "15.06.2026  (Montag)"
-                date_text = date_text.split("(")[0].strip()
-
-                try:
-                    collection_date = datetime.strptime(date_text, "%d.%m.%Y").date()
-                except ValueError:
-                    continue
-
-                entries.append(
-                    Collection(
-                        date=collection_date,
-                        t=collection_type,
-                        icon=ICON_MAP.get(collection_type),
-                    )
-                )
-
-        if not entries:
-            raise ValueError("Could not find any collection events.")
-
-        # Remove duplicates
-        unique_entries = {}
-        for entry in entries:
-            key = (entry.date, entry.type)
-            unique_entries[key] = entry
-
-        return sorted(unique_entries.values(), key=lambda x: x.date)
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.piberbach.ooe.gv.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "bdatum": "31.12.9999",
+    }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rohrbach_lafnitz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rohrbach_lafnitz_at.py
@@ -1,6 +1,5 @@
-import requests
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.service.ICS import ICS
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Rohrbach an der Lafnitz"
 DESCRIPTION = "Source for Rohrbach an der Lafnitz, Austria."
@@ -11,24 +10,6 @@ TEST_CASES: dict[str, dict] = {
     "All waste types": {},
 }
 
-ICS_BASE_URL = "https://www.rohrbach-lafnitz.at/system/web/CalendarService.ashx"
-ICS_PARAMS = {
-    "aqn": (
-        "UmlTS29tbXVuYWwuT2JqZWN0cy5LYWxlbmRlciwgUklTQ29tcG9uZW50cywgVmVyc2lvbj0xLjAuMC4w"
-        "LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPW51bGw="
-    ),
-    "sprache": "1",
-    "gnr": "2371",
-}
-
-# Calendar IDs for each waste type
-ICS_CALENDARS = {
-    "Biomüll": "MjI1MTc2NDk0",
-    "Leichtverpackungen": "MjI1MTc2NDg4",
-    "Restmüll": "MjI1MTc2NDky",
-    "Sperrmüll & Heckenschnitt": "MjI1MTc2NDk2",
-}
-
 ICON_MAP = {
     "Biomüll": Icons.BIO_KITCHEN,
     "Leichtverpackungen": Icons.RECYCLING,
@@ -37,30 +18,17 @@ ICON_MAP = {
 }
 
 
-class Source:
-    def __init__(self):
-        self._ics = ICS()
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.rohrbach-lafnitz.at"
+    ICON_MAP = ICON_MAP
+    GNR = "2371"
+    # Calendar IDs (do parameter) for each waste type
+    ICS_CALENDARS = {
+        "Biomüll": "MjI1MTc2NDk0",
+        "Leichtverpackungen": "MjI1MTc2NDg4",
+        "Restmüll": "MjI1MTc2NDky",
+        "Sperrmüll & Heckenschnitt": "MjI1MTc2NDk2",
+    }
 
-    def fetch(self) -> list[Collection]:
-        entries: list[Collection] = []
-
-        for waste_type, do_param in ICS_CALENDARS.items():
-            params = {**ICS_PARAMS, "do": do_param}
-            param_str = "&".join(f"{k}={v}" for k, v in params.items())
-            url = f"{ICS_BASE_URL}?{param_str}"
-
-            r = requests.get(url, timeout=60)
-            r.raise_for_status()
-
-            dates = self._ics.convert(r.text)
-
-            for d in dates:
-                icon = None
-                for key, value in ICON_MAP.items():
-                    if key.lower() in waste_type.lower():
-                        icon = value
-                        break
-
-                entries.append(Collection(date=d[0], t=waste_type, icon=icon))
-
-        return entries
+    def fetch(self):
+        return self.fetch_ics_by_label(self.GNR, self.ICS_CALENDARS)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
@@ -1,11 +1,5 @@
-import json
-import re
-from datetime import date, datetime, timedelta
-
-import requests
-from bs4 import BeautifulSoup
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
 TITLE = "Saalfelden am Steinernen Meer"
 DESCRIPTION = "Source for Saalfelden am Steinernen Meer waste collection."
@@ -66,181 +60,17 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     ),
 }
 
-CALENDAR_PAGE_URL = "https://www.saalfelden.at/Buergerservice/Abfallkalender"
-API_URL = "https://www.saalfelden.at/system/web/kalender.aspx"
-DETAIL_ONR = "225697049"
-MENU_ONR = "225696673"
-MAX_PAGES = 30
-LOOKAHEAD_DAYS = 365
 
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.saalfelden.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = "https://www.saalfelden.at/Buergerservice/Abfallkalender"
+    LOOKAHEAD_DAYS = 365
+    MAX_PAGES = 30
+    QUERY_PARAMS = {
+        "detailonr": "225697049",
+        "menuonr": "225696673",
+    }
 
-class Source:
-    def __init__(self, strasse: str, hausnummer):
-        self._strasse = str(strasse).strip()
-        self._hausnummer = str(hausnummer).strip()
-
-    def fetch(self) -> list[Collection]:
-        session = requests.Session()
-        page = session.get(CALENDAR_PAGE_URL, timeout=30)
-        page.raise_for_status()
-
-        typids = self._resolve_typids(page.text)
-
-        return self._fetch_collections(session, typids)
-
-    def _resolve_typids(self, html: str) -> str:
-        soup = BeautifulSoup(html, "html.parser")
-
-        street_select = soup.find(
-            "select",
-            attrs={"name": re.compile(r"boxmuellkalenderstrassedd$")},
-        )
-        if street_select is None:
-            raise Exception("Could not locate street selector on Saalfelden page")
-
-        name_to_id: dict[str, int] = {}
-        for opt in street_select.find_all("option"):
-            value = opt.get("value", "").strip()
-            text = opt.get_text(strip=True)
-            if value and text:
-                name_to_id[text] = int(value)
-
-        street_id = name_to_id.get(self._strasse)
-        if street_id is None:
-            for name, sid in name_to_id.items():
-                if name.casefold() == self._strasse.casefold():
-                    street_id = sid
-                    self._strasse = name
-                    break
-        if street_id is None:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "strasse", self._strasse, sorted(name_to_id)
-            )
-
-        strassen_arr = self._parse_strassen_arr(html)
-
-        for entry in strassen_arr:
-            if entry[0] != street_id:
-                continue
-            hnr_labels: list[str] = []
-            for hnr in entry[1]:
-                hnr_text = str(hnr[1])
-                hnr_labels.append(hnr_text)
-                if hnr_text.casefold() == self._hausnummer.casefold():
-                    return hnr[2]
-            raise SourceArgumentNotFoundWithSuggestions(
-                "hausnummer", self._hausnummer, hnr_labels
-            )
-
-        raise SourceArgumentNotFoundWithSuggestions(
-            "strasse", self._strasse, sorted(name_to_id)
-        )
-
-    @staticmethod
-    def _parse_strassen_arr(html: str) -> list:
-        match = re.search(r"var\s+strassenArr\s*=\s*", html)
-        if not match:
-            raise Exception("Could not locate strassenArr in page")
-
-        start = html.find("[", match.end())
-        depth = 0
-        end = start
-        for idx in range(start, len(html)):
-            ch = html[idx]
-            if ch == "[":
-                depth += 1
-            elif ch == "]":
-                depth -= 1
-                if depth == 0:
-                    end = idx + 1
-                    break
-        if depth != 0:
-            raise Exception("Could not parse strassenArr (unbalanced brackets)")
-
-        arr_js = html[start:end]
-        arr_json = arr_js.replace("'", '"')
-        arr_json = re.sub(r",\s*\]", "]", arr_json)
-        return json.loads(arr_json)
-
-    def _fetch_collections(
-        self, session: requests.Session, typids: str
-    ) -> list[Collection]:
-        entries: list[Collection] = []
-        seen_keys: set[tuple[str, str]] = set()
-        seen_first_row: set[tuple[str, str]] = set()
-
-        today = date.today()
-        end_date = today + timedelta(days=LOOKAHEAD_DAYS)
-
-        for page_idx in range(MAX_PAGES):
-            params = {
-                "detailonr": DETAIL_ONR,
-                "menuonr": MENU_ONR,
-                "typids": typids,
-                "page": page_idx,
-                "vdatum": today.strftime("%d.%m.%Y"),
-                "bdatum": end_date.strftime("%d.%m.%Y"),
-            }
-            r = session.get(API_URL, params=params, timeout=30)
-            r.raise_for_status()
-
-            soup = BeautifulSoup(r.text, "html.parser")
-            table = soup.find("table", class_="ris_table")
-            if table is None:
-                break
-
-            rows = table.find_all("tr")[1:]
-            page_rows: list[tuple[date, str]] = []
-            for row in rows:
-                tds = row.find_all("td", class_="td_kal")
-                if len(tds) != 2:
-                    continue
-                date_match = re.match(
-                    r"(\d{2}\.\d{2}\.\d{4})", tds[0].get_text(" ", strip=True)
-                )
-                if not date_match:
-                    continue
-                collection_date = datetime.strptime(
-                    date_match.group(1), "%d.%m.%Y"
-                ).date()
-                anchor = tds[1].find("a")
-                raw_type = (
-                    anchor.get_text(strip=True)
-                    if anchor
-                    else tds[1].get_text(" ", strip=True)
-                )
-                waste_type = re.sub(r"\s*\(.*\)\s*$", "", raw_type).strip()
-                page_rows.append((collection_date, waste_type))
-
-            if not page_rows:
-                break
-
-            first_key = (page_rows[0][0].isoformat(), page_rows[0][1])
-            if first_key in seen_first_row:
-                break
-            seen_first_row.add(first_key)
-
-            for collection_date, waste_type in page_rows:
-                if collection_date > end_date:
-                    continue
-                key = (collection_date.isoformat(), waste_type)
-                if key in seen_keys:
-                    continue
-                seen_keys.add(key)
-                icon = self._icon_for(waste_type)
-                entries.append(
-                    Collection(date=collection_date, t=waste_type, icon=icon)
-                )
-
-            if page_rows[-1][0] > end_date:
-                break
-
-        return entries
-
-    @staticmethod
-    def _icon_for(waste_type: str) -> str | None:
-        lowered = waste_type.casefold()
-        for key, icon in ICON_MAP.items():
-            if key.casefold() in lowered:
-                return icon
-        return None
+    def __init__(self, strasse, hausnummer):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
@@ -1,0 +1,74 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Schärding"
+DESCRIPTION = "Source for Schärding, Austria."
+URL = "https://www.schaerding.ooe.gv.at"
+COUNTRY = "at"
+
+TEST_CASES = {
+    "Adalbert-Stifter-Straße 1": {
+        "strasse": "Adalbert-Stifter-Straße",
+        "hausnummer": "1",
+    },
+    "Aigerdinger Straße 2": {
+        "strasse": "Aigerdinger Straße",
+        "hausnummer": 2,
+    },
+}
+
+ICON_MAP = {
+    "Restabfall wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 2-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 4-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 6-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall": Icons.GENERAL_WASTE,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Bioabfall": Icons.BIO_KITCHEN,
+    "Biomüll": Icons.BIO_KITCHEN,
+    "Altpapier": Icons.PAPER,
+    "Papier": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Gelbe Tonne": Icons.PLASTIC_PACKAGING,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Schärding waste calendar.",
+        "hausnummer": "House number as listed in the Schärding waste calendar.",
+    },
+    "de": {
+        "strasse": "Straßenname wie im Schärdinger Abfallkalender aufgelistet.",
+        "hausnummer": "Hausnummer wie im Schärdinger Abfallkalender aufgelistet.",
+    },
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.schaerding.ooe.gv.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = (
+        "https://www.schaerding.ooe.gv.at/system/web/kalender.aspx?menuonr=226878372"
+    )
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "226878372",
+    }
+
+    def __init__(self, strasse, hausnummer):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/kanzian_at.md
+++ b/doc/source/kanzian_at.md
@@ -1,0 +1,13 @@
+# St. Kanzian am Klopeiner See
+
+Support for waste collection schedules provided by [St. Kanzian am Klopeiner See](https://www.kanzian.at).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: kanzian_at
+```
+
+No further configuration is required; the source returns all collection types listed in the municipal waste calendar.

--- a/doc/source/schaerding_ooe_gv_at.md
+++ b/doc/source/schaerding_ooe_gv_at.md
@@ -1,0 +1,41 @@
+# Schärding
+
+Support for waste collection schedules provided by [Stadtgemeinde Schärding](https://www.schaerding.ooe.gv.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: schaerding_ooe_gv_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Schärding waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Schärding waste calendar dropdown.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: schaerding_ooe_gv_at
+      args:
+        strasse: "Adalbert-Stifter-Straße"
+        hausnummer: "1"
+```
+
+## How to get the source arguments
+
+Open <https://www.schaerding.ooe.gv.at/system/web/kalender.aspx?menuonr=226878372>, choose your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`.


### PR DESCRIPTION
This pull request refactors several Austria-based waste collection source integrations to use the common `RiSKommunalSource` service, streamlining code and reducing duplication. It removes custom parsing and network logic from individual source files, replacing them with standardized configuration and inheritance. Additionally, it introduces a new source for St. Kanzian am Klopeiner See.

**Migration to RiSKommunalSource (Major Refactor):**
- Refactored `badaussee_at.py`, `dienten_gv_at.py`, `edlitz_at.py`, `eggelsberg_at.py`, `goessendorf_at.py`, and `klosterneuburg_at.py` to inherit from `RiSKommunalSource`, removing custom HTML/ICS parsing and network code in favor of configuration via class variables such as `BASE_URL`, `ICON_MAP`, and query parameters. This change greatly simplifies maintenance and ensures consistent behavior across sources. [[1]](diffhunk://#diff-308d56d78419c3792f3ee8595190bece4d5898db431221f5296e6fd44206f6efL1-R7) [[2]](diffhunk://#diff-308d56d78419c3792f3ee8595190bece4d5898db431221f5296e6fd44206f6efL90-R109) [[3]](diffhunk://#diff-c5b4f47bbbadec696f52bce22855a636362e4c408fd09dc208ba36706a5c2793L1-L23) [[4]](diffhunk://#diff-c5b4f47bbbadec696f52bce22855a636362e4c408fd09dc208ba36706a5c2793L34-R34) [[5]](diffhunk://#diff-b09eea224ebbf971de440af593958a155aeef0aa0d006e1eb8e965ff69f7483eL1-R8) [[6]](diffhunk://#diff-b09eea224ebbf971de440af593958a155aeef0aa0d006e1eb8e965ff69f7483eL21-R21) [[7]](diffhunk://#diff-794f326eca96ed675a468ca15e378258a7a3fbab24f67648eff5535a8a09f704L1-R3) [[8]](diffhunk://#diff-794f326eca96ed675a468ca15e378258a7a3fbab24f67648eff5535a8a09f704L53-R71) [[9]](diffhunk://#diff-a95c2851c05918fb1ba72e1ae6331ae4a657b283e0aa16991cc79dacc0a36b86L1-R7) [[10]](diffhunk://#diff-a95c2851c05918fb1ba72e1ae6331ae4a657b283e0aa16991cc79dacc0a36b86L22-R22) [[11]](diffhunk://#diff-67b1d6126b4945c28c7d90322175c25fc95d12728d0ce2b68a3677df6c931047L1-R2) [[12]](diffhunk://#diff-67b1d6126b4945c28c7d90322175c25fc95d12728d0ce2b68a3677df6c931047L50-R56)

**New Source Addition:**
- Added a new integration for St. Kanzian am Klopeiner See (`kanzian_at.py`), utilizing `RiSKommunalSource` with appropriate configuration and waste type icon mapping.
- Added a new integration  for Schärding  (`schaerding_ooe_gv_at.py`), utilizing `RiSKommunalSource` with appropriate configuration and waste type icon mapping.

**Configuration and Metadata Improvements:**
- Added or standardized `COUNTRY` and `TEST_CASES` metadata in affected source files for improved clarity and test coverage. [[1]](diffhunk://#diff-308d56d78419c3792f3ee8595190bece4d5898db431221f5296e6fd44206f6efL1-R7) [[2]](diffhunk://#diff-c5b4f47bbbadec696f52bce22855a636362e4c408fd09dc208ba36706a5c2793L1-L23) [[3]](diffhunk://#diff-b09eea224ebbf971de440af593958a155aeef0aa0d006e1eb8e965ff69f7483eL1-R8) [[4]](diffhunk://#diff-a95c2851c05918fb1ba72e1ae6331ae4a657b283e0aa16991cc79dacc0a36b86L1-R7)

**Icon Mapping Consistency:**
- Centralized and clarified `ICON_MAP` usage in all refactored sources, ensuring correct icon assignment for each waste type. [[1]](diffhunk://#diff-308d56d78419c3792f3ee8595190bece4d5898db431221f5296e6fd44206f6efL90-R109) [[2]](diffhunk://#diff-c5b4f47bbbadec696f52bce22855a636362e4c408fd09dc208ba36706a5c2793L34-R34) [[3]](diffhunk://#diff-b09eea224ebbf971de440af593958a155aeef0aa0d006e1eb8e965ff69f7483eL21-R21) [[4]](diffhunk://#diff-794f326eca96ed675a468ca15e378258a7a3fbab24f67648eff5535a8a09f704L53-R71) [[5]](diffhunk://#diff-a95c2851c05918fb1ba72e1ae6331ae4a657b283e0aa16991cc79dacc0a36b86L22-R22) [[6]](diffhunk://#diff-65d0667b31f4f57c1efe6fe2a81df85d6396b8aac0c341ad2faa93035b949baaR1-R39) [[7]](diffhunk://#diff-67b1d6126b4945c28c7d90322175c25fc95d12728d0ce2b68a3677df6c931047L50-R56)

**Code Cleanup:**
- Removed unused imports, redundant constants, and legacy code paths now handled by the shared service. [[1]](diffhunk://#diff-308d56d78419c3792f3ee8595190bece4d5898db431221f5296e6fd44206f6efL1-R7) [[2]](diffhunk://#diff-c5b4f47bbbadec696f52bce22855a636362e4c408fd09dc208ba36706a5c2793L1-L23) [[3]](diffhunk://#diff-b09eea224ebbf971de440af593958a155aeef0aa0d006e1eb8e965ff69f7483eL1-R8) [[4]](diffhunk://#diff-794f326eca96ed675a468ca15e378258a7a3fbab24f67648eff5535a8a09f704L1-R3) [[5]](diffhunk://#diff-a95c2851c05918fb1ba72e1ae6331ae4a657b283e0aa16991cc79dacc0a36b86L1-R7) [[6]](diffhunk://#diff-67b1d6126b4945c28c7d90322175c25fc95d12728d0ce2b68a3677df6c931047L1-R2)

These changes significantly reduce code duplication, improve maintainability, and ensure a more robust and consistent integration experience.#
## Type of change

- [ ] New source
- [X] Bug fix / source fix
- [ ] Documentation update
- [X] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
