### PR TITLE
feat(at): add Fritzens waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fritzens_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fritzens_gv_at.py
@@ -1,0 +1,28 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Fritzens"
+DESCRIPTION = "Waste collection schedule for the municipality of Fritzens, Austria."
+URL = "https://www.fritzens.gv.at"
+COUNTRY = "at"
+
+TEST_CASES: dict[str, dict] = {"TestSource": {}}
+
+ICON_MAP = {
+    "Biomüll": Icons.ORGANIC,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Kunststoffmüll": Icons.PLASTIC_PACKAGING,
+    "Sperrmüll": Icons.BULKY,
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.fritzens.gv.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "bdatum": "31.12.9999",
+        "blnr": "",
+        "gnr_search": "0",
+        "menuonr": "219029364",
+    }

--- a/doc/source/fritzens_gv_at.md
+++ b/doc/source/fritzens_gv_at.md
@@ -1,0 +1,11 @@
+# Fritzens
+
+Support for waste collection schedules provided by [Fritzens](https://www.fritzens.gv.at).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: fritzens_gv_at
+```


### PR DESCRIPTION
## Summary

- Adds `fritzens_gv_at` source for the municipality of Fritzens, Austria
- Uses the shared `RiSKommunalAT` service module (merged in #6670); the source is a thin declaration (~20 lines) with no new logic
- No parameters required — the calendar at https://www.fritzens.gv.at/system/web/kalender.aspx is address-agnostic
- Closes #5769

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `python test_sources.py -s fritzens_gv_at -l` returns upcoming Biomüll, Restmüll, Kunststoffmüll, and/or Sperrmüll entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)