### PR TITLE
Add Ort im Innkreis (Austria) waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ort_im_innkreis_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ort_im_innkreis_at.py
@@ -1,0 +1,27 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Ort im Innkreis"
+DESCRIPTION = "Waste collection schedule for Ort im Innkreis, Austria."
+URL = "https://www.ort-im-innkreis.at"
+COUNTRY = "at"
+
+TEST_CASES: dict[str, dict] = {
+    "Default": {},
+}
+
+ICON_MAP = {
+    "Bioabfall": Icons.ORGANIC,
+    "Restabfall": Icons.GENERAL_WASTE,
+    "Altpapier": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Altglas": Icons.GLASS,
+    "Sperrmüll": Icons.BULKY,
+    "Problemstoff": Icons.HAZARDOUS,
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.ort-im-innkreis.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True

--- a/doc/source/ort_im_innkreis_at.md
+++ b/doc/source/ort_im_innkreis_at.md
@@ -1,0 +1,11 @@
+# Ort im Innkreis
+
+Support for schedules provided by [Ort im Innkreis](https://www.ort-im-innkreis.at).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ort_im_innkreis_at
+```


### PR DESCRIPTION
## Summary
- Adds `ort_im_innkreis_at` source for the municipality of Ort im Innkreis, Austria
- Uses the shared `RiSKommunalAT` service (HTML calendar parsing at `/system/web/kalender.aspx`)
- No address lookup required — single public calendar, returns 41 entries

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes (9/9)
- [x] `ruff check --fix` and `ruff format` clean
- [x] `test_sources.py -s ort_im_innkreis_at -l` returns 41 collection entries
- [x] `doc/source/ort_im_innkreis_at.md` created

Closes #5557

🤖 Generated with [Claude Code](https://claude.com/claude-code)