### PR TITLE
feat(at): add Micheldorf in Oberösterreich (micheldorf_at) waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
@@ -1,0 +1,68 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Micheldorf in Oberösterreich"
+DESCRIPTION = "Source for Micheldorf in Oberösterreich, Austria."
+URL = "https://www.micheldorf.at"
+COUNTRY = "at"
+
+TEST_CASES = {
+    "Adalbert-Stifter-Straße 1": {
+        "strasse": "Adalbert-Stifter-Straße",
+        "hausnummer": "1",
+    },
+    "Alterpichlstraße 2": {
+        "strasse": "Alterpichlstraße",
+        "hausnummer": "2",
+    },
+}
+
+ICON_MAP = {
+    "Bioabfall": Icons.ORGANIC,
+    "Restabfall 2-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 4-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 6-wöchentlich": Icons.GENERAL_WASTE,
+    "Altpapier": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Micheldorf waste calendar.",
+        "hausnummer": "House number as listed in the Micheldorf waste calendar.",
+    },
+    "de": {
+        "strasse": "Straßenname wie im Micheldorfer Abfallkalender aufgelistet.",
+        "hausnummer": "Hausnummer wie im Micheldorfer Abfallkalender aufgelistet.",
+    },
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.micheldorf.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = (
+        "https://www.micheldorf.at/system/web/kalender.aspx?sprache=1&menuonr=227975509"
+    )
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "227975509",
+    }
+
+    def __init__(self, strasse, hausnummer):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/micheldorf_at.md
+++ b/doc/source/micheldorf_at.md
@@ -1,0 +1,41 @@
+# Micheldorf in Oberösterreich
+
+Support for waste collection schedules provided by [Marktgemeinde Micheldorf in Oberösterreich](https://www.micheldorf.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: micheldorf_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Micheldorf waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Micheldorf waste calendar dropdown.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: micheldorf_at
+      args:
+        strasse: "Adalbert-Stifter-Straße"
+        hausnummer: "1"
+```
+
+## How to get the source arguments
+
+Open <https://www.micheldorf.at/system/web/kalender.aspx?sprache=1&menuonr=227975509>, choose your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`.


### PR DESCRIPTION
## Summary

Adds a new source `micheldorf_at` for the municipality of Micheldorf in Oberösterreich, Austria.

- Uses the existing `RiSKommunalAT` service (same platform as ~15 other AT sources).
- Requires `strasse` (street name) and `hausnummer` (house number) for address-based `typids` resolution.
- Supports waste types: Bioabfall, Restabfall (2/4/6-wöchentlich), Altpapier, Gelber Sack, Sperrmüll, Altglas, Problemstoff.
- Both TEST_CASES return 96 entries against the live endpoint.

Closes #3230.

## Test plan

- [x] `ruff check --fix` and `ruff format` pass
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] Live test: both test cases return 96 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)