### PR TITLE
feat(at): add Enns waste collection source (enns_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
@@ -17,6 +17,8 @@ TEST_CASES = {
     },
 }
 
+SOURCE_CODEOWNERS = ["@bbr111"]
+
 ICON_MAP = {
     "Bioabfall": Icons.ORGANIC,
     "Restabfall 2-wöchentlich": Icons.GENERAL_WASTE,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
@@ -1,0 +1,67 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Enns"
+DESCRIPTION = "Waste collection schedule for Enns, Austria."
+URL = "https://www.enns.at"
+COUNTRY = "at"
+
+TEST_CASES = {
+    "Am Damm 1": {
+        "strasse": "Am Damm",
+        "hausnummer": "1",
+    },
+    "Donaustraße 1": {
+        "strasse": "Donaustraße",
+        "hausnummer": "1",
+    },
+}
+
+ICON_MAP = {
+    "Bioabfall": Icons.ORGANIC,
+    "Restabfall 2-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 4-wöchentlich": Icons.GENERAL_WASTE,
+    "Altpapier": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Enns waste calendar.",
+        "hausnummer": "House number as listed in the Enns waste calendar.",
+    },
+    "de": {
+        "strasse": "Straßenname wie im Ennser Abfallkalender aufgelistet.",
+        "hausnummer": "Hausnummer wie im Ennser Abfallkalender aufgelistet.",
+    },
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.enns.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = (
+        "https://www.enns.at/system/web/kalender.aspx?sprache=1&menuonr=227945554"
+    )
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "227945554",
+    }
+
+    def __init__(self, strasse, hausnummer):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/enns_at.md
+++ b/doc/source/enns_at.md
@@ -1,0 +1,41 @@
+# Enns
+
+Support for waste collection schedules provided by [Stadtgemeinde Enns](https://www.enns.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: enns_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Enns waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Enns waste calendar dropdown.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: enns_at
+      args:
+        strasse: "Am Damm"
+        hausnummer: "1"
+```
+
+## How to get the source arguments
+
+Open <https://www.enns.at/system/web/kalender.aspx?sprache=1&menuonr=227945554>, choose your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`.


### PR DESCRIPTION
## Summary
- Adds `enns_at` source for the municipality of Enns, Austria
- Uses the existing `RiSKommunalAT` shared service (same platform as Micheldorf, Fritzens, Koppl, etc.)
- Street + house number address lookup via the embedded `strassenArr` JS array on the RiSKommunal calendar page
- `menuonr`: `227945554`

## Test plan
- [x] `python test_sources.py -s enns_at -l` returns results for both test cases (47 and 42 entries respectively)
- [x] `python -m pytest tests/test_source_components.py -q` passes (9/9)

Closes #4694

🤖 Generated with [Claude Code](https://claude.com/claude-code)