### PR TITLE
feat(at): add Kronstorf waste collection source (kronstorf_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
@@ -30,6 +30,7 @@ ICON_MAP = {
     "Problemstoff": Icons.HAZARDOUS,
 }
 
+SOURCE_CODEOWNERS = ["@bbr111"]
 
 class Source(RiSKommunalSource):
     BASE_URL = "https://www.kronstorf.at"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
@@ -10,7 +10,7 @@ TEST_CASES = {
     "Kronstorf": {},
 }
 
-SOURCE_CODEOWNERS = []
+SOURCE_CODEOWNERS = ["@bbr111"]
 
 ICON_MAP = {
     "Restabfall wöchentlich": Icons.GENERAL_WASTE,
@@ -30,7 +30,6 @@ ICON_MAP = {
     "Problemstoff": Icons.HAZARDOUS,
 }
 
-SOURCE_CODEOWNERS = ["@bbr111"]
 
 class Source(RiSKommunalSource):
     BASE_URL = "https://www.kronstorf.at"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
@@ -1,0 +1,41 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Kronstorf"
+DESCRIPTION = "Source for Kronstorf (Marktgemeinde Kronstorf), Austria."
+URL = "https://www.kronstorf.at"
+COUNTRY = "at"
+
+TEST_CASES = {
+    "Kronstorf": {},
+}
+
+SOURCE_CODEOWNERS = []
+
+ICON_MAP = {
+    "Restabfall wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 2-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 4-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall 6-wöchentlich": Icons.GENERAL_WASTE,
+    "Restabfall": Icons.GENERAL_WASTE,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Bioabfall": Icons.BIO_KITCHEN,
+    "Biomüll": Icons.BIO_KITCHEN,
+    "Altpapier": Icons.PAPER,
+    "Papier": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Gelbe Tonne": Icons.PLASTIC_PACKAGING,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.kronstorf.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "menuonr": "218754346",
+        "bdatum": "31.12.9999",
+    }

--- a/doc/source/kronstorf_at.md
+++ b/doc/source/kronstorf_at.md
@@ -1,0 +1,23 @@
+# Kronstorf
+
+Support for waste collection schedules provided by [Marktgemeinde Kronstorf](https://www.kronstorf.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: kronstorf_at
+```
+
+### Configuration Variables
+
+No arguments required — the source fetches the municipality-wide calendar automatically.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: kronstorf_at
+```


### PR DESCRIPTION
## Summary

- Adds `kronstorf_at` source for Marktgemeinde Kronstorf, Upper Austria
- Uses the existing `RiSKommunalSource` base class — no new platform code
- Municipality-wide calendar, no address parameters required
- 4 waste types confirmed live: `Restabfall 2-wöchentlich`, `Restabfall 4-wöchentlich`, `Altpapier`, `Gelber Sack`

Closes #2622

## Test plan

- [x] Live test via `test_sources.py -s kronstorf_at -l` returns 68 entries
- [x] `pytest tests/test_source_components.py` passes (9/9)
- [x] `ruff check` and `ruff format` clean
- [x] `doc/source/kronstorf_at.md` created

🤖 Generated with [Claude Code](https://claude.com/claude-code)