### PR TITLE
feat(at): add Jochberg waste collection source (jochberg_gv_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jochberg_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jochberg_gv_at.py
@@ -1,0 +1,34 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Jochberg"
+DESCRIPTION = "Waste collection schedule for the municipality of Jochberg, Austria."
+URL = "https://www.jochberg.gv.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES: dict[str, dict] = {
+    "Jochberg": {},
+}
+
+ICON_MAP = {
+    "Biomüll": Icons.ORGANIC,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Altpapier": Icons.PAPER,
+    "Papier": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Gelbe Tonne": Icons.PLASTIC_PACKAGING,
+    "Leichtverpackungen": Icons.PLASTIC_PACKAGING,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.jochberg.gv.at"
+    ICON_MAP = ICON_MAP
+    GNR = "312"
+
+    def fetch(self):
+        return self.fetch_ics(self.GNR, ["MjI1NTczMjE0"])

--- a/doc/source/jochberg_gv_at.md
+++ b/doc/source/jochberg_gv_at.md
@@ -1,0 +1,11 @@
+# Jochberg
+
+Support for waste collection schedules provided by [Jochberg](https://www.jochberg.gv.at).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: jochberg_gv_at
+```


### PR DESCRIPTION
## Summary

- Adds `jochberg_gv_at` source for the municipality of Jochberg, Austria
- Uses the existing `RiSKommunalSource` base class via its ICS feed helper (`fetch_ics`)
- No user-supplied parameters required — the ICS calendar URL is fully determined by the known `gnr=312` and calendar `do` ID

## Test plan

- [ ] `python test_sources.py -s jochberg_gv_at -l` returns collection entries
- [ ] `python -m pytest tests/test_source_components.py -q` passes

Closes #5187

🤖 Generated with [Claude Code](https://claude.com/claude-code)