### PR TITLE
feat(at): add Elsbethen waste collection source (elsbethen_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
@@ -1,0 +1,68 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Elsbethen"
+DESCRIPTION = "Source for Elsbethen waste collection."
+URL = "https://www.gde-elsbethen.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES = {
+    "Überfuhrstraße 2": {"strasse": "Überfuhrstraße", "hausnummer": "2"},
+}
+
+ICON_MAP = {
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Biomüll": Icons.BIO_KITCHEN,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Altpapier": Icons.PAPER,
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Elsbethen waste calendar.",
+        "hausnummer": "House number as listed in the Elsbethen waste calendar.",
+    },
+    "de": {
+        "strasse": "Straßenname wie im Elsbethener Abfallkalender aufgelistet.",
+        "hausnummer": "Hausnummer wie im Elsbethener Abfallkalender aufgelistet.",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Visit https://www.gde-elsbethen.at/Buergerservice/Abfall-Recycling/Abfallkalender, "
+        "pick your street and house number from the dropdowns, and use the same values here."
+    ),
+    "de": (
+        "Öffnen Sie https://www.gde-elsbethen.at/Buergerservice/Abfall-Recycling/Abfallkalender, "
+        "wählen Sie Ihre Straße und Hausnummer aus, und verwenden Sie dieselben Werte hier."
+    ),
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.gde-elsbethen.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = (
+        "https://www.gde-elsbethen.at/system/web/kalender.aspx?menuonr=223627736"
+    )
+    LOOKAHEAD_DAYS = 365
+    MAX_PAGES = 30
+    QUERY_PARAMS = {
+        "menuonr": "225141707",
+    }
+
+    def __init__(self, strasse, hausnummer):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/elsbethen_at.md
+++ b/doc/source/elsbethen_at.md
@@ -1,0 +1,28 @@
+# Elsbethen
+
+Support for schedules provided by [Elsbethen](https://www.gde-elsbethen.at).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: elsbethen_at
+      args:
+        strasse: Überfuhrstraße
+        hausnummer: "2"
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+Street name as listed in the Elsbethen waste calendar.
+
+**hausnummer**
+*(string) (required)*
+House number as listed in the Elsbethen waste calendar.
+
+## How to get the arguments
+
+Visit [https://www.gde-elsbethen.at/Buergerservice/Abfall-Recycling/Abfallkalender](https://www.gde-elsbethen.at/Buergerservice/Abfall-Recycling/Abfallkalender), pick your street and house number from the dropdowns, and use the same values here.


### PR DESCRIPTION
## Summary

- Adds `elsbethen_at` source for Elsbethen, Austria using the shared `RiSKommunalAT` service
- Address-based lookup (street + house number) via the municipality's RiSKommunal CMS
- Covers Biomüll, Restmüll, Gelber Sack, Altpapier

Closes #4039

## Test plan

- [x] `ruff check` / `ruff format` — clean
- [x] `python -m pytest tests/test_source_components.py` — all 9 passed
- [x] Live test (`test_sources.py -s elsbethen_at -l`) — 49 entries returned for Überfuhrstraße 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)