### PR TITLE
feat(at): add St. Margarethen im Lungau waste collection source (st_margarethen_salzburg_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_margarethen_salzburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_margarethen_salzburg_at.py
@@ -1,0 +1,33 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "St. Margarethen im Lungau"
+DESCRIPTION = "Waste collection schedule for St. Margarethen im Lungau, Austria."
+URL = "https://www.st.margarethen.salzburg.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES: dict[str, dict] = {
+    "St. Margarethen im Lungau": {},
+}
+
+ICON_MAP = {
+    "Abholung BIO-Tonne": Icons.ORGANIC,
+    "Abholung Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Abholung Hausmüll": Icons.GENERAL_WASTE,
+    "Abholung Altpapier": Icons.PAPER,
+    "Abholung Altglas": Icons.GLASS,
+    "Sperrmüllabfuhr": Icons.BULKY,
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.st.margarethen.salzburg.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "bdatum": "31.12.9999",
+        "blnr": "",
+        "gnr_search": "0",
+        "menuonr": "218716164",
+    }

--- a/doc/source/st_margarethen_salzburg_at.md
+++ b/doc/source/st_margarethen_salzburg_at.md
@@ -1,0 +1,13 @@
+# St. Margarethen im Lungau
+
+Support for waste collection schedules provided by [Gemeinde St. Margarethen im Lungau](https://www.st.margarethen.salzburg.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: st_margarethen_salzburg_at
+```
+
+No configuration arguments are required. The waste calendar covers the entire municipality.


### PR DESCRIPTION
## Summary

- Adds `st_margarethen_salzburg_at` source for waste collection schedules provided by the municipality of St. Margarethen im Lungau, Salzburg, Austria
- Uses the existing `RiSKommunalAT` shared service module (same platform as Dienten, Koppl, Saalfelden, and 30+ other Austrian sources)
- No address-based parameters required — whole-municipality calendar via `menuonr=218716164`

## Test plan

- [ ] `python test_sources.py -s st_margarethen_salzburg_at -l` returns collection entries
- [ ] `python -m pytest tests/test_source_components.py -q` passes

Closes #4986

🤖 Generated with [Claude Code](https://claude.com/claude-code)