### PR TITLE
feat(at): add Bürmoos waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
@@ -1,0 +1,83 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Gemeinde Bürmoos"
+DESCRIPTION = "Source for Gemeinde Bürmoos, Austria."
+URL = "https://www.buermoos.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES: dict[str, dict] = {
+    "Birkenstraße 76a": {
+        "strasse": "Birkenstraße",
+        "hausnummer": "76a",
+    },
+    "Almweg 2": {
+        "strasse": "Almweg",
+        "hausnummer": "2",
+    },
+}
+
+ICON_MAP = {
+    "Biomüllabfuhr": Icons.ORGANIC,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Altpapier": Icons.PAPER,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+    "GELB": Icons.PLASTIC_PACKAGING,
+    "WEIß": Icons.GENERAL_WASTE,
+    "ROT": Icons.GENERAL_WASTE,
+    "LVP": Icons.PLASTIC_PACKAGING,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Bürmoos waste calendar dropdown.",
+        "hausnummer": "House number as listed in the Bürmoos waste calendar dropdown.",
+    },
+    "de": {
+        "strasse": "Straßenname wie in der Abfallkalender-Auswahl von Bürmoos aufgeführt.",
+        "hausnummer": "Hausnummer wie in der Abfallkalender-Auswahl von Bürmoos aufgeführt.",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Open https://www.buermoos.at/Service/Aktuelles/Muellkalender, pick your "
+        "street and house number from the dropdowns, and use the same values for "
+        "'strasse' and 'hausnummer'."
+    ),
+    "de": (
+        "Öffnen Sie https://www.buermoos.at/Service/Aktuelles/Muellkalender, wählen "
+        "Sie Ihre Straße und Hausnummer aus den Dropdown-Menüs, und verwenden Sie "
+        "dieselben Werte für 'strasse' und 'hausnummer'."
+    ),
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.buermoos.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = "https://www.buermoos.at/Service/Aktuelles/Muellkalender"
+    LOOKAHEAD_DAYS = 365
+    MAX_PAGES = 30
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "219233420",
+    }
+
+    def __init__(self, strasse: str, hausnummer: str | int):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/buermoos_at.md
+++ b/doc/source/buermoos_at.md
@@ -1,0 +1,41 @@
+# Gemeinde Bürmoos
+
+Support for waste collection schedules provided by [Gemeinde Bürmoos](https://www.buermoos.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: buermoos_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Bürmoos waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Bürmoos waste calendar dropdown.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: buermoos_at
+      args:
+        strasse: "Birkenstraße"
+        hausnummer: "1a"
+```
+
+## How to get the source arguments
+
+Open <https://www.buermoos.at/Service/Aktuelles/Muellkalender>, pick your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`.


### PR DESCRIPTION
## Summary

- Adds `buermoos_at` source for Gemeinde Bürmoos, Salzburg, Austria
- Uses the shared `RiSKommunalAT` platform (gem2go / RIS CMS) with address-based lookup
- Users specify their street name and house number; the source resolves the collection zone via the embedded `strassenArr` on the municipality's calendar selection page
- Covers waste types: Biomüllabfuhr, Gelber Sack, Altpapier, and the colour-coded bin types (GELB, WEIß, ROT, LVP-Behälter)

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` — passes (9/9)
- [ ] Test case `Birkenstraße 76a` (example from the issue) resolves correctly and returns collection events
- [ ] Test case `Almweg 2` returns collection events
- [ ] All pre-commit hooks pass

Closes #4545

🤖 Generated with [Claude Code](https://claude.com/claude-code)