### PR TITLE
fix: add Breitenau (AT) to CitiesApps provider list

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/CitiesAppsCom.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/CitiesAppsCom.py
@@ -122,6 +122,11 @@ SERVICE_MAP = [
         "country": "at",
     },
     {
+        "title": "Breitenau",
+        "url": "https://www.breitenau.gv.at",
+        "country": "at",
+    },
+    {
         "title": "Breitenbrunn am Neusiedler See",
         "url": "http://www.breitenbrunn.at",
         "country": "at",


### PR DESCRIPTION
## Summary

- Adds Breitenau, Austria to the CitiesApps `SERVICE_MAP` in `CitiesAppsCom.py`
- The municipality's website (`https://www.breitenau.gv.at`) is fully powered by the CitiesApps platform; the old `/system/web/kalender.aspx` URL returns 404
- Closes #4200

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)