### PR TITLE
feat(at): add Stadtgemeinde Berndorf waste collection source (berndorf_gv_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berndorf_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berndorf_gv_at.py
@@ -1,0 +1,39 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Stadtgemeinde Berndorf"
+DESCRIPTION = "Source for Stadtgemeinde Berndorf, Austria."
+URL = "https://www.berndorf.gv.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES: dict[str, dict] = {
+    "Berndorf": {},
+}
+
+ICON_MAP = {
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Biotonne": Icons.ORGANIC,
+    "Bioabfall": Icons.ORGANIC,
+    "Biomüll": Icons.ORGANIC,
+    "Altpapier": Icons.PAPER,
+    "Papier": Icons.PAPER,
+    "Gelbe Säcke": Icons.PLASTIC_PACKAGING,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Gelbe Tonne": Icons.PLASTIC_PACKAGING,
+    "Aschetonne": Icons.COMBUSTIBLE,
+    "Sperrmüll": Icons.BULKY,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+    "Grünschnitt": Icons.GARDEN,
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.berndorf.gv.at"
+    ICON_MAP = ICON_MAP
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "226080602",
+    }

--- a/doc/source/berndorf_gv_at.md
+++ b/doc/source/berndorf_gv_at.md
@@ -1,0 +1,43 @@
+# Stadtgemeinde Berndorf
+
+Support for waste collection schedules provided by [Stadtgemeinde Berndorf](https://www.berndorf.gv.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: berndorf_gv_at
+      args:
+        strasse: STREET       # optional
+        hausnummer: HOUSE_NO  # required when strasse is set
+```
+
+Omit both `strasse` and `hausnummer` to receive events for all collection zones.
+
+### Configuration Variables
+
+**strasse**
+*(string) (optional)*
+
+Street name as listed in the Berndorf waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (optional)*
+
+House number as listed in the Berndorf waste calendar dropdown. Required when `strasse` is provided.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: berndorf_gv_at
+      args:
+        strasse: "Leobersdorfer Straße"
+        hausnummer: "199"
+```
+
+## How to get the source arguments
+
+Open <https://www.berndorf.gv.at/system/web/kalender.aspx?menuonr=226080602>, select your street and house number from the dropdowns, and use those exact values for `strasse` and `hausnummer`.


### PR DESCRIPTION
## Summary

- Adds `berndorf_gv_at` source for Stadtgemeinde Berndorf, Austria
- Built on the existing `RiSKommunalAT` shared service (`/system/web/kalender.aspx`)
- No address parameters required — the Berndorf calendar serves municipality-wide events without zone differentiation
- Adds `doc/source/berndorf_gv_at.md` documentation

Closes #3706

## Test plan

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] Live test: `python test_sources.py -s berndorf_gv_at -l` returns collection entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)