### PR TITLE
feat(at): add Steyr (Austria) waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
@@ -1,0 +1,68 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Stadtbetriebe Steyr GmbH"
+DESCRIPTION = "Source for Stadtbetriebe Steyr GmbH waste collection schedule."
+URL = "https://www.steyr.at"
+COUNTRY = "at"
+
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES = {
+    "Wolfernstraße 7": {
+        "strasse": "Wolfernstraße",
+        "hausnummer": "7",
+    },
+    "Aichetgasse 1": {
+        "strasse": "Aichetgasse",
+        "hausnummer": "1",
+    },
+}
+
+ICON_MAP = {
+    "Restabfall": Icons.GENERAL_WASTE,
+    "Bioabfall": Icons.ORGANIC,
+    "Altpapier": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Altglas": Icons.GLASS,
+    "Problemstoff": Icons.HAZARDOUS,
+    "Sperrmüll": Icons.BULKY,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Steyr waste calendar.",
+        "hausnummer": "House number as listed in the Steyr waste calendar.",
+    },
+    "de": {
+        "strasse": "Straßenname wie im Steyrer Abfallkalender aufgelistet.",
+        "hausnummer": "Hausnummer wie im Steyrer Abfallkalender aufgelistet.",
+    },
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.steyr.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = (
+        "https://www.steyr.at/system/web/kalender.aspx?sprache=1&menuonr=227376864"
+    )
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "227376864",
+    }
+
+    def __init__(self, strasse: str, hausnummer: str | int):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/steyr_at.md
+++ b/doc/source/steyr_at.md
@@ -1,0 +1,41 @@
+# Stadtbetriebe Steyr GmbH
+
+Support for waste collection schedules provided by [Stadtbetriebe Steyr GmbH](https://www.steyr.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: steyr_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Steyr waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Steyr waste calendar dropdown.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: steyr_at
+      args:
+        strasse: "Wolfernstraße"
+        hausnummer: "7"
+```
+
+## How to get the source arguments
+
+Open <https://www.steyr.at/system/web/kalender.aspx?sprache=1&menuonr=227376864>, choose your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`.


### PR DESCRIPTION
## Summary

- Adds `steyr_at` source for the Stadtbetriebe Steyr GmbH waste collection calendar
- Uses the existing `RiSKommunalAT` shared service (same RIS CMS platform as Enns, Schlierbach, Kronstorf, etc.)
- Users supply `strasse` (street name) and `hausnummer` (house number); the source resolves these to collection-zone IDs via the embedded JS address table on the calendar page
- Supported waste types: Restabfall, Bioabfall (+ icon mappings for Altpapier, Gelber Sack, Altglas, Problemstoff, Sperrmüll)

Closes #4671

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)