### PR TITLE
feat(at): add Oberndorf bei Schwanenstadt waste collection source (oberndorf_schwanenstadt_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
@@ -1,0 +1,69 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Oberndorf bei Schwanenstadt"
+DESCRIPTION = "Source for Oberndorf bei Schwanenstadt waste collection."
+URL = "https://www.oberndorf.ooe.gv.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES = {
+    "Am Hang 2": {"strasse": "Am Hang", "hausnummer": "2"},
+    "Bergstraße 5": {"strasse": "Bergstraße", "hausnummer": "5"},
+}
+
+ICON_MAP = {
+    "Restabfall": Icons.GENERAL_WASTE,
+    "Bioabfall": Icons.BIO_KITCHEN,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Altpapier": Icons.PAPER,
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Oberndorf bei Schwanenstadt waste calendar.",
+        "hausnummer": "House number as listed in the Oberndorf bei Schwanenstadt waste calendar.",
+    },
+    "de": {
+        "strasse": "Straßenname wie im Abfallkalender von Oberndorf bei Schwanenstadt aufgelistet.",
+        "hausnummer": "Hausnummer wie im Abfallkalender von Oberndorf bei Schwanenstadt aufgelistet.",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Visit https://www.oberndorf.ooe.gv.at, pick your street and house number "
+        "from the waste-calendar dropdowns on the homepage, and use the same values here."
+    ),
+    "de": (
+        "Öffnen Sie https://www.oberndorf.ooe.gv.at, wählen Sie Ihre Straße und "
+        "Hausnummer aus den Abfallkalender-Auswahlfeldern auf der Startseite, und "
+        "verwenden Sie dieselben Werte hier."
+    ),
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.oberndorf.ooe.gv.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = "https://www.oberndorf.ooe.gv.at"
+    LOOKAHEAD_DAYS = 365
+    MAX_PAGES = 30
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": "227435354",
+    }
+
+    def __init__(self, strasse: str, hausnummer: str | int):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/oberndorf_schwanenstadt_at.md
+++ b/doc/source/oberndorf_schwanenstadt_at.md
@@ -1,0 +1,39 @@
+# Oberndorf bei Schwanenstadt
+
+Support for schedules provided by [Oberndorf bei Schwanenstadt](https://www.oberndorf.ooe.gv.at).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: oberndorf_schwanenstadt_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+Street name as listed in the Oberndorf bei Schwanenstadt waste calendar.
+
+**hausnummer**
+*(string | integer) (required)*
+House number as listed in the Oberndorf bei Schwanenstadt waste calendar.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: oberndorf_schwanenstadt_at
+      args:
+        strasse: "Am Hang"
+        hausnummer: "2"
+```
+
+## How to get the arguments
+
+Visit [https://www.oberndorf.ooe.gv.at](https://www.oberndorf.ooe.gv.at), pick your street and house number from the waste-calendar dropdowns on the homepage, and use the same values here.


### PR DESCRIPTION
## Summary

- Adds `oberndorf_schwanenstadt_at` source for Oberndorf bei Schwanenstadt, Austria (closes #4445)
- Uses the shared `RiSKommunalAT` service with address-based lookup (street + house number)
- The `strassenArr` and form are embedded on the municipality's homepage (`https://www.oberndorf.ooe.gv.at`)
- Covers Restabfall, Bioabfall, Gelber Sack, Altpapier

## Test plan

- [x] Live test: 29 entries returned for Am Hang 2
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)