### PR TITLE
fix(at): add St. Marien test cases to gemeinde24_at

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
@@ -22,6 +22,14 @@ TEST_CASES = {
         "gemeinde": "Gaal",
         "strasse": "Gaal",
     },
+    "St. Marien - Pachersdorf Straße (3-wöchentlich)": {
+        "gemeinde_id": "83",
+        "street_id": "4129",
+    },
+    "St. Marien - Pachersdorf Straße (6-wöchentlich)": {
+        "gemeinde_id": "83",
+        "street_id": "3911",
+    },
 }
 
 API_BASE_URL = "https://www.gemeinde24.at/admin/API"


### PR DESCRIPTION
## Summary

- Adds two `TEST_CASES` entries for St. Marien (GemeindeID 83) to the existing `gemeinde24_at` source
- All streets in St. Marien come in `(3-wöchentlich)` / `(6-wöchentlich)` pairs, so users must provide `street_id` rather than `strasse` — the name alone is ambiguous
- Both frequency variants of Pachersdorf Straße (the requester's street) are covered
- No logic changes; no new files needed

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `ruff check` — clean

Closes #4456

🤖 Generated with [Claude Code](https://claude.com/claude-code)