### PR TITLE
feat(at): add Imst waste collection source (imst_at)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
@@ -1,0 +1,81 @@
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Imst"
+DESCRIPTION = "Waste collection schedule for Stadtgemeinde Imst, Austria."
+URL = "https://www.imst.gv.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES = {
+    "Auf Arzill 154": {
+        "strasse": "Auf Arzill",
+        "hausnummer": "154",
+    },
+    "Adlerweg 2": {
+        "strasse": "Adlerweg",
+        "hausnummer": "2",
+    },
+}
+
+ICON_MAP = {
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Biomüll": Icons.ORGANIC,
+    "Gelbe Säcke": Icons.PLASTIC_PACKAGING,
+    "Altpapier": Icons.PAPER,
+    "Sperrmüll": Icons.BULKY,
+    "Problemstoff": Icons.HAZARDOUS,
+    "Altglas": Icons.GLASS,
+    "Grünschnitt": Icons.GARDEN,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Imst waste calendar dropdown.",
+        "hausnummer": "House number as listed in the Imst waste calendar dropdown.",
+    },
+    "de": {
+        "strasse": "Straßenname wie in der Abfallkalender-Auswahl von Imst aufgeführt.",
+        "hausnummer": "Hausnummer wie in der Abfallkalender-Auswahl von Imst aufgeführt.",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Open https://www.imst.gv.at/Muellabfuhrplaene_1, pick your street and "
+        "house number from the dropdowns, and use the same values for "
+        "'strasse' and 'hausnummer'."
+    ),
+    "de": (
+        "Öffnen Sie https://www.imst.gv.at/Muellabfuhrplaene_1, wählen Sie Ihre "
+        "Straße und Hausnummer aus den Dropdown-Menüs, und verwenden Sie "
+        "dieselben Werte für 'strasse' und 'hausnummer'."
+    ),
+}
+
+_MENUONR = "222722602"
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://www.imst.gv.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = "https://www.imst.gv.at/Muellabfuhrplaene_1"
+    RAISE_ON_EMPTY = True
+    QUERY_PARAMS = {
+        "sprache": "1",
+        "menuonr": _MENUONR,
+    }
+
+    def __init__(self, strasse: str, hausnummer: str | int):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/imst_at.md
+++ b/doc/source/imst_at.md
@@ -1,0 +1,41 @@
+# Imst
+
+Support for waste collection schedules provided by [Stadtgemeinde Imst](https://www.imst.gv.at), Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: imst_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Imst waste calendar dropdown (case-insensitive).
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Imst waste calendar dropdown.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: imst_at
+      args:
+        strasse: "Auf Arzill"
+        hausnummer: "154"
+```
+
+## How to get the source arguments
+
+Open <https://www.imst.gv.at/Muellabfuhrplaene_1>, pick your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`.


### PR DESCRIPTION
## Summary

- Adds `imst_at` source for Stadtgemeinde Imst, Austria
- Uses the existing `RiSKommunalAT` shared service with address-based lookup (street + house number)
- Data fetched live from https://www.imst.gv.at/system/web/kalender.aspx

Closes #2618

## Test plan

- [ ] `python test_sources.py -s imst_at -l` returns collections for both test cases
- [ ] `python -m pytest tests/test_source_components.py -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)