### PR TITLE
feat(at): add Sollenau waste collection ICS source

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -149,3 +149,4 @@ Frequence
 Wil
 regist
 Ilkley
+noe

--- a/doc/ics/yaml/sollenau_at.yaml
+++ b/doc/ics/yaml/sollenau_at.yaml
@@ -1,0 +1,13 @@
+---
+title: Marktgemeinde Sollenau
+url: https://sollenau.noe.gv.at
+howto:
+  en: |
+    The municipality publishes a single public Google Calendar containing all waste collection events (Restmüll, Biomüll, Papier, Gelber Sack, Altkleidersammlung).
+
+    Use the following URL as the `url` parameter:
+
+    `https://calendar.google.com/calendar/ical/muellsollenau%40gmail.com/public/basic.ics`
+test_cases:
+  Müllplan Sollenau:
+    url: https://calendar.google.com/calendar/ical/muellsollenau%40gmail.com/public/basic.ics


### PR DESCRIPTION
## Summary

- Adds `doc/ics/yaml/sollenau_at.yaml` for Marktgemeinde Sollenau (Lower Austria / NÖ)
- The municipality publishes a public Google Calendar (`muellsollenau@gmail.com`) as its official Müllkalender — same pattern as `piesting_at.yaml`
- ICS feed covers all waste types: Restmüll, Biomüll, Papier, Gelber Sack, Altkleidersammlung
- Also adds `noe` to `.codespellignore` (the `.noe.gv.at` Austrian government domain was flagged)
- No new Python source required — handled by the existing generic `ics` source

Closes #3958

🤖 Generated with [Claude Code](https://claude.com/claude-code)