### PR TITLE
fix(at): remove duplicate PARAM_TRANSLATIONS in umweltverbaende_at

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
@@ -17,6 +17,7 @@ DESCRIPTION = (
     "Consolidated waste collection provider for several districts in Lower Austria"
 )
 URL = "https://www.umweltverbaende.at/"
+COUNTRY = "at"
 
 
 class E_I_TYPE(TypedDict):
@@ -223,7 +224,7 @@ PARAM_TRANSLATIONS = {
         "plz": "Postleitzahl",
         "street": "Straße",
         "hnr": "Hausnummer",
-        "zusatz": "Zusatz",
+        "addition": "Zusatz",
         "calendar": "Kalender",
         "calendar_title_separator": "Kalendertitel Separator",
         "calendar_splitter": "Kalendereintrag-Trenner",
@@ -235,7 +236,7 @@ PARAM_TRANSLATIONS = {
         "plz": "Postal code",
         "street": "Street",
         "hnr": "House number",
-        "zusatz": "Addition",
+        "addition": "Addition",
         "calendar": "Calendar",
         "calendar_title_separator": "Calendar title separator",
         "calendar_splitter": "Calendar entry splitter",
@@ -376,16 +377,6 @@ ICON_MAP = {
     "Strauchschnitt": Icons.GARDEN,
     "Verpackung": Icons.PAPER,
     "LVP": Icons.PLASTIC_PACKAGING,
-}
-
-PARAM_TRANSLATIONS = {
-    "de": {
-        "district": "Gebiet",
-        "municipal": "Gemeinde",
-        "calendar": "Kalender",
-        "calendar_title_separator": "Kalendertitel Separator",
-        "calendar_splitter": "Kalendereintrag-Trenner",
-    }
 }
 
 POSSIBLE_COLLECTION_PATHS = (


### PR DESCRIPTION
## Summary

- Removes a duplicate `PARAM_TRANSLATIONS` block (after `ICON_MAP`) that silently overwrote the correct, complete definition with a `"de"`-only, reduced-parameter version — breaking English labels in the HA config flow and causing sensors configured via the GUI to show "unknown"
- Fixes a pre-existing `"zusatz"` key in `PARAM_TRANSLATIONS` that should be `"addition"` (matching the `Source.__init__` parameter name)
- Adds the missing `COUNTRY = "at"` module-level constant

Fixes #5251

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)