### PR TITLE
feat(at): add Zillingdorf ICS calendar source (zillingdorf_at)

### DIFF
--- a/doc/ics/yaml/zillingdorf_at.yaml
+++ b/doc/ics/yaml/zillingdorf_at.yaml
@@ -1,0 +1,13 @@
+---
+title: Zillingdorf
+url: https://www.zillingdorf.gv.at
+howto:
+  en: |
+    The municipality publishes a single public Google Calendar containing all waste collection events.
+
+    Use the following URL as the `url` parameter:
+
+    `https://calendar.google.com/calendar/ical/v60bh2s8sl7tg2khv1kgg3qu5c%40group.calendar.google.com/public/basic.ics`
+test_cases:
+  Zillingdorf:
+    url: https://calendar.google.com/calendar/ical/v60bh2s8sl7tg2khv1kgg3qu5c%40group.calendar.google.com/public/basic.ics


### PR DESCRIPTION
## Summary

- Adds `doc/ics/yaml/zillingdorf_at.yaml` for Zillingdorf, Austria
- The municipality publishes its waste collection schedule as a public Google Calendar ICS feed
- Uses the existing `ics` source — no new Python code required

Closes #2906

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)