### PR TITLE
feat(at): add Gemeinde Passail ICS waste collection source

### DIFF
--- a/doc/ics/yaml/passail_at.yaml
+++ b/doc/ics/yaml/passail_at.yaml
@@ -1,0 +1,18 @@
+---
+title: Gemeinde Passail
+url: https://www.passail.at
+country: at
+howto:
+  en: |
+    - Visit <https://www.passail.at/muellentsorgung/>.
+    - Right-click the ICS download link for your collection area and copy the link address.
+    - Use this link as the `url` parameter.
+  de: |
+    - Besuchen Sie <https://www.passail.at/muellentsorgung/>.
+    - Klicken Sie mit der rechten Maustaste auf den ICS-Download-Link für Ihren Abfuhrbereich und kopieren Sie den Link.
+    - Verwenden Sie diesen Link als `url`-Parameter.
+test_cases:
+  Passail, Plenzengreith, teilw. Arzberg:
+    url: https://www.passail.at/wp-content/uploads/sites/18/2025/12/Kalender-von-Mülltermine-Passail-Plenzengreith-teilw.-Arzberg.ics
+  Hohenau, Neudorf, Rest Arzberg:
+    url: https://www.passail.at/wp-content/uploads/sites/18/2025/12/Kalender-von-Mülltermine-Hohenau-Neudorf-Rest-Arzberg.ics


### PR DESCRIPTION
## Summary

- Adds `doc/ics/yaml/passail_at.yaml` for Gemeinde Passail, Styria, Austria
- Uses the generic ICS source; users visit https://www.passail.at/muellentsorgung/ to find and copy the ICS download link for their collection area
- Two test cases covering both collection zones (2026 URLs)
- Includes English and German howto instructions

Closes #3431

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] All pre-commit hooks pass
- [x] Both ICS URLs verified reachable (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)