### PR TITLE
fix(jumomind_de): update ALW Wolfenbüttel URL (#5408)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -186,7 +186,10 @@ SERVICE_MAP = {
     "kbl": {"list": ["Langen"], "url": "https://www.kbl-langen.de/"},
     "ros": {"list": ["Rosbach Vor Der Höhe"], "url": "https://www.rosbach-hessen.de/"},
     "mkk": {"list": ["Main-Kinzig-Kreis"], "url": "https://abfall-mkk.de/"},
-    "wol": {"list": ["ALW Wolfenbüttel"], "url": "https://www.alw-wf.de"},
+    "wol": {
+        "list": ["ALW Wolfenbüttel"],
+        "url": "https://wol.jumomind.com/webmodul/alw/",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- Updates `SERVICE_MAP["wol"]["url"]` in `jumomind_de.py` from `https://www.alw-wf.de` to `https://wol.jumomind.com/webmodul/alw/`
- The ALW Wolfenbüttel waste collection service has migrated its public-facing website to the jumomind webmodule URL; the underlying API endpoint is unchanged so no functional change is required
- Resolves #5408

## Test plan

- [ ] Existing `TEST_CASES["ALW Wolfenbüttel"]` (`service_id: "wol"`, `city: "Linden"`, `street: "Am Buschkopf"`) continues to return collection entries
- [ ] `python -m pytest tests/test_source_components.py -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)