### PR TITLE
fix(api_golemio_cz): ignore containers regardless of int/str type

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/api_golemio_cz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/api_golemio_cz.py
@@ -135,7 +135,10 @@ class Source:
         self._radius = radius
         self._api_key = api_key
         self._only_monitored = only_monitored
-        self._ignored_containers = ignored_containers or []
+        # Normalize to strings: the UI config flow stores ignored_containers
+        # as strings, while the API returns container_id as an int. Comparing
+        # the two directly never matches, so coerce both sides to str.
+        self._ignored_containers = [str(x) for x in (ignored_containers or [])]
         self._auto_suffix = auto_suffix
         self._suffix = suffix
 
@@ -157,7 +160,7 @@ class Source:
 
         for feature in features:
             for container in feature["properties"]["containers"]:
-                if container["container_id"] in self._ignored_containers:
+                if str(container["container_id"]) in self._ignored_containers:
                     continue
 
                 trash_type = container["trash_type"]


### PR DESCRIPTION
## Summary

The `api_golemio_cz` source never excludes containers listed in `ignored_containers` when the integration is configured through the **UI / config flow**.

## Root cause

The Golemio API returns `container_id` as an **integer**, e.g. `41209`. The UI config flow, however, stores `ignored_containers` as a list of **strings**, e.g. `["41209"]`. The membership test compared the two directly:

```python
if container["container_id"] in self._ignored_containers:  # 41209 in ["41209"] -> False
```

So a container added to `ignored_containers` via the UI is never skipped. For a container without a pick date this means the warning

> No next pick date for container ID 41209 (Jedlé tuky a oleje), add it to ignored_containers.

keeps firing on every fetch **even after** the user has added that exact ID to the ignore list — with no way to silence it from the UI.

YAML-configured entries pass integers (see `TEST_CASES`), so they happened to work; only the UI path was affected.

## Fix

Coerce both sides to `str` so the comparison succeeds regardless of how the value was stored:

- normalize `ignored_containers` to strings in `__init__`
- compare `str(container["container_id"])` against that list

Works for both UI (str) and YAML (int) configurations.

## Testing

- Verified against a live Golemio response where `container_id` is an int and a UI-stored `ignored_containers` of `["41209"]`: the container is now correctly excluded and the warning no longer fires.
- `python -m py_compile` passes.
