### PR TITLE
ci: migrate GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -12,5 +12,5 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/issue-labeler.yaml
+++ b/.github/workflows/issue-labeler.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-label from issue template fields
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.issue.body || '';

--- a/.github/workflows/notify-source-owners.yaml
+++ b/.github/workflows/notify-source-owners.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Notify mapped source owners
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: pip

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: pip
@@ -37,9 +37,9 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Run pre-commit (PR changes only)
         if: github.event_name == 'pull_request'
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
+        run: |
+          pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
GitHub Actions runners are deprecating the Node 20 runtime (workflows currently emit a warning and are auto-run on Node 24). This bumps the first-party actions to their Node 24 majors so the warning clears.

## Changes

| File | Change |
|---|---|
| `validate.yaml` | `checkout@v4→v5`, `setup-python@v5→v6`, `pre-commit/action@v3.0.0` → direct `pre-commit run` |
| `update-docs.yaml` | `checkout@v4→v5`, `setup-python@v5→v6` |
| `hassfest.yaml` | `checkout@v4→v5` |
| `notify-source-owners.yaml` | `checkout@v4→v5`, `github-script@v7→v8` |
| `issue-labeler.yaml` | `github-script@v7→v8` |

## Notes

- **`pre-commit/action@v3.0.0`** is a composite action in maintenance-only mode that pulls in a Node-based `actions/cache` step, so a version bump alone wouldn't clear the warning. Replaced with a direct `pip install pre-commit` + `pre-commit run`, keeping its default flags (`--show-diff-on-failure --color=always`) and the PR-only `--from-ref/--to-ref` behaviour. Trade-off: loses that action's dedicated pre-commit-env cache.
- **`takanome-dev/assign-issue-action`** (`assign.yml`) is left as-is: its latest release (v3.1.0, already pinned) still ships `node20`, so there is no Node 24 version to move to yet.
- **`home-assistant/actions/hassfest@master`** is a Docker action and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)