### PR TITLE
fix(muellmax): remove unusable Düsseldorf service

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/MuellmaxDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/MuellmaxDe.py
@@ -2,11 +2,6 @@
 
 
 SERVICE_MAP = [
-    {
-        "title": "AWISTA Düsseldorf",
-        "url": "https://www.awista.de/",
-        "service_id": "Dus",
-    },
     # RSAG Rhein-Sieg-Kreis ("Rsa") is covered by the dedicated `rsag_de` source
     # (same Müllmax backend, friendlier city/street config) — see #6553. Entry
     # removed to avoid two listings for the same provider.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/muellmax_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/muellmax_de.py
@@ -89,7 +89,6 @@ def main():
     # select service
     service_choices = [
         ("Frankfurt", "Fes"),
-        ("Düsseldorf", "Dus"),
         ("Rhein-Sieg-Kreis", "Rsa"),
         ("Bochum", "Usb"),
         ("Münster", "Awm"),


### PR DESCRIPTION
## Summary

AWISTA Düsseldorf [switched](https://github.com/mampfes/hacs_waste_collection_schedule/issues/3500) the backend and you need to use the ICS source now. Since the Müllmax integration fails to work, it leads to user confusion during the setup process.


## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
