### PR TITLE
feat(source): add lookahead_days param to kiedyodpady_pl (default 365)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiedyodpady_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiedyodpady_pl.py
@@ -43,7 +43,7 @@ TEST_CASES = {
 }
 
 API_URL = "https://api.kiedyodpady.pl/public"
-DEFAULT_DAYS = 35
+DEFAULT_LOOKAHEAD_DAYS = 365
 
 ICON_MAP = {
     "bio": Icons.ORGANIC,
@@ -68,6 +68,7 @@ PARAM_TRANSLATIONS = {
         "city": "City Name",
         "street": "Street Name",
         "number": "House Number",
+        "lookahead_days": "Lookahead Days",
     },
 }
 
@@ -80,6 +81,10 @@ PARAM_DESCRIPTIONS = {
         "city": "City/locality name as shown in the kiedyodpady.pl UI.",
         "street": "Street name as shown in the kiedyodpady.pl UI (optional for some localities).",
         "number": "House number / address entry as shown in the kiedyodpady.pl UI (optional).",
+        "lookahead_days": (
+            "Number of days ahead to fetch the schedule. "
+            "Defaults to 365, matching the official Android app."
+        ),
     },
 }
 
@@ -112,11 +117,13 @@ class Source:
         city: str,
         street: str | None = None,
         number: str | None = None,
+        lookahead_days: int = DEFAULT_LOOKAHEAD_DAYS,
     ):
         self._municipality = municipality.strip().lower()
         self._city = city.strip()
         self._street = street.strip() if isinstance(street, str) else None
         self._number = number.strip() if isinstance(number, str) else None
+        self._lookahead_days = int(lookahead_days)
         self._session = requests.Session()
         self._session.headers.update(
             {
@@ -213,7 +220,7 @@ class Source:
         waste_type_map = self._get_waste_type_map()
 
         today = date.today()
-        date_to = today + timedelta(days=DEFAULT_DAYS)
+        date_to = today + timedelta(days=self._lookahead_days)
         payload = {
             "from": today.isoformat(),
             "to": date_to.isoformat(),

--- a/doc/source/kiedyodpady_pl.md
+++ b/doc/source/kiedyodpady_pl.md
@@ -13,6 +13,7 @@ waste_collection_schedule:
         city: "Pabianice (miasto)"
         street: 'ul. 15 Pułku Piechoty "Wilków"'   # optional for some localities
         number: "pozostałe"                          # optional for some localities
+        lookahead_days: 365                          # optional, default 365
 ```
 
 ### Configuration Variables
@@ -28,6 +29,9 @@ waste_collection_schedule:
 
 **number**
 *(String) (optional)* House number / address entry exactly as shown in the UI. Not required for all localities.
+
+**lookahead_days**
+*(Integer) (optional, default: 365)* Number of days ahead to fetch the schedule. Defaults to 365, matching the official Android app. Use a smaller value to reduce API load, or a larger value to see further ahead.
 
 ## How to get the source arguments
 


### PR DESCRIPTION
Closes #6708

## Summary

- Replaces the hard-coded `DEFAULT_DAYS = 35` constant in `kiedyodpady_pl.py` with a configurable `lookahead_days` parameter (default `365`).
- Default of 365 days matches the behaviour of the official Android app, as noted by the source codeowner in the issue.
- Updates `PARAM_TRANSLATIONS`, `PARAM_DESCRIPTIONS`, and `doc/source/kiedyodpady_pl.md` to document the new parameter.
- No changes to `TEST_CASES` — existing test cases are unaffected.

## Test plan

- [ ] `python test_sources.py -s kiedyodpady_pl -l` passes with existing TEST_CASES.
- [ ] `python -m pytest tests/test_source_components.py -q` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)