### PR TITLE
chore(release): v2.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,85 @@ All notable changes to this project will be documented in this file.
 
 Releases are listed in reverse chronological order.
 
+## [2.29.0] - 2026-06-22
+
+A warm welcome and huge thank-you to our **first-time contributors** in this release:
+@adbsmith, @fangedhex, @hrubymar10, @jcarr, @jjsmackay, @KingKemar, @Zaunei and @zenhas. 🎉
+Thanks as well to our returning contributors (@bbr111, @j-webb) for the fixes and new sources below.
+
+### Added Sources
+
+- added Hochfelden, CH (Mondstaub ICS platform) (#6711)
+- added North West Resource Recovery & Recycling, TAS, AU (nwrrr_com_au) (#6634)
+- added Toulouse Métropole (toulouse_metropole_fr), FR (thanks @fangedhex) (#6637)
+- added SICTOM du Val de Saône (sictomvds_com), FR (thanks @KingKemar) (#6642)
+- added VEVG Vorpommern-Greifswald (vevg_karlsburg_de), DE (#6643)
+- added UBZ Umwelt- und Servicebetrieb Zweibrücken, DE (#6659)
+- added Mühlenkreis / Kreis Minden-Lübbecke (muehlenkreis_de), DE (#6638)
+- added Stadt Vlotho to abfall_export_vcal, DE (#6657)
+- added Lysa nad Labem (lysa_nad_labem_cz), CZ (thanks @zenhas) (#6648)
+- added kiedyodpady.pl universal source for Polish municipalities (kiedyodpady_pl), PL (#6650)
+- added Cotswold District Council (cotswold_gov_uk), UK (#6673)
+- added Vogel Disposal Service, US (thanks @jcarr) (#6669)
+- added Piberbach (piberbach_ooe_gv_at), AT (#6632)
+- added Koppl (koppl_at), AT (#6667)
+- added St. Kanzian am Klopeiner See (kanzian_at), AT (#6670)
+- added Schärding (schaerding_ooe_gv_at), AT (#6670)
+- added Fritzens (fritzens_gv_at), AT (#6672)
+- added Ort im Innkreis, AT (#6674)
+- added Angern an der March, AT (#6675)
+- added Herzogsdorf, AT (#6676)
+- added Micheldorf in Oberösterreich (micheldorf_at), AT (#6677)
+- added Schlierbach, AT (#6678)
+- added Enns (enns_at), AT (#6679)
+- added Kronstorf (kronstorf_at), AT (#6680)
+- added Felixdorf (felixdorf_gv_at), AT (#6681)
+- added Hart bei Graz (hartbeigraz_at), AT (#6682)
+- added Baumkirchen (baumkirchen_gv_at), AT (#6683)
+- added Jochberg (jochberg_gv_at), AT (#6684)
+- added Kirchberg am Wechsel, AT (#6685)
+- added Elsbethen (elsbethen_at), AT (#6686)
+- added St. Margarethen im Lungau (st_margarethen_salzburg_at), AT (#6687)
+- added Puch bei Hallein, AT (#6688)
+- added Bürmoos (buermoos_at), AT (#6689)
+- added Stadtgemeinde Berndorf (berndorf_gv_at), AT (#6691)
+- added Steyr (steyr_at), AT (#6692)
+- added Oberndorf bei Schwanenstadt (oberndorf_schwanenstadt_at), AT (#6693)
+- added Imst (imst_at), AT (#6695)
+- added Sollenau, AT (#6696)
+- added Zillingdorf (zillingdorf_at), AT (#6698)
+- added Gemeinde Passail, AT (#6699)
+- added Torre de' Passeri to Junker APP, IT (#6664)
+- added ab_peine_de, gross_gerau_de, ilm_kreis_de, kreis_ploen_de — converted from ICS YAML to full Python sources with street autocomplete (SiteparkIES) (#6638)
+
+### Fixed Sources
+
+- fixed kiedyodpady_pl: add lookahead_days parameter (default 365) (#6714)
+- fixed wokingham_gov_uk: update for redesigned council website (#6713)
+- fixed muellmax: remove unusable Düsseldorf service (thanks @Zaunei) (#6707)
+- fixed api_golemio_cz: handle containers with int or str type (thanks @hrubymar10) (#6704)
+- fixed waste_management (wmlink): add retry handling for transient API gateway errors (thanks @adbsmith) (#6705)
+- fixed thurrock_gov_uk: A-streets URL, date-range separators, bin-text separators, NBSP in town names, and street-name comma split (#6658)
+- fixed app_abfallplus_de: URL-decode HNR IDs before extracting display name (#6662)
+- fixed ecoharmonogram_pl: add Wodzisław Śląski via communityId 23 (#6656)
+- fixed vivab_se: handle week-based date format for infrequent services (e.g. Slam/septic tank) (#6635)
+- fixed mpo_krakow_pl: fix TypeError when API returns dict instead of list (#6633)
+- fixed fylde_gov_uk: changed integration parameter (thanks @j-webb) (#6640)
+- fixed abfall_neunkirchen_siegerland_de: add Cloudflare bypass, metadata, icon fix (#6636)
+- fixed awb_mechernich_de: expand coverage to full Kreis Euskirchen (#6668)
+- fixed umweltverbaende_at: remove duplicate PARAM_TRANSLATIONS (#6697)
+- fixed gemeinde24_at: add St. Marien (GemeindeID 83) test cases (#6694)
+- fixed citiesapps: add Breitenau (AT) to provider list (#6690)
+- fixed abfall_neunkirchen_siegerland_de, hilchenbach_de, kwb_goslar_de, landkreis_wittmund_de, lk_mecklenburgische_seenplatte_de, ostprignitz_ruppin_de: harmonised onto SiteparkIES shared service (#6638)
+
+### Other
+
+- feat(ics): add optional impersonate parameter to pass TLS-fingerprinting WAFs (thanks @jjsmackay) (#6646)
+- feat(customize): support fnmatch wildcards in the customize type key (#6630)
+- migrated lint and format tooling from black/flake8/isort to Ruff (#6639)
+- ci: migrate GitHub Actions off the deprecated Node 20 runtime (#6706)
+- docs: fix typos in documentation and codespellignore (#6653)
+
 ## [2.28.0] - 2026-06-13
 
 A warm welcome and huge thank-you to our **first-time contributors** in this release:

--- a/custom_components/waste_collection_schedule/manifest.json
+++ b/custom_components/waste_collection_schedule/manifest.json
@@ -17,5 +17,5 @@
     "pypdf",
     "curl_cffi>=0.7.0"
   ],
-  "version": "2.28.0"
+  "version": "2.29.0"
 }


### PR DESCRIPTION
## Release v2.29.0

42 Added Sources, 17 Fixed Sources, 5 Other changes.

First-time contributors welcomed: @adbsmith, @fangedhex, @hrubymar10, @jcarr, @jjsmackay, @KingKemar, @Zaunei, @zenhas.

The full release notes (same content and section order as the CHANGELOG entry) will be used verbatim for the GitHub release after merge.

**Files changed:** `CHANGELOG.md`, `custom_components/waste_collection_schedule/manifest.json` (`version`: `2.28.0` → `2.29.0`).

---

*After merge, the maintainer cuts the tag and publishes the release — see hand-off commands in the linked session.*