### PR TITLE
feat(pl): add KOMA waste collection source (koma_pl)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/koma_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/koma_pl.py
@@ -1,0 +1,144 @@
+import urllib.parse
+from datetime import datetime
+
+from curl_cffi import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+TITLE = "KOMA"
+DESCRIPTION = "Source for KOMA waste collection (e.g. Nowy Dwór Gdański, Poland)."
+URL = "https://koma.pl"
+COUNTRY = "pl"
+
+API_URL = "https://bok.koma.pl"
+
+TEST_CASES = {
+    "Nowy Dwór Gdański, Kanałowa 5": {
+        "gmina": "Nowy Dwór Gdański",
+        "miejscowosc": "Nowy Dwór Gdański",
+        "ulica": "Kanałowa",
+        "numer_domu": "5",
+    },
+    "Nowy Dwór Gdański, Kanałowa 4/1": {
+        "gmina": "Nowy Dwór Gdański",
+        "miejscowosc": "Nowy Dwór Gdański",
+        "ulica": "Kanałowa",
+        "numer_domu": "4/1",
+    },
+}
+
+ICON_MAP = {
+    "Zmieszane": Icons.GENERAL_WASTE,
+    "Bio": Icons.ORGANIC,
+    "Odpady zielone": Icons.GARDEN,
+    "Papier": Icons.PAPER,
+    "Szkło": Icons.GLASS,
+    "Metale i tworzywa sztuczne": Icons.RECYCLING,
+    "Gabaryty": Icons.BULKY,
+    "Elektro": Icons.ELECTRONICS,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Open https://koma.pl/harmonogram-odpadow/ and step through the dropdowns "
+        "(Wybierz Miasto -> miejscowość -> ulica -> numer domu) to find the exact "
+        "spelling of your gmina, town, street and house number."
+    ),
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "gmina": "Commune (gmina)",
+        "miejscowosc": "Town",
+        "ulica": "Street",
+        "numer_domu": "House number",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "gmina": "Name of the commune (gmina) as listed on koma.pl.",
+        "miejscowosc": "Name of the town/village.",
+        "ulica": "Street name (leave empty for towns without streets).",
+        "numer_domu": "House number.",
+    },
+}
+
+
+class Source:
+    def __init__(
+        self, gmina: str, miejscowosc: str, numer_domu: str | int, ulica: str = ""
+    ):
+        self._gmina = str(gmina).strip()
+        self._miejscowosc = str(miejscowosc).strip()
+        self._ulica = str(ulica).strip()
+        self._numer_domu = str(numer_domu).strip()
+
+    def _get_json(self, session, path_segments, params=None):
+        url = (
+            API_URL
+            + "/"
+            + "/".join(urllib.parse.quote(segment) for segment in path_segments)
+        )
+        response = session.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session(impersonate="chrome")
+
+        # The API "prefix" path segment equals the gmina name.
+        prefix = self._gmina
+
+        # 1. Resolve the property id (numer_posesji) for the given house number.
+        posesje_path = ["api", "posesje", prefix, self._gmina, self._miejscowosc]
+        if self._ulica:
+            posesje_path.append(self._ulica)
+        properties = self._get_json(session, posesje_path)
+
+        if not properties:
+            if self._ulica:
+                streets = self._get_json(
+                    session, ["api", "ulice", prefix, self._gmina, self._miejscowosc]
+                )
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "ulica",
+                    self._ulica,
+                    sorted({s["ulica"] for s in streets if s.get("ulica")}),
+                )
+            raise SourceArgumentNotFoundWithSuggestions(
+                "miejscowosc", self._miejscowosc, []
+            )
+
+        match = next(
+            (
+                p
+                for p in properties
+                if str(p.get("numer_domu")).strip().casefold()
+                == self._numer_domu.casefold()
+            ),
+            None,
+        )
+        if match is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "numer_domu",
+                self._numer_domu,
+                sorted({str(p.get("numer_domu")) for p in properties}),
+            )
+
+        # 2. Fetch the schedule for the resolved property.
+        schedule = self._get_json(
+            session,
+            ["api", "apiharmonogram"],
+            {"value": f"{prefix}/{match['numer_posesji']}"},
+        )
+
+        entries: list[Collection] = []
+        for collection in schedule.get("odbior", []):
+            try:
+                day = datetime.strptime(collection["data"], "%Y-%m-%d").date()
+            except (ValueError, KeyError):
+                continue
+            waste_type = collection.get("typ", "")
+            entries.append(Collection(day, waste_type, icon=ICON_MAP.get(waste_type)))
+        return entries

--- a/doc/source/koma_pl.md
+++ b/doc/source/koma_pl.md
@@ -1,0 +1,42 @@
+# KOMA
+
+Support for waste collection schedules provided by [KOMA](https://koma.pl) via its address lookup at [koma.pl/harmonogram-odpadow](https://koma.pl/harmonogram-odpadow/) (e.g. Nowy Dwór Gdański, Poland).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: koma_pl
+      args:
+        gmina: Nowy Dwór Gdański
+        miejscowosc: Nowy Dwór Gdański
+        ulica: Kanałowa
+        numer_domu: "5"
+```
+
+### Configuration Variables
+
+**gmina**  
+*(string) (required)*
+
+Name of the commune (gmina) as listed on koma.pl.
+
+**miejscowosc**  
+*(string) (required)*
+
+Name of the town/village.
+
+**numer_domu**  
+*(string) (required)*
+
+House number.
+
+**ulica**  
+*(string) (optional)*
+
+Street name. Leave empty for towns without streets.
+
+## How to get the source arguments
+
+Open [koma.pl/harmonogram-odpadow](https://koma.pl/harmonogram-odpadow/) and step through the dropdowns (Wybierz Miasto → miejscowość → ulica → numer domu) to find the exact spelling of your gmina, town, street and house number.

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -495,6 +495,61 @@ def test_uk_cloud9_client_falls_back_to_secondary_domain(monkeypatch) -> None:
     ]
 
 
+def test_koma_pl_resolves_house_number_and_parses_schedule() -> None:
+    module = _get_module("koma_pl")
+
+    posesje = [
+        {"numer_posesji": "ND00050", "numer_domu": "4/1", "ulica": "Kanałowa"},
+        {"numer_posesji": "1941", "numer_domu": "5", "ulica": "Kanałowa"},
+    ]
+    schedule = {
+        "rok": "2026",
+        "odbior": [
+            {"data": "2026-01-07", "typ": "Bio"},
+            {"data": "2026-01-15", "typ": "Zmieszane"},
+            {"data": "bad-date", "typ": "Papier"},
+        ],
+    }
+
+    class _Response:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return self._payload
+
+    requested = []
+
+    class _Session:
+        def get(self, url, params=None, timeout=None):
+            requested.append((url, params))
+            if "apiharmonogram" in url:
+                return _Response(schedule)
+            return _Response(posesje)
+
+    with patch.object(module.requests, "Session", lambda **kwargs: _Session()):
+        entries = module.Source(
+            gmina="Nowy Dwór Gdański",
+            miejscowosc="Nowy Dwór Gdański",
+            ulica="Kanałowa",
+            numer_domu="5",
+        ).fetch()
+
+    # House number "5" must resolve to property id 1941 in the schedule request.
+    assert any(
+        params and params.get("value") == "Nowy Dwór Gdański/1941"
+        for _, params in requested
+    )
+    # Valid dates parsed, invalid date skipped.
+    assert [(entry.date.isoformat(), entry.type) for entry in entries] == [
+        ("2026-01-07", "Bio"),
+        ("2026-01-15", "Zmieszane"),
+    ]
+
+
 def test_uk_cloud9_client_requires_api_domains() -> None:
     module = import_module("waste_collection_schedule.service.uk_cloud9_apps")
 


### PR DESCRIPTION
## Summary

- Adds `koma_pl.py`, a dedicated source for KOMA waste collection (Nowy Dwór Gdański and other gminy served by koma.pl)
- KOMA doesn't publish an ICS feed, so this resolves the address (gmina, town, street, house number) to a property id via its `bok.koma.pl` API and then fetches the schedule
- Adds `doc/source/koma_pl.md` and two TEST_CASES using public Nowy Dwór Gdański addresses

## Type of change

- [x] New source

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` passes (structural suite imports and validates koma_pl)
- [x] Added a mocked unit test covering house-number resolution and schedule parsing (valid dates parsed, bad date skipped)
- [x] `ruff check` and `ruff format` clean on the new files

Note: the tests above are mocked, I haven't included a live run against koma.pl in this PR. Happy to add live output for a specific address if you'd like.

Closes #6184