### PR TITLE
add Alexandria VA provider

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/alexandria_va_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/alexandria_va_us.py
@@ -1,0 +1,111 @@
+from datetime import date, timedelta
+
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import (
+    ArcGisError,
+    geocode,
+    query_feature_layer,
+)
+
+TITLE = "Alexandria, VA"
+DESCRIPTION = "Source for City of Alexandria, VA trash and recycling collection."
+URL = "https://www.alexandriava.gov/RefuseCollection"
+COUNTRY = "us"
+
+TEST_CASES = {
+    "City Hall, 301 King St": {"address": "301 King St, Alexandria, VA 22314"},
+}
+
+SOURCE_CODEOWNERS = ["@lpukatch"]
+
+ICON_MAP = {
+    "Trash": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Full street address including city and state (e.g. '301 King St, Alexandria, VA 22314')",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+# City of Alexandria alx311Info MapServer.
+# Layer 3 = Refuse Day Zone (field DAYSERVED), layer 2 = Recycle Zones (field PICKUPDAY).
+MAPSERVER = "https://maps.alexandriava.gov/alexmaps/rest/services/alx311Info/MapServer"
+REFUSE_URL = f"{MAPSERVER}/3"
+RECYCLE_URL = f"{MAPSERVER}/2"
+
+WEEKDAYS = {
+    "Monday": 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+    "Saturday": 5,
+    "Sunday": 6,
+}
+
+WEEKS_AHEAD = 26
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        try:
+            location = geocode(self._address)
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        entries: list[Collection] = []
+
+        # Trash / refuse — every eligible address falls in a refuse day zone.
+        refuse_day = self._query_day(location, REFUSE_URL, "DAYSERVED")
+        if refuse_day is None:
+            # No refuse zone means the address could not be matched at all.
+            raise SourceArgumentNotFound("address", self._address)
+        entries += self._weekly_dates(refuse_day, "Trash")
+
+        # Recycling — not every address is eligible for city recycling
+        # (e.g. commercial buildings return PICKUPDAY "None"); skip if absent.
+        recycle_day = self._query_day(location, RECYCLE_URL, "PICKUPDAY")
+        if recycle_day is not None:
+            entries += self._weekly_dates(recycle_day, "Recycling")
+
+        return entries
+
+    @staticmethod
+    def _query_day(location: dict[str, float], url: str, field: str) -> str | None:
+        try:
+            features = query_feature_layer(url, geometry=location, out_fields=field)
+        except ArcGisError:
+            return None
+
+        value = (features[0].get(field) or "").strip().title()
+        if value not in WEEKDAYS:
+            return None
+        return value
+
+    @staticmethod
+    def _weekly_dates(day_name: str, waste_type: str) -> list[Collection]:
+        weekday = WEEKDAYS[day_name]
+        today = date.today()
+        days_ahead = (weekday - today.weekday()) % 7
+        next_date = today + timedelta(days=days_ahead)
+        icon = ICON_MAP.get(waste_type)
+        return [
+            Collection(
+                date=next_date + timedelta(weeks=i),
+                t=waste_type,
+                icon=icon,
+            )
+            for i in range(WEEKS_AHEAD)
+        ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/alexandria_va_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/alexandria_va_us.py
@@ -4,12 +4,13 @@ from waste_collection_schedule import Collection, Icons  # type: ignore[attr-def
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ArcGis import (
     ArcGisError,
+    epoch_ms_to_date,
     geocode,
     query_feature_layer,
 )
 
 TITLE = "Alexandria, VA"
-DESCRIPTION = "Source for City of Alexandria, VA trash and recycling collection."
+DESCRIPTION = "Source for City of Alexandria, VA trash, recycling and leaf collection."
 URL = "https://www.alexandriava.gov/RefuseCollection"
 COUNTRY = "us"
 
@@ -22,6 +23,7 @@ SOURCE_CODEOWNERS = ["@lpukatch"]
 ICON_MAP = {
     "Trash": Icons.GENERAL_WASTE,
     "Recycling": Icons.RECYCLING,
+    "Leaf Collection": Icons.ORGANIC,
 }
 
 PARAM_DESCRIPTIONS = {
@@ -37,10 +39,12 @@ PARAM_TRANSLATIONS = {
 }
 
 # City of Alexandria alx311Info MapServer.
-# Layer 3 = Refuse Day Zone (field DAYSERVED), layer 2 = Recycle Zones (field PICKUPDAY).
+# Layer 3 = Refuse Day Zone (field DAYSERVED), layer 2 = Recycle Zones (field PICKUPDAY),
+# layer 16 = Leaf Zones (field PassDate, one feature per seasonal collection pass).
 MAPSERVER = "https://maps.alexandriava.gov/alexmaps/rest/services/alx311Info/MapServer"
 REFUSE_URL = f"{MAPSERVER}/3"
 RECYCLE_URL = f"{MAPSERVER}/2"
+LEAF_URL = f"{MAPSERVER}/16"
 
 WEEKDAYS = {
     "Monday": 0,
@@ -80,6 +84,11 @@ class Source:
         if recycle_day is not None:
             entries += self._weekly_dates(recycle_day, "Recycling")
 
+        # Leaf collection — seasonal vacuum-leaf passes with explicit dates.
+        # The layer only holds the current season, so this yields nothing
+        # outside the fall/winter leaf-collection period.
+        entries += self._leaf_dates(location)
+
         return entries
 
     @staticmethod
@@ -93,6 +102,30 @@ class Source:
         if value not in WEEKDAYS:
             return None
         return value
+
+    @staticmethod
+    def _leaf_dates(location: dict[str, float]) -> list[Collection]:
+        try:
+            features = query_feature_layer(
+                LEAF_URL, geometry=location, out_fields="PassDate"
+            )
+        except ArcGisError:
+            return []
+
+        icon = ICON_MAP.get("Leaf Collection")
+        entries: list[Collection] = []
+        for attrs in features:
+            pass_date = attrs.get("PassDate")
+            if not pass_date:
+                continue
+            entries.append(
+                Collection(
+                    date=epoch_ms_to_date(pass_date),
+                    t="Leaf Collection",
+                    icon=icon,
+                )
+            )
+        return entries
 
     @staticmethod
     def _weekly_dates(day_name: str, waste_type: str) -> list[Collection]:

--- a/doc/source/alexandria_va_us.md
+++ b/doc/source/alexandria_va_us.md
@@ -31,6 +31,12 @@ waste_collection_schedule:
 
 ## How to get the source arguments
 
-Use your full street address including city, state, and ZIP code (e.g. "301 King St, Alexandria, VA 22314"). The source geocodes the address via the ArcGIS World Geocoder and then queries the city's refuse and recycle zone layers to determine your weekly trash and recycling pickup days.
+Use your full street address including city, state, and ZIP code (e.g. "301 King St, Alexandria, VA 22314"). The source geocodes the address via the ArcGIS World Geocoder and then queries the city's refuse, recycle and leaf zone layers to determine your trash, recycling and seasonal leaf collection dates.
 
-Note: Trash is collected for all city residential customers. Recycling is only returned for addresses eligible for city recycling service; addresses without city recycling (e.g. some multi-family or commercial buildings) will only show trash collection. The schedule is a fixed weekly pickup day and does not account for holiday shifts.
+Returned collection types:
+
+- **Trash** — weekly, for all city residential customers.
+- **Recycling** — weekly, only for addresses eligible for city recycling service. Addresses without city recycling (e.g. some multi-family or commercial buildings) will not show recycling.
+- **Leaf Collection** — seasonal vacuum-leaf collection passes (fall/winter) with explicit dates. The city's data only holds the current season, so leaf entries appear only during the leaf-collection period and are absent the rest of the year.
+
+Note: Trash and recycling are reported as a fixed weekly pickup day and do not account for holiday shifts.

--- a/doc/source/alexandria_va_us.md
+++ b/doc/source/alexandria_va_us.md
@@ -1,0 +1,36 @@
+# Alexandria, VA
+
+Support for schedules provided by [City of Alexandria, VA](https://www.alexandriava.gov/RefuseCollection).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: alexandria_va_us
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Full street address including city and state.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: alexandria_va_us
+      args:
+        address: 301 King St, Alexandria, VA 22314
+```
+
+## How to get the source arguments
+
+Use your full street address including city, state, and ZIP code (e.g. "301 King St, Alexandria, VA 22314"). The source geocodes the address via the ArcGIS World Geocoder and then queries the city's refuse and recycle zone layers to determine your weekly trash and recycling pickup days.
+
+Note: Trash is collected for all city residential customers. Recycling is only returned for addresses eligible for city recycling service; addresses without city recycling (e.g. some multi-family or commercial buildings) will only show trash collection. The schedule is a fixed weekly pickup day and does not account for holiday shifts.


### PR DESCRIPTION
## Summary

 Adds trash, recycling, and seasonal leaf collection schedules for the City of Alexandria, Virginia

The city publishes its collection zones through a public ArcGIS REST service ([alx311Info MapServer](https://maps.alexandriava.gov/alexmaps/rest/services/alx311Info/MapServer)). There is no ICS feed, so a dedicated source is the appropriate approach.

Structurally mirrors the existing chesapeake_va_us.py source.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
