### PR TITLE
Fixing URLs

### DIFF
--- a/doc/source/recyclecoach_com.md
+++ b/doc/source/recyclecoach_com.md
@@ -61,14 +61,14 @@ mentioned above.
 
 Now, to get the `zone_id`, use the following URL:
 
-    https://api-city.recyclecoach.com/zone-setup/address?sku=<project_id>&district=<district_id>&prompt=undefined&term=<specific address>
+    https://api-city.recyclecoach.com/zone-setup/address?sku=<project_id>&district=<district_id>&term=<specific address>
 
 Use the `project_id` and `district_id` from the last step. Replace
 `<specific address>` with your specific address.
 
 For example:
 
-    https://api-city.recyclecoach.com/zone-setup/address?sku=3107&district=OLYMP&prompt=undefined&term=250 Main St
+    https://api-city.recyclecoach.com/zone-setup/address?sku=3107&district=OLYMP&term=250 Main St
 
 This will produce another JSON blob, which contains some potential matches.
 Each result will have a "zones" key. Pick the best match, probably the first on the list.


### PR DESCRIPTION
## Summary

`prompt=undefined` is not needed to obtain the Zone ID; and causes the API to not return the zone ID

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [X] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
