### PR TITLE
Add human-readable daysToText attribute to sensors (#6534)

### DIFF
--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -51,6 +51,15 @@ class DetailsFormat(Enum):
     hidden = "hidden"  # hide details
 
 
+def get_days_to_text(days: int) -> str:
+    """Return a human-readable string for days until collection."""
+    if days == 0:
+        return "Today"
+    if days == 1:
+        return "Tomorrow"
+    return f"in {days} days"
+
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_NAME): cv.string,
@@ -383,6 +392,7 @@ class ScheduleSensor(SensorEntity):
         if len(upcoming1) > 0:
             if self._add_days_to:
                 attributes["daysTo"] = upcoming1[0].daysTo
+                attributes["daysToText"] = get_days_to_text(upcoming1[0].daysTo)
 
         self._attr_extra_state_attributes = attributes
         self._add_refreshtime()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,22 @@
+"""Tests for sensor logic."""
+
+__author__ = "Coderzz69"
+
+from custom_components.waste_collection_schedule.sensor import get_days_to_text
+
+
+def test_get_days_to_text_today():
+    """Test that 0 days returns 'Today'."""
+    assert get_days_to_text(0) == "Today"
+
+
+def test_get_days_to_text_tomorrow():
+    """Test that 1 day returns 'Tomorrow'."""
+    assert get_days_to_text(1) == "Tomorrow"
+
+
+def test_get_days_to_text_future():
+    """Test that >1 days returns formatted string."""
+    assert get_days_to_text(2) == "in 2 days"
+    assert get_days_to_text(7) == "in 7 days"
+    assert get_days_to_text(11) == "in 11 days"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,5 @@
 """Tests for sensor logic."""
 
-__author__ = "Coderzz69"
-
 from custom_components.waste_collection_schedule.sensor import get_days_to_text
 
 


### PR DESCRIPTION
## Summary

Fixes #6534 

This PR adds a human-readable `daysToText` string to the `extra_state_attributes` of the sensor (e.g. "Today", "Tomorrow", "in X days"). 

Currently, the default state can be overwritten by users with a `value_template` to isolate the integer for conditions, but this strips out the human-readable formatting, making it difficult to use in dashboard elements like Badges that do not natively support templating. By surfacing `daysToText` directly in the attributes alongside the existing numeric `daysTo`, users can easily map the raw integer to automations and the formatted string to UI Badges without needing to create secondary template sensors.

Additionally, this PR introduces a standalone test suite in `tests/test_sensor.py` to ensure the core logic handles the integer mappings correctly across edge cases (`0`, `1`, `> 1` days).

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [x] Other (Feature enhancement & tests)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources (N/A)
- [ ] TEST_CASES use real, publicly accessible addresses (not my own) (N/A)
