### PR TITLE
Fix West Suffolk ICON_MAP and year parsing (#6583)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westsuffolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westsuffolk_gov_uk.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import requests
 from bs4 import BeautifulSoup, Tag
 from dateutil import parser
@@ -16,8 +18,13 @@ TEST_CASES = {
 
 ICON_MAP = {
     "Black bin": Icons.GENERAL_WASTE,
+    "Black Bins": Icons.GENERAL_WASTE,
     "Brown bin": Icons.BIO_KITCHEN,
+    "Brown Bins": Icons.BIO_KITCHEN,
     "Blue bin": Icons.RECYCLING,
+    "Blue Bins": Icons.RECYCLING,
+    "Food Bins": Icons.BIO_KITCHEN,
+    "Green Bins": Icons.GARDEN,
 }
 
 
@@ -51,16 +58,16 @@ class Source:
         for collection in waste_panel.contents:
             if isinstance(collection, Tag):
                 if collection.name == "strong":
-                    bin_type = " ".join(
-                        a.strip()
-                        for a in collection.text.strip().strip(":").split("\n")
-                    ).replace("   ", " ")
+                    bin_type = " ".join(collection.text.strip().strip(":").split())
                 continue
 
             collection = collection.strip()
             date_str = collection.strip()
             # date: Saturday 30th December
             coll_date = parser.parse(date_str).date()
+            if (datetime.now().date() - coll_date).days > 180:
+                coll_date = coll_date.replace(year=coll_date.year + 1)
+
             entries.append(
                 Collection(date=coll_date, t=bin_type, icon=ICON_MAP.get(bin_type))
             )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westsuffolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westsuffolk_gov_uk.py
@@ -54,6 +54,7 @@ class Source:
 
         bin_type = None
         entries = []
+        today = datetime.now().date()
 
         for collection in waste_panel.contents:
             if isinstance(collection, Tag):
@@ -65,7 +66,7 @@ class Source:
             date_str = collection.strip()
             # date: Saturday 30th December
             coll_date = parser.parse(date_str).date()
-            if (datetime.now().date() - coll_date).days > 180:
+            if (today - coll_date).days > 180:
                 coll_date = coll_date.replace(year=coll_date.year + 1)
 
             entries.append(


### PR DESCRIPTION
## Summary

Fixes #6583 

This PR addresses two bugs with the `westsuffolk_gov_uk` source:
1. **Year Rollover Bug:** The source parsed dates like `"Saturday 30th December"` using the current year. When crossing into January, this caused dates to be parsed 11 months in the past, resulting in schedules silently disappearing over the new year period. A 6-month timedelta check has been added to automatically increment the year for future dates.
2. **Missing Icons:** West Suffolk introduced new text formatting (e.g. `"Green     Bins:"` with multiple spaces) and new bin types (`"Food Bins"`). The scraper now strips extraneous whitespaces and maps the pluralised bin types correctly in the `ICON_MAP` so that `mdi:food-apple`, `mdi:trash-can`, `mdi:recycle`, and `mdi:flower` are properly assigned.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources (N/A)
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
