### PR TITLE
fix(de): rebuild ahe_de source on abfallplus platform after atino.net shutdown

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -288,6 +288,7 @@ MAP_APP_USERAGENTS = {
     "abfallMA.ucom.de": "Abfall-Ma",
     "de.ahrweiler.meinawb": "Abfall App",
     "de.abfallwecker": "ABFALL+",
+    "de.abfallplus.ahe": "AHE",
     "de.albagroup.app": "Abfuhrtermine",
     "de.biberach.abfallapp": "Abfall App",
     "de.cmcitymedia.hokwaste": "Abfallinfo HOK",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ahe_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ahe_de.py
@@ -1,122 +1,64 @@
-import requests
-from bs4 import BeautifulSoup
+import waste_collection_schedule.service.AppAbfallplusDe as AppAbfallplusDe
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import (
-    SourceArgumentNotFound,
-    SourceArgumentNotFoundWithSuggestions,
-)
-from waste_collection_schedule.service.ICS import ICS
 
 TITLE = "AHE Ennepe-Ruhr-Kreis"
 DESCRIPTION = "Source for AHE Ennepe-Ruhr-Kreis."
 URL = "https://ahe.de"
+COUNTRY = "de"
 TEST_CASES = {
-    "58300 Ahornstraße 1": {"plz": "58300", "strasse": "Ahornstraße", "hnr": 1},
-    "58313 Alte Straße 1": {"plz": 58313, "strasse": "alte STraße", "hnr": "1"},
+    "Wetter Ahornstraße 1": {
+        "city": "Wetter",
+        "strasse": "Ahornstraße",
+        "hnr": "1",
+    },
+    "Herdecke Alte Straße 1": {
+        "city": "Herdecke",
+        "strasse": "Alte Straße",
+        "hnr": "1",
+    },
 }
 
-
 ICON_MAP = {
-    "Restabfall": Icons.GENERAL_WASTE,
-    "Bioabfall": Icons.BIO_KITCHEN,
-    "Papier": Icons.PAPER,
-    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "restabfall": Icons.GENERAL_WASTE,
+    "restmüll": Icons.GENERAL_WASTE,
+    "bioabfall": Icons.BIO_KITCHEN,
+    "bio": Icons.ORGANIC,
+    "papier": Icons.PAPER,
+    "gelber sack": Icons.PLASTIC_PACKAGING,
+    "wertstoff": Icons.RECYCLING,
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
-    "en": "Find the parameter of your address using [https://ahe.atino.net/pickup-dates](https://ahe.atino.net/pickup-dates) and write them exactly like on the web page."
+    "en": "Visit [https://ahe.de/abfallkalender/](https://ahe.de/abfallkalender/) and select your city and street. Use the exact city name as the `city` parameter (e.g. `Wetter`, `Herdecke`, `Gevelsberg`)."
 }
 
-
-API_URL = "https://ahe.atino.net/{search}"
-SEARCH_API_URL = API_URL.format(search="search/{search}")
+APP_ID = "de.abfallplus.ahe"
 
 
 class Source:
-    def __init__(self, plz: str | int, strasse: str, hnr: str | int):
-        self._plz: str = str(plz).strip()
-        self._strasse: str = strasse
-        self._hnr: str | int = hnr
-        self._ics = ICS()
-
-    def fetch(self):
-        s = requests.Session()
-        r = s.get(API_URL.format(search="pickup-dates"))
-        r.raise_for_status()
-
-        token = BeautifulSoup(r.text, "html.parser").find(
-            "input", {"name": "pickup_date[_token]"}
-        )["value"]
-
-        r = s.get(
-            SEARCH_API_URL.format(search="postalcode"),
-            params={
-                "q": self._plz,
-            },
+    def __init__(
+        self,
+        city: str,
+        strasse: str,
+        hnr: str | int | None = None,
+        bezirk: str | None = None,
+    ):
+        self._app = AppAbfallplusDe.AppAbfallplusDe(
+            app_id=APP_ID,
+            kommune=city,
+            strasse=strasse,
+            hnr=str(hnr) if isinstance(hnr, int) else hnr,
+            bezirk=bezirk,
         )
-        r.raise_for_status()
 
-        post_id = None
-        for entry in r.json():
-            if entry["text"] == self._plz.replace(" ", ""):
-                post_id = entry["id"]
-                break
-        if post_id is None:
-            raise SourceArgumentNotFound("plz", self._plz)
-
-        r = s.get(
-            SEARCH_API_URL.format(search="city"),
-            params={
-                "postalCode": self._plz,
-            },
-        )
-        r.raise_for_status()
-
-        data = r.json()
-        if "id" not in data:
-            raise SourceArgumentNotFound("plz", self._plz)
-
-        city_id = data["id"]
-
-        r = s.get(
-            SEARCH_API_URL.format(search="street"),
-            params={"cityId": city_id, "q": self._strasse},
-        )
-        r.raise_for_status()
-
-        street_id = None
-        data = r.json()
-        for entry in data:
-            if (
-                entry["name"].replace(" ", "").replace(" ", "").strip().lower()
-                == self._strasse.replace(" ", "").replace(" ", "").strip().lower()
-            ):
-                street_id = entry["id"]
-                break
-        if street_id is None:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "strasse", self._strasse, (entry["name"] for entry in data)
-            )
-
-        data = {
-            "pickup_date[postalCode]": post_id,
-            "fake_pickup_date[postalCode]": post_id,
-            "pickup_date[street]": street_id,
-            "pickup_date[houseNumber]": self._hnr,
-            "pickup_date[format]": "1",
-            "pickup_date[submit]": "",
-            "pickup_date[_token]": token,
-        }
-        r = s.post(API_URL.format(search="pickup-dates"), data=data)
-        r.raise_for_status()
-        if "Es wurden keine Termine gefunden." in r.text:
-            raise Exception(
-                "No dates found for provided addresses please check https://ahe.atino.net/pickup-dates"
-            )
-
-        dates = self._ics.convert(r.text)
-
+    def fetch(self) -> list[Collection]:
         entries = []
-        for d in dates:
-            entries.append(Collection(d[0], d[1], icon=ICON_MAP.get(d[1])))
+        for d in self._app.generate_calendar():
+            bin_type = d["category"]
+            icon = None
+            for name, icon_value in ICON_MAP.items():
+                if name in bin_type.lower():
+                    icon = icon_value
+                    break
+            entries.append(Collection(date=d["date"], t=bin_type, icon=icon))
         return entries

--- a/doc/source/ahe_de.md
+++ b/doc/source/ahe_de.md
@@ -9,22 +9,28 @@ waste_collection_schedule:
     sources:
     - name: ahe_de
       args:
-        plz: POSTLEITZAHL
+        city: STADT
         strasse: STRAßE
         hnr: HAUSNUMMER
-        
 ```
 
 ### Configuration Variables
 
-**plz**  
-*(String | Integer) (required)*
-
-**strasse**  
+**city**
 *(String) (required)*
 
-**hnr**  
-*(String | Integer) (required)*
+City name. Supported cities: Breckerfeld, Ennepetal, Gevelsberg, Hagen, Hattingen, Herdecke, Schwelm, Sprockhövel, Wetter, Witten.
+
+**strasse**
+*(String) (required)*
+
+**hnr**
+*(String | Integer) (optional)*
+
+**bezirk**
+*(String) (optional)*
+
+Required for some streets that are divided into named districts.
 
 ## Example
 
@@ -33,12 +39,13 @@ waste_collection_schedule:
     sources:
     - name: ahe_de
       args:
-        plz: 58300
+        city: Wetter
         strasse: Ahornstraße
         hnr: 1
-        
 ```
 
 ## How to get the source argument
 
-Find the parameter of your address using [https://ahe.atino.net/pickup-dates](https://ahe.atino.net/pickup-dates) and write them exactly like on the web page.
+Visit [https://ahe.de/abfallkalender/](https://ahe.de/abfallkalender/) and select your city and street.
+
+> **Migration note (from pre-July 2026 config):** The old `plz` (postal code) parameter is no longer supported. Replace it with `city` (city name, e.g. `Wetter`, `Herdecke`).


### PR DESCRIPTION
## Summary
- `ahe.atino.net` is fully decommissioned as of 2026-07-01; every call to the old API returns 404.
- AHE confirmed migration to the abfallplus platform at https://ahe.de/abfallkalender/ (Android package `de.abfallplus.ahe`).
- Rewrites `ahe_de.py` to wrap the existing `AppAbfallplusDe` service, which handles the new API.
- Adds `de.abfallplus.ahe` to `MAP_APP_USERAGENTS` in `AppAbfallplusDe.py`.
- **Breaking change:** the `plz` parameter is replaced by `city` (city name, e.g. `Wetter`, `Herdecke`). Existing YAML configs must be updated.

Supported cities: Breckerfeld, Ennepetal, Gevelsberg, Hagen, Hattingen, Herdecke, Schwelm, Sprockhövel, Wetter, Witten.

## Test plan
- [ ] Live test passes: `python test_sources.py -s ahe_de -l`
- [ ] Structural test passes: `python -m pytest tests/test_source_components.py -q`
- [ ] Doc file reflects new parameters

Closes #6740

🤖 Generated with [Claude Code](https://claude.com/claude-code)