### PR TITLE
feat(source): add Westminster City Council (UK) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+from urllib.parse import quote
 
 import requests
 from bs4 import BeautifulSoup
@@ -126,9 +127,9 @@ def _days_from_row(cells, cols) -> set[int]:
     return days
 
 
-def _extract_pairs(soup) -> set:
+def _extract_pairs(soup) -> set[tuple[str, int]]:
     """Parse the rubbish + recycling panels into deduped (waste_type, weekday) pairs."""
-    pairs: set = set()
+    pairs: set[tuple[str, int]] = set()
 
     rubbish = soup.find("div", id="pnlrubbishcollection")
     if rubbish is not None:
@@ -173,7 +174,7 @@ class Source:
 
     def fetch(self) -> list[Collection]:
         response = requests.get(
-            API_URL.format(usrn=self._usrn), headers=HEADERS, timeout=30
+            API_URL.format(usrn=quote(self._usrn)), headers=HEADERS, timeout=30
         )
         response.raise_for_status()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -135,6 +135,12 @@ def _extract_pairs(soup) -> set:
             cols = _column_index(table)
             for row in _data_rows(table):
                 cells = row.find_all(["td", "th"])
+                # A row with a different cell count than the header (e.g. a
+                # merged/omitted cell) can't be trusted to align positionally
+                # with `cols` — skip it rather than silently reading the
+                # wrong column.
+                if len(cells) != len(cols):
+                    continue
                 for weekday in _days_from_row(cells, cols):
                     pairs.add((RUBBISH_TYPE, weekday))
 
@@ -146,6 +152,8 @@ def _extract_pairs(soup) -> set:
             sd = cols.get("service description")
             for row in _data_rows(table):
                 cells = row.find_all(["td", "th"])
+                if len(cells) != len(cols):
+                    continue
                 if sd is None or sd >= len(cells):
                     continue
                 waste_type = cells[sd].get_text(strip=True)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -98,6 +98,65 @@ def _get_icon(waste_type: str) -> Icons | None:
     return ICON_MAP.get(waste_type)
 
 
+def _column_index(table) -> dict[str, int]:
+    """Map lowercased header-cell text -> column index for a table's first row."""
+    header = table.find("tr")
+    cols: dict[str, int] = {}
+    if header is None:
+        return cols
+    for i, cell in enumerate(header.find_all(["th", "td"])):
+        cols[cell.get_text(strip=True).lower()] = i
+    return cols
+
+
+def _data_rows(table):
+    """All rows after the header row."""
+    return table.find_all("tr")[1:]
+
+
+def _days_from_row(cells, cols) -> set[int]:
+    """Union of Week Days + Weekend Days cells for one row."""
+    days: set[int] = set()
+    for key in ("week days", "weekend days"):
+        idx = cols.get(key)
+        if idx is not None and idx < len(cells):
+            days |= _parse_days(cells[idx].get_text())
+    return days
+
+
+def _extract_pairs(soup) -> set:
+    """Parse the rubbish + recycling panels into deduped (waste_type, weekday) pairs."""
+    pairs: set = set()
+
+    rubbish = soup.find("div", id="pnlrubbishcollection")
+    if rubbish is not None:
+        table = rubbish.find("table")
+        if table is not None:
+            cols = _column_index(table)
+            for row in _data_rows(table):
+                cells = row.find_all(["td", "th"])
+                for weekday in _days_from_row(cells, cols):
+                    pairs.add((RUBBISH_TYPE, weekday))
+
+    recycling = soup.find("div", id="pnlrecyclingcollections")
+    if recycling is not None:
+        table = recycling.find("table")
+        if table is not None:
+            cols = _column_index(table)
+            sd = cols.get("service description")
+            for row in _data_rows(table):
+                cells = row.find_all(["td", "th"])
+                if sd is None or sd >= len(cells):
+                    continue
+                waste_type = cells[sd].get_text(strip=True)
+                if not waste_type:
+                    continue
+                for weekday in _days_from_row(cells, cols):
+                    pairs.add((waste_type, weekday))
+
+    return pairs
+
+
 class Source:
     def __init__(self, usrn):
         self._usrn = str(usrn)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -93,6 +93,11 @@ def _parse_days(text: str) -> set[int]:
     return result
 
 
+def _get_icon(waste_type: str):
+    """Return the mapped Icons member for a waste type, or None if unmapped."""
+    return ICON_MAP.get(waste_type)
+
+
 class Source:
     def __init__(self, usrn):
         self._usrn = str(usrn)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -10,7 +10,9 @@ DESCRIPTION = "Source for Westminster City Council (London, UK) bin collections.
 URL = "https://www.westminster.gov.uk"
 COUNTRY = "uk"
 
-API_URL = "https://transact.westminster.gov.uk/env/streetreport.aspx?Street=NA&USRN={usrn}"
+API_URL = (
+    "https://transact.westminster.gov.uk/env/streetreport.aspx?Street=NA&USRN={usrn}"
+)
 
 TEST_CASES = {
     "Shirland Mews (short street)": {"usrn": "8400172"},
@@ -169,5 +171,32 @@ class Source:
     def __init__(self, usrn):
         self._usrn = str(usrn)
 
-    def fetch(self):
-        raise NotImplementedError
+    def fetch(self) -> list[Collection]:
+        response = requests.get(
+            API_URL.format(usrn=self._usrn), headers=HEADERS, timeout=30
+        )
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        pairs = _extract_pairs(soup)
+        if not pairs:
+            raise SourceArgumentNotFound(
+                "usrn",
+                f"No collections found for USRN '{self._usrn}'. Check the USRN is correct.",
+            )
+
+        today = date.today()
+        horizon_end = today + timedelta(days=_HORIZON_DAYS)
+
+        entries: list[Collection] = []
+        for waste_type, weekday in pairs:
+            offset = (weekday - today.weekday()) % 7
+            collection_date = today + timedelta(days=offset)
+            icon = _get_icon(waste_type)
+            while collection_date <= horizon_end:
+                entries.append(
+                    Collection(date=collection_date, t=waste_type, icon=icon)
+                )
+                collection_date += timedelta(days=7)
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -190,7 +190,7 @@ class Source:
         horizon_end = today + timedelta(days=_HORIZON_DAYS)
 
         entries: list[Collection] = []
-        for waste_type, weekday in pairs:
+        for waste_type, weekday in sorted(pairs):
             offset = (weekday - today.weekday()) % 7
             collection_date = today + timedelta(days=offset)
             icon = _get_icon(waste_type)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -56,6 +56,42 @@ PARAM_DESCRIPTIONS = {
     },
 }
 
+_WEEKDAYS = {
+    "mon": 0,
+    "tue": 1,
+    "wed": 2,
+    "thu": 3,
+    "fri": 4,
+    "sat": 5,
+    "sun": 6,
+}
+
+
+def _parse_days(text: str) -> set[int]:
+    """Expand a day cell (e.g. 'Tue, Fri', 'Mon-Fri') into weekday() indices."""
+    text = text.replace("\xa0", " ")
+    result: set[int] = set()
+    for token in text.split(","):
+        token = token.strip().lower()
+        if not token:
+            continue
+        if "-" in token:
+            start, _, end = token.partition("-")
+            s = _WEEKDAYS.get(start.strip()[:3])
+            e = _WEEKDAYS.get(end.strip()[:3])
+            if s is None or e is None:
+                continue
+            if s <= e:
+                result.update(range(s, e + 1))
+            else:  # wrap-around range, e.g. Sat-Mon
+                result.update(range(s, 7))
+                result.update(range(0, e + 1))
+        else:
+            v = _WEEKDAYS.get(token[:3])
+            if v is not None:
+                result.add(v)
+    return result
+
 
 class Source:
     def __init__(self, usrn):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -93,7 +93,7 @@ def _parse_days(text: str) -> set[int]:
     return result
 
 
-def _get_icon(waste_type: str):
+def _get_icon(waste_type: str) -> Icons | None:
     """Return the mapped Icons member for a waste type, or None if unmapped."""
     return ICON_MAP.get(waste_type)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -1,0 +1,65 @@
+from datetime import date, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+TITLE = "Westminster City Council"
+DESCRIPTION = "Source for Westminster City Council (London, UK) bin collections."
+URL = "https://www.westminster.gov.uk"
+COUNTRY = "uk"
+
+API_URL = "https://transact.westminster.gov.uk/env/streetreport.aspx?Street=NA&USRN={usrn}"
+
+TEST_CASES = {
+    "Shirland Mews (short street)": {"usrn": "8400172"},
+    "Shirland Road (long street)": {"usrn": 8400243},
+}
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/117.0",
+}
+
+SOURCE_CODEOWNERS = ["@parmymansam"]
+
+# The recurring weekly schedule has no end date; project this far ahead.
+_HORIZON_DAYS = 365
+
+# Waste type for the rubbish panel (that table has no per-row type column).
+RUBBISH_TYPE = "Residential rubbish and commercial waste"
+
+ICON_MAP = {
+    "Residential rubbish and commercial waste": Icons.GENERAL_WASTE,
+    "Food Recycling Collection": Icons.BIO_KITCHEN,
+    "Recycling Collection": Icons.RECYCLING,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "You need the USRN (Unique Street Reference Number) for your street. Find it "
+        "by searching your street on https://www.findmyaddress.co.uk or by inspecting "
+        "the USRN value in the URL of Westminster's own street-report search at "
+        "https://transact.westminster.gov.uk/env/streetreport.aspx"
+    ),
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "usrn": "USRN",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "usrn": "Unique Street Reference Number (USRN) for your street.",
+    },
+}
+
+
+class Source:
+    def __init__(self, usrn):
+        self._usrn = str(usrn)
+
+    def fetch(self):
+        raise NotImplementedError

--- a/doc/source/westminster_gov_uk.md
+++ b/doc/source/westminster_gov_uk.md
@@ -1,0 +1,40 @@
+# Westminster City Council
+
+Support for waste collection schedules provided by [Westminster City Council](https://www.westminster.gov.uk), for the City of Westminster in London, UK.
+
+Westminster publishes a recurring **weekly** schedule per street, keyed by USRN (Unique Street Reference Number). This source reads the rubbish and recycling tables for your street and projects the weekly schedule one year ahead. (The street-cleaning schedule is not included.)
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: westminster_gov_uk
+      args:
+        usrn: USRN
+```
+
+### Configuration Variables
+
+**usrn** _(string) (required)_: The Unique Street Reference Number (USRN) for your street.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: westminster_gov_uk
+      args:
+        usrn: "8400172"
+```
+
+## How to find your USRN
+
+Your USRN identifies your street. You can find it by:
+
+- Searching your street name at [FindMyAddress](https://www.findmyaddress.co.uk) and reading the USRN, or
+- Opening Westminster's own [street-report search](https://transact.westminster.gov.uk/env/streetreport.aspx) for your street and copying the `USRN` value from the page URL.
+
+Examples of valid USRNs:
+- `8400172` (Shirland Mews)
+- `8400243` (Shirland Road)

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -66,3 +66,7 @@ def test_parse_days_empty_and_nbsp():
 
 def test_parse_days_ignores_unknown_tokens():
     assert westminster_gov_uk._parse_days("Someday, Tue") == {1}
+
+
+def test_parse_days_wraparound_range():
+    assert westminster_gov_uk._parse_days("Fri-Mon") == {0, 4, 5, 6}

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -29,7 +29,6 @@ from waste_collection_schedule import Icons  # noqa: E402
 from waste_collection_schedule.exceptions import SourceArgumentNotFound  # noqa: E402
 from waste_collection_schedule.source import westminster_gov_uk  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Section 1: _parse_days (pure function)
 # ---------------------------------------------------------------------------

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -96,3 +96,80 @@ def test_get_icon_recycling():
 
 def test_get_icon_unknown_returns_none():
     assert westminster_gov_uk._get_icon("Some New Service") is None
+
+
+# ---------------------------------------------------------------------------
+# Section 3: _extract_pairs (panel parser)
+# ---------------------------------------------------------------------------
+
+# Minimal page mirroring the live structure: a long-street rubbish row using a
+# Mon-Fri range + Sat, Sun weekend, two recycling rows, and a street-cleaning
+# panel that must be ignored.
+FULL_HTML = """
+<html><body>
+<div id="pnlrubbishcollection">
+<table>
+<tr><th>Location</th><th>Week Days</th><th>Week Times</th><th>Weekend Days</th><th>Weekend Times</th></tr>
+<tr><td>Some St (BOS)</td><td>Mon-Fri</td><td>09:00 - 10:00</td><td>Sat, Sun</td><td>09:00 - 10:00</td></tr>
+</table>
+</div>
+<div id="pnlrecyclingcollections">
+<table>
+<tr><th>Location</th><th>Service Description</th><th>Week Days</th><th>Week Times</th><th>Weekend Days</th><th>Weekend Times</th></tr>
+<tr><td>Some St</td><td>Food Recycling Collection</td><td>Tue</td><td>08:00 - 14:00</td><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td>Some St (part)</td><td>Recycling Collection</td><td>Tue, Fri</td><td>08:00 - 14:00</td><td>&nbsp;</td><td>&nbsp;</td></tr>
+</table>
+</div>
+<div id="pnlstreetcleaning">
+<table>
+<tr><th>Location</th><th>Service Description</th><th>Week Days</th><th>Weekend Days</th></tr>
+<tr><td>Some St</td><td>Your street will be swept on…</td><td>Mon - Fri</td><td>Sat, Sun</td></tr>
+</table>
+</div>
+</body></html>
+"""
+
+# A page for a USRN with no collections: panels present but no data rows.
+EMPTY_HTML = """
+<html><body>
+<div id="pnlrubbishcollection"><table>
+<tr><th>Location</th><th>Week Days</th><th>Week Times</th><th>Weekend Days</th><th>Weekend Times</th></tr>
+</table></div>
+<div id="pnlrecyclingcollections"><table>
+<tr><th>Location</th><th>Service Description</th><th>Week Days</th><th>Week Times</th><th>Weekend Days</th><th>Weekend Times</th></tr>
+</table></div>
+</body></html>
+"""
+
+
+def _pairs(html):
+    from bs4 import BeautifulSoup
+
+    return westminster_gov_uk._extract_pairs(BeautifulSoup(html, "html.parser"))
+
+
+def test_extract_pairs_rubbish_all_seven_days():
+    pairs = _pairs(FULL_HTML)
+    for weekday in range(7):
+        assert (westminster_gov_uk.RUBBISH_TYPE, weekday) in pairs
+
+
+def test_extract_pairs_recycling_types():
+    pairs = _pairs(FULL_HTML)
+    assert ("Food Recycling Collection", 1) in pairs
+    assert ("Recycling Collection", 1) in pairs
+    assert ("Recycling Collection", 4) in pairs
+
+
+def test_extract_pairs_total_count():
+    # 7 rubbish + 1 food + 2 recycling = 10 deduped pairs
+    assert len(_pairs(FULL_HTML)) == 10
+
+
+def test_extract_pairs_skips_street_cleaning():
+    pairs = _pairs(FULL_HTML)
+    assert not any("swept" in t.lower() for t, _ in pairs)
+
+
+def test_extract_pairs_empty_page_yields_no_pairs():
+    assert _pairs(EMPTY_HTML) == set()

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for Westminster City Council waste collection source.
+
+Note: This test file is not auto-discovered by pytest due to pytest.ini configuration
+(python_files = test_source_components.py). Run it explicitly:
+
+    pytest tests/test_westminster_gov_uk.py -v
+"""
+
+import os
+import sys
+from datetime import date as real_date
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule import Icons  # noqa: E402
+from waste_collection_schedule.exceptions import SourceArgumentNotFound  # noqa: E402
+from waste_collection_schedule.source import westminster_gov_uk  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Section 1: _parse_days (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_days_comma_list():
+    assert westminster_gov_uk._parse_days("Tue, Fri") == {1, 4}
+
+
+def test_parse_days_hyphen_range_no_spaces():
+    assert westminster_gov_uk._parse_days("Mon-Fri") == {0, 1, 2, 3, 4}
+
+
+def test_parse_days_hyphen_range_with_spaces():
+    assert westminster_gov_uk._parse_days("Mon - Fri") == {0, 1, 2, 3, 4}
+
+
+def test_parse_days_weekend():
+    assert westminster_gov_uk._parse_days("Sat, Sun") == {5, 6}
+
+
+def test_parse_days_full_comma_list():
+    assert westminster_gov_uk._parse_days("Mon, Tue, Wed, Thu, Fri") == {0, 1, 2, 3, 4}
+
+
+def test_parse_days_single_day():
+    assert westminster_gov_uk._parse_days("Tue") == {1}
+
+
+def test_parse_days_empty_and_nbsp():
+    assert westminster_gov_uk._parse_days("") == set()
+    assert westminster_gov_uk._parse_days("\xa0") == set()
+
+
+def test_parse_days_ignores_unknown_tokens():
+    assert westminster_gov_uk._parse_days("Someday, Tue") == {1}

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -192,3 +192,103 @@ SHIFTED_ROW_HTML = """
 
 def test_extract_pairs_skips_row_with_mismatched_cell_count():
     assert _pairs(SHIFTED_ROW_HTML) == set()
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Source.fetch()
+# ---------------------------------------------------------------------------
+
+# 2026-06-01 is a Monday; pin date.today() for deterministic projection.
+FROZEN_MONDAY = real_date(2026, 6, 1)
+
+
+class MockResponse:
+    """Minimal requests.Response stand-in (the source reads .text)."""
+
+    def __init__(self, text="", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            from requests import HTTPError
+
+            raise HTTPError(f"HTTP {self.status_code}")
+
+
+def test_init_coerces_usrn_to_string():
+    s = westminster_gov_uk.Source(usrn=8400243)
+    assert s._usrn == "8400243"
+
+
+@patch("waste_collection_schedule.source.westminster_gov_uk.date")
+@patch("waste_collection_schedule.source.westminster_gov_uk.requests")
+def test_fetch_types_and_icons(mock_requests, mock_date):
+    mock_date.today.return_value = FROZEN_MONDAY
+    mock_requests.get.return_value = MockResponse(text=FULL_HTML)
+
+    entries = westminster_gov_uk.Source(usrn="8400243").fetch()
+
+    by_type = {e.type: e.icon for e in entries}
+    assert by_type["Residential rubbish and commercial waste"] == Icons.GENERAL_WASTE
+    assert by_type["Food Recycling Collection"] == Icons.BIO_KITCHEN
+    assert by_type["Recycling Collection"] == Icons.RECYCLING
+
+
+@patch("waste_collection_schedule.source.westminster_gov_uk.date")
+@patch("waste_collection_schedule.source.westminster_gov_uk.requests")
+def test_fetch_dates_within_horizon_and_future(mock_requests, mock_date):
+    mock_date.today.return_value = FROZEN_MONDAY
+    mock_requests.get.return_value = MockResponse(text=FULL_HTML)
+
+    entries = westminster_gov_uk.Source(usrn="8400243").fetch()
+
+    horizon_end = FROZEN_MONDAY + westminster_gov_uk.timedelta(
+        days=westminster_gov_uk._HORIZON_DAYS
+    )
+    for e in entries:
+        assert FROZEN_MONDAY <= e.date <= horizon_end
+
+
+@patch("waste_collection_schedule.source.westminster_gov_uk.date")
+@patch("waste_collection_schedule.source.westminster_gov_uk.requests")
+def test_fetch_food_dates_all_tuesdays(mock_requests, mock_date):
+    mock_date.today.return_value = FROZEN_MONDAY
+    mock_requests.get.return_value = MockResponse(text=FULL_HTML)
+
+    entries = westminster_gov_uk.Source(usrn="8400243").fetch()
+
+    food = [e for e in entries if e.type == "Food Recycling Collection"]
+    assert len(food) >= 50  # weekly across ~52 weeks
+    assert all(e.date.weekday() == 1 for e in food)  # Tuesday
+
+
+@patch("waste_collection_schedule.source.westminster_gov_uk.requests")
+def test_fetch_builds_url_with_usrn(mock_requests):
+    mock_requests.get.return_value = MockResponse(text=FULL_HTML)
+
+    westminster_gov_uk.Source(usrn="8400243").fetch()
+
+    called_url = mock_requests.get.call_args[0][0]
+    assert "USRN=8400243" in called_url
+    assert "Street=NA" in called_url
+
+
+@patch("waste_collection_schedule.source.westminster_gov_uk.requests")
+def test_fetch_raises_source_not_found_when_no_collections(mock_requests):
+    mock_requests.get.return_value = MockResponse(text=EMPTY_HTML)
+
+    with pytest.raises(SourceArgumentNotFound) as exc_info:
+        westminster_gov_uk.Source(usrn="0000000").fetch()
+
+    assert exc_info.value.argument == "usrn"
+
+
+@patch("waste_collection_schedule.source.westminster_gov_uk.requests")
+def test_fetch_http_error_propagates(mock_requests):
+    from requests import HTTPError
+
+    mock_requests.get.return_value = MockResponse(status_code=503)
+
+    with pytest.raises(HTTPError):
+        westminster_gov_uk.Source(usrn="8400243").fetch()

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -70,3 +70,29 @@ def test_parse_days_ignores_unknown_tokens():
 
 def test_parse_days_wraparound_range():
     assert westminster_gov_uk._parse_days("Fri-Mon") == {0, 4, 5, 6}
+
+
+# ---------------------------------------------------------------------------
+# Section 2: _get_icon (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_get_icon_rubbish():
+    assert (
+        westminster_gov_uk._get_icon("Residential rubbish and commercial waste")
+        == Icons.GENERAL_WASTE
+    )
+
+
+def test_get_icon_food():
+    assert (
+        westminster_gov_uk._get_icon("Food Recycling Collection") == Icons.BIO_KITCHEN
+    )
+
+
+def test_get_icon_recycling():
+    assert westminster_gov_uk._get_icon("Recycling Collection") == Icons.RECYCLING
+
+
+def test_get_icon_unknown_returns_none():
+    assert westminster_gov_uk._get_icon("Some New Service") is None

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -173,3 +173,22 @@ def test_extract_pairs_skips_street_cleaning():
 
 def test_extract_pairs_empty_page_yields_no_pairs():
     assert _pairs(EMPTY_HTML) == set()
+
+
+# A recycling row missing its leading Location cell (e.g. a merged/omitted
+# cell) has one fewer <td> than the header. This must be skipped rather than
+# silently reading each subsequent column shifted by one position.
+SHIFTED_ROW_HTML = """
+<html><body>
+<div id="pnlrecyclingcollections">
+<table>
+<tr><th>Location</th><th>Service Description</th><th>Week Days</th><th>Week Times</th><th>Weekend Days</th><th>Weekend Times</th></tr>
+<tr><td>Recycling Collection</td><td>Wed</td><td>Thu</td><td>&nbsp;</td><td>&nbsp;</td></tr>
+</table>
+</div>
+</body></html>
+"""
+
+
+def test_extract_pairs_skips_row_with_mismatched_cell_count():
+    assert _pairs(SHIFTED_ROW_HTML) == set()


### PR DESCRIPTION
## Summary

Adds a new source `westminster_gov_uk` for Westminster City Council (London, UK) bin collections. It scrapes the council's public street-report page (`transact.westminster.gov.uk/env/streetreport.aspx`), keyed by USRN (Unique Street Reference Number).

The page publishes a recurring **weekly** schedule (day-of-week, not calendar dates) across rubbish and recycling HTML panels. This source parses those into deduped `(waste_type, weekday)` pairs and projects them forward 365 days into dated `Collection` entries. The street-cleaning panel is intentionally out of scope (not a bin collection). Handles both simple (single-row) and long (multi-row, day-range) street layouts, verified live against two real USRNs.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)