### PR TITLE
feat(hvcgroep_nl): add Sliedrecht to supported organizations

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
@@ -41,6 +41,11 @@ TEST_CASES = {
         "house_number": "1",
         "service": "peelenmaas",
     },
+    "Sliedrecht": {
+        "postal_code": "3361AK",
+        "house_number": "397",
+        "service": "sliedrecht",
+    },
     "Tollebeek": {"postal_code": "8309AV", "house_number": "1"},
     "Hvcgroep: Tollebeek": {
         "postal_code": "8309AV",
@@ -199,6 +204,16 @@ SERVICE_MAP = [
             "appel-gft": "mdi:leaf",
             "doos-karton-papier": "mdi:archive",
             "doos-karton-blik-fles-glas-plastic-hero-logo": "mdi:recycle",
+        },
+    },
+    {
+        "title": "Gemeente Sliedrecht",
+        "api_url": "https://afvalkalender.sliedrecht.nl",
+        "icons": {
+            "plastic-blik-drinkpak": "mdi:recycle",
+            "gft": "mdi:leaf",
+            "papier-en-karton": "mdi:archive",
+            "restafval": "mdi:trash-can",
         },
     },
     {

--- a/doc/source/hvcgroep_nl.md
+++ b/doc/source/hvcgroep_nl.md
@@ -48,6 +48,7 @@ Use one of the following codes as service code:
 - prezero
 - purmerend
 - schouwen-duiveland
+- sliedrecht
 - spaarnelanden
 - sudwestfryslan
 - venray


### PR DESCRIPTION
## Summary

It adds Sliedrecht to the supported organizations by HVC Groep

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
