### PR TITLE
fix(uk): flag defunct newcastle_gov_uk, add Newcastle to ReCollect list

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_gov_uk.py
@@ -44,6 +44,16 @@ class Source:
         entries = []
         res = requests.get(f"{API_URL}?uprn={self._uprn}")
 
+        if "not currently available" in res.text:
+            _LOGGER.warning(
+                "Newcastle City Council has retired the community.newcastle.gov.uk "
+                "bin lookup used by this source. Bin collection info is now provided "
+                "via ReCollect (area 'NewcastleUponTyneUK') on "
+                "https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day "
+                "- please switch to the shared ReCollect ICS source, see "
+                "https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/ics/recollect.md"
+            )
+
         for section_match in SECTION_RE.finditer(res.text):
             collection_type = section_match.group(1)
             section_text = section_match.group(2)

--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -191,6 +191,9 @@ extra_info:
   - title: Atlantic Waste Services, GA
     url: https://atlanticwaste.com
     country: us
+  - title: Newcastle upon Tyne
+    url: https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day
+    country: uk
 
 howto:
   en: |
@@ -245,6 +248,7 @@ howto:
     |Oxford County, ON|Canada|[oxfordcounty.ca](https://www.oxfordcounty.ca/services-for-you/garbage-and-recycling/curbside-collection/)|
     |City of Coquitlam, BC|Canada|[coquitlam.ca](https://www.coquitlam.ca/157/Collection-Calendar-and-Guidelines)|
     |Atlantic Waste Services, GA|USA|[atlanticwaste.com](https://atlanticwaste.com)|
+    |Newcastle upon Tyne|UK|[new.newcastle.gov.uk](https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day)|
 
     and probably a lot more.
 

--- a/doc/source/newcastle_gov_uk.md
+++ b/doc/source/newcastle_gov_uk.md
@@ -4,6 +4,12 @@ Support for schedules provided by [Newcastle City Council](https://community.new
 
 **Note**: Collection schedule will only show the next date, not all future dates
 
+**Deprecation notice**: Newcastle City Council has retired the `community.newcastle.gov.uk` bin
+lookup that this source depends on. It now always returns an empty result. The council has
+moved bin collection information to [ReCollect](https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day)
+(area `NewcastleUponTyneUK`). Please switch to the shared [ReCollect ICS source](ics.md) instead
+— see [doc/ics/recollect.md](../ics/recollect.md) for setup instructions.
+
 ## Configuration via configuration.yaml
 
 ```yaml


### PR DESCRIPTION
## Summary
- Newcastle City Council has fully retired the `community.newcastle.gov.uk` bin
  lookup used by `newcastle_gov_uk.py`. Verified live against 5 different UPRNs
  (including both existing TEST_CASES) — every one now returns
  "The details are not currently available."
- The council's bin-day page (`new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day`)
  now embeds a ReCollect widget (`area: "NewcastleUponTyneUK"`), matching the
  approach already documented in `doc/ics/yaml/recollect.yaml` and the precedent
  set by `calgary_ca.py` for a similar migration.
- `newcastle_gov_uk.py` now logs an actionable warning pointing users at the
  ReCollect ICS alternative instead of failing silently with no explanation.
- Added Newcastle upon Tyne to the ReCollect shared-platform doc so users can
  migrate to a working setup today.

Fixes #6747

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed source file
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `python test_sources.py -s newcastle_gov_uk -l` — runs cleanly, logs the new warning, 0 entries (matches current live API behaviour)
- [x] Confirmed `doc/ics/yaml/recollect.yaml` still parses via `yaml.safe_load`