### PR TITLE
feat(burgerportaal_nl): add afvalbeheer, fix address_id typo

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/burgerportaal_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/burgerportaal_nl.py
@@ -31,6 +31,11 @@ TEST_CASES = {
         "house_number": 2,
         "addition": "A",
     },
+    "Barendrecht Albrandswaard Ridderkerk": {
+        "organization": "afvalbeheer",
+        "post_code": "2991AA",
+        "house_number": 1,
+    },
     "BAT Tilburg": {
         "organization": "bat",
         "post_code": "5071EN",
@@ -48,7 +53,14 @@ TEST_CASES = {
     },
 }
 
-Organization = Literal["assen", "bat", "groningen", "rmn", "utrecht"]
+Organization = Literal[
+    "assen",
+    "afvalbeheer",
+    "bat",
+    "groningen",
+    "rmn",
+    "utrecht",
+]
 
 SERVICE_MAP = [
     {
@@ -56,6 +68,12 @@ SERVICE_MAP = [
         "url": "https://www.assen.nl/",
         "uuid": "138204213565303512",
         "organization": "assen",
+    },
+    {
+        "title": "Barendrecht Albrandswaard Ridderkerk",
+        "url": "https://www.bar-afvalbeheer.nl/",
+        "uuid": "138204213564933497",
+        "organization": "afvalbeheer",
     },
     {
         "title": "BAT Tilburg",
@@ -113,8 +131,8 @@ class Source:
             f"https://www.googleapis.com/identitytoolkit/v3/relyingparty/signupNewUser?key={self._api_key}"
         )
         payload = res.json()
-        if not payload:
-            _LOGGER.error("Unable to fetch refresh token!")
+        if not payload or "refreshToken" not in payload:
+            _LOGGER.error(f"Unable to fetch refresh token: {payload}")
             return
 
         self._refresh_token = payload["refreshToken"]
@@ -150,7 +168,7 @@ class Source:
 
         for address in payload:
             if "addition" in address and address["addition"] == self._addition.upper():
-                self.address_id = address["addressId"]
+                self._address_id = address["addressId"]
 
         if not self._address_id:
             self._address_id = payload[-1]["addressId"]
@@ -159,12 +177,16 @@ class Source:
         # get refresh token and id token
         if not self._refresh_token:
             self._set_refresh_token()
+            if not self._refresh_token:
+                raise ValueError("Authentication token could not be retrieved")
         else:
             self._set_id_token()
 
         # get address id
         if not self._address_id:
             self._set_address_id()
+            if not self._address_id:
+                raise ValueError("Address ID could not be retrieved")
 
         headers = {"authorization": self._id_token}
         res = requests.get(

--- a/doc/source/burgerportaal_nl.md
+++ b/doc/source/burgerportaal_nl.md
@@ -21,6 +21,7 @@ waste_collection_schedule:
 
 Use one of the following codes as organization code:
 
+- afvalbeheer
 - assen
 - bat
 - groningen
@@ -40,6 +41,7 @@ For example if you house is `2A` you will put `A` here.
 
 ## Supported Operators
 
+- `afvalbeheer` (Barendrecht Albrandswaard Ridderkerk): <https://21burgerportaal.mendixcloud.com/p/afvalbeheer/landing/>
 - `assen` (Gemeente Assen): <https://21burgerportaal.mendixcloud.com/p/assen/landing/>
 - `bat` (BAT Tilburg): <https://21burgerportaal.mendixcloud.com/p/bat/landing/>
 - `groningen` (Gemeente Groningen): <https://21burgerportaal.mendixcloud.com/p/groningen/landing/>


### PR DESCRIPTION
## Summary

Adds `afvalbeheer` organization to the `burgerportaal_nl`. There was a typo in `_address_id` field which is fixed, and 2 new guards were added.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
