### PR TITLE
Rename test cases - south_norfolk_and_broadland

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/south_norfolk_and_broadland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/south_norfolk_and_broadland_gov_uk.py
@@ -27,7 +27,7 @@ EXTRA_INFO = [
     },
 ]
 TEST_CASES = {
-    "Random Broadland address": {
+    "Broadland residential address - UPRN payload": {
         "address_payload": {
             "Uprn": "010014355477",
             "Address": "29 Mallard Way, Sprowston, Norwich, Norfolk, NR7 8DN",
@@ -40,11 +40,11 @@ TEST_CASES = {
             "Authority": "2610",
         }
     },
-    "Random Broadland address new Method": {
+    "Broadland residential address - postcode": {
         "postcode": "NR7 8DN",
         "address": "29 Mallard Way, Sprowston, Norfolk, NR7 8DN",
     },
-    "Random South Norfolk address": {
+    "South Norfolk residential address - UPRN payload": {
         "address_payload": {
             "Uprn": "002630130840",
             "Address": "1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX",
@@ -57,11 +57,11 @@ TEST_CASES = {
             "Authority": "2630",
         }
     },
-    "Random South Norfolk address new Method": {
+    "South Norfolk residential address - postcode": {
         "postcode": "NR14 8BX",
         "address": "1 Brindle Drive, Mulbarton, Norfolk, NR14 8BX",
     },
-    "Big Tesco": {
+    "Broadland business address (Tesco) - UPRN payload": {
         "address_payload": {
             "Uprn": "100091575309",
             "Address": "Tesco Stores Ltd, Blue Boar Lane, Sprowston, Norwich, Norfolk, NR7 8AB",


### PR DESCRIPTION
Clarify test cases to make it clearer why they are all used.

## Summary

Just a minor text change to clarify each of the test cases in this source. They're all there for a reason and the name changes clarify those reasons a little better (two districts * two address methods = 4 tests, plus one additional test case for a business address which gets a different subset of services).

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [x] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
