### PR TITLE
Fix St Helens waste type matching when council label capitalisation changes

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_helens_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_helens_gov_uk.py
@@ -25,9 +25,9 @@ ICON_MAP = {
 }
 
 WASTE_TYPE_MAP = {
-    "General non-recyclable waste": "General Waste",
-    "Recycling": "Recycling",
-    "Garden waste": "Garden Waste",
+    "general non-recyclable waste": "General Waste",
+    "recycling": "Recycling",
+    "garden waste": "Garden Waste",
 }
 
 
@@ -188,7 +188,9 @@ class Source:
                     waste_types = [w.strip() for w in waste_description.split("&")]
 
                     for waste_type in waste_types:
-                        bin_type = WASTE_TYPE_MAP.get(waste_type)
+                        bin_type = WASTE_TYPE_MAP.get(
+                            " ".join(waste_type.split()).casefold()
+                        )
                         if bin_type:
                             entries.append(
                                 Collection(


### PR DESCRIPTION
## Summary

This makes waste type matching in the St Helens Council source case-insensitive and more robust against changes to whitespace.

This follows on from #6424, which added support for garden waste collections. The council appears to have varied the returned label capitalisation from `Garden waste` to `Garden Waste`. Since the current lookup is an exact string match, the garden waste row can be parsed but then silently skipped.

The change keeps the canonical output labels unchanged, for example `Garden Waste`, but normalises the council-provided waste type before looking it up in `WASTE_TYPE_MAP`.

Tested locally in Home Assistant:

- before the change, `calendar.get_events` returned `Recycling` only for the next collection date;
- after applying the change, restarting Home Assistant, and running `waste_collection_schedule.fetch_data`, the garden waste collection was returned correctly.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/.md` created for new sources — N/A, this is not a new source
- [x] TEST_CASES use real, publicly accessible addresses (not my own) — no TEST_CASES changed