### PR TITLE
fix(braintree_gov_uk):

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/braintree_gov_uk.py
@@ -13,9 +13,18 @@ TEST_CASES = {
     "20 Peel Crescent": {"house_number": "20", "post_code": "CM7 2RS"},
     "Causeway House": {"house_number": "Causeway House", "post_code": "CM7 9HB"},
 }
+NAME_MAP = {
+    "Non-recyclable waste(grey bin)": "Grey Bin",
+    "Outdoorfood caddy": "Food Bin",
+    "Outdoor food caddy": "Food Bin",
+    "Mixed recycling(blue-lidded bin)": "Mixed Recycling",
+    "Paper and card recycling(red-lidded bin)": "Paper & Card",
+    "Garden bin(green bin)": "Garden Bin",
+}
 ICON_MAP = {
     "Grey Bin": Icons.GENERAL_WASTE,
-    "Clear Sack": Icons.RECYCLING,
+    "Mixed Recycling": Icons.RECYCLING,
+    "Paper & Card": Icons.PAPER,
     "Garden Bin": Icons.GARDEN,
     "Food Bin": Icons.BIO_KITCHEN,
 }
@@ -58,7 +67,9 @@ class Source:
         ):
             try:
                 collection_info = results.text.strip().split("\n")
-                collection_type = collection_info[0].strip()
+                collection_type = NAME_MAP.get(
+                    collection_info[0].strip(), collection_info[0].strip()
+                )
 
                 # Skip if no collection date is found
                 if len(collection_info) < 2:


### PR DESCRIPTION
## Summary

Braintree District Council recently added new bin collection services and changed
the raw collection type names returned by their web form, breaking icon mappings
and returning unformatted type names.
 
- Added `NAME_MAP` to normalise raw HTML strings (e.g. `"Non-recyclable waste(grey bin)"` → `"Grey Bin"`, `"Paper and card recycling(red-lidded bin)"` → `"Paper & Card"`)
- Updated `ICON_MAP` to match normalised names: replaced defunct `"Clear Sack"` with `"Mixed Recycling"`, added `"Paper & Card"`
- Updated fetch logic to pass raw type through `NAME_MAP`

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
