### PR TITLE
fix(app_abfallplus_de): don't append empty subtitle to waste-type names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -795,8 +795,10 @@ class AppAbfallplusDe:
         if self._strasse_search is None and len(streets) == 0:
             return
         elif self._strasse_search is None:
-            SourceArgumentRequiredWithSuggestions(
-                "strasse", [s["name"] for s in streets]
+            raise SourceArgumentRequiredWithSuggestions(
+                "strasse",
+                "multiple streets found, please specify one",
+                [s["name"] for s in streets],
             )
 
         for street in streets:
@@ -849,7 +851,9 @@ class AppAbfallplusDe:
             return
         elif self._hnr_search is None:
             raise SourceArgumentRequiredWithSuggestions(
-                "hnr", [hnr["name"] for hnr in hnrs]
+                "hnr",
+                "multiple house numbers found, please specify one",
+                [hnr["name"] for hnr in hnrs],
             )
         for hnr in hnrs:
             if compare(hnr["name"], self._hnr_search, remove_space=True):
@@ -1001,8 +1005,9 @@ class AppAbfallplusDe:
 
         categories = {}
         for cat_id, name, subtitle in raw_categories:
-            if any(s_id in cat_id for s_id in self._needs_subtitle) or (
-                name_counts[name] > 1 and subtitle
+            if subtitle and (
+                any(s_id in cat_id for s_id in self._needs_subtitle)
+                or name_counts[name] > 1
             ):
                 name += " - " + subtitle
             categories[cat_id] = name


### PR DESCRIPTION
## Summary
- Fixes a bug in the shared `AppAbfallplusDe` service where waste-type category names were silently renamed to `"<name> - "` (trailing dash, no text) whenever a category id matched the "needs subtitle" disambiguation heuristic but its actual subtitle was empty. This broke sensors for `de.k4systems.abfallmsp` (Landkreis Main-Spessart) — most bin types (Restabfall/Bioabfall/Papierabfall) went "Unknown" while "Gelber Sack" (whose id never matched the heuristic) kept working, matching the report exactly.
- Fix: only append `" - " + subtitle` when `subtitle` is non-empty. Verified live that genuine duplicate-name disambiguation (the original motivation for #6412 / #3002, e.g. `de.k4systems.avea` Leverkusen's "Restmülltonne" vs "Restmülltonne (4-wöchentlich)") still works correctly.
- Also fixes two `SourceArgumentRequiredWithSuggestions(...)` call sites (in `select_street` / `select_hnr`) that used the wrong number of positional arguments (missing the required `reason` string), one of which was also missing `raise` — both crashed with an opaque `TypeError` instead of surfacing a helpful list of suggestions to the user.

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `python test_sources.py -s app_abfallplus_de` — 9/10 TEST_CASES pass with live data (10th fails for a pre-existing, unrelated ambiguous-house-number reason unrelated to this fix)
- [x] Reproduced the exact reported symptom live against `de.k4systems.abfallmsp` (Arnstein) before the fix, and confirmed it is resolved after

Fixes #6726