### PR TITLE
Add New Rochelle, NY to RecycleCoach EXTRA_INFO

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -314,6 +314,12 @@ EXTRA_INFO = [
         "country": "ca",
         "default_params": {"project_id": "3194", "district_id": "GUEL"},
     },
+    {
+        "title": "New Rochelle (NY)",
+        "url": "https://www.newrochelleny.gov/791/Collection-Dates",
+        "country": "us",
+        "default_params": {"project_id": "3015", "district_id": "NEWRO"},
+    },
 ]
 
 TEST_CASES = {
@@ -418,6 +424,11 @@ TEST_CASES = {
         "district_id": "LAK",
         "project_id": 583,
         "zone_id": "zone-z9942",
+    },
+    "New Rochelle, NY, USA (with district_id, project_id & zone_id)": {
+        "district_id": "NEWRO",
+        "project_id": 3015,
+        "zone_id": "zone-z19582-z19705",
     },
 }
 


### PR DESCRIPTION
New Rochelle, NY's official "Collection Dates" / "DPW Online" page (https://www.newrochelleny.gov/791/Collection-Dates) is powered by the RecycleCoach platform, which this project already supports via `recyclecoach_com.py`. This adds an `EXTRA_INFO` entry so New Rochelle is discoverable in the README/config wizard, plus a `TEST_CASES` entry.

**Provider details**
- `project_id`: `3015`
- `district_id`: `NEWRO`

**How residents get parameters:** just their street address, city ("New Rochelle"), and state ("NY") — no portal ID required.

**Test case used:** City Hall, 515 North Ave, New Rochelle, NY (public municipal address, not a private residence).

- [x] `ruff check` / `ruff format` clean
- [x] `pytest tests/test_source_components.py` — 9/9 passed