### PR TITLE
Add Hedemora Energi source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hedemora_energi_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hedemora_energi_se.py
@@ -1,0 +1,142 @@
+from datetime import date
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+    SourceArgumentRequired,
+)
+
+TITLE = "Hedemora Energi"
+DESCRIPTION = "Source for Hedemora Energi waste collection schedules, Sweden."
+URL = "https://www.hedemoraenergi.se/"
+COUNTRY = "se"
+TEST_CASES = {
+    "Åsgatan 28": {"address": "Åsgatan 28"},
+    "Pickup ID 1392000": {"pickup_id": "1392000"},
+}
+
+API_URL = "https://www.hedemoraenergi.se/wp-json/internal/v1/fetchplanner"
+HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; HomeAssistant-WCS/1.0)"}
+
+ICON_MAP = {
+    "Brännbart": Icons.GENERAL_WASTE,
+    "Kompost": Icons.BIO_KITCHEN,
+    "Matavfall": Icons.BIO_KITCHEN,
+}
+DEFAULT_ICON = Icons.GENERAL_WASTE
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Use `pickup_id` if known. Otherwise enter the exact address as shown in Hedemora Energi's fetch planner search.",
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Address",
+        "pickup_id": "Pickup ID",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Address to search for. Required only when pickup_id is not provided.",
+        "pickup_id": "Hedemora Energi pickup ID. Preferred when known.",
+    },
+}
+
+
+class Source:
+    def __init__(self, address: str | None = None, pickup_id: str | None = None):
+        if not address and not pickup_id:
+            raise SourceArgumentRequired(
+                "pickup_id",
+                "Either pickup_id or address is required to fetch the collection schedule.",
+            )
+
+        self._address = address.strip() if address else None
+        self._pickup_id = pickup_id.strip() if pickup_id else None
+
+    def fetch(self) -> list[Collection]:
+        pickup_id = self._pickup_id or self._get_pickup_id()
+
+        r = requests.get(
+            f"{API_URL}/calendar",
+            params={"pickup_id": pickup_id},
+            headers=HEADERS,
+            timeout=30,
+        )
+        r.raise_for_status()
+
+        data = r.json()
+        if data.get("success") is not True:
+            raise ValueError("Unexpected response from Hedemora Energi calendar API")
+
+        entries = []
+        seen = set()
+        for item in data.get("data", []):
+            waste_type = item["ContentType"]
+            collection_date = date.fromisoformat(item["ExecutionDate"])
+            key = (collection_date, waste_type)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type, DEFAULT_ICON),
+                )
+            )
+
+        return entries
+
+    def _get_pickup_id(self) -> str:
+        if not self._address:
+            raise SourceArgumentRequired(
+                "address",
+                "Address is required when pickup_id is not provided.",
+            )
+
+        r = requests.post(
+            f"{API_URL}/search",
+            params={"address": self._address},
+            headers=HEADERS,
+            timeout=30,
+        )
+        r.raise_for_status()
+
+        data = r.json()
+        if data.get("success") is not True:
+            raise ValueError("Unexpected response from Hedemora Energi search API")
+
+        results = data.get("results", [])
+        if not results:
+            raise SourceArgumentNotFound("address", self._address)
+
+        if len(results) > 1:
+            suggestions = [
+                _format_address_suggestion(result)
+                for result in results
+                if result.get("address")
+            ]
+            raise SourceArgAmbiguousWithSuggestions(
+                "address",
+                self._address,
+                suggestions,
+            )
+
+        return results[0]["id"]
+
+
+def _format_address_suggestion(result: dict) -> str:
+    address = result["address"]
+    city = result.get("city")
+    zip_code = result.get("zipCode")
+
+    if city and zip_code:
+        return f"{address}, {zip_code} {city}"
+    if city:
+        return f"{address}, {city}"
+    return address

--- a/doc/source/hedemora_energi_se.md
+++ b/doc/source/hedemora_energi_se.md
@@ -1,0 +1,57 @@
+# Hedemora Energi
+
+Support for schedules provided by [Hedemora Energi](https://www.hedemoraenergi.se/), serving Hedemora, Sweden.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: hedemora_energi_se
+      args:
+        pickup_id: PICKUP_ID
+```
+
+Alternatively, the source can search for the pickup ID from an address:
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: hedemora_energi_se
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**pickup_id**  
+*(String) (optional)*
+
+Hedemora Energi pickup ID. This is the recommended configuration because it skips address lookup.
+
+**address**  
+*(String) (optional)*
+
+Address to search for. Required only when `pickup_id` is not provided. The address must match exactly one result.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: hedemora_energi_se
+      args:
+        pickup_id: "1392000"
+```
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: hedemora_energi_se
+      args:
+        address: Åsgatan 28
+```
+
+## How to get the source argument
+
+Use `pickup_id` if you know it. Otherwise, enter your street address as shown in Hedemora Energi's fetch planner. If the address search returns multiple matches, use a more specific address or configure the source with `pickup_id`.


### PR DESCRIPTION
## Summary

Adds a new source for Hedemora Energi, Sweden.

The source supports:
- address lookup via POST /search
- direct pickup_id configuration via GET /calendar

It deduplicates entries with the same date and waste type to match the provider website display.

Tested with:
python test_sources.py -s hedemora_energi_se -l

Results:
- Åsgatan 28: 10 entries
- Pickup ID 1392000: 10 entries
- includes Kompost and Brännbart


## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
