### PR TITLE
Add Jacksonville FL waste source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jacksonville_fl_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jacksonville_fl_us.py
@@ -1,0 +1,111 @@
+from datetime import date, datetime
+from xml.etree import ElementTree
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import ArcGisError, geocode
+
+TITLE = "Jacksonville, FL"
+DESCRIPTION = "Source for Jacksonville, FL waste collection."
+URL = "https://myjax.custhelp.com/app/hauler"
+COUNTRY = "us"
+
+TEST_CASES = {
+    "EverBank Stadium": {"address": "1 EverBank Stadium Dr, Jacksonville, FL"},
+    "Mandarin": {"address": "11743 Heather Grove Ln, Jacksonville, FL"},
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Full street address including city and state (e.g. '11743 Heather Grove Ln, Jacksonville, FL')",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Use the same address you would enter on the MyJax hauler lookup page.",
+}
+
+API_URL = (
+    "https://myjax.custhelp.com/cgi-bin/myjax.cfg/php/custom/src/callgisservice.php"
+)
+
+DATE_FORMAT = "%m/%d/%Y"
+TIMEOUT = 30
+
+NS = {"tns": "https://cityofjacksonville.custhelp.com/"}
+
+COLLECTIONS = (
+    ("GARBAGEWASTE", "PICKUPDATE", "Garbage", Icons.GENERAL_WASTE),
+    ("YARDWASTE", "PICKUPDATE", "Yard Waste", Icons.GARDEN),
+    ("RECYWASTE", "PICKUPDATE", "Recycling", Icons.RECYCLING),
+    ("BULKWASTE", "PICKUPDATE", "Bulk Waste", Icons.BULKY),
+    ("TIREWASTE", "TIRE_PICKUP_DATE", "Tires", Icons.BULKY),
+    ("APPLIANCEWASTE", "PICKUPDATE", "Appliances", Icons.BULKY),
+)
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+
+    try:
+        return datetime.strptime(value.strip(), DATE_FORMAT).date()
+    except ValueError:
+        return None
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        try:
+            location = geocode(self._address)
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        response = requests.get(
+            API_URL,
+            params={
+                "lng": location["x"],
+                "lat": location["y"],
+                "intersection": "n",
+            },
+            headers={
+                "Referer": URL,
+                "User-Agent": "Mozilla/5.0",
+            },
+            timeout=TIMEOUT,
+        )
+        response.raise_for_status()
+
+        try:
+            root = ElementTree.fromstring(response.text.strip())
+        except ElementTree.ParseError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        error = root.findtext("ERROR")
+        if error:
+            raise SourceArgumentNotFound("address", self._address, error)
+
+        entries = []
+
+        for section, date_tag, waste_type, icon in COLLECTIONS:
+            date_value = root.findtext(f"tns:{section}/tns:{date_tag}", namespaces=NS)
+            collection_date = _parse_date(date_value)
+            if collection_date is None:
+                continue
+
+            entries.append(Collection(date=collection_date, t=waste_type, icon=icon))
+
+        if not entries:
+            raise SourceArgumentNotFound("address", self._address)
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jacksonville_fl_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jacksonville_fl_us.py
@@ -10,6 +10,7 @@ TITLE = "Jacksonville, FL"
 DESCRIPTION = "Source for Jacksonville, FL waste collection."
 URL = "https://myjax.custhelp.com/app/hauler"
 COUNTRY = "us"
+SOURCE_CODEOWNERS = ["@biggiebytes"]
 
 TEST_CASES = {
     "EverBank Stadium": {"address": "1 EverBank Stadium Dr, Jacksonville, FL"},

--- a/doc/source/jacksonville_fl_us.md
+++ b/doc/source/jacksonville_fl_us.md
@@ -1,0 +1,34 @@
+# Jacksonville, FL
+
+Support for schedules provided by [MyJax Hauler Lookup](https://myjax.custhelp.com/app/hauler).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: jacksonville_fl_us
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Full street address including city and state.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: jacksonville_fl_us
+      args:
+        address: 11743 Heather Grove Ln, Jacksonville, FL
+```
+
+## How to get the source arguments
+
+Use the same street address you would enter on the MyJax hauler lookup page. The source geocodes the address and returns the next dated pickups supplied by Jacksonville's hauler lookup service.


### PR DESCRIPTION
## Summary

Adds support for Jacksonville, Florida residential waste collection schedules using the official MyJax hauler lookup service.

The source geocodes the supplied address using the existing ArcGIS helper, queries Jacksonville's backend XML endpoint, and returns only official collection dates supplied by the City.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (`README.md`, `info.md`, `sources.json`, `translations/*.json`)
- [x] `doc/source/jacksonville_fl_us.md` created
- [x] `TEST_CASES` use real, publicly accessible addresses (not my own)

## Notes

Verified with multiple Jacksonville addresses. The implementation uses the City's live MyJax service and does not generate schedules from weekday rules.