### PR TITLE
fix(burgerportaal_nl): add Gemeente Breda organization

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/burgerportaal_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/burgerportaal_nl.py
@@ -41,6 +41,11 @@ TEST_CASES = {
         "post_code": "5071EN",
         "house_number": 122,
     },
+    "Breda": {
+        "organization": "breda",
+        "post_code": "4762BD",
+        "house_number": 21,
+    },
     "Groningen": {
         "organization": "groningen",
         "post_code": "9733AH",
@@ -57,6 +62,7 @@ Organization = Literal[
     "assen",
     "afvalbeheer",
     "bat",
+    "breda",
     "groningen",
     "rmn",
     "utrecht",
@@ -80,6 +86,12 @@ SERVICE_MAP = [
         "url": "https://www.batafvalbeheer.nl/",
         "uuid": "452048812597339353",
         "organization": "bat",
+    },
+    {
+        "title": "Gemeente Breda",
+        "url": "https://www.breda.nl/",
+        "uuid": "452048812597352613",
+        "organization": "breda",
     },
     {
         "title": "Gemeente Groningen",

--- a/doc/source/burgerportaal_nl.md
+++ b/doc/source/burgerportaal_nl.md
@@ -24,6 +24,7 @@ Use one of the following codes as organization code:
 - afvalbeheer
 - assen
 - bat
+- breda
 - groningen
 - rmn
 - utrecht
@@ -44,6 +45,7 @@ For example if you house is `2A` you will put `A` here.
 - `afvalbeheer` (Barendrecht Albrandswaard Ridderkerk): <https://21burgerportaal.mendixcloud.com/p/afvalbeheer/landing/>
 - `assen` (Gemeente Assen): <https://21burgerportaal.mendixcloud.com/p/assen/landing/>
 - `bat` (BAT Tilburg): <https://21burgerportaal.mendixcloud.com/p/bat/landing/>
+- `breda` (Gemeente Breda): <https://21burgerportaal.mendixcloud.com/p/breda/landing/>
 - `groningen` (Gemeente Groningen): <https://21burgerportaal.mendixcloud.com/p/groningen/landing/>
 - `rmn` (Reinigingsdienst Midden Nederland): <https://21burgerportaal.mendixcloud.com/p/rmn/landing/>
 - `utrecht` (Gemeente Utrecht): <https://21burgerportaal.mendixcloud.com/p/utrecht/landing/>


### PR DESCRIPTION
## Summary
- BurgerPortaal has now activated collection data for Gemeente Breda (it was previously excluded in #5805 because it had no address data loaded yet)
- Adds `breda` as a new `organization` option for the `burgerportaal_nl` source
- Checked the platform's other newly-listed organizations (Leiden, Cyclus NV, Gemeente Almere) via their public API; none of them have working calendar data yet, so they are intentionally left out of this PR

Closes #6778

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed source file
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `python test_sources.py -s burgerportaal_nl -l` — all test cases pass; Breda (reporter's example address `4762BD` / `21`) returns 35 live collection entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)