### PR TITLE
Expand ruff lint scope to source/, enable bugbear/comprehensions/pie/ruf rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,13 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.17
     hooks:
-      # Linting (replaces flake8 + isort). Source modules carry pre-existing
-      # issues out of scope here, matching what flake8 excluded.
+      # Linting (replaces flake8 + isort).
       - id: ruff
         args: [--fix]
-        files: ^(custom_components|script|tests)/.+\.py$
-        exclude: ^custom_components/waste_collection_schedule/waste_collection_schedule/source/
+        files: ^(custom_components|script|tests)/.+\.py$|^[^/]+\.py$
       # Formatting (replaces black). Runs on the full tree, like black did.
       - id: ruff-format
-        files: ^(custom_components|script|tests)/.+\.py$
+        files: ^(custom_components|script|tests)/.+\.py$|^[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:
@@ -35,7 +33,7 @@ repos:
           - --quiet
           - --format=custom
           - --configfile=tests/bandit.yaml
-        files: ^(custom_components|script|tests)/.+\.py$
+        files: ^(custom_components|script|tests)/.+\.py$|^[^/]+\.py$
         # Source modules carry pre-existing bandit warnings (mostly
         # xml.etree.ElementTree usage) that are out of scope for the
         # canonical-icons migration. Source-level security review is

--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -5,7 +5,7 @@ import logging
 import types
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Literal, Tuple, TypedDict, Union, cast, get_origin
+from typing import Any, ClassVar, Literal, Tuple, TypedDict, Union, cast, get_origin
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -146,7 +146,9 @@ SUPPORTED_ARG_TYPES = {
 }
 
 
-def get_customize_schema(defaults: dict[str, Any] = {}):
+def get_customize_schema(defaults: dict[str, Any] | None = None):
+    if defaults is None:
+        defaults = {}
     schema = {
         vol.Optional(CONF_ALIAS, default=defaults.get(CONF_ALIAS, UNDEFINED)): str,
         vol.Optional(CONF_SHOW, default=defaults.get(CONF_SHOW, True)): cv.boolean,
@@ -166,7 +168,9 @@ def get_customize_schema(defaults: dict[str, Any] = {}):
     return schema
 
 
-def get_sensor_schema(fetched_types, add_delete=False, defaults: dict = {}):
+def get_sensor_schema(fetched_types, add_delete=False, defaults: dict | None = None):
+    if defaults is None:
+        defaults = {}
     schema = {
         vol.Optional(CONF_NAME, default=defaults.get(CONF_NAME, UNDEFINED)): cv.string,
     }
@@ -287,7 +291,7 @@ def validate_sensor_user_input(
             args.pop(preset_key, None)
             args[key] = sensor_input[preset_key]
 
-        if key in args and args[key]:
+        if args.get(key):
             try:
                 cv.template(args[key])
             except vol.Invalid:
@@ -303,7 +307,7 @@ def validate_sensor_user_input(
     if not args.get(CONF_NAME):
         errors[CONF_NAME] = "sensor_name_empty"
     # enforce unique Name
-    elif any([x[CONF_NAME] == args[CONF_NAME] for x in existing_sensors]):
+    elif any(x[CONF_NAME] == args[CONF_NAME] for x in existing_sensors):
         errors[CONF_NAME] = "name_exists"
 
     return args, errors if args.get("skip", False) is False else {}
@@ -346,8 +350,11 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
     _country: str | None = None
     _source: str | None = None
 
-    _options: dict = {}
-    _sources: dict[str, list[SourceDict]] = {}
+    _options: ClassVar[dict] = {}
+    # Not a ClassVar: the empty dict is only a per-instance "not yet
+    # initialized" sentinel; _async_setup_sources() below rebinds it to the
+    # shared _SOURCES cache on first use.
+    _sources: dict[str, list[SourceDict]] = {}  # noqa: RUF012
     _error_suggestions: dict[str, list[Any]]
 
     async def _async_setup_sources(self) -> None:
@@ -481,11 +488,8 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
     async def __get_type_by_annotation(self, annotation: Any) -> Any:
         if a := await self.__get_simple_annotation_type(annotation):
             return a
-        if (
-            (isinstance(annotation, types.GenericAlias))
-            or (
-                get_origin(annotation) is not None and hasattr(annotation, "__origin__")
-            )
+        if (isinstance(annotation, types.GenericAlias)) or (
+            (get_origin(annotation) is not None and hasattr(annotation, "__origin__"))
             and (a := await self.__get_simple_annotation_type(annotation.__origin__))
         ):
             return a

--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -17,8 +17,8 @@ from .waste_collection_schedule.service.DeviceKeyStore import (
 )
 from .wcs_coordinator import WCSCoordinator
 
-from . import const  # type: ignore # isort:skip # noqa: E402
-from .waste_collection_schedule import SourceShell, Customize  # type: ignore # isort:skip # noqa: E402
+from . import const  # type: ignore # isort:skip
+from .waste_collection_schedule import SourceShell, Customize  # type: ignore # isort:skip
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/waste_collection_schedule/service.py
+++ b/custom_components/waste_collection_schedule/service.py
@@ -7,7 +7,7 @@ from .wcs_coordinator import WCSCoordinator
 
 def get_fetch_all_service(hass: HomeAssistant):
     async def async_fetch_data(service: ServiceCall) -> None:
-        for entry_id, coordinator in hass.data[const.DOMAIN].items():
+        for _entry_id, coordinator in hass.data[const.DOMAIN].items():
             if isinstance(coordinator, WCSCoordinator):
                 hass.add_job(coordinator._fetch_now)
             elif isinstance(coordinator, WasteCollectionApi):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -123,7 +123,7 @@ class CollectionGroup(CollectionBase):
             x.set_picture(group[0].picture)
         else:
             x.set_icon(f"mdi:numeric-{len(group)}-box-multiple")
-        x["types"] = list(it.type for it in group)
+        x["types"] = [it.type for it in group]
 
         ordered_locs: list[str] = []
         for it in group:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
@@ -77,7 +77,7 @@ class CollectionAggregator:
             lambda e: e.date,
         )
 
-        for key, group in iterator:
+        for _key, group in iterator:
             entries.append(CollectionGroup.create(list(group)))
         if start_index is not None:
             entries = entries[start_index:]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/exceptions.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/exceptions.py
@@ -62,7 +62,7 @@ class SourceArgumentSuggestionsExceptionBase(SourceArgumentException, Generic[T]
         super().__init__(argument=argument, message=message)
         self._suggestions = suggestions
         self._suggestion_type: Type[T] | None = (
-            type(list(suggestions)[0]) if suggestions else None
+            type(next(iter(suggestions))) if suggestions else None
         )
 
     @property

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/A_region_ch.py
@@ -162,7 +162,7 @@ class A_region_ch:
         if len(districts) > 0:
             if len(districts) == 1:
                 # only one district found -> use it
-                return self.get_ICS_sources(list(districts.values())[0], tour)
+                return self.get_ICS_sources(next(iter(districts.values())), tour)
             if self._district is None:
                 raise SourceArgumentRequiredWithSuggestions(
                     "district",
@@ -176,7 +176,7 @@ class A_region_ch:
                 )
             return self.get_ICS_sources(districts[self._district], tour)
 
-        dates = list()
+        dates = []
 
         downloads = soup.find_all("a", href=True)
         for download in downloads:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from datetime import datetime
+from typing import ClassVar
 
 import requests
 
@@ -173,7 +174,7 @@ DEFAULT_TIMEOUT = 20
 class AbfallnaviDe:
     # Services where the per-service subdomain DNS is dead;
     # use the shared domain directly to avoid DNS timeout.
-    SHARED_DOMAIN_SERVICES = {
+    SHARED_DOMAIN_SERVICES: ClassVar = {
         "unna",
         "frankenthal",
         "awvlippe",
@@ -279,7 +280,7 @@ class AbfallnaviDe:
         if len(house_numbers) == 0:
             return None
         if len(house_numbers) == 1:
-            return list(house_numbers.keys())[0]
+            return next(iter(house_numbers.keys()))
         if house_number is None:
             raise SourceArgumentRequiredWithSuggestions(
                 "house_number",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -439,7 +439,9 @@ def extract_onclicks(
         try:
             to_return.append(json.loads(string))
         except json.decoder.JSONDecodeError:
-            raise Exception(f"Failed to parse '{string}', onclick: '{onclick}'")
+            raise Exception(
+                f"Failed to parse '{string}', onclick: '{onclick}'"
+            ) from None
         if hnr:
             res = re.search(r"\.val\([0-9]+\)", onclick)
             if res:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/CitiesAppsCom.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/CitiesAppsCom.py
@@ -1712,9 +1712,9 @@ class CitiesApps:
         supported_len = len(supported_dict["supported"])
         for id, city in enumerate(supported_dict["supported"]):
             if city["name"] in [c["title"] for c in SERVICE_MAP]:
-                city_homepage = [
+                city_homepage = next(
                     c["url"] for c in SERVICE_MAP if city["name"] == c["title"]
-                ][0]
+                )
             else:
                 print(f"{id + 1}/{supported_len} {city['name']}")
                 city_homepage = self.get_city_home_page(city)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/EcoHarmonogramPL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/EcoHarmonogramPL.py
@@ -231,7 +231,7 @@ class Ecoharmonogram:
             matching_towns,
         )
 
-        town = list(matching_towns_district)[0]
+        town = next(iter(matching_towns_district))
 
         schedule_periods_data = self.fetch_scheduled_periods(town)
         schedule_periods = schedule_periods_data["schedulePeriods"]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/IntraMaps.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/IntraMaps.py
@@ -27,19 +27,13 @@ from urllib3.util.retry import Retry
 class IntraMapsError(Exception):
     """Base exception class for all IntraMaps-related failures."""
 
-    pass
-
 
 class IntraMapsSessionError(IntraMapsError):
     """Raised when the client fails to establish or maintain a session token."""
 
-    pass
-
 
 class IntraMapsSearchError(IntraMapsError):
     """Raised when an address lookup fails or returns zero matches."""
-
-    pass
 
 
 # --- Configuration ---
@@ -213,7 +207,7 @@ class MapsClient:
             return self.intramaps_session
 
         except requests.RequestException as e:
-            raise IntraMapsSessionError(f"Failed to connect to IntraMaps: {e}")
+            raise IntraMapsSessionError(f"Failed to connect to IntraMaps: {e}") from e
 
     def _get_form_template_id(self) -> str:
         """

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/RiSKommunalAT.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import ast
 import re
 from datetime import date, datetime
+from typing import ClassVar
 
 import requests
 from bs4 import BeautifulSoup
@@ -68,8 +69,8 @@ class RiSKommunalSource:
     """
 
     BASE_URL: str = ""
-    ICON_MAP: dict = {}
-    QUERY_PARAMS: dict = {}
+    ICON_MAP: ClassVar[dict] = {}
+    QUERY_PARAMS: ClassVar[dict] = {}
     VDATUM_TODAY: bool = False
     MAX_PAGES: int = 50
     SELECTION_URL: str | None = None

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/Sepan.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/Sepan.py
@@ -54,7 +54,7 @@ class SepanClient:
                 # A well-formed response that just didn't match: no point
                 # retrying against another base URL, the argument is wrong.
                 raise
-            except Exception as e:  # noqa: BLE001 - network/format failures only
+            except Exception as e:
                 last_error = e
                 continue
         raise last_error or Exception("Could not resolve address: no base URL worked")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhatBinDay.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhatBinDay.py
@@ -2,7 +2,7 @@
 
 import datetime
 import logging
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Callable, ClassVar, Dict, List, Optional
 
 import requests
 
@@ -36,12 +36,12 @@ class WhatBinDayService:
     and regions, primarily in Australia.
     """
 
-    API_URLS = {
+    API_URLS: ClassVar = {
         "register_device": "https://api.whatbinday.com/V3/Device",
         "services": "https://api.whatbinday.com/V3/Device/{}/Services",
     }
 
-    HEADERS = {
+    HEADERS: ClassVar = {
         "Content-Type": "application/json",
         "User-Agent": "Mozilla/5.0 (Linux; Android 11; Pixel 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Mobile Safari/537.36",
         "Accept": "application/json",
@@ -49,13 +49,13 @@ class WhatBinDayService:
         "Accept-Language": "en-US,en;q=0.9",
     }
 
-    DEFAULT_ICON_MAP = {
+    DEFAULT_ICON_MAP: ClassVar = {
         "WasteBin": "mdi:trash-can",
         "RecycleBin": "mdi:recycle",
         "GreenBin": "mdi:leaf",
     }
 
-    DEFAULT_BIN_NAMES = {
+    DEFAULT_BIN_NAMES: ClassVar = {
         "WasteBin": "General waste (landfill)",
         "RecycleBin": "Recycling",
         "GreenBin": "Food and garden waste",
@@ -331,8 +331,8 @@ class WhatBinDayService:
             return entries
 
         except requests.RequestException as e:
-            raise Exception(f"Network error: {e}")
+            raise Exception(f"Network error: {e}") from e
         except KeyError as e:
-            raise Exception(f"Unexpected API response format: {e}")
+            raise Exception(f"Unexpected API response format: {e}") from e
         except Exception as e:
-            raise Exception(f"Error fetching collection schedule: {e}")
+            raise Exception(f"Error fetching collection schedule: {e}") from e

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/generate_ukbcd_json.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/generate_ukbcd_json.py
@@ -17,10 +17,10 @@ FILENAME = "test_ukbcd.json"
 WASTES = ["Refuse", "Recycling", "Garden", "Food", "Paper & Cardboard", "Batteries"]
 
 data: dict = {"bins": []}
-year = datetime.date.today().year
-for year in range(year, year + 6):
+start_year = datetime.date.today().year
+for year in range(start_year, start_year + 6):
     for month in range(1, 13):
-        for days in range(0, 4):
+        for _days in range(4):
             day = randint(1, 28)
             dt = f"{day:02d}" + "/" + f"{month:02d}" + "/" + f"{year:04d}"
             dict_data = {"type": choice(WASTES), "collectionDate": dt}

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/junker_app.py
@@ -39,7 +39,7 @@ class AreaNotFound(Exception):
         super().__init__("Area not found")
 
 
-class AreaRequired(AreaNotFound): ...  # noqa: E701
+class AreaRequired(AreaNotFound): ...
 
 
 def replace_accents(text: str) -> str:
@@ -62,8 +62,10 @@ class Junker:
         area: int | None = None,
         area_name: str | None = None,
         use_embed_url: bool = True,
-        municipalities_with_area: dict[str, list[int]] = {},
+        municipalities_with_area: dict[str, list[int]] | None = None,
     ):
+        if municipalities_with_area is None:
+            municipalities_with_area = {}
         self._municipality: str = municipality
         self._area: int | None = area
         self._municipalities_with_area = municipalities_with_area

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
@@ -103,8 +103,10 @@ class Source:
         f_id_strasse,
         f_id_bezirk=None,
         f_id_strasse_hnr=None,
-        f_abfallarten=[],
+        f_abfallarten=None,
     ):
+        if f_abfallarten is None:
+            f_abfallarten = []
         self._key = key
         self._kommune = f_id_kommune
         self._bezirk = f_id_bezirk
@@ -173,7 +175,7 @@ class Source:
             args[f"f_id_abfalltyp_{i}"] = self._abfallarten[i]
 
         args["f_abfallarten_index_max"] = len(self._abfallarten)
-        args["f_abfallarten"] = ",".join(map(lambda x: str(x), self._abfallarten))
+        args["f_abfallarten"] = ",".join(str(x) for x in self._abfallarten)
 
         now = datetime.datetime.now()
         date2 = now + datetime.timedelta(days=365)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_lro_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_lro_de.py
@@ -173,7 +173,7 @@ class Source:
                 break
         if mun_link is None:
             raise SourceArgumentNotFoundWithSuggestions(
-                "municipality", self._municipality, municipalities + ["Güstrow"]
+                "municipality", self._municipality, [*municipalities, "Güstrow"]
             )
 
         self._letters = mun_link.split("/")[-1].split(".")[0]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_wiener_neustadt_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_wiener_neustadt_at.py
@@ -164,7 +164,7 @@ class Source:
             raise Exception(
                 f"Failed to connect to {self._base_url}. "
                 f"Please check your internet connection and verify the website is accessible. Error: {e}"
-            )
+            ) from e
 
         soup = BeautifulSoup(response.text, "html.parser")
 
@@ -232,7 +232,7 @@ class Source:
             raise Exception(
                 f"Failed to retrieve zone information for street '{str_name_full}'. "
                 f"The website may be temporarily unavailable. Error: {e}"
-            )
+            ) from e
 
         reload_soup = BeautifulSoup(reload_response.text, "html.parser")
         tn_ez_zone_input = reload_soup.find(
@@ -306,7 +306,7 @@ class Source:
             raise Exception(
                 f"Failed to fetch collection schedule for street ID '{str_id}'. "
                 f"The website may be temporarily unavailable or the street ID is invalid. Error: {e}"
-            )
+            ) from e
 
         # Parse response
         return self._parse_schedule(response.text)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltransport_li.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltransport_li.py
@@ -126,7 +126,7 @@ class Source:
     def _parse_waste_types(self, waste_type: str) -> list[str]:
         requested_types = []
         valid_types = list(WASTE_TYPES.keys())
-        accepted_types = valid_types + ["all", "both"]
+        accepted_types = [*valid_types, "all", "both"]
         for token in waste_type.lower().replace(";", ",").split(","):
             selected_type = token.strip()
             if not selected_type:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_vechta_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_vechta_de.py
@@ -109,9 +109,9 @@ class Source:
                     .strip()
                 )
 
-                if f"{bin_type} {str(d[0])}" in string_entries:
+                if f"{bin_type} {d[0]!s}" in string_entries:
                     continue
-                string_entries.append(f"{bin_type} {str(d[0])}")
+                string_entries.append(f"{bin_type} {d[0]!s}")
 
                 collection_entries.append(
                     Collection(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfuhrplan_landkreis_neumarkt_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfuhrplan_landkreis_neumarkt_de.py
@@ -80,7 +80,7 @@ class Source:
             print(e.response.status_code)
             if e.response.status_code == 404:
                 cities = Source._get_all_elements(BASE_API_URL)
-                raise SourceArgumentNotFoundWithSuggestions("city", city, cities)
+                raise SourceArgumentNotFoundWithSuggestions("city", city, cities) from e
             raise e
 
     def fetch(self) -> list[Collection]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
@@ -143,14 +143,14 @@ def select_test_cases(municipalities, mode="random_one_from_each_parser"):
             parser_test_cases[parser].append((name, info))
 
     if mode == "random_one_from_each_parser":
-        for parser, cases in parser_test_cases.items():
+        for _parser, cases in parser_test_cases.items():
             selected_case = random.choice(cases)
             test_cases[selected_case[0]] = {
                 "municipality": selected_case[0],
                 "values": selected_case[1]["values"],
             }
     elif mode == "first_from_each_parser":
-        for parser, cases in parser_test_cases.items():
+        for _parser, cases in parser_test_cases.items():
             selected_case = cases[0]
             test_cases[selected_case[0]] = {
                 "municipality": selected_case[0],
@@ -164,14 +164,14 @@ def select_test_cases(municipalities, mode="random_one_from_each_parser"):
             "values": selected_case[1]["values"],
         }
     elif mode == "first_one":
-        first_parser = list(parser_test_cases.keys())[0]
+        first_parser = next(iter(parser_test_cases.keys()))
         selected_case = parser_test_cases[first_parser][0]
         test_cases[selected_case[0]] = {
             "municipality": selected_case[0],
             "values": selected_case[1]["values"],
         }
     elif mode == "all":
-        for parser, cases in parser_test_cases.items():
+        for _parser, cases in parser_test_cases.items():
             for case in cases:
                 test_cases[case[0]] = {
                     "municipality": case[0],

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/alchenstorf_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/alchenstorf_ch.py
@@ -36,7 +36,9 @@ class Source:
         try:
             data = json.loads(table.attrs["data-entities"])
         except (json.JSONDecodeError, KeyError):
-            raise ValueError("Could not parse the waste collection data from the page")
+            raise ValueError(
+                "Could not parse the waste collection data from the page"
+            ) from None
 
         entries = []
         for item in data.get("data", []):
@@ -80,6 +82,6 @@ class Source:
                     )
 
             except Exception:
-                raise ValueError("Could not parse the waste collection entry")
+                raise ValueError("Could not parse the waste collection entry") from None
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aliaserviziambientali_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aliaserviziambientali_it.py
@@ -205,9 +205,10 @@ def print_municipalities() -> None:
         for link in junker_links:
             if "area" in link["href"]:
                 area = int(link["href"].split("/")[-2])
-                municipalities_with_area[mun_name] = municipalities_with_area.get(
-                    mun_name, []
-                ) + [area]
+                municipalities_with_area[mun_name] = [
+                    *municipalities_with_area.get(mun_name, []),
+                    area,
+                ]
             else:
                 municipalites_without_area.append(mun_name)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_my_local_services_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_my_local_services_au.py
@@ -138,12 +138,12 @@ class Source:
             try:
                 lat = float(lat)
             except ValueError:
-                raise ValueError("Latitude must be a float")
+                raise ValueError("Latitude must be a float") from None
         if not isinstance(lon, float):
             try:
                 lon = float(lon)
             except ValueError:
-                raise ValueError("Longitude must be a float")
+                raise ValueError("Longitude must be a float") from None
 
         self._lat: float = lat
         self._lon: float = lon

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/armadale_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/armadale_wa_gov_au.py
@@ -77,7 +77,7 @@ class Source:
         current_day = current_day + datetime.timedelta(days=diff_to_next)
 
         entries = []
-        for i in range(52):
+        for _i in range(52):
             date = current_day
             start_of_week = date - datetime.timedelta(days=date.weekday())
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_ammerland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_ammerland_de.py
@@ -161,7 +161,7 @@ class Source:
         # Fall back to older years if no entry for current year
         current_year = datetime.date.today().year
         sd = None
-        for year_offset in range(0, current_year - 2017):
+        for year_offset in range(current_year - 2017):
             year = current_year - year_offset
             jahr = year - 2000
             candidates = [

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_bad_kreuznach_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_bad_kreuznach_de.py
@@ -207,7 +207,7 @@ class Source:
 
         entries = []
         for cal_entry in data["data"]["calendars"]:
-            collection_dates[cal_entry["name"]] = list(
+            collection_dates[cal_entry["name"]] = [
                 d.date()
                 for d in rrule(
                     freq=DAILY,
@@ -219,7 +219,7 @@ class Source:
                         else to_time
                     ),
                 )
-            )
+            ]
 
         moved: list[(str, date)] = []
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_es_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_es_de.py
@@ -79,7 +79,7 @@ class Source:
 
         soup = BeautifulSoup(r.text, features="html.parser")
         downloads = soup.find_all("a", href=True)
-        ics_urls = list()
+        ics_urls = []
         for download in downloads:
             href = download.get("href")
             if (

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
@@ -85,7 +85,7 @@ class Source:
         parsed = re.findall(
             '<INPUT\\sNAME="([^"]+?)"\\sID="[^"]+?"(?:\\sVALUE="([^"]*?)")?', text
         )
-        return {k: v for k, v in parsed}
+        return dict(parsed)
 
     def _address(self):
         return {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
@@ -562,10 +562,8 @@ class Source:
                 hsnbr_to_oid = {
                     hsnbr["value"].strip().lower(): hsnbr["key"] for (hsnbr) in hsnbrs
                 }
-                if (
-                    len(hsnbr_to_oid) == 0
-                    or len(hsnbr_to_oid) == 1
-                    and "" in hsnbr_to_oid
+                if len(hsnbr_to_oid) == 0 or (
+                    len(hsnbr_to_oid) == 1 and "" in hsnbr_to_oid
                 ):
                     _LOGGER.warning(
                         "No housenumbers found for street, using street only"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bad_eisenkappel_info.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bad_eisenkappel_info.py
@@ -77,8 +77,8 @@ class Source:
                     entries.append(Collection(date=date, t=bin_type, icon=icon))
 
         regions.remove("Gesamtes Gemeindegebiet")
-        if self._region.lower().replace(" ", "") not in map(
-            lambda x: x.lower().replace(" ", ""), regions
+        if self._region.lower().replace(" ", "") not in (
+            x.lower().replace(" ", "") for x in regions
         ):
             raise SourceArgumentNotFoundWithSuggestions(
                 argument="region",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bathnes_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bathnes_gov_uk.py
@@ -57,7 +57,7 @@ class Source:
         try:
             uprn = int(val)
         except (ValueError, TypeError):
-            raise SourceArgumentException("uprn", message)
+            raise SourceArgumentException("uprn", message) from None
         if uprn <= 0:
             raise SourceArgumentException("uprn", message)
         return uprn

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/baumkirchen_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/baumkirchen_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -19,7 +21,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.baumkirchen.gv.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "menuonr": "218617457",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
@@ -90,8 +90,8 @@ class Source:
                 )
         except (ValueError, TypeError) as e:
             raise Exception(
-                f"Invalid coordinate format. Please provide numeric values. Error: {str(e)}"
-            )
+                f"Invalid coordinate format. Please provide numeric values. Error: {e!s}"
+            ) from e
 
     def fetch(self):
         try:
@@ -102,7 +102,7 @@ class Source:
             raise Exception(
                 f"Coordinates ({self._latitude}, {self._longitude}) not found in any Bendigo collection zone. "
                 "Please check your location at https://www.bendigo.vic.gov.au/residents/general-waste-recycling-and-organics/bin-night",
-            )
+            ) from None
 
         _LOGGER.debug(
             "Found collection zone: %s",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berndorf_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berndorf_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -33,7 +35,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.berndorf.gv.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "226080602",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
@@ -52,7 +52,7 @@ class HiddenInputParser(HTMLParser):
             if str(d["type"]).lower() == "hidden":
                 self._args[d["name"]] = d["value"] if "value" in d else ""
             if str(d["type"]).lower() == "radio":
-                if "value" in d and d["value"]:
+                if d.get("value"):
                     if not self._radio_args:
                         self._radio_args.append({d["name"]: d["value"]})
                     else:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackburn_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blackburn_gov_uk.py
@@ -45,7 +45,7 @@ class Source:
         year = date.year
         month = date.month
         entries = []
-        for i in range(1, 13):
+        for _i in range(1, 13):
             PARAMS = {
                 "month": month,
                 "year": year,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bolton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bolton_gov_uk.py
@@ -135,10 +135,8 @@ class Source:
 
         for address in data["data"]:
             label = address["label"]
-            if (
-                label == self._house_number
-                or label.startswith(f"{self._house_number} ")
-                or label.startswith(f"{self._house_number},")
+            if label == self._house_number or label.startswith(
+                (f"{self._house_number} ", f"{self._house_number},")
             ):
                 return address["value"], auth_token
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/brimbank_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/brimbank_vic_gov_au.py
@@ -183,7 +183,7 @@ def _parse_pdf(pdf_bytes):
         # Remove spurious Saturday entries that aren't holiday shifts
         # A Saturday is only valid if the preceding Friday is NONE (holiday)
         to_remove = []
-        for d, color in schedule.items():
+        for d, _color in schedule.items():
             if d.weekday() == 5:  # Saturday
                 friday = d - timedelta(days=1)
                 if schedule.get(friday) != "NONE":

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/buergerportal_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/buergerportal_de.py
@@ -271,13 +271,13 @@ class Source:
                         for entry in payload["d"]
                         if entry["Ortsname"] == self.district
                     ],
-                )
+                ) from None
             else:
                 raise SourceArgumentNotFoundWithSuggestions(
                     "district",
                     self.district,
                     {entry["Ortsname"] for entry in payload["d"]},
-                )
+                ) from None
 
     def fetch_street_id(self, session: requests.Session, district_id: int):
         res = session.get(
@@ -300,7 +300,7 @@ class Source:
         except StopIteration:
             raise SourceArgumentNotFoundWithSuggestions(
                 "street", self.street, [entry["Name"] for entry in payload["d"]]
-            )
+            ) from None
 
 
 # Typed dictionaries for the API

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -74,7 +76,7 @@ class Source(RiSKommunalSource):
     SELECTION_URL = "https://www.buermoos.at/Service/Aktuelles/Muellkalender"
     LOOKAHEAD_DAYS = 365
     MAX_PAGES = 30
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "219233420",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
@@ -227,7 +227,7 @@ class Source:
         self.ical_url_file = ical_url_file
         self._ics = ICS(regex=r"Abfuhr: (.*)")
         if not abfall:
-            abfall = "|".join(str(i) for i in range(0, 300))
+            abfall = "|".join(str(i) for i in range(300))
         self._abfall = abfall
 
     def fetch(self):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cardinia_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cardinia_vic_gov_au.py
@@ -40,7 +40,7 @@ class Source:
             next_collect = next_collect + timedelta(days=7)
         next_dates = []
         next_dates.append(next_collect)
-        for i in range(1, int(4 / weeks)):
+        for _i in range(1, int(4 / weeks)):
             next_collect = next_collect + timedelta(days=(weeks * 7))
             next_dates.append(next_collect)
         return next_dates

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/casey_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/casey_vic_gov_au.py
@@ -143,7 +143,7 @@ class Source:
             # properties come through like "NextGarbageDate", "NextRecycleDate" or "PrevGardenDate" etc
             # extracting waste type name from the middle of "Next{x}Date" to support future waste types without direct mapping
             if key.endswith(_DATE_STRING) and (
-                key.startswith(_NEXT_STRING) or key.startswith(_PREV_STRING)
+                key.startswith((_NEXT_STRING, _PREV_STRING))
             ):
                 name = (
                     key.replace(_DATE_STRING, "")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/chelmsford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/chelmsford_gov_uk.py
@@ -61,7 +61,7 @@ class Source:
                 for item in items:
                     it = item.get_text(strip=True)
                     date_str, items = it.split(":")
-                    day, date, month = date_str.split()
+                    _day, date, month = date_str.split()
 
                     year = None
                     for h in heading_items:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cidiu_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cidiu_it.py
@@ -88,7 +88,7 @@ class Source:
                 continue
 
             # date format is "11/08/2024, Domenica" - we can get rid of the italian day name
-            date_str, day = date_cell.split(", ")
+            date_str, _day = date_cell.split(", ")
             try:
                 date = datetime.strptime(date_str, "%d/%m/%Y").date()
             except ValueError:
@@ -96,7 +96,7 @@ class Source:
                 continue
 
             collections = []
-            for header, cell in zip(headers, cells[1:]):
+            for header, cell in zip(headers, cells[1:], strict=False):
                 if cell.text.strip():
                     collections.append(header)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
@@ -115,13 +115,13 @@ class Source:
             current_date_part: str | None = None
             current_types_parts: list[str] = []
 
-            def flush() -> None:
-                if current_date_part is None:
+            def flush(date_part: str | None, types_parts: list[str]) -> None:
+                if date_part is None:
                     return
 
                 try:
-                    waste_date = self.append_year(current_date_part)
-                    types_part = _normalize_space(" ".join(current_types_parts))
+                    waste_date = self.append_year(date_part)
+                    types_part = _normalize_space(" ".join(types_parts))
                     for waste_type in (
                         t.strip()
                         for t in re.split(r"\s+and\s+", types_part)
@@ -135,7 +135,7 @@ class Source:
                             )
                         )
                 except Exception as e:
-                    _LOGGER.warning(f"Error processing item '{current_date_part}': {e}")
+                    _LOGGER.warning(f"Error processing item '{date_part}': {e}")
 
             for raw_line in editor.get_text("\n", strip=True).splitlines():
                 line = _normalize_space(raw_line)
@@ -143,13 +143,13 @@ class Source:
                     continue
 
                 if ":" in line:
-                    flush()
+                    flush(current_date_part, current_types_parts)
                     date_part, types_part = (p.strip() for p in line.split(":", 1))
                     current_date_part = date_part
                     current_types_parts = [types_part] if types_part else []
                 elif current_date_part is not None:
                     current_types_parts.append(line)
 
-            flush()
+            flush(current_date_part, current_types_parts)
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/crawley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/crawley_gov_uk.py
@@ -85,9 +85,7 @@ class Source:
         entries = []
         for collection in collections:
             for key in [
-                k
-                for k in collection.keys()
-                if k.endswith("DateCurrent") or k.endswith("DateNext")
+                k for k in collection.keys() if k.endswith(("DateCurrent", "DateNext"))
             ]:
                 date_str = collection[key]
                 try:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/data_angers_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/data_angers_fr.py
@@ -216,7 +216,7 @@ CONFIG_FLOW_TYPES = {
     },
     "city": {
         "type": "SELECT",
-        "values": [f for f in CITY_NAME],
+        "values": list(CITY_NAME),
         "multiple": False,
     },
     "num_voie": {
@@ -321,7 +321,7 @@ class Source:
         except requests.RequestException as e:
             raise SourceArgumentException(
                 "address", f"Error fetching address data: {e}"
-            )
+            ) from e
 
         entries: list[EntryType] = []
         for id_secteur in id_secteurs:
@@ -352,7 +352,7 @@ class Source:
             except requests.RequestException as e:
                 raise SourceArgumentException(
                     "city", f"Error fetching collection data: {e}"
-                )
+                ) from e
         final_entries = []
         # print(entries)
         for entry in entries:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/delight_system_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/delight_system_com.py
@@ -366,7 +366,7 @@ class Source:
                 self._area_name,
                 "The API rejected this collection area. Check your municipality "
                 "and area name match the ThreeR app.",
-            )
+            ) from None
         return result["user_id"]
 
     def _get_calendar_data(self, user_id: str) -> dict:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dienten_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dienten_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -26,7 +28,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.dienten.gv.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "blnr": "",
         "gnr_search": "0",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dillingen_saar_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dillingen_saar_de.py
@@ -52,7 +52,7 @@ class Source:
 
         params = {"format": "ics", "type": "rm,gs,bio,pa"}
         r = requests.get(
-            f"{API_URL}/{self._street}/{str(now.year)}-01-01/+1%20year/", params=params
+            f"{API_URL}/{self._street}/{now.year!s}-01-01/+1%20year/", params=params
         )
         r.raise_for_status()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdevon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdevon_gov_uk.py
@@ -36,7 +36,7 @@ class Source:
         dates = soup.findAll("em")
 
         entries = []
-        for b, d in zip(bins, dates):
+        for b, d in zip(bins, dates, strict=False):
             # check cases where no date is given for a collection
             if d:
                 bin_type = b.text.replace(" collection", "").replace("Your ", "")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdunbarton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdunbarton_gov_uk.py
@@ -43,7 +43,7 @@ class Source:
         r = s.get(
             f"https://www.eastdunbarton.gov.uk/services/a-z-of-services/bins-waste-and-recycling/bins-and-recycling/collections/?uprn={self._uprn}"
         )
-        r.raise_for_status
+        r.raise_for_status()
         soup = BeautifulSoup(r.content, "html.parser")
 
         entries = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -311,14 +311,10 @@ class Source:
                     town = town_district
                     break
             if not match:
-                matches = list(
-                    map(
-                        lambda x: (
-                            "town: " + x.get("name") + ", district:" + x.get("district")
-                        ),
-                        matching_towns_district,
-                    )
-                )
+                matches = [
+                    ("town: " + x.get("name") + ", district:" + x.get("district"))
+                    for x in matching_towns_district
+                ]
 
                 raise Exception(
                     f"Found multiple matches but no exact match found {matches}"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
@@ -53,7 +55,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.eggelsberg.at"
     ICON_MAP = ICON_MAP
     VDATUM_TODAY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "blnr": "",
         "gnr_search": "0",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ekosystem_wroc_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ekosystem_wroc_pl.py
@@ -85,4 +85,4 @@ class Source:
         calendar_url = html.unescape(match.group(1))
         parsed_url = urlparse(calendar_url)
         params_list = parse_qsl(parsed_url.query)
-        return {k: v for (k, v) in params_list}
+        return dict(params_list)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -60,7 +62,7 @@ class Source(RiSKommunalSource):
     )
     LOOKAHEAD_DAYS = 365
     MAX_PAGES = 30
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "menuonr": "225141707",
     }
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -60,7 +62,7 @@ class Source(RiSKommunalSource):
         "https://www.enns.at/system/web/kalender.aspx?sprache=1&menuonr=227945554"
     )
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "227945554",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/example.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/example.py
@@ -32,7 +32,7 @@ class Source:
         ap_type = 0
 
         for day in range(self._days):
-            for idx in range(self._per_day):
+            for _idx in range(self._per_day):
                 waste_type = f"Type{(ap_type % self._types) + 1}"
                 entries.append(
                     Collection(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/exeter_gov_uk.py
@@ -40,7 +40,7 @@ class Source:
         dates = soup.findAll("h3")
 
         entries = []
-        for b, d in zip(bins, dates):
+        for b, d in zip(bins, dates, strict=False):
             raw_date = re.compile(REGEX_ORDINALS).sub("", d.get_text(strip=True))
             for fmt in ("%A, %d %B %Y", "%A %d %B %Y"):
                 try:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fcc_group_eu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fcc_group_eu.py
@@ -153,7 +153,7 @@ class Source:
         if self._frequency in available_freqs:
             return data
 
-        changed: dict[str, FREQUENCIES_LITERAL] = dict()
+        changed: dict[str, FREQUENCIES_LITERAL] = {}
 
         if (
             data["defaultFrequencyTitle"]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/felixdorf_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/felixdorf_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
@@ -45,7 +47,7 @@ VALID_ZONES = ["Rayon 1", "Rayon 2"]
 class Source(RiSKommunalSource):
     BASE_URL = "https://www.felixdorf.gv.at"
     ICON_MAP = ICON_MAP
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "blnr": "",
         "gnr_search": "0",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fkf_bo_hu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fkf_bo_hu.py
@@ -55,10 +55,8 @@ class Source:
         communal_divs = soup.find_all("div", attrs={"class": "communal"})
 
         selective = soup.find_all("div", attrs={"class": "selective"})
-        communal = [
-            i for i in filter(lambda div: div.text == "Kommunális", communal_divs)
-        ]
-        green = [i for i in filter(lambda div: div.text == "Zöld", communal_divs)]
+        communal = list(filter(lambda div: div.text == "Kommunális", communal_divs))
+        green = list(filter(lambda div: div.text == "Zöld", communal_divs))
 
         for element in communal:
             entries.append(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/flintshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/flintshire_gov_uk.py
@@ -49,7 +49,7 @@ class Source:
 
         for row in rows:
             cols = row.find_all("div")
-            cols = list(map(lambda x: x.text.strip(), cols))
+            cols = [x.text.strip() for x in cols]
             if len(cols) == 0 or not re.match(r"\d{2}/\d{2}/\d{4}", cols[0]):
                 continue
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
@@ -55,7 +55,7 @@ class Source:
         next_dates = [next_collect]
 
         # Generate the subsequent collection dates
-        for i in range(1, 4 // weeks):
+        for _i in range(1, 4 // weeks):
             next_collect += timedelta(days=weeks * 7)
             next_dates.append(next_collect)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fritzens_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fritzens_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -20,7 +22,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.fritzens.gv.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "blnr": "",
         "gnr_search": "0",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gastrikeatervinnare_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gastrikeatervinnare_se.py
@@ -49,7 +49,7 @@ class Source:
         cities = []
         streets = []
 
-        for addressTag, info in zip(addresses, infos):
+        for addressTag, info in zip(addresses, infos, strict=False):
             street = addressTag.text.split(",")[0].strip().lower()
             city = (
                 addressTag.find("span", attrs={"class": "pickup-locality"})

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gateshead_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gateshead_gov_uk.py
@@ -94,9 +94,9 @@ class Source:
             decoded_data = base64.b64decode(response_data)
             data = json.loads(decoded_data)
         except (binascii.Error, ValueError) as e:
-            raise ValueError(f"Failed to decode base64 data: {e}")
+            raise ValueError(f"Failed to decode base64 data: {e}") from e
         except json.JSONDecodeError as e:
-            raise ValueError(f"Failed to parse JSON data: {e}")
+            raise ValueError(f"Failed to parse JSON data: {e}") from e
 
         if "HOUSEHOLDCOLLECTIONS_1" not in data:
             raise ValueError("HOUSEHOLDCOLLECTIONS_1 not found in response data")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
@@ -79,7 +79,7 @@ class Source:
         next4s = div.find_all("ul")
         entries = []  # List that holds collection schedule
 
-        for bin, next4 in zip(bins, next4s):
+        for bin, next4 in zip(bins, next4s, strict=False):
             t = bin.text.split(" (", 1)[0]
             dates = next4.find_all("li")
             for date in dates:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemuenden_wohra_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemuenden_wohra_de.py
@@ -136,7 +136,7 @@ class Source:
         if col_boundaries is None:
             return []
 
-        col_ends = col_boundaries[1:] + [col_boundaries[-1] + 50]
+        col_ends = [*col_boundaries[1:], col_boundaries[-1] + 50]
         first_col_slice = slice(max(0, col_boundaries[0] - 5), col_boundaries[0] + 35)
 
         entries: list[Collection] = []
@@ -151,7 +151,7 @@ class Source:
             day = int(first_col_m.group(1))
 
             for month_idx, (col_start, col_end) in enumerate(
-                zip(col_boundaries, col_ends)
+                zip(col_boundaries, col_ends, strict=False)
             ):
                 if col_start >= len(line):
                     continue

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geovest_it.py
@@ -208,7 +208,7 @@ class Source:
                 "days",
                 days,
                 "Enter a positive number of days to fetch.",
-            )
+            ) from None
         self._calendar_id = None
 
         if self._calendar_type_id not in {"1", "2"}:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/grafikai_svara_lt.py
@@ -108,7 +108,7 @@ def _seroval_decode(node):
         p = node.get("p") or {}
         keys = p.get("k", [])
         vals = p.get("v", [])
-        return {k: _seroval_decode(v) for k, v in zip(keys, vals)}
+        return {k: _seroval_decode(v) for k, v in zip(keys, vals, strict=False)}
     return None
 
 
@@ -212,7 +212,7 @@ class Source:
             raise SourceArgumentException(
                 "waste_object_ids",
                 "waste_object_ids must be a list of numeric values",
-            )
+            ) from None
         # Cached server-fn id, populated lazily on first fetch and
         # invalidated when an upstream redeploy makes the cached id stale.
         self._fn_id: str | None = None
@@ -266,7 +266,7 @@ class Source:
                     raise Exception(
                         f"grafikai.svara.lt rejected request to {api_path!r} "
                         "even after re-discovering the server-function id"
-                    )
+                    ) from None
         raise AssertionError("unreachable")
 
     def fetch(self) -> list[Collection]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/greater_cambridge_waste_org.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/greater_cambridge_waste_org.py
@@ -74,9 +74,9 @@ class Source:
 
     def get_address_details(self, a: str) -> str:
         matches = re.findall(REGEX["details"], a, flags=re.IGNORECASE | re.DOTALL)
-        temp_id: str = [
+        temp_id: str = next(
             did.strip() for addr, did in matches if self._name_or_number in addr
-        ][0]
+        )
         return temp_id
 
     def fetch(self) -> Collection:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hartbeigraz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hartbeigraz_at.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import ClassVar
+
 import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
@@ -75,7 +77,7 @@ class Source(RiSKommunalSource):
     ICON_MAP = ICON_MAP
     SELECTION_URL = "https://www.hartbeigraz.at/Service/Muell"
     MAX_PAGES = 25
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": _MENUONR,
         "bdatum": "31.12.9999",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hastingsdc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hastingsdc_govt_nz.py
@@ -78,7 +78,7 @@ class Source:
         except Exception as e:
             raise ValueError(
                 f"Failed while locating address: {self._address} with error: {e}"
-            )
+            ) from e
 
     def fetch(self):
         v, s, r = self.fetch_property_details()
@@ -93,7 +93,7 @@ class Source:
             response.raise_for_status()
             data = response.json()
         except requests.RequestException as e:
-            raise ValueError(f"API request failed: {e}")
+            raise ValueError(f"API request failed: {e}") from e
 
         if not data.get("success", False):
             raise ValueError("API response indicates failure.")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/heidelberg_de.py
@@ -183,7 +183,7 @@ class WasteInformation:
         self._include_relevant_postponements(postponement_data)
 
     def get_collection_dates(self) -> list[datetime.date]:
-        return list(map(lambda x: x.date(), list(self._collection_ruleset)))
+        return [x.date() for x in list(self._collection_ruleset)]
 
 
 class Source:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/herefordshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/herefordshire_gov_uk.py
@@ -45,7 +45,7 @@ class Source:
         r.raise_for_status()
         addresses = r.json()
         if (
-            ("error" in addresses and addresses["error"])
+            (addresses.get("error"))
             or "results" not in addresses
             or len(addresses["results"]) == 0
         ):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/herzogsdorf_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/herzogsdorf_ooe_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -33,7 +35,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.herzogsdorf.ooe.gv.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "menuonr": "225680057",
         "bdatum": "31.12.9999",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/highland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/highland_gov_uk.py
@@ -57,7 +57,7 @@ class Source:
 
         entries = []
         for key, value in rows_data.items():
-            if not (key.endswith("NextDate") or key.endswith(next_date_key)):
+            if not (key.endswith(("NextDate", next_date_key))):
                 continue
 
             bin_type = key.split("NextDate")[0]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hornsby_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hornsby_nsw_gov_au.py
@@ -571,7 +571,7 @@ def _extract_events_from_weekly_pdf(pdf_bytes: bytes) -> list[Collection]:
 
         keep = [
             it
-            for it, w, h in zip(items, item_widths, item_heights)
+            for it, w, h in zip(items, item_widths, item_heights, strict=False)
             if abs(w - med_w) < 2.0 and abs(h - med_h) < 2.0
         ]
         if len(keep) >= 10:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hume_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hume_vic_gov_au.py
@@ -56,7 +56,7 @@ class Source:
     def collect_dates(self, start_date, weeks):
         dates = []
         dates.append(start_date)
-        for i in range(1, int(4 / weeks)):
+        for _i in range(1, int(4 / weeks)):
             start_date = start_date + timedelta(days=(weeks * 7))
             dates.append(start_date)
         return dates

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -147,9 +147,11 @@ class Source:
         split_at: str | None = None,
         version: int | None = None,
         verify_ssl: bool = True,
-        headers: dict = {},
+        headers: dict | None = None,
         impersonate: str | None = None,
     ):
+        if headers is None:
+            headers = {}
         self._url = re.sub("^webcal", "https", url) if url else None
         self._file = file
         if bool(self._url is not None) == bool(self._file is not None):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -72,7 +74,7 @@ class Source(RiSKommunalSource):
     ICON_MAP = ICON_MAP
     SELECTION_URL = "https://www.imst.gv.at/Muellabfuhrplaene_1"
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": _MENUONR,
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_gov_uk.py
@@ -140,7 +140,9 @@ class Source:
                 if current_month is None or current_year is None:
                     continue  # <dl> before any recognisable month heading
 
-                for dt, dd in zip(element.find_all("dt"), element.find_all("dd")):
+                for dt, dd in zip(
+                    element.find_all("dt"), element.find_all("dd"), strict=False
+                ):
                     bin_name, icon = _classify(dt.get_text(strip=True))
                     for day in _parse_days(dd.get_text(strip=True)):
                         try:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/isontinambiente_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/isontinambiente_it.py
@@ -78,7 +78,7 @@ class Source:
             try:
                 year = int(year_str)
             except ValueError:
-                raise Exception(f"Cannot parse year: {year_str}")
+                raise Exception(f"Cannot parse year: {year_str}") from None
 
             legend = calendar.find_next_sibling()
             if not isinstance(legend, Tag):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ittre_be.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ittre_be.py
@@ -44,7 +44,7 @@ def clean_string(text: str) -> str:
 
 
 class Source:
-    def __init__(self): ...  # noqa: E704
+    def __init__(self): ...
 
     def fetch(self) -> list[Collection]:
         r = requests.get(API_URL)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jointwastesolutions_org.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jointwastesolutions_org.py
@@ -131,7 +131,7 @@ class Source:
         waste_dates = schedule[::2]
 
         entries = []
-        for i in range(0, len(waste_dates)):
+        for i in range(len(waste_dates)):
             entries.append(
                 Collection(
                     date=datetime.strptime(waste_dates[i].text, "%d/%m/%Y").date(),

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -408,7 +408,7 @@ class Source:
 def print_md_table():
     table = "|service_id|cities|\n|---|---|\n"
 
-    for service, data in sorted(SERVICE_MAP.items()):
+    for service, _data in sorted(SERVICE_MAP.items()):
         print(f"service: {service}")
         args = {"r": "cities"}
         r = requests.get(f"https://{service}.jumomind.com/mmapp/api.php", params=args)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -367,8 +367,8 @@ class Source(Junker):
         except AreaRequired as e:
             raise SourceArgumentRequiredWithSuggestions(
                 "area", "required for this municipality", [a[0] for a in e.areas]
-            )
+            ) from e
         except AreaNotFound as e:
             raise SourceArgumentNotFoundWithSuggestions(
                 "area", self._area, [a[0] for a in e.areas]
-            )
+            ) from e

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kanzian_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kanzian_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -31,7 +33,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.kanzian.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "detailonr": "225258384",
         "menuonr": "225275269",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -47,7 +49,7 @@ class Source(RiSKommunalSource):
         "https://www.klosterneuburg.at/Natur_Umwelt/Recycling/Muellabfuhr/"
         "Muellabfuhrkalender"
     )
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "226582740",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/knowsley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/knowsley_gov_uk.py
@@ -53,13 +53,21 @@ class Source:
         s: requests.Session,
         action: str,
         x_csrf_token: str,
-        changes: dict = {},
-        objects: list = [],
-        params: dict[str, str | list[str] | dict] = {},
-        profile_data: dict[str, int] = {},
+        changes: dict | None = None,
+        objects: list | None = None,
+        params: dict[str, str | list[str] | dict] | None = None,
+        profile_data: dict[str, int] | None = None,
         operation_id: str | None = None,
         validation_guids: list[str] | None = None,
     ) -> dict:
+        if profile_data is None:
+            profile_data = {}
+        if params is None:
+            params = {}
+        if objects is None:
+            objects = []
+        if changes is None:
+            changes = {}
         time_str = str(int(time.time()))
         headers = {
             "Content-Type": "application/json",
@@ -128,7 +136,7 @@ class Source:
 
         objects = data["objects"]
         changes_postcode = data["changes"]
-        changes_postcode[list(changes_postcode.keys())[0]][
+        changes_postcode[next(iter(changes_postcode.keys()))][
             "EnquiryPostcodeOrStreetName"
         ] = {"value": self._postcode}
 
@@ -170,7 +178,7 @@ class Source:
         params = {"Generic_Address": {"guid": objects[-1]["guid"]}}
 
         changes = changes_postcode.copy()
-        changes[list(changes.keys())[0]]["ShowAddressResults"] = {"value": True}
+        changes[next(iter(changes.keys()))]["ShowAddressResults"] = {"value": True}
 
         changes.update({uprn_chage_element[0]: uprn_chage_element[1]})
         data = self._do_request(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kom_lub_com_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kom_lub_com_pl.py
@@ -152,7 +152,7 @@ def normalize_district(district: int | str | None) -> str:
         raise SourceArgumentException(
             "district",
             f"Nieprawidłowa wartość district={district!r}. Podaj liczbę 1–7.",
-        )
+        ) from None
 
     if n not in _DISTRICT_ROMAN:
         raise SourceArgumentException(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/koppl_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/koppl_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -29,7 +31,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.koppl.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "detailonr": "225241960",
         "menuonr": "225241969",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
@@ -78,7 +78,7 @@ class Source(RiSKommunalSource):
             .replace("'", '"')
         )
 
-        number_dict = dict()
+        number_dict = {}
 
         for idx, street_id in enumerate(possible_numbers):
             number_dict[street_id[0]] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kositeast_sk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kositeast_sk.py
@@ -80,7 +80,7 @@ def _nearest_color(color: tuple) -> str | None:
     """Return the nearest waste-type name for *color*, or None if too far away."""
     best_name, best_dist = None, float("inf")
     for known, name in COLOR_MAP.items():
-        dist = sum((a - b) ** 2 for a, b in zip(color, known)) ** 0.5
+        dist = sum((a - b) ** 2 for a, b in zip(color, known, strict=False)) ** 0.5
         if dist < best_dist:
             best_dist = dist
             best_name = name

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -35,7 +37,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.kronstorf.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "menuonr": "218754346",
         "bdatum": "31.12.9999",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lacity_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lacity_gov.py
@@ -77,7 +77,7 @@ class Source:
             data = response.json()
 
         except RequestException as ex:
-            raise Exception(f"Error fetching collection data: {str(ex)}")
+            raise Exception(f"Error fetching collection data: {ex!s}") from ex
 
         # Verify Address was found
         if data["status"] != "exactMatch":

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lakemac_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lakemac_nsw_gov_au.py
@@ -65,7 +65,7 @@ class Source:
                 continue
             waste_date.append(date_object)
 
-        waste = list(zip(waste_type, waste_date))
+        waste = list(zip(waste_type, waste_date, strict=False))
 
         entries = []
         for item in waste:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lambeth_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lambeth_gov_uk.py
@@ -82,14 +82,14 @@ class Source:
             )
             response.raise_for_status()
         except requests.Timeout:
-            raise Exception("API request timed out")
+            raise Exception("API request timed out") from None
         except requests.RequestException as e:
-            raise Exception(f"API request failed: {e}")
+            raise Exception(f"API request failed: {e}") from e
 
         try:
             data = response.json()
         except ValueError:
-            raise Exception("Invalid JSON response")
+            raise Exception("Invalid JSON response") from None
 
         services = data.get("SiteServices")
         if not services:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lewisham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lewisham_gov_uk.py
@@ -65,17 +65,17 @@ class Source:
             addresses = r.json()
 
             if self._name:
-                self._uprn = [
+                self._uprn = next(
                     x["Uprn"]
                     for x in addresses
                     if (x["Title"]).upper().startswith(self._name.upper())
-                ][0]
+                )
             elif self._number:
-                self._uprn = [
+                self._uprn = next(
                     x["Uprn"]
                     for x in addresses
                     if (x["Title"]).startswith(str(self._number))
-                ][0]
+                )
 
             if not self._uprn:
                 raise Exception(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
@@ -68,7 +68,7 @@ class Source:
             try:
                 address_list = response.json().get("html")
             except Exception:
-                raise SourceArgumentNotFound("postcode", self._postcode)
+                raise SourceArgumentNotFound("postcode", self._postcode) from None
 
             soup = bs4.BeautifulSoup(address_list, features="html.parser")
 
@@ -107,7 +107,7 @@ class Source:
         try:
             next_collections = response.json().get("nextCollections")
         except Exception:
-            raise ValueError("No collection data in response")
+            raise ValueError("No collection data in response") from None
 
         entries = []  # List that holds collection schedule
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lobbe_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lobbe_app.py
@@ -151,8 +151,13 @@ class Source:
 
     @staticmethod
     def _get_id(
-        action: str, compare_to: str, param_name: str, params: dict[str, str | int] = {}
+        action: str,
+        compare_to: str,
+        param_name: str,
+        params: dict[str, str | int] | None = None,
     ) -> tuple[int, str]:
+        if params is None:
+            params = {}
         params = {"action": action, **params}
         original_compare_to = compare_to
         compare_to = make_comparable(compare_to)
@@ -211,7 +216,7 @@ class Source:
             "place[text]": self._city_name,
             "street[id]": self._street_id,
             "street[text]": self._street_name,
-            **{t: 1 for t in TYPES},
+            **dict.fromkeys(TYPES, 1),
             "hours": 18,
             "minutes": 00,
             "action": "create_ical",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lodz_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lodz_pl.py
@@ -109,7 +109,7 @@ class Source:
         try:
             events = json.loads(json_data)
         except json.JSONDecodeError as e:
-            raise ValueError(f"Error parsing the JSON schedule: {e}")
+            raise ValueError(f"Error parsing the JSON schedule: {e}") from e
 
         entries = []
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/meinawb_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/meinawb_de.py
@@ -91,7 +91,7 @@ class Source:
         parsed = re.findall(
             '<INPUT\\sNAME="([^"]+?)"\\sID="[^"]+?"(?:\\sVALUE="([^"]*?)")?', text
         )
-        return {k: v for k, v in parsed}
+        return dict(parsed)
 
     def _address(self):
         return {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_gov_uk.py
@@ -59,7 +59,7 @@ class Source:
         r = s.get(
             "https://my.melton.gov.uk/set-location", headers=HEADERS, params=params
         )
-        r.raise_for_status
+        r.raise_for_status()
         soup: BeautifulSoup = BeautifulSoup(r.content, "html.parser")
 
         entries: list = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
@@ -126,7 +126,7 @@ class Source:
                     )
 
         # RedLid (General Waste) — fortnightly, next date given
-        if "RedLid" in fields and fields["RedLid"]:
+        if fields.get("RedLid"):
             try:
                 next_red = dateparse(fields["RedLid"], dayfirst=True).date()
                 for d in rrule(WEEKLY, interval=2, dtstart=next_red, count=13):
@@ -141,7 +141,7 @@ class Source:
                 pass
 
         # YellowLid (Recycling) — fortnightly, next date given
-        if "YellowLid" in fields and fields["YellowLid"]:
+        if fields.get("YellowLid"):
             try:
                 next_yellow = dateparse(fields["YellowLid"], dayfirst=True).date()
                 for d in rrule(WEEKLY, interval=2, dtstart=next_yellow, count=13):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -59,7 +61,7 @@ class Source(RiSKommunalSource):
         "https://www.micheldorf.at/system/web/kalender.aspx?sprache=1&menuonr=227975509"
     )
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "227975509",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mid_devon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mid_devon_gov_uk.py
@@ -145,7 +145,7 @@ class Source:
             raise SourceArgumentException(
                 "uprn",
                 f"Council lookup returned invalid response: {e}",
-            )
+            ) from e
         if not rows:
             raise SourceArgumentNotFound(
                 "uprn",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midsussex_gov_uk.py
@@ -125,7 +125,9 @@ class Source:
             try:
                 track_token = dynamic_link.split("Track=")[1].split("&")[0]  # type: ignore[union-attr]
             except IndexError:
-                raise ValueError("Could not parse dynamic Track token in Step 1.")
+                raise ValueError(
+                    "Could not parse dynamic Track token in Step 1."
+                ) from None
 
             # --- STEP 2: Submit the Address ---
             post_url = f"{BASE_URL}/mop.php?serviceID=A&Track={track_token}&seq=2"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mijnafvalwijzer_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mijnafvalwijzer_nl.py
@@ -97,7 +97,7 @@ class Source:
         entries: list[Collection] = []
 
         for day, month, year, bin_type in zip(
-            date_day, date_month, date_year, types_list
+            date_day, date_month, date_year, types_list, strict=False
         ):
             try:
                 entries.append(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/milton_keynes_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/milton_keynes_gov_uk.py
@@ -85,7 +85,7 @@ class Source:
 
         # Extract bin types and next collection dates
         entries = []
-        for index, item in rowdata.items():
+        for _index, item in rowdata.items():
             # print(item)
             bin_type = item["AssetTypeName"]
             icon = None

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
@@ -140,10 +140,8 @@ class Source:
         communal_divs = soup.find_all("div", attrs={"class": "communal"})
 
         selective = soup.find_all("div", attrs={"class": "selective"})
-        communal = [
-            i for i in filter(lambda div: div.text == "Kommunális", communal_divs)
-        ]
-        green = [i for i in filter(lambda div: div.text == "Zöld", communal_divs)]
+        communal = list(filter(lambda div: div.text == "Kommunális", communal_divs))
+        green = list(filter(lambda div: div.text == "Zöld", communal_divs))
 
         for element in communal:
             entries.append(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -242,7 +242,7 @@ class Source:
             elif re.match(r"(.*\d+.*){1,}", line):
                 # Multiple dates ?
                 dates_defined = True
-                for month, month_id in MONTHS.items():
+                for month in MONTHS:
                     if re.search(rf"{month}", line, re.IGNORECASE):
                         months_found.append(month)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/multiple.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/multiple.py
@@ -86,17 +86,15 @@ PARAM_TRANSLATIONS = {
 def get_source(source: str, args: dict | list[dict]) -> list:
     if isinstance(args, list):
         return [
-            getattr(
-                importlib.import_module(f"waste_collection_schedule.source.{source}"),
-                "Source",
-            )(**arg)
+            importlib.import_module(
+                f"waste_collection_schedule.source.{source}"
+            ).Source(**arg)
             for arg in args
         ]
     return [
-        getattr(
-            importlib.import_module(f"waste_collection_schedule.source.{source}"),
-            "Source",
-        )(**args)
+        importlib.import_module(f"waste_collection_schedule.source.{source}").Source(
+            **args
+        )
     ]
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mundaring_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mundaring_wa_gov_au.py
@@ -76,13 +76,18 @@ class Source:
         entries = []
         for pickup in pickups[1:]:
             details: list = self.tidytext(pickup.text.split(":"))
-            for detail in details:
+            for _detail in details:
                 if "FOGO" in details[0]:
-                    dt = list(
-                        rrule(
-                            WEEKLY, byweekday=DAYS[details[1]], dtstart=today, count=1
+                    dt = next(
+                        iter(
+                            rrule(
+                                WEEKLY,
+                                byweekday=DAYS[details[1]],
+                                dtstart=today,
+                                count=1,
+                            )
                         )
-                    )[0]
+                    )
                     waste = "FOGO Bin"
                 elif "Bulk" in details[0]:
                     dt = datetime.strptime(details[1], "%d %B %Y")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mustankorkea_fi.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mustankorkea_fi.py
@@ -179,7 +179,7 @@ class Source:
                         raise TypeError(
                             f"Expected allEmptyings to be a dict, not {type(details['allEmptyings'])}"
                         )
-                    for kind, info in details["allEmptyings"].items():
+                    for _kind, info in details["allEmptyings"].items():
                         if not isinstance(info, list):
                             continue
                         for entry in info:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzv_rotenburg_bebra_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzv_rotenburg_bebra_de.py
@@ -117,12 +117,12 @@ class Source:
                     "city",
                     self._city,
                     "make sure the city is spelled exactly like in the link of the website https://www.mzv-rotenburg-bebra.de//webapp.html",
-                )
+                ) from None
             raise SourceArgumentNotFoundWithSuggestions(
                 "city",
                 self._city,
                 cities,
-            )
+            ) from None
 
         entries = []
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/napier_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/napier_govt_nz.py
@@ -78,7 +78,7 @@ class Source:
         except Exception as e:
             raise ValueError(
                 f"Failed while locating address: {self._address} with error: {e}"
-            )
+            ) from e
 
     def fetch(self):
         v, s, r = self.fetch_property_details()
@@ -93,7 +93,7 @@ class Source:
             response.raise_for_status()
             data = response.json()
         except requests.RequestException as e:
-            raise ValueError(f"API request failed: {e}")
+            raise ValueError(f"API request failed: {e}") from e
 
         if not data.get("success", False):
             raise ValueError("API response indicates failure.")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/neath_port_talbot_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/neath_port_talbot_gov_uk.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import re
 from dataclasses import dataclass
+from typing import ClassVar
 
 import requests
 from bs4 import BeautifulSoup
@@ -62,10 +63,10 @@ ICON_MAP = {
 }
 
 
-class FailedToFindTokensError(Exception): ...  # noqa: E701
+class FailedToFindTokensError(Exception): ...
 
 
-class FailedToFindCollections(Exception): ...  # noqa: E701
+class FailedToFindCollections(Exception): ...
 
 
 _DAY_MONTH_RE = re.compile(
@@ -98,7 +99,7 @@ class Source:
     """
 
     _BASE_URL = f"{URL}bins-and-recycling/equipment-and-collections/bin-day-finder/"
-    _HEADERS = {
+    _HEADERS: ClassVar = {
         "User-Agent": "Mozilla/5.0",
         "Referer": _BASE_URL,
         "Origin": URL,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nelincs_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nelincs_gov_uk.py
@@ -49,7 +49,7 @@ class Source:
 
         entries = []
         for heading, col_list in zip(
-            collection_div.select("div.h4"), collection_div.select("ul")
+            collection_div.select("div.h4"), collection_div.select("ul"), strict=False
         ):
             bin_type = heading.text.strip()
             icon = ICON_MAP.get(bin_type.casefold())  # Collection icon

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newforest_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newforest_gov_uk.py
@@ -110,7 +110,7 @@ class Source:
         # First GET: server returns 302 with JSESSIONID in the first Set-Cookie header.
         # The server sends two Set-Cookie headers; the second is a malformed "Secure; HttpOnly"
         # that would overwrite JSESSIONID in a dict.  We use raw header iteration instead.
-        status, raw_headers, _ = self._get(conn, FORM_PATH)
+        _status, raw_headers, _ = self._get(conn, FORM_PATH)
         jsessionid = None
         for k, v in raw_headers:
             if k.lower() == "set-cookie" and "JSESSIONID=" in v:
@@ -123,11 +123,11 @@ class Source:
 
         # Second GET: follows the location from the 302
         loc1 = self._header(raw_headers, "location") or FORM_PATH
-        status, raw_headers, _ = self._get(conn, f"/ufs/{loc1}", jsessionid)
+        _status, raw_headers, _ = self._get(conn, f"/ufs/{loc1}", jsessionid)
 
         # Third GET: follows to the parameterised form URL (ebd=0&ebp=10&ebz=...)
         loc2 = self._header(raw_headers, "location") or loc1
-        status, raw_headers, body = self._get(conn, f"/ufs/{loc2}", jsessionid)
+        _status, raw_headers, body = self._get(conn, f"/ufs/{loc2}", jsessionid)
 
         soup = BeautifulSoup(body, "html.parser")
         form = soup.find("form")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_kesteven_org_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_kesteven_org_uk.py
@@ -36,7 +36,7 @@ class Source:
         bin_dates = soup.find_all("strong")
 
         entries = []
-        for idx in range(0, len(bin_type)):
+        for idx in range(len(bin_type)):
             entries.append(
                 Collection(
                     date=datetime.strptime(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_norfolk_gov_uk.py
@@ -57,7 +57,7 @@ class Source:
         # If it is, increment the year by 1.
         today: date = datetime.now().date()
         year: int = today.year
-        dt: date = datetime.strptime(f"{d} {str(year)}", "%A %d %B %Y").date()
+        dt: date = datetime.strptime(f"{d} {year!s}", "%A %d %B %Y").date()
         if (dt - today) < timedelta(days=-31):
             dt = dt.replace(year=dt.year + 1)
         return dt

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/northlanarkshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/northlanarkshire_gov_uk.py
@@ -61,13 +61,13 @@ class Source:
         r = s.get(
             f"https://www.northlanarkshire.gov.uk/bin-collection-dates/{self._uprn}/{self._usrn}"
         )
-        r.raise_for_status
+        r.raise_for_status()
 
         soup = BeautifulSoup(r.text, "html.parser")
         containers = soup.findAll("div", {"class": "waste-type-container"})
 
         entries = []
-        for idx, container in enumerate(containers):
+        for _idx, container in enumerate(containers):
             waste_type = container.find("h3").text
             waste_days = container.findAll("p")
             for day in waste_days:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/npdc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/npdc_govt_nz.py
@@ -189,11 +189,8 @@ class Source:
             # Blue address → Glass+Landfill on odd (blue glass) weeks
             # Yellow address → Glass+Landfill on even (non-blue glass) weeks
             is_glass_landfill_week = (
-                pick_week_colour == "blue"
-                and blue_glass_week
-                or pick_week_colour == "yellow"
-                and not blue_glass_week
-            )
+                pick_week_colour == "blue" and blue_glass_week
+            ) or (pick_week_colour == "yellow" and not blue_glass_week)
 
             if is_glass_landfill_week:
                 waste_type = "Glass and Landfill"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nvaa_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nvaa_se.py
@@ -68,7 +68,7 @@ def parse_date(next_pickup_date):
             "november": 11,
             "december": 12,
         }
-        day, day_number, month, year = next_pickup_date.split()
+        _day, day_number, month, year = next_pickup_date.split()
         month = swedish_months[month]
         date_obj = datetime.strptime(f"{year}-{month}-{day_number}", "%Y-%m-%d").date()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -60,7 +62,7 @@ class Source(RiSKommunalSource):
     SELECTION_URL = "https://www.oberndorf.ooe.gv.at"
     LOOKAHEAD_DAYS = 365
     MAX_PAGES = 30
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "227435354",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oldham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oldham_gov_uk.py
@@ -44,7 +44,7 @@ class Source:
         r = s.get(
             f"https://portal.oldham.gov.uk/bincollectiondates/details?uprn={self._uprn}"
         )
-        r.raise_for_status
+        r.raise_for_status()
 
         soup = BeautifulSoup(r.content, "html.parser")
         pickups: list = soup.find_all("table", {"class": "data-table confirmation"})

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/onkaparingacity_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/onkaparingacity_com.py
@@ -68,7 +68,7 @@ class Source:
                 date_object = datetime.strptime(tag_text, "%a %d/%m/%Y").date()
                 waste_date.append(date_object)
 
-        waste = list(zip(waste_type, waste_date))
+        waste = list(zip(waste_type, waste_date, strict=False))
 
         entries = []
         for item in waste:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/opendata_bordeauxmetropole_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/opendata_bordeauxmetropole_fr.py
@@ -2,6 +2,7 @@ import json
 import urllib.parse
 from datetime import date, datetime, timedelta
 from enum import Enum
+from typing import ClassVar
 
 import requests
 from waste_collection_schedule import Collection, Icons
@@ -198,7 +199,7 @@ class Source:
     geocoder_url = "https://api.publidata.io/v2/geocoder"
     api_url = "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/en_frcol_s/exports/json?lang=fr&refine=commune%3A%22{city}%22&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B"
 
-    INSEE_CODES = {
+    INSEE_CODES: ClassVar = {
         "Bordeaux": 33063,
         "Mérignac": 33281,
         "Gradignan": 33192,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/orange_nsw_gov_au.py
@@ -113,7 +113,7 @@ def _year_from_pdf_text(session: requests.Session, url: str) -> int | None:
             m = _YEAR_IN_URL_RE.search(text)
             if m:
                 return int(m.group(1))
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         _LOGGER.debug(
             "orange_nsw_gov_au: Could not extract year from PDF text: %s", exc
         )
@@ -180,7 +180,7 @@ class Source:
             year = _year_from_pdf_url(pdf_url)
             if year is None:
                 year = _year_from_pdf_text(session, pdf_url)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             _LOGGER.warning(
                 "orange_nsw_gov_au: Could not fetch booklet from %s (%s). "
                 "Falling back to current calendar year.",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/piberbach_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/piberbach_ooe_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -24,6 +26,6 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.piberbach.ooe.gv.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/portenf_sa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/portenf_sa_gov_au.py
@@ -68,8 +68,10 @@ class Source:
         self._unit_number: str = str(unit_number)
 
     def __set_args(
-        self, soup: BeautifulSoup, event_taget=None, additional: dict = {}
+        self, soup: BeautifulSoup, event_taget=None, additional: dict | None = None
     ) -> dict:
+        if additional is None:
+            additional = {}
         args = {
             "ctl00$MainContent$txtSuburb": self._suburb,
             "ctl00$MainContent$txtStreetName": self._street,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/portstephens_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/portstephens_nsw_gov_au.py
@@ -59,9 +59,11 @@ def get_id(
     url_key: str,
     val_key: str,
     name: str,
-    params: dict = {},
+    params: dict | None = None,
     init_param_name: str | None = None,
 ):
+    if params is None:
+        params = {}
     response = s.get(API_URLS[url_key], params=params, headers=HEADERS)
     data = json.loads(response.text)
     for val in data[val_key]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/potsdam_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/potsdam_de.py
@@ -111,7 +111,7 @@ class Source:
             r.raise_for_status()
         except Exception:
             if year == today.year:
-                raise Exception("Could not get data from URL")
+                raise Exception("Could not get data from URL") from None
             return None
 
         try:
@@ -266,23 +266,25 @@ class Source:
             )
             or (
                 (
-                    (node["rhythmus"] == 4)
-                    and self.__typematch(
-                        day.strftime("%m"),
-                        day.strftime("%d"),
-                        node["typ"],
-                        1,
-                        self._rhythms[1],
-                        self._rhythms[2],
-                        self._rhythms[4],
+                    (
+                        (node["rhythmus"] == 4)
+                        and self.__typematch(
+                            day.strftime("%m"),
+                            day.strftime("%d"),
+                            node["typ"],
+                            1,
+                            self._rhythms[1],
+                            self._rhythms[2],
+                            self._rhythms[4],
+                        )
+                    )
+                    and (
+                        (node["tag1"] == dow)
+                        or ((node["tag2"] > 0) and (node["tag2"] == dow))
                     )
                 )
-                and (
-                    (node["tag1"] == dow)
-                    or ((node["tag2"] > 0) and (node["tag2"] == dow))
-                )
+                and (weekno >= node["beginn"])
             )
-            and (weekno >= node["beginn"])
         )
 
     def fetch(self):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_ca.py
@@ -386,7 +386,7 @@ class Source:
             opening_hours = opening_hours.replace(
                 f"{time_start}-{time_end}", ""
             ).strip()
-            start_hour, start_minute, end_hour, end_minute = self._parse_hours(
+            start_hour, start_minute, _end_hour, _end_minute = self._parse_hours(
                 time_start, time_end
             )
         else:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -682,8 +682,8 @@ class Source:
             if part == "week":
                 kwargs["freq"] = WEEKLY
                 kwargs.update(self._parse_week_no(parts.pop(0)))
-            elif (
-                part.startswith("off") or part.startswith('"')
+            elif part.startswith(
+                ("off", '"')
             ):  # schedule should be of type "closed" or "closing_exception", or part should be a comment
                 continue
             else:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/puchbeihallein_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/puchbeihallein_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -63,7 +65,7 @@ class Source(RiSKommunalSource):
     )
     LOOKAHEAD_DAYS = 365
     MAX_PAGES = 30
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "226095231",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rctcbc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rctcbc_gov_uk.py
@@ -78,7 +78,7 @@ class Source:
         s = requests.Session()
         # website appears to display ~4 months worth of collections, so iterate through those pages
         entries: list[Collection] = []
-        for month in range(0, 4):
+        for month in range(4):
             r = s.get(
                 f"https://www.rctcbc.gov.uk/EN/Resident/RecyclingandWaste/RecyclingandWasteCollectionDays.aspx?uprn={self._uprn}&month={month}"
             )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rd4_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rd4_nl.py
@@ -50,7 +50,7 @@ class Source:
             return entries + self._get_collections(year)
         except Exception:
             if exception:
-                raise exception
+                raise exception from None
             return entries
 
     def _get_collections(self, year) -> list[Collection]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/renfrewshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/renfrewshire_gov_uk.py
@@ -57,7 +57,7 @@ class Source:
             for date_str, bins in binData.items():
                 date = datetime.fromisoformat(date_str).date()
 
-                for bin_name, details in bins.items():
+                for _bin_name, details in bins.items():
                     if details is None:
                         continue  # skip empty bins
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ressourceindsamling_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ressourceindsamling_dk.py
@@ -92,7 +92,7 @@ class Source:
             response_data = address_response.json()
         except json.JSONDecodeError as e:
             _LOGGER.error("Failed to parse address lookup JSON response: %s", e)
-            raise ValueError(f"Failed to parse address lookup response: {e}")
+            raise ValueError(f"Failed to parse address lookup response: {e}") from e
 
         _LOGGER.debug(f"Address search response: {response_data}")
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rochdale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rochdale_gov_uk.py
@@ -75,7 +75,7 @@ class Source:
         except KeyError:
             raise ValueError(
                 f"Rochdale API: Failed to retrieve bartecToken for UPRN {self._uprn}."
-            )
+            ) from None
 
         # 3. STEP 2: Fetch the Calendar
         # Lookup 68b58a1364572 returns the annual calendar using the token and date bounds

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rockingham_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rockingham_wa_gov_au.py
@@ -160,7 +160,7 @@ class Source:
                         item for item in fields if item.get("name") == waste_name
                     ]
 
-                    for match in matches:
+                    for _match in matches:
                         # Get the first result, that's all we need
                         raw_value = matches[0]["value"]["value"]
                         if not raw_value:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rohrbach_lafnitz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rohrbach_lafnitz_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -23,7 +25,7 @@ class Source(RiSKommunalSource):
     ICON_MAP = ICON_MAP
     GNR = "2371"
     # Calendar IDs (do parameter) for each waste type
-    ICS_CALENDARS = {
+    ICS_CALENDARS: ClassVar = {
         "Biomüll": "MjI1MTc2NDk0",
         "Leichtverpackungen": "MjI1MTc2NDg4",
         "Restmüll": "MjI1MTc2NDky",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rotorua_lakes_council_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rotorua_lakes_council_nz.py
@@ -52,7 +52,7 @@ class Source:
         except Exception as e:
             raise ValueError(
                 f"Geolocation failed for address: {self._address} with error: {e}"
-            )
+            ) from e
 
     def fetch(self):
         lat, lon = self.fetch_coordinates()
@@ -71,7 +71,7 @@ class Source:
             response.raise_for_status()
             data = response.json()
         except requests.RequestException as e:
-            raise ValueError(f"API request failed: {e}")
+            raise ValueError(f"API request failed: {e}") from e
 
         entries = []
         for feature in data.get("features", []):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/roundrocktexas_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/roundrocktexas_gov.py
@@ -28,15 +28,15 @@ DAYS = {
     "Sunday": SU,
 }
 HOLIDAYS = {  # website indicates collections falling on these days will be shifted by 1 day
-    "Thanksgiving": list(
-        rrule(YEARLY, bymonth=11, byweekday=TH(4), dtstart=datetime.now())
-    )[0].date(),  # 4th Thursday in November
-    "Christmas Day": list(
-        rrule(YEARLY, bymonth=12, bymonthday=25, dtstart=datetime.now())
-    )[0].date(),  # 25th December
-    "New Years Day": list(
-        rrule(YEARLY, bymonth=1, bymonthday=1, dtstart=datetime.now())
-    )[0].date(),  # 1st January
+    "Thanksgiving": next(
+        iter(rrule(YEARLY, bymonth=11, byweekday=TH(4), dtstart=datetime.now()))
+    ).date(),  # 4th Thursday in November
+    "Christmas Day": next(
+        iter(rrule(YEARLY, bymonth=12, bymonthday=25, dtstart=datetime.now()))
+    ).date(),  # 25th December
+    "New Years Day": next(
+        iter(rrule(YEARLY, bymonth=1, bymonthday=1, dtstart=datetime.now()))
+    ).date(),  # 1st January
 }
 
 
@@ -60,7 +60,7 @@ class Source:
         )
         r.raise_for_status()
         areas = json.loads(r.text)
-        for idx, area in enumerate(areas):
+        for _idx, area in enumerate(areas):
             if self._area.upper() == area["Neighborhood Name"].upper():
                 recycling_zone = area["Recycling Zone"]
 
@@ -72,7 +72,7 @@ class Source:
         )
         r.raise_for_status()
         recycling_schedule = json.loads(r.text)
-        for idx, zone in enumerate(recycling_schedule):
+        for _idx, zone in enumerate(recycling_schedule):
             if recycling_zone == zone["Recycling Zone"]:
                 end_date = datetime.strptime(zone["Date"], "%Y-%m-%d")
                 dt = datetime.strptime(zone["Date"], "%Y-%m-%d").date()
@@ -90,7 +90,7 @@ class Source:
         trash_dates = list(
             rrule(WEEKLY, byweekday=DAYS[trash_day], dtstart=today, until=end_date)
         )
-        for idx, item in enumerate(trash_dates):
+        for _idx, item in enumerate(trash_dates):
             item = self.check_holidays(item.date())
             entries.append(
                 Collection(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rova_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rova_nl.py
@@ -87,7 +87,7 @@ class Source:
             return entries + self._get_collections(year)
         except Exception:
             if exception:
-                raise exception
+                raise exception from None
             return entries
 
     def _get_collections(self, year: int) -> list[Collection]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/royalgreenwich_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/royalgreenwich_gov_uk.py
@@ -107,7 +107,7 @@ class Source:
             raise Exception("Could not find address form")
 
         headers = black_top_bin_schedule_table.find_all("th")
-        week_column_index = list(map(lambda h: h.text, headers)).index(week_name)
+        week_column_index = [h.text for h in headers].index(week_name)
         if week_column_index < 0:
             raise Exception("Cannot find black top bin collection weeks")
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -67,7 +69,7 @@ class Source(RiSKommunalSource):
     SELECTION_URL = "https://www.saalfelden.at/Buergerservice/Abfallkalender"
     LOOKAHEAD_DAYS = 365
     MAX_PAGES = 30
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "detailonr": "225697049",
         "menuonr": "225696673",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sammelkalender_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sammelkalender_ch.py
@@ -192,9 +192,8 @@ class Source:
         streets = self._get_streets()
 
         # switch to Sammelgebiete if API either returns no streets or one dummy street
-        if (
-            not streets
-            or len(streets) == 1
+        if not streets or (
+            len(streets) == 1
             and streets[0].get("STRname") is None
             and streets[0].get("SAGEid") is not None
         ):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
@@ -73,7 +73,7 @@ class Source:
             byweekday=(weekday),
             dtstart=date_start,
         )
-        dates = [dt for dt in rr.between(date_start, date_end, inc=True)]
+        dates = list(rr.between(date_start, date_end, inc=True))
         return dates
 
     def fetch(self):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -65,7 +67,7 @@ class Source(RiSKommunalSource):
         "https://www.schaerding.ooe.gv.at/system/web/kalender.aspx?menuonr=226878372"
     )
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "226878372",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schlierbach_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schlierbach_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
@@ -51,7 +53,7 @@ VALID_ZONES = ["1", "Wohnhausanlagen"]
 class Source(RiSKommunalSource):
     BASE_URL = "https://www.schlierbach.at"
     ICON_MAP = ICON_MAP
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "225603725",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sector27_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sector27_de.py
@@ -123,7 +123,7 @@ class Source:
         city = CITIES.get(self._city)
         if city is None:
             raise SourceArgumentNotFoundWithSuggestions(
-                "city", self._city, [x for x in CITIES.keys()]
+                "city", self._city, list(CITIES.keys())
             )
 
         street_id = self._lookup_street_id(city)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/shellharbourwaste_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/shellharbourwaste_com_au.py
@@ -24,7 +24,7 @@ def findUrl(zoneID):
     r = requests.get(
         f"https://www.shellharbourwaste.com.au/wp-json/rb_co/v1/get-waste-url?zone={zoneID}"
     )
-    r.raise_for_status
+    r.raise_for_status()
     d = r.json()
     return d["url"]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sica_lu.py
@@ -94,7 +94,7 @@ class Source:
         try:
             data = r.json()
         except ValueError as e:
-            raise ValueError(f"Error decoding JSON from API: {e} - {r.text}")
+            raise ValueError(f"Error decoding JSON from API: {e} - {r.text}") from e
         return data
 
     def _get_municipality_id(self) -> None:
@@ -107,7 +107,7 @@ class Source:
             {
                 item["name"]["en"].lower(): item["id"]
                 for m in data.get("data", [])
-                for item in [m] + m.get("children", [])
+                for item in [m, *m.get("children", [])]
                 if not item["isDisabled"] and not item.get("children", [])
             }
         )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sims_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sims_pl.py
@@ -270,7 +270,7 @@ class Source:
                     break
             if owner_id is None:
                 raise SourceArgumentNotFoundWithSuggestions(
-                    "owner", owner, [o_name for o_name in OWNER_IDS.values()]
+                    "owner", owner, list(OWNER_IDS.values())
                 )
         self._owner_id: str = str(owner_id)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sivom_rivedroite_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sivom_rivedroite_fr.py
@@ -54,9 +54,11 @@ class Source:
                 and data[1][0] == "description"
             ):
                 to_return = {data[0][1][0].lower(): data[1][1][0]}
-                for nom in data[0][1][0].lower().split(" et "):
+                for _nom in data[0][1][0].lower().split(" et "):
                     to_return.update(
-                        {d: data[1][1][0] for d in data[0][1][0].lower().split(" et ")}
+                        dict.fromkeys(
+                            data[0][1][0].lower().split(" et "), data[1][1][0]
+                        )
                     )
 
             for d in data:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/skaraborg_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/skaraborg_se.py
@@ -67,4 +67,4 @@ class Source:
                 if x["zip_city"] == self._city and x["address"] == self._address
             )
         except StopIteration:
-            raise SourceArgumentNotFound("address", self._address)
+            raise SourceArgumentNotFound("address", self._address) from None

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/solihull_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/solihull_gov_uk.py
@@ -85,6 +85,5 @@ class Source:
                             )
                     except Exception as e:
                         _LOGGER.warning(f"Error predicting next collection: {e}")
-                        pass
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_helens_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_helens_gov_uk.py
@@ -60,7 +60,7 @@ class Source:
                 timeout=30,
             )
         except Exception as err:
-            raise RuntimeError("Failed to get initial form", err)
+            raise RuntimeError("Failed to get initial form", err) from err
 
         response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_margarethen_salzburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_margarethen_salzburg_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -25,7 +27,7 @@ class Source(RiSKommunalSource):
     BASE_URL = "https://www.st.margarethen.salzburg.at"
     ICON_MAP = ICON_MAP
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "bdatum": "31.12.9999",
         "blnr": "",
         "gnr_search": "0",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from waste_collection_schedule import Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 
@@ -59,7 +61,7 @@ class Source(RiSKommunalSource):
         "https://www.steyr.at/system/web/kalender.aspx?sprache=1&menuonr=227376864"
     )
     RAISE_ON_EMPTY = True
-    QUERY_PARAMS = {
+    QUERY_PARAMS: ClassVar = {
         "sprache": "1",
         "menuonr": "227376864",
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/subiaco_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/subiaco_wa_gov_au.py
@@ -67,7 +67,7 @@ class Source:
 
         target_weekday = WEEKDAYS.index(self._day_of_week)
 
-        for i in range(0, 400):
+        for i in range(400):
             d = start_date + datetime.timedelta(days=i)
 
             if d.weekday() == target_weekday:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sunderland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sunderland_gov_uk.py
@@ -41,7 +41,7 @@ class Source:
 
         # visit webpage to get viewstate info
         r = s.get(API_URL, headers=HEADERS)
-        r.raise_for_status
+        r.raise_for_status()
 
         # update payload and perform address search
         payload = self.get_viewstate(r.content)
@@ -53,7 +53,7 @@ class Source:
             }
         )
         r = s.post(API_URL, data=payload, headers=HEADERS)
-        r.raise_for_status
+        r.raise_for_status()
 
         # search results for address and get unique house code
         soup = BeautifulSoup(r.content, "html.parser")
@@ -72,7 +72,7 @@ class Source:
             }
         )
         r = s.post(API_URL, data=payload, headers=HEADERS)
-        r.raise_for_status
+        r.raise_for_status()
 
         # extract collection dates
         entries = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -51,7 +51,7 @@ class Source:
         # If it is, increment the year by 1.
         today: date = datetime.now().date()
         year: int = today.year
-        dt: date = datetime.strptime(f"{d} {str(year)}", "%d %B %Y").date()
+        dt: date = datetime.strptime(f"{d} {year!s}", "%d %B %Y").date()
         if (dt - today) < timedelta(days=-31):
             dt = dt.replace(year=dt.year + 1)
         return dt

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tsceskybrod_cz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tsceskybrod_cz.py
@@ -173,7 +173,7 @@ class Source:
         entries = []
 
         while current_date <= end_date:
-            year, week, _ = current_date.isocalendar()
+            _year, week, _ = current_date.isocalendar()
             month = current_date.month
 
             even_week = week % 2 == 0

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
@@ -513,7 +513,7 @@ class Source:
                     return self.fetch_old()
                 except Exception:
                     # If both methods fail, raise the original error from new method
-                    raise e
+                    raise e from None
         return self.fetch_old()
 
     def fetch_old(self) -> list[Collection]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/valorlux_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/valorlux_lu.py
@@ -50,12 +50,12 @@ class Source:
 
         # Step 1: If no commune is provided, raise an exception with a list of all communes
         if self._commune is None:
-            commune_names = sorted(list(communes.keys()))
+            commune_names = sorted(communes.keys())
             raise SourceArgumentRequiredWithSuggestions("commune", None, commune_names)
 
         # Step 2: If commune is provided, check if it's valid
         if self._commune not in communes:
-            commune_names = sorted(list(communes.keys()))
+            commune_names = sorted(communes.keys())
             raise SourceArgumentNotFoundWithSuggestions(
                 "commune", self._commune, commune_names
             )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vogeldisposal_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vogeldisposal_com.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from typing import ClassVar
 
 from bs4 import BeautifulSoup
 from curl_cffi import requests
@@ -60,7 +61,7 @@ API_BASE = "https://www.vogeldisposal.com"
 
 
 class Source:
-    _MONTHS = {
+    _MONTHS: ClassVar = {
         "january": 1,
         "february": 2,
         "march": 3,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wanneroo_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wanneroo_wa_gov_au.py
@@ -211,11 +211,11 @@ class Source:
 
         addresses = []
         for entry in result:
-            address = [v for v in entry if v["name"] == "Address"][0]["value"]
+            address = next(v for v in entry if v["name"] == "Address")["value"]
             addresses.append(address)
             if self._match_address(address):
-                self._dbkey = [v for v in entry if v["name"] == "dbkey"][0]["value"]
-                self._mapkey = [v for v in entry if v["name"] == "mapkey"][0]["value"]
+                self._dbkey = next(v for v in entry if v["name"] == "dbkey")["value"]
+                self._mapkey = next(v for v in entry if v["name"] == "mapkey")["value"]
                 return self._fetch_map_session(config_id)
 
         raise SourceArgumentNotFoundWithSuggestions(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/warrington_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/warrington_gov_uk.py
@@ -54,7 +54,7 @@ class Source:
             # List contains duplicates, so skip if already added.
             if self.contains(
                 entries,
-                lambda x: (
+                lambda x, job=job, bin_type=bin_type: (
                     x.date
                     == datetime.strptime(
                         job["ScheduledStart"], "%Y-%m-%dT%H:00:00"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wastecollection_mt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wastecollection_mt.py
@@ -127,7 +127,7 @@ class Source:
                 bin_type, rule = self._parse_flowtext(p)
 
             if bin_type and rule:
-                rules[bin_type] = rules.get(bin_type, []) + [rule]
+                rules[bin_type] = [*rules.get(bin_type, []), rule]
             continue
 
         entries = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/west_lindsey_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/west_lindsey_gov_uk.py
@@ -51,14 +51,14 @@ PARAM_DESCRIPTIONS = {
 
 class Source:
     def __init__(self, x: int | str, y: int | str, id: int | str):
-        self._query: str = f"x={str(x)};y={str(y)};id={str(id)}"
+        self._query: str = f"x={x!s};y={y!s};id={id!s}"
 
     def append_year(self, d: list) -> list[date]:
         today = datetime.now().date()
         year: int = today.year
         dates: list[date] = []
         for dt in d:
-            dt = datetime.strptime(f"{dt}/{str(year)}", "%d/%m/%Y").date()
+            dt = datetime.strptime(f"{dt}/{year!s}", "%d/%m/%Y").date()
             if (dt - today) < timedelta(days=-31):
                 dt = dt.replace(year=dt.year + 1)
             dates.append(dt)
@@ -79,7 +79,7 @@ class Source:
             headers=HEADERS,
             params=params,
         )
-        r.raise_for_status
+        r.raise_for_status()
 
         soup: BeautifulSoup = BeautifulSoup(
             r.content.decode("unicode-escape"), "html.parser"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/western_bay_of_plenty_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/western_bay_of_plenty_nz.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
 
     # Ensure the local package is importable when running directly
     try:
-        from waste_collection_schedule import Collection  # noqa: F811
+        from waste_collection_schedule import Collection
     except ModuleNotFoundError:
         sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -183,7 +183,7 @@ if __name__ == "__main__":
         collections = src.fetch()
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
     if not collections:
         print("No collections found for the provided address.")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westminster_gov_uk.py
@@ -88,7 +88,7 @@ def _parse_days(text: str) -> set[int]:
                 result.update(range(s, e + 1))
             else:  # wrap-around range, e.g. Sat-Mon
                 result.update(range(s, 7))
-                result.update(range(0, e + 1))
+                result.update(range(e + 1))
         else:
             v = _WEEKDAYS.get(token[:3])
             if v is not None:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wiltshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wiltshire_gov_uk.py
@@ -49,7 +49,7 @@ class Source:
         fetch_month = date.today().replace(day=1)
 
         entries = []
-        for i in range(0, 7):
+        for _i in range(7):
             entries.extend(self.fetch_month(fetch_month))
             fetch_month = add_month(fetch_month)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/winterthur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/winterthur_ch.py
@@ -33,7 +33,7 @@ class Source:
             "https://m.winterthur.ch/api/v1/callmethod/trash/asyncLookupStreet?usid=9749&container=1066394&uri=/index.php?apid=737670",
             regex=r"(?:Tour \d{1,2} )?(.*?)(?=\s*ganze Stadt|$)",
         ).fetch()
-        for source in self._ics_sources:
+        for _source in self._ics_sources:
             r"(\d{2}\.\d{2}\.\d{4})"
 
     def fetch(self) -> list[Collection]:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wolverhampton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wolverhampton_gov_uk.py
@@ -47,7 +47,9 @@ class Source:
             r = session.get(url, allow_redirects=True, timeout=30)
             r.raise_for_status()
         except requests.exceptions.RequestException as e:
-            raise Exception(f"Error fetching data from Wolverhampton Council: {e}")
+            raise Exception(
+                f"Error fetching data from Wolverhampton Council: {e}"
+            ) from e
 
         soup = BeautifulSoup(r.text, "html.parser")
         entries = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/woollahra_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/woollahra_nsw_gov_au.py
@@ -79,7 +79,7 @@ class Source:
 
             except requests.RequestException as e:
                 if attempt == max_retries - 1:
-                    raise Exception(f"Network error: {str(e)}")
+                    raise Exception(f"Network error: {e!s}") from e
                 time.sleep(2**attempt)
 
         raise requests.exceptions.RequestException(
@@ -138,9 +138,11 @@ class Source:
             if "Access Denied" in r.text:
                 raise Exception(
                     "Access denied by Woollahra website. This may be due to bot protection measures. Please try again later."
-                )
+                ) from None
             else:
-                raise Exception("Invalid JSON response from address search API")
+                raise Exception(
+                    "Invalid JSON response from address search API"
+                ) from None
 
         # Find the ID for our address
         if data.get("Items") and len(data["Items"]) > 0:
@@ -170,9 +172,11 @@ class Source:
             if "Access Denied" in r.text:
                 raise Exception(
                     "Access denied by Woollahra website during waste services fetch."
-                )
+                ) from None
             else:
-                raise Exception("Invalid JSON response from waste services API")
+                raise Exception(
+                    "Invalid JSON response from waste services API"
+                ) from None
 
         if not data.get("success") or not data.get("responseContent"):
             raise RuntimeError("Invalid response from waste services API")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wsz_moosburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wsz_moosburg_at.py
@@ -95,7 +95,7 @@ class Source:
 
         r = requests.get(f"https://wsz-moosburg.at/api/address/{municipal_id}")
         addressData = json.loads(r.text)["address"]
-        address = [x for x in addressData if x["address"]["name"] == address][0][
+        address = next(x for x in addressData if x["address"]["name"] == address)[
             "address"
         ]
 
@@ -107,7 +107,7 @@ class Source:
                 f"https://wsz-moosburg.at/api/address/{municipal_id}/{address['id']}"
             )
             streetData = json.loads(r.text)["address"]
-            street = [x for x in streetData if x["address"]["name"] == street][0][
+            street = next(x for x in streetData if x["address"]["name"] == street)[
                 "address"
             ]
             return street["id"]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wuerzburg_de.py
@@ -65,7 +65,7 @@ class Source:
             except KeyError:
                 raise SourceArgumentNotFoundWithSuggestions(
                     "street", street, strdict.keys()
-                )
+                ) from None
 
         if district:
             reglist = next(iter([s for s in selects if s["id"] == "reglist"]))
@@ -80,7 +80,7 @@ class Source:
             except KeyError:
                 raise SourceArgumentNotFoundWithSuggestions(
                     "district", district, regdict.keys()
-                )
+                ) from None
 
     def fetch(self):
         LOGGER.warning(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wyndham_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wyndham_vic_gov_au.py
@@ -41,7 +41,7 @@ class Source:
         response.raise_for_status()
         response = session.get(
             "https://digital.wyndham.vic.gov.au/myWyndham/ajax/address-search-suggestions.asp?",
-            params=dict(ASEARCH=self._street_address),
+            params={"ASEARCH": self._street_address},
         )
         response.raise_for_status()
         html = response.content
@@ -60,9 +60,11 @@ class Source:
         _LOGGER.debug("Fetched Property Number: %s", property_number)
         response = session.get(
             "https://digital.wyndham.vic.gov.au/myWyndham/init-map-data.asp",
-            params=dict(
-                propnum=property_number, radius="1000", mapfeatures="23,37,22,33,35"
-            ),
+            params={
+                "propnum": property_number,
+                "radius": "1000",
+                "mapfeatures": "23,37,22,33,35",
+            },
         )
         response.raise_for_status()
         wasteApiResult = response.content

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wyre_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wyre_gov_uk.py
@@ -35,7 +35,7 @@ class Source:
 
         bins = soup.find_all("h3", class_="bin-collection-tasks__heading")
         dates = soup.find_all("p", class_="bin-collection-tasks__date")
-        for date_tag, bin_tag in zip(dates, bins):
+        for date_tag, bin_tag in zip(dates, bins, strict=False):
             bint = " ".join(bin_tag.text.split()[2:4])
             date = parser.parse(date_tag.text).date()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wyreforestdc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wyreforestdc_gov_uk.py
@@ -147,7 +147,7 @@ class Source:
         headings = [td.text.strip() for td in coll_day_rows[0].find_all("td")]
         values = [td.text.strip() for td in coll_day_rows[1].find_all("td")]
 
-        for heading, value in list(zip(headings, values)):
+        for heading, value in list(zip(headings, values, strict=False)):
             if REGEX_GET_BIN_TYPE.match(heading):
                 bin_type_match = REGEX_GET_BIN_TYPE.match(heading)
                 if not bin_type_match:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zaw_sr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zaw_sr_de.py
@@ -116,7 +116,7 @@ class Source:
         parsed = re.findall(
             '<INPUT\\sNAME="([^"]+?)"\\sID="[^"]+?"(?:\\sVALUE="([^"]*?)")?', text
         )
-        result = {k: v for k, v in parsed}
+        result = dict(parsed)
         for sel_block in re.finditer(
             r'<SELECT\sNAME="([^"]+?)".*?</SELECT>', text, re.DOTALL
         ):
@@ -151,7 +151,9 @@ class Source:
             init_request,
             action="CITYCHANGED",
             period=calendar,
-            **{"Ort": self._city, "Strasse": "", "Hausnummer": ""},
+            Ort=self._city,
+            Strasse="",
+            Hausnummer="",
         )
         city_response = session.post(
             API_URL, headers=self._headers(), data=payload, verify=False
@@ -162,7 +164,9 @@ class Source:
             city_response.text,
             action="STREETCHANGED",
             period=calendar,
-            **{"Ort": self._city, "Strasse": self._street, "Hausnummer": ""},
+            Ort=self._city,
+            Strasse=self._street,
+            Hausnummer="",
         )
         street_response = session.post(
             API_URL, headers=self._headers(), data=payload, verify=False

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -38,7 +38,7 @@ def match_customize(
 
 
 class Fetchable(Protocol):
-    def fetch(self) -> list[Collection]: ...  # noqa: E704
+    def fetch(self) -> list[Collection]: ...
 
 
 class SourceModule(Protocol):
@@ -200,11 +200,11 @@ class SourceShell:
         entries = filter(lambda x: filter_function(x, self._customize), entries)
 
         # customize fetched entries
-        entries = map(lambda x: customize_function(x, self._customize), entries)
+        entries = (customize_function(x, self._customize) for x in entries)
 
         # apply day offset
         if self._day_offset != 0:
-            entries = map(lambda x: apply_day_offset(x, self._day_offset), entries)
+            entries = (apply_day_offset(x, self._day_offset) for x in entries)
 
         result = list(entries)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py
@@ -73,7 +73,7 @@ def main():
         # no ICS yaml files given --> test all source files
         source_files = filter(
             lambda x: x != "__init__",
-            map(lambda x: x.stem, source_dir.glob("*.py")),
+            (x.stem for x in source_dir.glob("*.py")),
         )
     else:
         # ICS yaml file(s) given

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/abfall_io_graphql.py
@@ -163,7 +163,7 @@ def main():
         service_key = answers["key"].strip()
 
     print("Connecting to abfall.io...")
-    api_key, pub_waste_types = get_api_key(service_key)
+    api_key, _pub_waste_types = get_api_key(service_key)
 
     # City search
     while True:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/app_abfallplus_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/app_abfallplus_de.py
@@ -91,8 +91,10 @@ def select_bezirk(
     questions = [
         inquirer.List(
             "bezirk",
-            choices=sorted([(s["name"], s["name"]) for s in bezirke])
-            + [("BACK", "BACK")],
+            choices=[
+                *sorted([(s["name"], s["name"]) for s in bezirke]),
+                ("BACK", "BACK"),
+            ],
             message="Select your Bezirk",
         )
     ]
@@ -120,8 +122,10 @@ def select_street(app: AppAbfallplusDe.AppAbfallplusDe, bund_select: bool):
         questions = [
             inquirer.List(
                 "street",
-                choices=sorted([(s["name"], s["name"]) for s in streets])
-                + [("BACK", "BACK")],
+                choices=[
+                    *sorted([(s["name"], s["name"]) for s in streets]),
+                    ("BACK", "BACK"),
+                ],
                 message="Select your Street",
             )
         ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/citiesapps_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/citiesapps_com.py
@@ -24,7 +24,7 @@ def ask_city():
         )
     ]
     city_id = inquirer.prompt(questions)["city"]
-    city = [c["name"] for c in cities if c["_id"] == city_id][0]
+    city = next(c["name"] for c in cities if c["_id"] == city_id)
 
     return [city_id, city]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/cmcitymedia_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/wizard/cmcitymedia_de.py
@@ -101,7 +101,7 @@ def generate_md_file():
     all_districts = get_all_districts()
     # Open file ../../../doc/source/cmcitymedia_de.md and replace content between <!-- cmcitymedia_de --> and <!-- /cmcitymedia_de --> with all_districts
     content_lines = []
-    for found, data in all_districts.items():
+    for _found, data in all_districts.items():
         content_lines.append(f"### {data[0][1][0]['name']}\n")
         content_lines.append(f"* HPID: {data[0][0]}\n")
         content_lines.append("#### Available Waste Types\n")

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,8 +6,12 @@ line-length = 88
 # and import sorting (I, equivalent to isort profile=black). E203/E501 were
 # ignored by flake8; E721 is stricter in ruff than pycodestyle, so keep it off
 # to avoid new findings the old tool chain never reported.
-select = ["E", "F", "W", "I"]
-ignore = ["E203", "E501", "E721"]
+# B (bugbear), C4 (comprehensions), PIE and RUF catch real bugs/dead code
+# cheaply across the whole tree, including source/.
+select = ["E", "F", "W", "I", "B", "C4", "PIE", "RUF"]
+# E203/E501/E721: see above. RUF001-003 flag "ambiguous" unicode (en-dashes,
+# curly quotes) that legitimately occurs in non-English provider names/titles.
+ignore = ["E203", "E501", "E721", "RUF001", "RUF002", "RUF003"]
 
 [format]
 quote-style = "double"

--- a/tests/test_colchester_gov_uk.py
+++ b/tests/test_colchester_gov_uk.py
@@ -28,8 +28,8 @@ sys.path.append(
     )
 )
 
-from waste_collection_schedule import Icons  # noqa: E402
-from waste_collection_schedule.source import colchester_gov_uk  # noqa: E402
+from waste_collection_schedule import Icons
+from waste_collection_schedule.source import colchester_gov_uk
 
 
 class MockResponse:

--- a/tests/test_darebin_vic_gov_au.py
+++ b/tests/test_darebin_vic_gov_au.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 # Insert repo root to sys.path for absolute imports to work
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from custom_components.waste_collection_schedule.waste_collection_schedule.source import (  # noqa: E402
+from custom_components.waste_collection_schedule.waste_collection_schedule.source import (
     darebin_vic_gov_au,
 )
 

--- a/tests/test_hillingdon_gov_uk.py
+++ b/tests/test_hillingdon_gov_uk.py
@@ -27,9 +27,9 @@ sys.path.append(
     )
 )
 
-from waste_collection_schedule import Icons  # noqa: E402
-from waste_collection_schedule.exceptions import SourceArgumentNotFound  # noqa: E402
-from waste_collection_schedule.source import hillingdon_gov_uk  # noqa: E402
+from waste_collection_schedule import Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.source import hillingdon_gov_uk
 
 # ---------------------------------------------------------------------------
 # Shared fixtures and helpers

--- a/tests/test_midlothian_gov_uk.py
+++ b/tests/test_midlothian_gov_uk.py
@@ -17,7 +17,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from custom_components.waste_collection_schedule.waste_collection_schedule.source import (  # noqa: E402
+from custom_components.waste_collection_schedule.waste_collection_schedule.source import (
     midlothian_gov_uk,
 )
 

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -9,8 +9,8 @@ from unittest.mock import patch
 
 import yaml
 
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))  # isort:skip # noqa: E402
-from update_docu_links import (  # isort:skip # noqa: E402
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))  # isort:skip
+from update_docu_links import (  # isort:skip
     BLACK_LIST,
     COUNTRYCODES,
     LANGUAGES,
@@ -223,7 +223,9 @@ def _test_source_has_necessary_parameters_extra_info(
         try:
             extra_info = extra_info()
         except Exception as e:
-            assert False, f"EXTRA_INFO() function in source {source} failed with {e}"
+            raise AssertionError(
+                f"EXTRA_INFO() function in source {source} failed with {e}"
+            ) from e
 
         # check if is iterable (list, tupüle, set)
         assert isinstance(extra_info, (list, tuple, set, GeneratorType)), (
@@ -498,7 +500,7 @@ def test_uk_cloud9_client_requires_api_domains() -> None:
 
     try:
         module.Cloud9Client("rugby", api_domains=())
-        assert False, "Expected ValueError when no API domains are configured"
+        raise AssertionError("Expected ValueError when no API domains are configured")
     except ValueError as err:
         assert "At least one API domain" in str(err)
 

--- a/tests/test_source_shell_customize.py
+++ b/tests/test_source_shell_customize.py
@@ -9,8 +9,8 @@ sys.path.append(
     )
 )
 
-from waste_collection_schedule.collection import Collection  # noqa: E402
-from waste_collection_schedule.source_shell import (  # noqa: E402
+from waste_collection_schedule.collection import Collection
+from waste_collection_schedule.source_shell import (
     Customize,
     customize_function,
     filter_function,

--- a/tests/test_southlanarkshire_gov_uk.py
+++ b/tests/test_southlanarkshire_gov_uk.py
@@ -17,11 +17,11 @@ sys.path.append(
     )
 )
 
-from waste_collection_schedule.exceptions import (  # noqa: E402
+from waste_collection_schedule.exceptions import (
     SourceArgumentNotFound,
     SourceArgumentNotFoundWithSuggestions,
 )
-from waste_collection_schedule.source import southlanarkshire_gov_uk  # noqa: E402
+from waste_collection_schedule.source import southlanarkshire_gov_uk
 
 _PREMISES_JSON = json.dumps(
     [

--- a/tests/test_stockport_gov_uk.py
+++ b/tests/test_stockport_gov_uk.py
@@ -16,7 +16,7 @@ sys.path.append(
     )
 )
 
-from waste_collection_schedule.source import stockport_gov_uk  # noqa: E402
+from waste_collection_schedule.source import stockport_gov_uk
 
 # Sample HTML that mimics the Stockport council website structure
 # This is the key test fixture - it should match the real website structure

--- a/tests/test_westminster_gov_uk.py
+++ b/tests/test_westminster_gov_uk.py
@@ -25,9 +25,9 @@ sys.path.append(
     )
 )
 
-from waste_collection_schedule import Icons  # noqa: E402
-from waste_collection_schedule.exceptions import SourceArgumentNotFound  # noqa: E402
-from waste_collection_schedule.source import westminster_gov_uk  # noqa: E402
+from waste_collection_schedule import Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.source import westminster_gov_uk
 
 # ---------------------------------------------------------------------------
 # Section 1: _parse_days (pure function)

--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -152,12 +152,20 @@ class SourceInfo:
         url: str,
         country: str,
         params: list[str],
-        extra_info_default_params: dict[str, Any] = {},
-        custom_param_translation: dict[str, dict[str, str]] = {},
-        custom_param_description: dict[str, dict[str, str]] = {},
-        custom_howto: dict[str, str] = {},
+        extra_info_default_params: dict[str, Any] | None = None,
+        custom_param_translation: dict[str, dict[str, str]] | None = None,
+        custom_param_description: dict[str, dict[str, str]] | None = None,
+        custom_howto: dict[str, str] | None = None,
         source_owners: list[str] | None = None,
     ):
+        if custom_howto is None:
+            custom_howto = {}
+        if custom_param_description is None:
+            custom_param_description = {}
+        if custom_param_translation is None:
+            custom_param_translation = {}
+        if extra_info_default_params is None:
+            extra_info_default_params = {}
         self._filename = filename
         self._module = module
         self._title = title
@@ -303,11 +311,15 @@ class IcsSourceInfo(SourceInfo):
         url: str,
         country: str,
         limit_params: list[str],
-        extra_info_default_params: dict[str, Any] = {},
-        custom_howto: dict[str, str] = {},
+        extra_info_default_params: dict[str, Any] | None = None,
+        custom_howto: dict[str, str] | None = None,
         source_owners: list | None = None,
         ics_stem: str | None = None,
     ):
+        if custom_howto is None:
+            custom_howto = {}
+        if extra_info_default_params is None:
+            extra_info_default_params = {}
         _, ics_sources = get_source_by_file("ics")
         ics_source = ics_sources[0]
         params = set(ics_source.params) - set(limit_params)
@@ -434,7 +446,7 @@ def browse_sources() -> list[SourceInfo]:
 
     files = filter(
         lambda x: x != "__init__",
-        map(lambda x: x.stem, SOURCE_DIR.glob("*.py")),
+        (x.stem for x in SOURCE_DIR.glob("*.py")),
     )
 
     modules: dict[str, ModuleType] = {}
@@ -668,7 +680,7 @@ def update_sources_json(countries: dict[str, list[SourceInfo]]) -> None:
     source_metadata_by_module: dict[str, dict[str, Any]] = {}
     source_owners_by_module: dict[str, list[str]] = {}
 
-    for country in ["Generic"] + sorted(c for c in countries if c != "Generic"):
+    for country in ["Generic", *sorted(c for c in countries if c != "Generic")]:
         output[country] = []
         for e in sorted(
             countries[country],
@@ -792,8 +804,10 @@ def get_custom_translations(
 
 
 def update_json(
-    countries: dict[str, list[SourceInfo]], generics: list[SourceInfo] = []
+    countries: dict[str, list[SourceInfo]], generics: list[SourceInfo] | None = None
 ):
+    if generics is None:
+        generics = []
     countries = countries.copy()
     countries["Generic"] = generics
     update_sources_json(countries)
@@ -801,7 +815,7 @@ def update_json(
         param_translations,
         param_descriptions,
         source_howto,
-        source_doc_url,
+        _source_doc_url,
     ) = get_custom_translations(countries)
 
     for lang in LANGUAGES:
@@ -833,7 +847,7 @@ def update_json(
         # sorted order of the keys
         step_keys = list(translations["config"]["step"].keys())
         for key in step_keys:
-            if key.startswith("args_") or key.startswith("reconfigure_"):
+            if key.startswith(("args_", "reconfigure_")):
                 translations["config"]["step"].pop(key)
 
         for key, value in (
@@ -858,20 +872,20 @@ def update_json(
 
         for module, module_params in param_translations.items():
             translations["config"]["step"][f"args_{module}"] = keys_for_all_args.copy()
-            translations["config"]["step"][
-                f"reconfigure_{module}"
-            ] = keys_for_all_reconfigure.copy()
+            translations["config"]["step"][f"reconfigure_{module}"] = (
+                keys_for_all_reconfigure.copy()
+            )
 
-            translations["config"]["step"][f"args_{module}"][
-                "data"
-            ] = translation_for_all.copy()
-            translations["config"]["step"][f"reconfigure_{module}"][
-                "data"
-            ] = translation_for_all.copy()
+            translations["config"]["step"][f"args_{module}"]["data"] = (
+                translation_for_all.copy()
+            )
+            translations["config"]["step"][f"reconfigure_{module}"]["data"] = (
+                translation_for_all.copy()
+            )
 
-            translations["config"]["step"][f"args_{module}"][
-                "data_description"
-            ] = description_for_all_args.copy()
+            translations["config"]["step"][f"args_{module}"]["data_description"] = (
+                description_for_all_args.copy()
+            )
             translations["config"]["step"][f"reconfigure_{module}"][
                 "data_description"
             ] = description_for_all_reconfigure.copy()


### PR DESCRIPTION
## Summary

`ruff.toml` previously only enabled `E, F, W, I` (mirroring the old flake8+isort setup), and the pre-commit `ruff` lint hook fully excluded the `~600`-file `source/` directory. This PR:

- Adds `B` (flake8-bugbear), `C4` (flake8-comprehensions), `PIE` (flake8-pie) and `RUF` (ruff-native) rule groups, ignoring `RUF001-003` (ambiguous-unicode) since they misfire heavily on non-English provider names/titles.
- Removes the `source/` exclude from the lint hook, and extends the hook's file pattern to also cover the two root-level scripts (`update_docu_links.py`, `default_translations.py`).
- Fixes everything the new rules flagged.

## Notable fixes

- **Real bugs**: several `source/` scrapers called `r.raise_for_status` **without parentheses** — the check never actually ran, so HTTP errors were silently swallowed (`B018`, caught in `eastdunbarton_gov_uk`, `melton_gov_uk`, `northlanarkshire_gov_uk`, `oldham_gov_uk`, `shellharbourwaste_com_au`, `sunderland_gov_uk`, `west_lindsey_gov_uk`).
- Two closures (`coventry_gov_uk`, `warrington_gov_uk`) read loop variables without binding them (`B023`); fixed by passing the values explicitly as parameters/lambda defaults instead of relying on late-binding closures.
- A first automated pass wrongly wanted to mark `config_flow.py`'s `_sources` as `ClassVar`, but it's actually rebound per-instance as a lazy-init cache — reverted that one to a plain mutable default with a `noqa: RUF012` and an explanatory comment.
- **Mechanical**: missing `raise ... from err/None` (`B904`), mutable class attributes annotated `ClassVar` where they're genuinely shared/read-only lookups (`RUF012`), mutable default arguments replaced with `None` sentinels (`B006`), unused loop/unpack variables prefixed with `_` (`B007`/`B020`/`RUF059`), comprehension/dict simplifications (`C4xx`, `RUF005`).

## Test plan

- [x] `python -m pytest tests/` — full suite passes
- [x] `ruff check` — clean across `custom_components/`, `tests/`, and the two root scripts
- [x] `mypy` (pre-commit hook scope) — before/after diff shows **zero newly introduced errors** (56 pre-existing errors, unchanged, confirmed via a side-by-side worktree comparison against `master`)
- [x] `pre-commit run --all-files` equivalent (ran via commit hooks) — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)