### PR TITLE
Add eThekwini Municipality (Durban) source via hosted ICS feed

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/durban_gov_za.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/durban_gov_za.py
@@ -1,0 +1,157 @@
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "eThekwini Municipality"
+DESCRIPTION = "Source for eThekwini Municipality / Durban refuse collection schedules."
+URL = "https://www.durban.gov.za/page/refuse-collection-schedules"
+COUNTRY = "za"
+SOURCE_CODEOWNERS = ["@robtesch"]
+
+ICS_BASE = (
+    "https://raw.githubusercontent.com/robtesch/hacs_waste_collection_schedule/"
+    "refs/heads/data/durban-gov-za"
+)
+INDEX_URL = f"{ICS_BASE}/index.json"
+ODD_RECYCLING_SUMMARY = "Recycling (odd ISO weeks)"
+
+TEST_CASES = {
+    "Outer West Hillcrest": {
+        "region": "outer_west",
+        "area": "hillcrest",
+        "recycling_in_even_week": True,
+    },
+    "Outer West Drummond": {
+        "region": "outer_west",
+        "area": "drummond_montesseel",
+        "recycling_in_even_week": True,
+    },
+    "North Umdloti": {
+        "region": "north",
+        "area": "umdloti",
+        "recycling_in_even_week": True,
+    },
+    "North Central Overport": {
+        "region": "north_central",
+        "area": "overport_drive",
+        "recycling_in_even_week": True,
+    },
+    "South Central Montclair": {
+        "region": "south_central",
+        "area": "montclair_w3",
+        "recycling_in_even_week": True,
+    },
+    "Inner West Westville": {
+        "region": "inner_west",
+        "area": "westville",
+        "recycling_in_even_week": True,
+    },
+    "South Umlazi": {
+        "region": "south",
+        "area": "umlazi_section",
+        "recycling_in_even_week": True,
+    },
+}
+
+ICON_MAP = {
+    "General Waste": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Visit the <a href='https://www.durban.gov.za/page/refuse-collection-schedules'>"
+        "refuse collection schedules</a> page, open your region's DOCX file, and find "
+        "your suburb or area under the weekday column. Use the matching "
+        "<code>region</code> and <code>area</code> values shown in the documentation."
+    ),
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "region": (
+            "Regional office area, e.g. outer_west, north, south_central, "
+            "north_central, inner_west, or south"
+        ),
+        "area": (
+            "Suburb or collection area slug from the regional schedule DOCX, "
+            "e.g. hillcrest or drummond_montesseel"
+        ),
+        "recycling_in_even_week": (
+            "Set to True if orange-bag recycling is collected on even ISO week "
+            "numbers, False if collected on odd ISO week numbers. Check your last "
+            "recycling collection date to determine this."
+        ),
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "region": "Region",
+        "area": "Collection Area",
+        "recycling_in_even_week": "Recycling collected on even ISO weeks",
+    },
+}
+
+
+def _load_index() -> dict:
+    response = requests.get(INDEX_URL, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+class Source:
+    def __init__(
+        self,
+        region: str,
+        area: str,
+        recycling_in_even_week: bool = True,
+    ):
+        region_key = region.strip().lower()
+        area_key = area.strip().lower()
+        index = _load_index()
+        regions = index.get("regions", {})
+
+        if region_key not in regions:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "region",
+                region,
+                sorted(regions.keys()),
+            )
+
+        region_areas = regions[region_key].get("areas", {})
+        if area_key not in region_areas:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "area",
+                area,
+                sorted(region_areas.keys()),
+            )
+
+        self._region = region_key
+        self._area = area_key
+        self._recycling_in_even_week = recycling_in_even_week
+        self._ics = ICS()
+
+    def fetch(self) -> list[Collection]:
+        calendar_url = f"{ICS_BASE}/calendars/{self._region}/{self._area}.ics"
+        response = requests.get(calendar_url, timeout=30)
+        response.raise_for_status()
+
+        entries: list[Collection] = []
+        for collection_date, summary in self._ics.convert(response.text):
+            if summary == ODD_RECYCLING_SUMMARY:
+                if self._recycling_in_even_week:
+                    continue
+                summary = "Recycling"
+            elif summary == "Recycling" and not self._recycling_in_even_week:
+                continue
+
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=summary,
+                    icon=ICON_MAP.get(summary),
+                )
+            )
+        return entries

--- a/doc/source/durban_gov_za.md
+++ b/doc/source/durban_gov_za.md
@@ -1,0 +1,82 @@
+# eThekwini Municipality
+
+Support for schedules provided by [eThekwini Municipality refuse collection schedules](https://www.durban.gov.za/page/refuse-collection-schedules).
+
+Schedules are maintained as hosted ICS calendars by [@robtesch](https://github.com/robtesch), regenerated from the council's published regional DOCX files. The live feed is published on the [`data/durban-gov-za`](https://github.com/robtesch/hacs_waste_collection_schedule/tree/data/durban-gov-za) branch of the code owner's fork.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: durban_gov_za
+      args:
+        region: REGION
+        area: AREA
+        recycling_in_even_week: RECYCLING_IN_EVEN_WEEK
+```
+
+### Configuration Variables
+
+**region**  
+*(string) (required)* Regional office area. One of: `outer_west`, `north`, `north_central`, `south`, `south_central`, `inner_west`.
+
+**area**  
+*(string) (required)* Suburb or collection area slug from your region's schedule DOCX (see below).
+
+**recycling_in_even_week**  
+*(bool) (optional, default: `True`)* Set to `True` if orange-bag recycling is collected on even ISO week numbers, `False` if collected on odd ISO week numbers. Check your last recycling collection date at [whatweekisit.org](https://whatweekisit.org/) to determine this.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: durban_gov_za
+      args:
+        region: outer_west
+        area: hillcrest
+        recycling_in_even_week: true
+```
+
+## How to get the source arguments
+
+1. Visit the [refuse collection schedules](https://www.durban.gov.za/page/refuse-collection-schedules) page.
+2. Download the DOCX for your region (e.g. **Outer West - Collection Schedule**).
+3. Find your suburb or area in the table under the weekday column where it is listed.
+4. Use the matching `region` slug for your DOCX file and the `area` slug for your suburb.
+
+### Region slugs
+
+| Region DOCX | `region` value |
+|---|---|
+| Outer West | `outer_west` |
+| North Region | `north` |
+| North Central | `north_central` |
+| South Region | `south` |
+| South Central | `south_central` |
+| Inner West | `inner_west` |
+
+### Area slugs
+
+Area slugs are lowercase with underscores instead of spaces, for example:
+
+- `Hillcrest` → `hillcrest`
+- `Drummond & Montesseel` → `drummond_montesseel`
+- `Umdloti` → `umdloti`
+
+If the same suburb name appears on multiple weekdays in your region's schedule, a weekday suffix is added (e.g. `montclair_w3` for Montclair on Thursday). Use the slug that matches your collection day.
+
+## Collection types
+
+- **General Waste** — collected weekly on your mapped weekday (including public holidays).
+- **Recycling** (orange bags) — collected fortnightly on the same weekday; not collected on South African public holidays.
+
+## Hosted feed
+
+At runtime this source fetches:
+
+- an area index from `index.json` on the `data/durban-gov-za` branch (for validation), and
+- per-area ICS calendars under `calendars/{region}/{area}.ics`.
+
+If you prefer to configure a calendar URL yourself, you can use the generic [ICS source](ics.md) with a direct `.ics` URL instead.

--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -1205,6 +1205,10 @@ COUNTRYCODES = [
         "name": "United States of America",
     },
     {
+        "code": "za",
+        "name": "South Africa",
+    },
+    {
         "code": "uk",
         "name": "United Kingdom",
     },


### PR DESCRIPTION
## Summary

- Adds `durban_gov_za` for eThekwini Municipality (Durban, South Africa), fetching live per-area ICS calendars from a maintainer-hosted feed instead of embedding static schedule data.
- Supersedes the closed #6785 approach per maintainer feedback: DOCX parsing and calendar regeneration stay in the code owner's fork (`tooling/durban-updater` branch + weekly Action), while this integration only fetches the published calendars at runtime.
- Adds South Africa (`za`) to `COUNTRYCODES` in `update_docu_links.py`.

## Hosted feed

Calendars are published on the [`data/durban-gov-za`](https://github.com/robtesch/hacs_waste_collection_schedule/tree/data/durban-gov-za) branch of my fork (1,793 areas across six regions), regenerated from the official council DOCX schedules. The source fetches `index.json` for validation and `calendars/{region}/{area}.ics` for collection dates.

## Type of change

- [x] New source

## Checklist

- [x] `python test_sources.py -s durban_gov_za -l` passes against live hosted URLs
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff
- [x] `doc/source/durban_gov_za.md` created
- [x] TEST_CASES use real, publicly accessible area slugs

## Test plan

```
$ python test_sources.py -s durban_gov_za -l
Testing source durban_gov_za ...
  found 77 entries for Outer West Hillcrest
  found 78 entries for Outer West Drummond
  found 77 entries for North Umdloti
  found 77 entries for North Central Overport
  found 80 entries for South Central Montclair
  found 77 entries for Inner West Westville
  found 77 entries for South Umlazi
```

- [x] Live fetch from `raw.githubusercontent.com/robtesch/.../data/durban-gov-za` works
- [x] General Waste weekly + Recycling fortnightly returned for all TEST_CASES
- [x] `recycling_in_even_week` filters the correct biweekly stream