### PR TITLE
refactor(pl): extend SepanClient with /years+token flow, migrate ichisystem_eu

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/Sepan.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/Sepan.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 import requests
 from bs4 import BeautifulSoup
@@ -8,10 +9,11 @@ from waste_collection_schedule.exceptions import (
     SourceArgumentRequiredWithSuggestions,
 )
 
-# Shared client for the "SEPAN" waste-schedule platform, used (via different
-# deployments/base URLs) by sepan_remondis_pl.py, zys_harmonogram_pl.py and
-# alba_com_pl.py. All three expose the identical address-resolution and
-# HTML-report API; see issue #6749 for the consolidation rationale.
+# Shared client for the "SEPAN" (aka "ICHI System") waste-schedule platform,
+# used (via different deployments/base URLs) by sepan_remondis_pl.py,
+# zys_harmonogram_pl.py, alba_com_pl.py and ichisystem_eu.py. All four expose
+# the identical address-resolution API; see issue #6749 for the
+# consolidation rationale and issue #6763 for the /years+token report flow.
 
 POLISH_MONTHS = {
     "STYCZEŃ": 1,
@@ -28,6 +30,37 @@ POLISH_MONTHS = {
     "GRUDZIEŃ": 12,
 }
 
+_PL_DIACRITICS = str.maketrans(
+    {
+        "ą": "a",
+        "Ą": "a",
+        "ć": "c",
+        "Ć": "c",
+        "ę": "e",
+        "Ę": "e",
+        "ł": "l",
+        "Ł": "l",
+        "ń": "n",
+        "Ń": "n",
+        "ó": "o",
+        "Ó": "o",
+        "ś": "s",
+        "Ś": "s",
+        "ź": "z",
+        "Ź": "z",
+        "ż": "z",
+        "Ż": "z",
+    }
+)
+
+
+def normalize_pl(text: str) -> str:
+    """Normalise Polish text for matching: uppercase, drop diacritics,
+    collapse whitespace. This lets e.g. "Swiety Marcin" (diacritics
+    dropped, as many users type) still match a platform's "ŚWIĘTY MARCIN"
+    listing. See issue #6763."""
+    return re.sub(r"\s+", " ", text.translate(_PL_DIACRITICS).upper()).strip()
+
 
 class SepanClient:
     """Client for the SEPAN waste-schedule platform.
@@ -39,6 +72,8 @@ class SepanClient:
 
     def __init__(self, base_urls: list[str]):
         self._base_urls = base_urls
+        self._resolved_base_url: str | None = None
+        self._resolved_number: dict | None = None
 
     def resolve_address(self, city: str, street: str, number: str) -> str:
         """Resolve city/street/number to an address id, trying each base URL
@@ -62,8 +97,8 @@ class SepanClient:
     def _resolve_address_at(
         self, base_url: str, city: str, street: str, number: str
     ) -> str:
-        city = city.upper().strip()
-        street = street.upper().strip()
+        city = normalize_pl(city)
+        street = normalize_pl(street)
         number = str(number).strip()
 
         cities = requests.get(f"{base_url}/addresses/cities", timeout=30).json()
@@ -72,9 +107,7 @@ class SepanClient:
             raise SourceArgumentRequiredWithSuggestions(
                 "city", "Select your city.", city_suggestions
             )
-        city_match = next(
-            (c for c in cities if c["value"].upper().strip() == city), None
-        )
+        city_match = next((c for c in cities if normalize_pl(c["value"]) == city), None)
         if not city_match:
             raise SourceArgumentNotFoundWithSuggestions("city", city, city_suggestions)
         city_id = city_match["id"]
@@ -88,7 +121,7 @@ class SepanClient:
                 "street", "Select your street.", street_suggestions
             )
         street_match = next(
-            (s for s in streets if s["value"].upper().strip() == street), None
+            (s for s in streets if normalize_pl(s["value"]) == street), None
         )
         if not street_match:
             raise SourceArgumentNotFoundWithSuggestions(
@@ -113,23 +146,63 @@ class SepanClient:
             )
 
         self._resolved_base_url = base_url
+        self._resolved_number = number_match
         return number_match["id"]
 
-    def fetch_report_html(self, address_id: str) -> str:
+    def _fetch_years(self) -> list[dict] | None:
+        """Return this deployment's report years (list of {"id", "value"}),
+        or None if it doesn't expose a `/years` endpoint (or the endpoint
+        errors/returns something unexpected). Older/simpler SEPAN
+        deployments only expose the current report via `/reports` without a
+        `yearId`; newer ones (see issue #6763) expose `/years` plus a
+        per-address `token` (already returned alongside the address id by
+        `/addresses/numbers/...`) to fetch any year's report on demand."""
+        if self._resolved_base_url is None:
+            return None
+        try:
+            resp = requests.get(f"{self._resolved_base_url}/years", timeout=30)
+            resp.raise_for_status()
+            years = resp.json()
+        except Exception:  # noqa: BLE001 - treat any failure as "unsupported"
+            return None
+        if not isinstance(years, list) or not years:
+            return None
+        return years
+
+    def fetch_report_html(
+        self,
+        address_id: str,
+        year_id: str | None = None,
+        token: str | None = None,
+    ) -> str:
         """Fetch the raw HTML report for a resolved address id.
 
-        Parsing is intentionally left to the caller: the three known SEPAN
+        If `year_id` (and the matching `token`, as returned alongside the
+        address id by `resolve_address()`'s underlying
+        `/addresses/numbers/...` call) are given, the report for that
+        specific year is requested; otherwise the deployment's
+        default/current report is requested (previous behaviour, still used
+        by deployments without a `/years` endpoint).
+
+        Parsing is intentionally left to the caller: the known SEPAN
         deployments don't all render the report table the same way (see
-        `parse_month_name_table` for the format shared by zys_harmonogram_pl
-        and alba_com_pl; sepan_remondis_pl uses its own positional parser).
+        `parse_month_name_table` for the format shared by zys_harmonogram_pl,
+        alba_com_pl and ichisystem_eu; sepan_remondis_pl uses its own
+        positional parser).
         """
-        base_url = getattr(self, "_resolved_base_url", None)
+        base_url = self._resolved_base_url
         if base_url is None:
             raise Exception("fetch_report_html() called before resolve_address()")
 
+        params: dict[str, str | None] = {"type": "html", "id": address_id}
+        if year_id is not None:
+            params["responseType"] = "json"
+            params["token"] = token
+            params["yearId"] = year_id
+
         report = requests.get(
             f"{base_url}/reports",
-            params={"type": "html", "id": address_id},
+            params=params,
             timeout=30,
         ).json()
         if report.get("status") != "success":
@@ -138,21 +211,63 @@ class SepanClient:
         return requests.get(report["filePath"], timeout=30).content.decode("utf-8")
 
     def fetch_schedule(self, address_id: str) -> list[tuple[datetime.date, str]]:
-        """Fetch and parse the HTML report using the shared month-name table
-        format (see `parse_month_name_table`)."""
-        return parse_month_name_table(self.fetch_report_html(address_id))
+        """Fetch and parse the HTML report(s) using the shared month-name
+        table format (see `parse_month_name_table`).
+
+        If the deployment exposes a `/years` endpoint, every available
+        year's report is fetched (using the `token` returned alongside the
+        address id by `resolve_address()`) and merged, deduplicating
+        entries. This is more robust across a calendar-year rollover than
+        guessing a year-suffixed base URL (see issue #6763). Deployments
+        without a `/years` endpoint fall back to the single "current"
+        report returned by `/reports` (previous behaviour).
+        """
+        years = self._fetch_years()
+        if not years:
+            return parse_month_name_table(self.fetch_report_html(address_id))
+
+        token = (self._resolved_number or {}).get("token")
+        entries: list[tuple[datetime.date, str]] = []
+        seen: set[tuple[datetime.date, str]] = set()
+        for year_entry in years:
+            try:
+                year_value = int(year_entry["value"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            try:
+                html = self.fetch_report_html(
+                    address_id, year_id=year_entry.get("id"), token=token
+                )
+            except Exception:  # noqa: BLE001 - skip years that fail to fetch
+                continue
+            for entry in parse_month_name_table(html, year=year_value):
+                if entry in seen:
+                    continue
+                seen.add(entry)
+                entries.append(entry)
+        return entries
 
 
-def parse_month_name_table(html: str) -> list[tuple[datetime.date, str]]:
-    """Parse a SEPAN report table whose rows are "<Month> <Year>" plus one
-    comma-separated-days cell per waste-type column (the format used by
-    zys_harmonogram_pl and alba_com_pl's deployments).
+def parse_month_name_table(
+    html: str, year: int | None = None
+) -> list[tuple[datetime.date, str]]:
+    """Parse a SEPAN report table whose rows are one comma-separated-days
+    cell per waste-type column, keyed by a leading "<Month>" or
+    "<Month> <Year>" cell (the format used by zys_harmonogram_pl,
+    alba_com_pl and ichisystem_eu's deployments).
 
     Column names are read from the header row itself (rather than assumed
     by position) because some deployments have a two-row <thead> (an outer
     grouping row plus the real per-column names) — only the row that
     actually contains "Miesiąc" is used for header names, so the extra
     grouping row's cells don't get misread as data columns.
+
+    Some deployments (e.g. ichisystem_eu) render just the month name
+    without a year in each row, relying on the report having been requested
+    for a specific year (see `SepanClient.fetch_schedule`'s /years+token
+    flow); pass that year explicitly via `year` for those. If a row's first
+    cell does include a year (as zys_harmonogram_pl / alba_com_pl do), that
+    embedded year always takes precedence over `year`.
     """
     soup = BeautifulSoup(html, "html.parser")
 
@@ -180,13 +295,19 @@ def parse_month_name_table(html: str) -> list[tuple[datetime.date, str]]:
             continue
 
         parts = cells[0].get_text(strip=True).split()
-        if len(parts) < 2:
+        if not parts:
             continue
 
         month = POLISH_MONTHS.get(parts[0].upper())
         if not month:
             continue
-        year = int(parts[-1])
+
+        if len(parts) >= 2 and parts[-1].isdigit():
+            row_year = int(parts[-1])
+        elif year is not None:
+            row_year = year
+        else:
+            continue
 
         for i, cell in enumerate(cells[1:]):
             if i >= len(headers):
@@ -203,7 +324,7 @@ def parse_month_name_table(html: str) -> list[tuple[datetime.date, str]]:
                 try:
                     entries.append(
                         (
-                            datetime.date(year, month, int(day_str)),
+                            datetime.date(row_year, month, int(day_str)),
                             waste_type,
                         )
                     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/Sepan.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/Sepan.py
@@ -163,7 +163,7 @@ class SepanClient:
             resp = requests.get(f"{self._resolved_base_url}/years", timeout=30)
             resp.raise_for_status()
             years = resp.json()
-        except Exception:  # noqa: BLE001 - treat any failure as "unsupported"
+        except Exception:
             return None
         if not isinstance(years, list) or not years:
             return None
@@ -238,7 +238,7 @@ class SepanClient:
                 html = self.fetch_report_html(
                     address_id, year_id=year_entry.get("id"), token=token
                 )
-            except Exception:  # noqa: BLE001 - skip years that fail to fetch
+            except Exception:
                 continue
             for entry in parse_month_name_table(html, year=year_value):
                 if entry in seen:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ichisystem_eu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ichisystem_eu.py
@@ -1,18 +1,17 @@
 """Source for Hemar (ichisystem.eu), Poland."""
 
-import re
-from datetime import date, datetime
-from html.parser import HTMLParser
-from typing import List, Optional
+from datetime import date
+from typing import List
 
-import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+from waste_collection_schedule.service.Sepan import SepanClient
 
 TITLE = "Hemar (ichisystem.eu)"
 DESCRIPTION = (
     "Source for the Hemar waste collection schedule platform "
-    "(harmonogram.ichisystem.eu) used by several Polish municipalities."
+    "(harmonogram.ichisystem.eu) used by several Polish municipalities. "
+    'This deployment runs on the same underlying "SEPAN"/ICHI System '
+    "platform as sepan_remondis_pl, zys_harmonogram_pl and alba_com_pl."
 )
 URL = "https://harmonogram.ichisystem.eu/hemar/"
 COUNTRY = "pl"
@@ -68,254 +67,35 @@ PARAM_TRANSLATIONS = {
     },
 }
 
+# Waste-type names as rendered by this deployment's report table (matches
+# the wording used by the alba_com_pl / zys_harmonogram_pl deployments of
+# the same underlying platform).
 ICON_MAP = {
-    "zmieszane": Icons.GENERAL_WASTE,
-    "papier": Icons.PAPER,
-    "metale": Icons.METAL,
-    "tworzywa": Icons.RECYCLING,
-    "szk": Icons.GLASS_COLORED,
-    "bio": Icons.ORGANIC,
-    "drzewka": Icons.CHRISTMAS_TREE,
-    "wystawkow": Icons.BULKY,
-    "gabaryt": Icons.BULKY,
-    "popi": Icons.GENERAL_WASTE,
-    "choink": Icons.CHRISTMAS_TREE,
+    "Zmieszane odpady komunalne": Icons.GENERAL_WASTE,
+    "Metale i tworzywa sztuczne": Icons.RECYCLING,
+    "Papier": Icons.PAPER,
+    "Szkło": Icons.GLASS,
+    "Bioodpady": Icons.ORGANIC,
+    "Bioodpady - Drzewka świąteczne": Icons.CHRISTMAS_TREE,
+    "Odpady wystawkowe": Icons.BULKY,
 }
 
 API_BASE = "https://harmonogram.ichisystem.eu/hemar"
 
-# Polish month names as used in the schedule HTML, mapped to month numbers.
-PL_MONTHS = {
-    "styczen": 1,
-    "luty": 2,
-    "marzec": 3,
-    "kwiecien": 4,
-    "maj": 5,
-    "czerwiec": 6,
-    "lipiec": 7,
-    "sierpien": 8,
-    "wrzesien": 9,
-    "pazdziernik": 10,
-    "listopad": 11,
-    "grudzien": 12,
-}
-
-
-def _strip_pl(text: str) -> str:
-    """Normalise Polish text: lowercase + drop diacritics + collapse whitespace."""
-    table = str.maketrans(
-        {
-            "ą": "a",
-            "Ą": "a",
-            "ć": "c",
-            "Ć": "c",
-            "ę": "e",
-            "Ę": "e",
-            "ł": "l",
-            "Ł": "l",
-            "ń": "n",
-            "Ń": "n",
-            "ó": "o",
-            "Ó": "o",
-            "ś": "s",
-            "Ś": "s",
-            "ź": "z",
-            "Ź": "z",
-            "ż": "z",
-            "Ż": "z",
-        }
-    )
-    return re.sub(r"\s+", " ", text.translate(table).lower()).strip()
-
-
-def _icon_for(waste_type: str) -> Optional[str]:
-    key = _strip_pl(waste_type)
-    for needle, icon in ICON_MAP.items():
-        if needle in key:
-            return icon
-    return None
-
-
-class _ScheduleTableParser(HTMLParser):
-    """Extract the first schedule table from the Hemar report HTML.
-
-    The table has a header row with waste-type names and one body row per
-    month. The first cell of each body row is a Polish month name; the
-    remaining cells contain comma-separated day numbers (or empty).
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._in_table = False
-        self._in_thead = False
-        self._in_tbody = False
-        self._in_tr = False
-        self._in_cell = False
-        self._cell_text: List[str] = []
-        self._current_row: List[str] = []
-        self.headers: List[str] = []
-        self.rows: List[List[str]] = []
-        self._captured = False
-
-    def handle_starttag(self, tag: str, attrs):  # type: ignore[override]
-        if self._captured:
-            return
-        if tag == "table":
-            self._in_table = True
-        elif tag == "thead" and self._in_table:
-            self._in_thead = True
-        elif tag == "tbody" and self._in_table:
-            self._in_tbody = True
-        elif tag == "tr" and self._in_table:
-            self._in_tr = True
-            self._current_row = []
-        elif tag in ("td", "th") and self._in_tr:
-            self._in_cell = True
-            self._cell_text = []
-
-    def handle_endtag(self, tag: str):  # type: ignore[override]
-        if self._captured:
-            return
-        if tag in ("td", "th") and self._in_cell:
-            self._current_row.append("".join(self._cell_text).strip())
-            self._in_cell = False
-        elif tag == "tr" and self._in_tr:
-            if self._in_thead:
-                # Take the longest header row (real header may be the 2nd row).
-                if len(self._current_row) > len(self.headers):
-                    self.headers = self._current_row
-            elif self._in_tbody:
-                self.rows.append(self._current_row)
-            self._in_tr = False
-        elif tag == "thead":
-            self._in_thead = False
-        elif tag == "tbody":
-            self._in_tbody = False
-            if self.headers and self.rows:
-                self._captured = True
-        elif tag == "table":
-            self._in_table = False
-
-    def handle_data(self, data: str):  # type: ignore[override]
-        if self._in_cell:
-            self._cell_text.append(data)
-
 
 class Source:
     def __init__(self, city: str, street: str, house_number: str):
-        self._city = str(city).strip()
-        self._street = str(street).strip()
-        self._house_number = str(house_number).strip()
-        self._session = requests.Session()
-
-    def _get_json(self, path: str):
-        r = self._session.get(f"{API_BASE}{path}", timeout=30)
-        r.raise_for_status()
-        return r.json()
-
-    def _find(self, items, target: str, arg_name: str):
-        norm_target = _strip_pl(target)
-        for item in items:
-            if _strip_pl(item["value"]) == norm_target:
-                return item
-        suggestions = [item["value"] for item in items]
-        raise SourceArgumentNotFoundWithSuggestions(
-            arg_name, target, suggestions=suggestions
-        )
+        self._client = SepanClient([API_BASE])
+        self._address_id = self._client.resolve_address(city, street, house_number)
 
     def fetch(self) -> List[Collection]:
-        cities = self._get_json("/addresses/cities")
-        city = self._find(cities, self._city, "city")
-
-        streets = self._get_json(f"/addresses/streets/{city['id']}")
-        street = self._find(streets, self._street, "street")
-
-        numbers = self._get_json(f"/addresses/numbers/{city['id']}/{street['id']}")
-        number = self._find(numbers, self._house_number, "house_number")
-
-        years = self._get_json("/years")
-        if not years:
-            return []
-
+        entries = self._client.fetch_schedule(self._address_id)
         today = date.today()
-        entries: List[Collection] = []
-        seen: set = set()
-
-        for year_entry in years:
-            year_id = year_entry["id"]
-            year_value = int(year_entry["value"])
-            report = self._session.get(
-                f"{API_BASE}/reports",
-                params={
-                    "type": "html",
-                    "id": number["id"],
-                    "responseType": "json",
-                    "token": number["token"],
-                    "yearId": year_id,
-                },
-                timeout=30,
+        return [
+            Collection(
+                date=collection_date, t=waste_type, icon=ICON_MAP.get(waste_type)
             )
-            report.raise_for_status()
-            payload = report.json()
-            if payload.get("status") != "success" or not payload.get("filePath"):
-                continue
-
-            html_resp = self._session.get(payload["filePath"], timeout=30)
-            html_resp.raise_for_status()
-            html_resp.encoding = "utf-8"
-
-            for collection in self._parse_schedule(html_resp.text, year_value):
-                key = (collection.date, collection.type)
-                if key in seen:
-                    continue
-                seen.add(key)
-                # Skip dates more than 30 days in the past to keep payload small.
-                if (today - collection.date).days > 30:
-                    continue
-                entries.append(collection)
-
-        return entries
-
-    @staticmethod
-    def _parse_schedule(html: str, year: int) -> List[Collection]:
-        parser = _ScheduleTableParser()
-        parser.feed(html)
-
-        if not parser.headers or not parser.rows:
-            return []
-
-        # First header column is the month name; remaining are waste types.
-        waste_types = parser.headers[1:]
-        results: List[Collection] = []
-
-        for row in parser.rows:
-            if not row:
-                continue
-            month_name = _strip_pl(row[0])
-            month = PL_MONTHS.get(month_name)
-            if month is None:
-                continue
-            for col_idx, cell in enumerate(row[1:], start=0):
-                if col_idx >= len(waste_types):
-                    break
-                cell = cell.strip()
-                if not cell:
-                    continue
-                waste_type = waste_types[col_idx].strip()
-                for piece in re.split(r"[,;/]", cell):
-                    piece = piece.strip()
-                    if not piece.isdigit():
-                        continue
-                    day = int(piece)
-                    try:
-                        collection_date = datetime(year, month, day).date()
-                    except ValueError:
-                        continue
-                    results.append(
-                        Collection(
-                            date=collection_date,
-                            t=waste_type,
-                            icon=_icon_for(waste_type),
-                        )
-                    )
-        return results
+            for collection_date, waste_type in entries
+            # Skip dates more than 30 days in the past to keep payload small.
+            if (today - collection_date).days <= 30
+        ]


### PR DESCRIPTION
## Summary
- Extends `SepanClient` (introduced in #6762) with an opt-in `/years`+`token`-aware report-fetch path: when a SEPAN deployment exposes a `/years` endpoint, `fetch_schedule()` now fetches and merges every available year's report using the per-address `token` already returned by `/addresses/numbers/...`, instead of guessing a year-suffixed base URL. Deployments without `/years` (e.g. the Kleszczewo/Kostrzyn zys_harmonogram_pl deployment) fall back to the previous single-report behaviour unchanged.
- Migrates `ichisystem_eu.py` (Hemar / harmonogram.ichisystem.eu) onto `SepanClient`, removing ~200 lines of bespoke HTML parsing and address-resolution code that duplicated the shared client.
- Folds Polish-diacritic-insensitive matching into `SepanClient`'s own city/street/number matching (all four SEPAN-platform sources benefit), replacing the plain `.upper()` comparison.

## Why
Follow-up to #6749/#6762. `ichisystem_eu.py` turned out to run on the same underlying platform as the other three SEPAN sources, but its report-fetching was already more robust (using the API's own year discovery instead of guessing a year-suffixed URL). This folds that robustness back into the shared client. See #6763 for the full investigation.

Note: `alba_com_pl.py`'s hardcoded `harmonogram2025_swarzedz` year-suffix was **not** touched in this PR — `sepan-wroclaw.alba.com.pl` was unreachable during testing, so switching it to the new year-discovery mechanism needs separate live verification.

## Test plan
- [x] `ruff check --fix` / `ruff format` on both changed files
- [x] `python -m pytest tests/test_source_components.py -q` — passes
- [x] `python -m pytest tests/ -q` — passes
- [x] `python test_sources.py -s ichisystem_eu -l` — live-verified, returns full multi-year schedule
- [x] `python test_sources.py -s zys_harmonogram_pl -l` — live-verified, no regression (no `/years` on this deployment, old fallback path exercised)
- [ ] `python test_sources.py -s alba_com_pl -l` — could not verify; `sepan-wroclaw.alba.com.pl` unreachable in CI sandbox. Deployment's report-fetch path is unchanged for this source (still calls `fetch_schedule()` which safely no-ops the new `/years` path when unavailable), so no regression expected, but not independently confirmed.
- [ ] `python test_sources.py -s sepan_remondis_pl -l` — fails with "fetch report failed" both before and after this change (confirmed via `git stash`); pre-existing, unrelated issue — flagging separately, not fixed here.

Fixes #6763