### PR TITLE
fix(ryde_nsw_gov_au): use curl_cffi to bypass Akamai 403 on City of Ryde API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ryde_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ryde_nsw_gov_au.py
@@ -1,8 +1,8 @@
 import datetime
 import json
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons
 
 TITLE = "City of Ryde (NSW)"
@@ -45,6 +45,7 @@ ICON_MAP = {
     "General Waste": Icons.GENERAL_WASTE,
     "Recycling": Icons.RECYCLING,
     "Green Waste": Icons.GARDEN,
+    "Garden Organics": Icons.GARDEN,
 }
 
 
@@ -64,8 +65,10 @@ class Source:
             self.street_number, self.street_name, self.suburb, self.post_code
         )
 
+        session = requests.Session(impersonate="chrome")
+
         # Retrieve suburbs
-        r = requests.get(
+        r = session.get(
             API_URLS["address_search"], params={"keywords": address}, headers=HEADERS
         )
 
@@ -82,7 +85,7 @@ class Source:
             )
 
         # Retrieve the upcoming collections for our property
-        r = requests.get(
+        r = session.get(
             API_URLS["collection"],
             params={"geolocationid": locationId, "ocsvclang": "en-AU"},
             headers=HEADERS,


### PR DESCRIPTION
## Summary
- Fixes #6788: `ryde_nsw_gov_au` source fails with `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` since ~2 July 2026.
- Root cause: the provider's Akamai edge WAF (edgesuite.net) now returns HTTP 403 "Access Denied" for plain `requests`/`urllib3` TLS fingerprints on both `api/v1/myarea/search` and `ocapi/Public/myarea/wasteservices`, producing an empty response body.
- Fix: switch to `curl_cffi` with `impersonate="chrome"`, per project convention for Cloudflare/Akamai-protected sites.
- Also added `"Garden Organics"` to `ICON_MAP` (→ `Icons.GARDEN`), since the site renamed this waste-type label from `"Green Waste"`; kept the old key too in case it's still used elsewhere.

## Test plan
- [x] `python test_sources.py -s ryde_nsw_gov_au -l` — all 3 TEST_CASES return valid entries
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `ruff check --fix` / `ruff format` — clean