### PR TITLE
Fix HTTP/2 header violation breaking uk_cloud9_apps sources

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/uk_cloud9_apps.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/uk_cloud9_apps.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 from typing import Any, Optional, Sequence, cast
 
 from curl_cffi import requests
+from curl_cffi.const import CurlHttpVersion
 
 from waste_collection_schedule import Collection
 from waste_collection_schedule.exceptions import (
@@ -177,7 +178,15 @@ class Cloud9Client:
         ]
         if not self._base_urls:
             raise ValueError("At least one API domain must be configured.")
-        self._session = requests.Session(impersonate="chrome")
+        # The Cloud9 API is fronted by an AWS ELB that sometimes echoes
+        # HTTP/1.1-only response headers (e.g. "keep-alive: timeout=5") on
+        # an HTTP/2 connection. This violates RFC 7540 8.1.2.2 and causes
+        # curl_cffi/nghttp2 to abort with CurlError 92 ("Invalid HTTP
+        # header field was received"). Forcing HTTP/1.1 avoids the strict
+        # HTTP/2 header validation and lets the request succeed.
+        self._session = requests.Session(
+            impersonate="chrome", http_version=CurlHttpVersion.V1_1
+        )
         self._session.headers.update(BASE_HEADERS)
 
     def _request_json(


### PR DESCRIPTION
## Summary
- `arun_gov_uk` (and the other sources sharing `service/uk_cloud9_apps.py`: `northherts_gov_uk`, `rugby_gov_uk`) started failing with `curl_cffi.curl.CurlError: ... Invalid HTTP header field was received: ... name: [keep-alive], value: [timeout=5]`.
- Root cause: the Cloud9 API's AWS ELB sometimes sends an HTTP/1.1-only `keep-alive: timeout=5` response header while negotiating HTTP/2, which violates RFC 7540 §8.1.2.2 (connection-specific headers are forbidden on HTTP/2). curl_cffi's nghttp2 backend aborts the stream and raises `HTTPError`, which wasn't in the service's retry/except tuple, so the fetch failed entirely.
- Fix: force the curl_cffi session in `Cloud9Client` to use HTTP/1.1 (`http_version=CurlHttpVersion.V1_1`), which avoids the strict HTTP/2 header validation. Verified with a raw `curl -v` reproduction of the malformed header and confirmed the workaround returns a clean `200` with valid JSON.

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python -m pytest tests/test_source_components.py -q` (9 passed)
- [x] Live `test_sources.py -s arun_gov_uk -l` — all 4 test cases pass
- [x] Live `test_sources.py -s northherts_gov_uk -l` — all 4 test cases pass
- [x] Live `test_sources.py -s rugby_gov_uk -l` — all 3 test cases pass

Fixes #6793