### PR TITLE
fix(waverley_gov_uk): match both `<ul>` and malformed `<u1>` tags in WhitespaceWRP

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhitespaceWRP.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/WhitespaceWRP.py
@@ -102,8 +102,13 @@ class WhitespaceClient:
             raise ValueError("Could not find scheduled-collections section on WRP page")
 
         results = []
-        for u1 in scheduled.find_all("u1"):
-            lis = u1.find_all("li", recursive=False)
+        # Some WRP portals emit well-formed "<ul>" list markup, while others
+        # (e.g. Lancaster) emit a malformed "<u1>" tag (digit one instead of
+        # letter "l") for the same list structure. Match both so the shared
+        # client keeps working regardless of which variant a given council's
+        # portal serves.
+        for ul in scheduled.find_all(["ul", "u1"]):
+            lis = ul.find_all("li", recursive=False)
             if len(lis) < 3:
                 continue
 


### PR DESCRIPTION
## Summary
- Fixes #6789 — Waverley Borough Council (`waverley_gov_uk`) stopped returning any collections after updating to the latest version.
- Root cause: `WhitespaceClient.fetch_schedule` (shared by `waverley_gov_uk`, `lancaster_gov_uk`, `allerdale_gov_uk`) looked for a literal `<u1>` tag (digit "1") when parsing the scheduled-collections list. This was originally a bug that happened to match malformed HTML on some councils' WRP portals (confirmed Lancaster's portal genuinely emits `<u1>`), but Waverley's portal emits standard `<ul>` markup for the same structure, so the match failed there and `fetch()` returned an empty list.
- Fix: match both `<ul>` and `<u1>` tags so the shared client keeps working across portals regardless of which markup variant they serve.

## Test plan
- [x] `python test_sources.py -s waverley_gov_uk -l` → 12/12 entries found for both test cases (was 0/0 before the fix)
- [x] `python test_sources.py -s lancaster_gov_uk -l` → 10/10 entries found, unchanged (regression check on the shared service)
- [x] `python -m pytest tests/test_source_components.py -q` → 9 passed
- [ ] `allerdale_gov_uk` could not be live-tested in CI/sandbox (host connection refused), but the change is additive (widens tag matching) and does not alter existing behavior for portals already using `<u1>`