### PR TITLE
fix(blacktown_nsw_gov_au): restore literal characters mangled in #6799

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/blacktown_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/blacktown_nsw_gov_au.py
@@ -15,7 +15,7 @@ TEST_CASES = {
         "street_name": "Jersey Rd",
         "street_number": "260",
     },
-    "Rooty Hill Tennis &amp; Squash Centre": {
+    "Rooty Hill Tennis & Squash Centre": {
         "post_code": "2766",
         "suburb": "Rooty Hill",
         "street_name": "Learmonth St",
@@ -99,7 +99,7 @@ class Source:
 
         entries = []
         for item in services:
-            # test if &lt;div&gt; contains a valid date. If not, is is not a collection item.
+            # test if <div> contains a valid date. If not, is is not a collection item.
             date_text = item.find("div", attrs={"class": "next-service"})
             # The date format currently used on https://www.blacktown.nsw.gov.au/Services/Waste-services-and-collection/Waste-collection-days
             date_format = "%a %d/%m/%Y"


### PR DESCRIPTION
## Summary
- PR #6799 introduced HTML-escaped entities into two places in `blacktown_nsw_gov_au.py` instead of the intended literal characters: a `TEST_CASES` key became `"Rooty Hill Tennis &amp; Squash Centre"` instead of `"Rooty Hill Tennis & Squash Centre"`, and a comment became `# test if &lt;div&gt; contains a valid date...` instead of `# test if <div> contains a valid date...`.
- This restores the literal characters. No functional change — the source's behavior (curl_cffi fetch logic from #6799) is unaffected.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] Live test via `test_sources.py -s blacktown_nsw_gov_au -l` — all 5 TEST_CASES return correct General Waste / Recycling dates, including the corrected "Rooty Hill Tennis & Squash Centre" label