### PR TITLE
fix(kingston_vic_gov_au): geocode address instead of using fixed coordinate

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kingston_vic_gov_au.py
@@ -1,7 +1,9 @@
 import logging
 from typing import List
 
+import requests
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 from ..service.WhatBinDay import WhatBinDayService
 
@@ -10,6 +12,8 @@ _LOGGER = logging.getLogger(__name__)
 TITLE = "City of Kingston"
 DESCRIPTION = "Source for City of Kingston (VIC) waste collection."
 URL = "https://www.kingston.vic.gov.au"
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 TEST_CASES = {
     "randomHouse": {
         "street_number": "30C",
@@ -55,6 +59,46 @@ class Source:
         self.post_code = str(post_code)
 
         self._service: WhatBinDayService | None = None
+        self._coordinates: dict | None = None
+
+    def _geocode(self) -> dict:
+        """Resolve the address to its real coordinates via Nominatim.
+
+        Kingston's fortnightly recycling / food-and-garden-waste roster
+        (and even the weekday of collection) differs from street to
+        street, so a single fixed coordinate cannot be used for every
+        address: the upstream API resolves the applicable roster from
+        the submitted coordinates, not from the address text fields. See
+        https://github.com/mampfes/hacs_waste_collection_schedule/issues/6772
+        """
+        if self._coordinates is not None:
+            return self._coordinates
+
+        query = (
+            f"{self.street_number} {self.street_name}, "
+            f"{self.suburb} VIC {self.post_code}, Australia"
+        )
+        response = requests.get(
+            NOMINATIM_URL,
+            params={
+                "q": query,
+                "format": "json",
+                "limit": "1",
+                "countrycodes": "au",
+            },
+            headers={"User-Agent": "hacs_waste_collection_schedule"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        results = response.json()
+        if not results:
+            raise SourceArgumentNotFound("street_name", self.street_name)
+
+        self._coordinates = {
+            "lat": float(results[0]["lat"]),
+            "lng": float(results[0]["lon"]),
+        }
+        return self._coordinates
 
     def _get_service(self) -> WhatBinDayService:
         """Get or create the WhatBinDay service instance."""
@@ -75,6 +119,7 @@ class Source:
     def fetch(self) -> List[Collection]:
         """Fetch waste collection schedule."""
         service = self._get_service()
+        coordinates = self._geocode()
         return service.fetch_collections(
             self.street_number,
             self.street_name,
@@ -82,8 +127,5 @@ class Source:
             self.post_code,
             state="VIC",
             country="Australia",
-            coordinates={
-                "lat": -37.9759,
-                "lng": 145.1350,
-            },  # Default Kingston area coordinates
+            coordinates=coordinates,
         )


### PR DESCRIPTION
## Summary
- The Kingston (VIC) source sent the same hardcoded coordinate
  (`-37.9759, 145.1350`, "Default Kingston area coordinates") to the
  upstream WhatBinDay API for every address. The API resolves the
  applicable fortnightly Recycling/Food-and-garden-waste roster (and
  the collection weekday) from the submitted coordinates, not from the
  address text — so every user in the LGA was silently getting
  whichever roster happens to apply at that one fixed point, which is
  frequently wrong for their actual street.
- Added a small Nominatim geocoding step (same approach already used
  by `melvillecity_com_au.py`) so the real coordinates of the entered
  address are used instead. Verified live: the module's three existing
  TEST_CASES (three different real Kingston suburbs) previously
  returned byte-for-byte identical schedules; after the fix each
  returns its own distinct weekday/roster.
- Geocode failures raise `SourceArgumentNotFound` rather than silently
  falling back to the old hardcoded value.

Fixes #6772

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python test_sources.py -s kingston_vic_gov_au -l` — all three
      TEST_CASES fetch successfully and now show distinct
      weekday/roster combinations
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)