### PR TITLE
Fix umlaut/ß street search on affected SiteparkIES installations

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/SiteparkIES.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/SiteparkIES.py
@@ -11,6 +11,21 @@ from waste_collection_schedule.exceptions import (
 from waste_collection_schedule.service.ICS import ICS
 
 
+def _mojibake(term: str) -> str:
+    """Re-encode a term to work around a server-side double UTF-8 decode.
+
+    Some Sitepark installations (e.g. hilchenbach.de) mis-decode the
+    ``term`` query parameter, so a correctly UTF-8-encoded term containing
+    umlauts or "ß" never matches (e.g. "Am Bühl" or "Dammstraße" return no
+    results at all). Re-encoding the term as UTF-8 bytes and decoding those
+    bytes as Latin-1 reproduces the same mis-decoding the server applies,
+    which cancels it out and lets the match succeed. Other installations
+    (e.g. ab-peine.de) decode correctly already and this would break them,
+    so it is only tried as a fallback, not applied unconditionally.
+    """
+    return term.encode("utf-8").decode("latin-1")
+
+
 def match_icon(waste_type: str, icon_map: dict):
     """Return the first icon whose key is contained in the waste type.
 
@@ -167,19 +182,25 @@ class SiteparkIES:
         return candidates[0][0]
 
     def _query(self, term: Optional[str], refid: Optional[str]) -> List[list]:
-        """Autocomplete with a fallback for terms the endpoint cannot match.
+        """Autocomplete with fallbacks for terms the endpoint cannot match.
 
-        The abto endpoint returns an empty result for some inputs (e.g. terms
-        containing "ß", a trailing space, parentheses or a comma). When that
-        happens, retry with the leading, more tolerant part of the term and let
-        the caller filter the (broader) result set locally.
+        The abto endpoint returns an empty result for some inputs: umlauts
+        or "ß" on installations affected by the double-decode bug (see
+        ``_mojibake``), or a trailing space, parentheses or a comma on any
+        installation. When that happens, retry with a more tolerant form of
+        the term and let the caller filter the (broader) result set locally.
         """
         results = self.autocomplete(term, refid=refid)
         if results or not term:
             return results
 
+        if not term.isascii():
+            results = self.autocomplete(_mojibake(term), refid=refid)
+            if results:
+                return results
+
         short = term
-        for sep in ("ß", "(", ",", "  "):
+        for sep in ("(", ",", "  "):
             short = short.split(sep)[0]
         short = short.strip()
         if short and short != term:


### PR DESCRIPTION
## Summary
- `hilchenbach.de`'s `abto` autocomplete endpoint double-decodes its `term` query parameter server-side, so any street name containing an umlaut or "ß" (e.g. "Am Bühl", "Dammstraße") returned zero results — the `Am Bühl (Allenbach)` test case for `hilchenbach_de` was actually failing.
- Added a mojibake re-encoding fallback (UTF-8 bytes decoded as Latin-1) in `SiteparkIES._query` that cancels out the server-side bug. It's only tried when the plain-UTF-8 query returns empty, since other Sitepark installations sharing this service (e.g. `ab-peine.de`) decode correctly already and would break under the same transform.
- Dropped the now-redundant `"ß"` entry from the existing prefix-stripping fallback, since the new mojibake retry handles it directly instead of falling back to a truncated prefix.

## Test plan
- [x] `python test_sources.py -s hilchenbach_de` — both test cases pass, including `Am Bühl (Allenbach)` which previously failed with a "could not find values" error.
- [x] Live-tested all 11 sources sharing `SiteparkIES` (28 test cases total): `hilchenbach_de`, `abfall_neunkirchen_siegerland_de`, `ab_peine_de`, `gross_gerau_de`, `ilm_kreis_de`, `kreis_ploen_de`, `landkreis_wittmund_de`, `kwb_goslar_de`, `lk_mecklenburgische_seenplatte_de`, `muehlenkreis_de`, `ostprignitz_ruppin_de` — all pass, no regressions.
- [x] `ruff check` / `ruff format --check` on the changed file
- [x] `python -m pytest tests/test_source_components.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)