### PR TITLE
docs(ics): add Hüllhorst (Gemeinde Hüllhorst, NRW) to ICS provider list

### DIFF
--- a/doc/ics/yaml/huellhorst_de.yaml
+++ b/doc/ics/yaml/huellhorst_de.yaml
@@ -1,0 +1,18 @@
+---
+title: Gemeinde Hüllhorst
+url: https://www.huellhorst.de/
+howto:
+  en: |
+    The village community "Dorfgemeinschaft für ein zukunftsorientiertes Büttendorf" publishes
+    the waste collection calendar of the whole municipality of Hüllhorst as an ICS file every year.
+
+    - Go to <https://www.buettendorf.info/abfuhrkalender/>.
+    - Right-click -> copy link address on one of the `Download` buttons
+      (`Abfuhrkalender <year> mit Erinnerung` includes a reminder at 18:00 the day before,
+      `Abfuhrkalender <year> ohne Erinnerung` does not).
+    - Use this link as the `url` parameter.
+    - Note: a new link is published every year, so you will need to revisit the page
+      and update the `url` parameter once the current year's calendar is no longer valid.
+test_cases:
+  Abfuhrkalender ohne Erinnerung:
+    url: https://www.buettendorf.info/app/download/13461722949/Abfuhrkalender+2026+ohne+Erinnerung.ics?t=1772087961


### PR DESCRIPTION
## Summary
- Adds `Gemeinde Hüllhorst` (North Rhine-Westphalia, Germany) to the documented list of providers supported by the generic ICS source.
- The municipality's waste collection calendar is published as a public, unauthenticated ICS file by the village community association "Dorfgemeinschaft für ein zukunftsorientiertes Büttendorf" (https://www.buettendorf.info/abfuhrkalender/), covering the whole municipality of Hüllhorst.
- Verified the ICS file parses correctly with `service/ICS.py` (29 events, correct dates and waste types, no regex required).
- Note: the download link's asset ID changes each year (not just the year number), so the `howto` instructs users to revisit the page annually and update the `url` parameter — it cannot use the `{%Y}` auto-templating trick.

Fixes #5623

## Test plan
- [x] `pre-commit run yamlfmt --files doc/ics/yaml/huellhorst_de.yaml`
- [x] `python -m pytest tests/test_source_components.py -q`
- [x] Manually verified the ICS URL returns HTTP 200 and parses via `service/ICS.py`