### PR TITLE
fix(publidata_fr): add Métropole du Grand Nancy to Publidata source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -46,6 +46,11 @@ TEST_CASES = {
         "insee_code": "37018",
         "instance_id": 65,
     },
+    "Grand Nancy, Laxou": {
+        "address": "1 Rue de l'Embanie",
+        "insee_code": "54304",
+        "instance_id": 1436,
+    },
     # "Saumur Val de Loire, Allones": {
     # "address": "5 rue du Bellay",
     # "insee_code": "49002",
@@ -281,6 +286,11 @@ EXTRA_INFO = [
         "title": "Communauté de Communes Pévèle Carembault",
         "url": "https://www.pevelecarembault.fr/",
         "default_params": {"instance_id": 1141},
+    },
+    {
+        "title": "Métropole du Grand Nancy",
+        "url": "https://mhdd.grandnancy.eu/",
+        "default_params": {"instance_id": 1436},
     },
 ]
 


### PR DESCRIPTION
## Summary
- Adds Métropole du Grand Nancy (requested for Laxou, France in #2728) as a supported instance of the existing `publidata_fr` shared source.
- The Grand Nancy waste page embeds a Publidata widget (`MDVArtzp7X`); resolved its numeric `instance_id` (1436) via the Publidata widget config API.
- Added a `TEST_CASES` entry ("Grand Nancy, Laxou") and an `EXTRA_INFO` entry so the metropolis shows up in the config UI and generated docs.

Closes #2728

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python test_sources.py -s publidata_fr -l` — all test cases pass, including the new Laxou case (160 entries found: Ordures ménagères + Emballages)
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed