### PR TITLE
Fix typo in 'Whitehorse City Council' header

### DIFF
--- a/doc/source/whitehorse_vic_gov_au.md
+++ b/doc/source/whitehorse_vic_gov_au.md
@@ -1,6 +1,6 @@
-# Whitehorse City Counfil
+# Whitehorse City Council
 
-Support for schedules provided by [Whitehorse City Counfil](https://www.whitehorse.vic.gov.au), serving Whitehorse, Australia.
+Support for schedules provided by [Whitehorse City Council](https://www.whitehorse.vic.gov.au), serving Whitehorse, Australia.
 
 ## Configuration via configuration.yaml
 


### PR DESCRIPTION
## Summary

Fixes typo in Whitehorse City Council information

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [x] Documentation update
- [ ] Other