### PR TITLE
feat(source): add myWasteWatcher / WasteWatcher.NET (mywastewatcher_de)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mywastewatcher_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mywastewatcher_de.py
@@ -1,0 +1,446 @@
+import re
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentException,
+    SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequired,
+)
+
+TITLE = "myWasteWatcher (WasteWatcher.NET)"
+DESCRIPTION = (
+    "Source for mywastewatcher.de (WasteWatcher.NET) waste collection schedules."
+)
+URL = "https://www.mywastewatcher.de"
+COUNTRY = "de"
+SOURCE_CODEOWNERS = ["@ItsMly"]
+
+TEST_CASES = {
+    "Hamminkeln, Molkereistraße (default oguid/app_path)": {
+        "ort": "Hamminkeln",
+        "strasse": "Molkereistraße",
+    },
+    "Hamminkeln, Ackerstraße Mehrhoog": {
+        "oguid": "B3E02353-2090-4EFA-B3C7-AEC81FBC1E6F",
+        "app_path": "abfallkalenderdk",
+        "ort": "Hamminkeln",
+        "strasse": "Ackerstraße",
+        "ortsteil": "Mehrhoog",
+    },
+    "Hamminkeln, Marktstraße": {
+        "oguid": "B3E02353-2090-4EFA-B3C7-AEC81FBC1E6F",
+        "app_path": "abfallkalenderdk",
+        "ort": "Hamminkeln",
+        "strasse": "Marktstraße",
+    },
+    "Hamminkeln, dropdown label": {
+        "strasse": "Ackerstraße (Mehrhoog)",
+    },
+}
+
+# Grid rows carry short fraction codes with a tour suffix (e.g. "LP HAM02"),
+# so lookups fall back to the first token of the waste-type string.
+ICON_MAP = {
+    "restabfall": Icons.GENERAL_WASTE,
+    "restmüll": Icons.GENERAL_WASTE,
+    "ra": Icons.GENERAL_WASTE,
+    "bioabfall": Icons.ORGANIC,
+    "biomüll": Icons.ORGANIC,
+    "ba": Icons.ORGANIC,
+    "papier": Icons.PAPER,
+    "papier, pappe, karton": Icons.PAPER,
+    "altpapier": Icons.PAPER,
+    "pa": Icons.PAPER,
+    "leichtverpackung": Icons.PLASTIC_PACKAGING,
+    "leichtverpackungen": Icons.PLASTIC_PACKAGING,
+    "gelbe tonne": Icons.PLASTIC_PACKAGING,
+    "gelber sack": Icons.PLASTIC_PACKAGING,
+    "lp": Icons.PLASTIC_PACKAGING,
+    "glas": Icons.GLASS,
+    "glasverpackungen": Icons.GLASS,
+    "gl": Icons.GLASS,
+    "grünschnitt": Icons.GARDEN,
+    "gb": Icons.GARDEN,
+    "schadstoffe": Icons.HAZARDOUS,
+    "schadstoffmobil": Icons.HAZARDOUS,
+    "sc": Icons.HAZARDOUS,
+    "sperrmüll": Icons.BULKY,
+    "sp": Icons.BULKY,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "The pre-filled oguid and app_path select Hamminkeln — then just enter "
+        "city and street exactly as shown on the website. For another "
+        "municipality, open its calendar page on https://www.mywastewatcher.de "
+        "(e.g. via the link from your local waste authority): the first path "
+        "segment of the URL is the app_path (e.g. 'abfallkalenderdk'), and the "
+        "oguid is the value of the 'oguid' parameter in the URL."
+    ),
+    "de": (
+        "Die vorausgefüllten Werte für oguid und app_path wählen Hamminkeln aus "
+        "— dann nur noch Ort und Straße genau wie auf der Webseite angezeigt "
+        "eingeben. Für eine andere Kommune deren Abfallkalender-Seite auf "
+        "https://www.mywastewatcher.de öffnen (z.B. über den Link des "
+        "Entsorgungsbetriebs): Das erste Pfad-Segment der URL ist der App-Pfad "
+        "(z.B. 'abfallkalenderdk'), die OGUID ist der Wert des URL-Parameters "
+        "'oguid'."
+    ),
+}
+
+PARAM_TRANSLATIONS = {
+    "de": {
+        "oguid": "OGUID (Kennung des Entsorgungsgebiets)",
+        "app_path": "App-Pfad (z.B. abfallkalenderdk)",
+        "ort": "Ort",
+        "strasse": "Straße",
+        "ortsteil": "Ortsteil",
+        "bemerkung": "Bemerkung (z.B. Hausnummern)",
+    },
+    "en": {
+        "oguid": "OGUID (waste management area identifier)",
+        "app_path": "App path (e.g. abfallkalenderdk)",
+        "ort": "City",
+        "strasse": "Street",
+        "ortsteil": "District",
+        "bemerkung": "Remark (e.g. house numbers)",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "oguid": "Unique identifier for the waste management area (OGUID), visible in the URL of the provider's page. The default selects Hamminkeln.",
+        "app_path": "Path segment of the provider URL (e.g. 'abfallkalenderdk'). The default selects Hamminkeln.",
+        "ort": "City name exactly as shown on the website.",
+        "strasse": "Street name exactly as shown on the website.",
+        "ortsteil": "District name (optional), used when multiple districts share the same street name.",
+        "bemerkung": "Remark field shown in the street list (e.g. house number ranges like '1-50'). Use when multiple entries exist for the same street.",
+    },
+    "de": {
+        "oguid": "Eindeutige Kennung des Entsorgungsgebiets (OGUID), in der URL der Anbieterseite sichtbar. Der Standardwert wählt Hamminkeln aus.",
+        "app_path": "Pfad-Segment der Anbieter-URL (z.B. 'abfallkalenderdk'). Der Standardwert wählt Hamminkeln aus.",
+        "ort": "Ortsname genau wie auf der Webseite angezeigt.",
+        "strasse": "Straßenname genau wie auf der Webseite angezeigt.",
+        "ortsteil": "Ortsteil (optional), wenn mehrere Ortsteile denselben Straßennamen haben.",
+        "bemerkung": "Bemerkungsfeld aus der Straßenliste (z.B. Hausnummernbereiche wie '1-50'). Angeben, wenn mehrere Einträge für dieselbe Straße existieren.",
+    },
+}
+
+BASE_URL = "https://www.mywastewatcher.de/{app_path}/"
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "de-DE,de;q=0.9,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Referer": "https://www.mywastewatcher.de/",
+}
+
+_FORM = "ctl00$MainContent$frmKalender$"
+_FORM_ID = "ctl00_MainContent_frmKalender_"
+
+_DATA_ROW_RE = re.compile(r"<tr[^>]*class=\"[^\"]*dxgvDataRow.*?</tr>", re.DOTALL)
+_CELL_RE = re.compile(r"<td.*?</td>", re.DOTALL)
+_CALLBACK_STATE_RE = re.compile(r"'callbackState':'([^']+)'")
+_GRID_STATE_RE = re.compile(
+    r"ASPxClientGridView,'" + _FORM_ID + r"dgvPickUpDates'.*?'callbackState':'([^']+)'",
+    re.DOTALL,
+)
+
+
+class Source:
+    # The defaults select Hamminkeln, currently the only instance that
+    # publishes schedule data. The abfallkalenderdk2 (Kalkar) and
+    # abfallkalenderRBE (Rheinberg) instances exist but return "Keine Daten
+    # zum Anzeigen" for every street (checked 2026-07).
+    def __init__(
+        self,
+        oguid: str = "B3E02353-2090-4EFA-B3C7-AEC81FBC1E6F",
+        app_path: str = "abfallkalenderdk",
+        ort: str | None = None,
+        strasse: str | None = None,
+        ortsteil: str | None = None,
+        bemerkung: str | None = None,
+    ):
+        if not strasse:
+            raise SourceArgumentRequired(
+                "strasse", "the street is needed to select the correct schedule"
+            )
+        self._oguid = oguid.lower()
+        self._app_path = app_path
+        self._ort = ort or ""
+        self._strasse = strasse
+        self._ortsteil = ortsteil or ""
+        self._bemerkung = bemerkung or ""
+        self._base_url = BASE_URL.format(app_path=app_path)
+        self._page_url = f"{self._base_url}default.aspx?oguid={self._oguid}"
+
+    def _parse_response(self, r: requests.Response) -> BeautifulSoup:
+        r.raise_for_status()
+        r.encoding = "utf-8"
+        return BeautifulSoup(r.text, "html.parser")
+
+    def _build_base_form(self, soup: BeautifulSoup) -> dict[str, str]:
+        """Build the form payload from the current page state.
+
+        Hidden fields carry the ASP.NET ViewState; text fields carry the
+        DevExpress control state (including the visually hidden checkbox
+        state inputs, which render as text inputs with value "C"/"U").
+        """
+        data: dict[str, str] = {}
+        for inp in soup.find_all("input"):
+            name = inp.get("name") or inp.get("id")
+            if not name:
+                continue
+            itype = inp.get("type", "text")
+            if itype == "hidden":
+                data[name] = inp.get("value", "")
+            elif itype == "text":
+                val = inp.get("value", "")
+                # Only include non-empty or DevExpress state fields
+                if val or "State" in name or "_VI" in name or "DDD" in name:
+                    data[name] = val
+        return data
+
+    def _select_city(self, session: requests.Session) -> BeautifulSoup:
+        """Load the page and select the city (the oguid is the city VI value)."""
+        r = session.get(self._page_url, allow_redirects=True)
+        soup = self._parse_response(r)
+
+        data = self._build_base_form(soup)
+        data["__EVENTTARGET"] = _FORM + "cboCities"
+        data["__EVENTARGUMENT"] = ""
+        data[_FORM_ID + "cboCities_VI"] = self._oguid
+        data[_FORM + "cboCities"] = self._ort
+        data[_FORM + "cboCities$DDD$L"] = self._oguid
+        return self._parse_response(session.post(self._page_url, data=data))
+
+    def _find_street_guid(self, soup: BeautifulSoup) -> tuple[str | None, list[str]]:
+        """
+        Extract the DevExpress GUID for the matching street from the page JS.
+        The itemsValue array in the ListBox createControl call maps 1:1 to the
+        HTML table rows (Straße, Ortsteil, Bemerkung).
+        Returns (guid, all_street_labels) — guid is None when no match found.
+        all_street_labels can be used as suggestions in the error message.
+        """
+        html = str(soup)
+
+        # Extract itemsValue GUIDs from the JS createControl call
+        match = re.search(
+            r"createControl\(ASPxClientListBox,'" + _FORM_ID + r"cboStreets_DDD_L'"
+            r".*?'itemsValue':\[([^\]]+)\]",
+            html,
+            re.DOTALL,
+        )
+        if not match:
+            return None, []
+        guids = re.findall(
+            r"'([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'",
+            match.group(1),
+            re.I,
+        )
+
+        # Extract street name rows from the HTML table (same order as GUIDs)
+        table = soup.find("table", {"id": _FORM_ID + "cboStreets_DDD_L_LBT"})
+        if not table:
+            return None, []
+        rows = table.find_all("tr")
+
+        all_streets: list[str] = []
+        for i, row in enumerate(rows):
+            if i >= len(guids):
+                break
+            cells = row.find_all("td")
+            if not cells:
+                continue
+            street = cells[0].get_text(strip=True)
+            ortsteil = cells[1].get_text(strip=True) if len(cells) > 1 else ""
+            bemerkung = cells[2].get_text(strip=True) if len(cells) > 2 else ""
+
+            # Build a human-readable label for the suggestions list
+            label = street
+            if ortsteil:
+                label += f" ({ortsteil})"
+            if bemerkung:
+                label += f" – {bemerkung}"
+            all_streets.append(label)
+
+            if self._strasse.lower() != street.lower():
+                continue
+            if self._ortsteil and self._ortsteil.lower() != ortsteil.lower():
+                continue
+            if self._bemerkung and self._bemerkung.lower() != bemerkung.lower():
+                continue
+
+            return guids[i], all_streets
+
+        return None, all_streets
+
+    def _split_street_label(self) -> bool:
+        """Split a combined "Street (Ortsteil) – Bemerkung" suggestion label.
+
+        The config flow re-offers the labels built in _find_street_guid as a
+        dropdown when the street was not found; accept a picked label as
+        strasse input by splitting it back into its parts.
+        Returns True if strasse was changed.
+        """
+        match = re.fullmatch(r"(.+?)(?: \(([^()]+)\))?(?: – (.+))?", self._strasse)
+        if not match or (not match.group(2) and not match.group(3)):
+            return False
+        self._strasse = match.group(1)
+        self._ortsteil = self._ortsteil or match.group(2) or ""
+        self._bemerkung = self._bemerkung or match.group(3) or ""
+        return True
+
+    def _collection(
+        self, bin_type: str, date_str: str, description: str | None
+    ) -> Collection | None:
+        try:
+            day = datetime.strptime(date_str, "%d.%m.%Y").date()
+        except ValueError:
+            return None
+        icon = ICON_MAP.get(bin_type.lower())
+        if icon is None:
+            # "LP HAM02" style entries: fraction code plus tour suffix
+            icon = ICON_MAP.get(bin_type.split()[0].lower())
+        return Collection(day, bin_type, icon, description=description)
+
+    def _parse_grid_page(self, soup: BeautifulSoup) -> list[Collection]:
+        """Parse the dgvPickUpDates grid of a full page into Collection entries."""
+        entries: list[Collection] = []
+        table = soup.find("table", {"id": re.compile(r"dgvPickUpDates_DXMainTable")})
+        if not table:
+            return entries
+
+        for row in table.find_all("tr"):
+            cls = " ".join(row.get("class", []))
+            if "dxgvDataRow" not in cls:
+                continue
+            cells = [td.get_text(strip=True) for td in row.find_all("td")]
+            entries.extend(self._entries_from_cells(cells))
+        return entries
+
+    def _parse_grid_fragment(self, text: str) -> list[Collection]:
+        """Parse grid rows out of a DevExpress callback response.
+
+        The callback payload wraps the grid HTML in a JavaScript string that
+        html.parser cannot digest as a whole, so the data rows are extracted
+        with regexes and parsed individually.
+        """
+        entries: list[Collection] = []
+        for row_html in _DATA_ROW_RE.findall(text):
+            cells = [
+                BeautifulSoup(cell, "html.parser").get_text(strip=True)
+                for cell in _CELL_RE.findall(row_html)
+            ]
+            entries.extend(self._entries_from_cells(cells))
+        return entries
+
+    def _entries_from_cells(self, cells: list[str]) -> list[Collection]:
+        # Columns: Farbe/Symbol | Abfallart/Bezirk | Abfuhrtag | Wochentag | V | Bemerkung
+        if len(cells) < 3:
+            return []
+        bin_type, date_str = cells[1], cells[2]
+        if not bin_type or not date_str:
+            return []
+        # Bemerkung carries e.g. the stops and times of the Schadstoffmobil
+        description = cells[5] if len(cells) > 5 else None
+        collection = self._collection(bin_type, date_str, description or None)
+        return [collection] if collection else []
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update(_HEADERS)
+
+        soup = self._select_city(session)
+
+        # The street dropdown only lists streets starting with the letter
+        # selected in the "Beginnt mit" combo (defaults to "A"), so switch
+        # the filter to the street's first letter before looking it up.
+        letter = self._strasse[0].upper()
+        if letter != "A":
+            data = self._build_base_form(soup)
+            data["__EVENTTARGET"] = _FORM + "cboBeginntMit"
+            data["__EVENTARGUMENT"] = ""
+            data[_FORM_ID + "cboBeginntMit_VI"] = letter
+            data[_FORM + "cboBeginntMit"] = letter
+            soup = self._parse_response(session.post(self._page_url, data=data))
+
+        street_guid, suggestions = self._find_street_guid(soup)
+        if not street_guid and self._split_street_label():
+            street_guid, suggestions = self._find_street_guid(soup)
+        if not street_guid:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "strasse", self._strasse, suggestions
+            )
+
+        if letter != "A":
+            # A "Beginnt mit" postback leaves state behind that makes the
+            # grid paging callbacks below return empty pages, so restart
+            # with a clean session now that the street GUID is known.
+            session = requests.Session()
+            session.headers.update(_HEADERS)
+            soup = self._select_city(session)
+
+        # Select the street ...
+        data = self._build_base_form(soup)
+        data["__EVENTTARGET"] = _FORM + "cboStreets"
+        data["__EVENTARGUMENT"] = ""
+        data[_FORM_ID + "cboStreets_VI"] = street_guid
+        data[_FORM + "cboStreets"] = self._strasse
+        data[_FORM + "cboStreets$DDD$L"] = street_guid
+        soup = self._parse_response(session.post(self._page_url, data=data))
+
+        # ... and press "Termine abrufen", which binds the result grid
+        btn = soup.find("input", {"id": _FORM_ID + "btnTermineHolen_I"})
+        data = self._build_base_form(soup)
+        if btn is not None:
+            data[btn["name"]] = btn.get("value") or "Termine abrufen"
+        r = session.post(self._page_url, data=data)
+        soup = self._parse_response(r)
+
+        entries = self._parse_grid_page(soup)
+
+        # Remaining grid pages are served via DevExpress callbacks. Each
+        # request must carry the grid's client state (from the createControl
+        # JS; refreshed from every callback response) including the
+        # "selection" key — without it the server discards the state and
+        # returns an empty grid.
+        page_match = re.search(r"Seite \d+ von (\d+)", r.text)
+        total_pages = int(page_match.group(1)) if page_match else 1
+        state_match = _GRID_STATE_RE.search(r.text)
+        base_form = self._build_base_form(soup)
+
+        for page_num in range(1, total_pages if state_match else 1):
+            state = state_match.group(1)
+            arg = f"PN{page_num}"
+            inner = f"12|PAGERONCLICK{len(arg)}|{arg}"
+            data = dict(base_form)
+            data[_FORM + "dgvPickUpDates"] = (
+                "{&quot;keys&quot;:[],&quot;callbackState&quot;:&quot;"
+                + state
+                + "&quot;,&quot;selection&quot;:&quot;&quot;}"
+            )
+            data["__CALLBACKID"] = _FORM + "dgvPickUpDates"
+            data["__CALLBACKPARAM"] = f"c0:KV|2;[];GB|{len(inner)};{inner};"
+            r = session.post(self._page_url, data=data)
+            r.raise_for_status()
+            entries.extend(self._parse_grid_fragment(r.text))
+            state_match = _CALLBACK_STATE_RE.search(r.text) or state_match
+
+        if not entries:
+            raise SourceArgumentException(
+                "strasse",
+                "No collection dates found. The provider may not publish any "
+                "schedule data at the moment, or the address parameters are "
+                "incorrect.",
+            )
+
+        return entries

--- a/doc/source/mywastewatcher_de.md
+++ b/doc/source/mywastewatcher_de.md
@@ -1,0 +1,90 @@
+# myWasteWatcher (WasteWatcher.NET)
+
+Support for schedules provided by [mywastewatcher.de](https://www.mywastewatcher.de), a WasteWatcher.NET waste-calendar platform used by municipalities on the Lower Rhine (NRW), Germany.
+
+The default values for `oguid` and `app_path` select **Hamminkeln**, currently the only instance known to publish schedule data. The `abfallkalenderdk2` (Kalkar) and `abfallkalenderRBE` (Rheinberg) instances exist on the platform but return no schedule data for any street (as of July 2026). Other municipalities hosted on mywastewatcher.de should work by supplying their own `app_path` and `oguid` — see [How to get the source arguments](#how-to-get-the-source-arguments).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mywastewatcher_de
+      args:
+        ort: ORT
+        strasse: STRASSE
+        ortsteil: ORTSTEIL
+        bemerkung: BEMERKUNG
+        oguid: OGUID
+        app_path: APP_PATH
+```
+
+### Configuration Variables
+
+**strasse** *(string) (required)*: Street name exactly as shown on the website. If the street cannot be matched, the error lists all streets starting with the same letter (shown as a dropdown in the UI configuration); a picked entry like `Ackerstraße (Mehrhoog)` is accepted as-is.
+
+**ort** *(string) (optional)*: City name exactly as shown on the website.
+
+**ortsteil** *(string) (optional)*: District, needed when the same street name exists in multiple districts. The error message lists all matching street/district combinations if your street cannot be matched.
+
+**bemerkung** *(string) (optional)*: Remark column from the street list (e.g. house-number ranges like `1-50`), needed when multiple entries exist for the same street.
+
+**oguid** *(string) (optional, default: `B3E02353-2090-4EFA-B3C7-AEC81FBC1E6F` = Hamminkeln)*: Identifier of the waste management area. Visible as the `oguid` parameter in the URL of your municipality's calendar page.
+
+**app_path** *(string) (optional, default: `abfallkalenderdk` = Hamminkeln)*: First path segment of your municipality's calendar URL, e.g. `abfallkalenderdk` for `https://www.mywastewatcher.de/abfallkalenderdk/...`.
+
+## Example
+
+Hamminkeln (defaults apply):
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mywastewatcher_de
+      args:
+        ort: Hamminkeln
+        strasse: Ackerstraße
+        ortsteil: Mehrhoog
+```
+
+## How to get the source arguments
+
+For Hamminkeln, the pre-filled defaults already fit — just enter city and street.
+
+For another municipality on the platform:
+
+1. Open your municipality's calendar page on [mywastewatcher.de](https://www.mywastewatcher.de) (use the link provided by your local waste authority).
+2. Read `app_path` and `oguid` directly from the browser address bar: `https://www.mywastewatcher.de/<app_path>/default.aspx?oguid=<oguid>`.
+3. Enter `ort` and `strasse` exactly as they appear in the dropdowns on that page. If the street dropdown shows a district (`Ortsteil`) or remark (`Bemerkung`) column for your street, provide those too.
+
+## Notes
+
+The waste types are reported exactly as shown on the website: a fraction code followed by the collection district (Abfuhrbezirk), e.g. `PA HAM03` = paper collection in district HAM03. The fraction codes, as defined in the website's legend:
+
+| Code | German | English |
+|---|---|---|
+| RA | Restabfall | residual waste |
+| BA | Bioabfall | organic waste |
+| PA | Papier | paper |
+| LP | Leichtverpackung | lightweight packaging (yellow bag) |
+| GL | Glas | glass |
+| GB | Grünschnitt | garden/green waste |
+| SC | Schadstoffe (Schadstoffmobil) | hazardous waste (mobile collection) |
+| SP | Sperrmüll | bulky waste |
+
+The website's `Bemerkung` column is passed along as the collection's `description` — for `SC` entries it contains the stops and times of the Schadstoffmobil, and around holidays it flags rescheduled pickups (e.g. `Vorverlegung`). It is available in the sensor attributes (with `details_format: generic`); the calendar entity does not currently display descriptions.
+
+Use the `customize` option to rename the sensors if desired, e.g.:
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mywastewatcher_de
+      args:
+        strasse: Molkereistraße
+      customize:
+        - type: "RA HAM03"
+          alias: Restabfall
+        - type: "PA HAM03"
+          alias: Papier
+```


### PR DESCRIPTION
## Summary

Adds a source for [mywastewatcher.de](https://www.mywastewatcher.de), a WasteWatcher.NET waste-calendar platform used by municipalities on the Lower Rhine (NRW), Germany. The parameter defaults preselect **Hamminkeln**, currently the only instance that publishes schedule data — the `abfallkalenderdk2` (Kalkar) and `abfallkalenderRBE` (Rheinberg) instances exist but return "Keine Daten zum Anzeigen" for every street (checked 07/2026), so they are intentionally not listed. Other instances work by supplying `app_path` and `oguid`, both readable from the calendar URL (`https://www.mywastewatcher.de/<app_path>/default.aspx?oguid=<oguid>`); `HOW_TO_GET_ARGUMENTS_DESCRIPTION` explains this in the config flow (en/de).

The site is an ASP.NET/DevExpress application without an API, so the source replays the browser flow: select city (the `oguid` is the city value), switch the "Beginnt mit" letter filter to the street's first letter, select the street, and press "Termine abrufen". Remaining grid pages are fetched via DevExpress grid callbacks (`PAGERONCLICK` callback protocol incl. the grid's `callbackState`), so the full published schedule is returned (~34 entries / full year per street). Quirks are documented in code comments.

Details:
- Unmatched streets raise `SourceArgumentNotFoundWithSuggestions` listing all streets with the same first letter; the config flow renders these as a dropdown, and picked combined labels like `Ackerstraße (Mehrhoog)` are accepted and split back into street/district.
- The website's `Bemerkung` column is passed as the collection `description` (Schadstoffmobil stops/times, holiday reschedule notes like "Vorverlegung").
- `ICON_MAP` covers the site's fraction codes (RA/BA/PA/LP/GL/GB/SC/SP) with canonical `Icons` members.

All four TEST_CASES pass live (`test_sources.py -s mywastewatcher_de`), covering the default parameters, letter filtering, district disambiguation, and dropdown-label input.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
