### PR TITLE
feat(calendar): expose collection description and location on calendar events

### DIFF
--- a/custom_components/waste_collection_schedule/calendar.py
+++ b/custom_components/waste_collection_schedule/calendar.py
@@ -118,6 +118,8 @@ class WasteCollectionCalendar(CalendarEntity):
             summary=collection.type,
             start=collection.date,
             end=collection.date + timedelta(days=1),
+            description=collection.description,
+            location=collection.location,
             uid=uuid.uuid4(),
         )
 


### PR DESCRIPTION
## Summary

`Collection` carries optional `description` and `location` fields (populated by e.g. the `ics` source, `abfall_io`, and the new `mywastewatcher_de`), but the calendar entity dropped them when converting to `CalendarEvent`. This passes both through, so e.g. mobile hazardous-waste collection stops/times and holiday reschedule notes ("Vorverlegung") appear in the calendar event details.

Both fields default to `None` on `CollectionBase` (and `CollectionGroup` aggregates them), so events from sources without this data are unchanged. Verified live on a Home Assistant instance.

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [x] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources — n/a
- [ ] TEST_CASES use real, publicly accessible addresses (not my own) — n/a
