### PR TITLE
fix(staffsmoorlands_gov_uk): follow council migration to Bartec Public Dashboard

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/staffsmoorlands_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/staffsmoorlands_gov_uk.py
@@ -1,15 +1,14 @@
+import json
 import logging
+import re
 from datetime import datetime
 
 import requests
-import urllib3
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
-
-# With verify=True requests fail due to SSLCertVerificationError (missing intermediate CA).
-# verify=False is the established workaround used by other affected UK council sources.
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ ICON_MAP = {
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
-    "en": "Your UPRN can be found by searching your postcode at https://www.staffsmoorlands.gov.uk/findyourbinday and selecting your address. The value shown in the address dropdown is your UPRN. Alternatively, find your UPRN at https://www.findmyaddress.co.uk/",
+    "en": "Your UPRN can be found by searching your postcode at https://www.staffsmoorlands.gov.uk/findyourbinday (which redirects to the council's Public Dashboard) and selecting your address. The value shown in the address dropdown is your UPRN. Alternatively, find your UPRN at https://www.findmyaddress.co.uk/",
 }
 
 PARAM_TRANSLATIONS: dict = {
@@ -53,161 +52,115 @@ PARAM_DESCRIPTIONS: dict = {
     }
 }
 
-_BASE_URL = "https://www.staffsmoorlands.gov.uk"
-_FORM_NAME = "FINDBINDAYSSTAFFORDSHIREMOORLANDS"
+# Staffordshire Moorlands migrated their bin day lookup from a standalone
+# form (/findyourbinday, now redirects) to a Bartec Municipal "Public
+# Dashboard" portal — the same platform used by highpeak_gov_uk.py (the two
+# councils share back-office services), southlanarkshire_gov_uk.py and
+# scotborders_gov_uk.py.
+API_URL = "https://bins.staffsmoorlands.gov.uk/PublicDashboard"
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+}
+
+TOKEN_REGEX = re.compile(r'name="__RequestVerificationToken"[^>]*value="([^"]+)"')
+DATASOURCE_REGEX = re.compile(
+    r'dataSource":\s*ejs\.data\.DataUtil\.parse\.isJson\(\s*(\[.*?\])\s*\)',
+    re.DOTALL,
+)
 
 
 class Source:
-    def __init__(self, postcode: str, uprn: str):
-        self._postcode = postcode.strip().upper()
-        self._uprn = str(uprn).strip()
+    def __init__(self, postcode: str, uprn: str | int):
+        self._postcode: str = postcode.strip()
+        self._uprn: str = str(uprn).strip()
 
-    def _get_hidden(self, soup: BeautifulSoup, name: str) -> str:
-        inp = soup.find("input", {"name": name})
-        if not inp:
-            return ""
-        value = inp.get("value")
-        return str(value) if value else ""
+    @staticmethod
+    def _get_token(html: str) -> str:
+        match = TOKEN_REGEX.search(html)
+        if not match:
+            raise RuntimeError(
+                "Could not find verification token on Staffordshire Moorlands bin day lookup page."
+            )
+        return match.group(1)
+
+    @staticmethod
+    def _extract_json_blocks(html: str) -> list[list[dict]]:
+        blocks = []
+        for raw in DATASOURCE_REGEX.findall(html):
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, list):
+                blocks.append(data)
+        return blocks
 
     def fetch(self) -> list[Collection]:
         session = requests.Session()
-        prefix = _FORM_NAME
+        session.headers.update(HEADERS)
 
-        # Step 1: Load the initial form to obtain session tokens
-        response = session.get(
-            f"{_BASE_URL}/findyourbinday",
-            timeout=30,
-            verify=False,
+        # Step 1: load the dashboard to obtain the anti-forgery token
+        r = session.get(API_URL)
+        r.raise_for_status()
+        token = self._get_token(r.text)
+
+        # Step 2: search for the postcode to obtain the list of premises
+        r = session.post(
+            f"{API_URL}?handler=SearchPostcode",
+            data={
+                "__RequestVerificationToken": token,
+                "SelectedPostcode": self._postcode,
+            },
         )
-        response.raise_for_status()
-        soup = BeautifulSoup(response.text, "html.parser")
+        r.raise_for_status()
+        token = self._get_token(r.text)
 
-        page_session_id = self._get_hidden(soup, f"{prefix}_PAGESESSIONID")
-        session_id = self._get_hidden(soup, f"{prefix}_SESSIONID")
-        nonce = self._get_hidden(soup, f"{prefix}_NONCE")
+        premises_blocks = [
+            block
+            for block in self._extract_json_blocks(r.text)
+            if block and "UPRN" in block[0]
+        ]
+        if not premises_blocks:
+            raise SourceArgumentNotFound("postcode", self._postcode)
 
-        if not page_session_id or not session_id or not nonce:
-            raise RuntimeError(
-                "Failed to extract session tokens from the Staffordshire Moorlands bin day page"
+        known_uprns = sorted(
+            {str(int(item["UPRN"])) for item in premises_blocks[0] if "UPRN" in item}
+        )
+
+        # Step 3: select the premises (by UPRN) to obtain the collection schedule
+        r = session.post(
+            f"{API_URL}?handler=SelectPrem",
+            data={
+                "__RequestVerificationToken": token,
+                "SelectedPostcode": self._postcode,
+                "SelectedPremises": self._uprn,
+            },
+        )
+        r.raise_for_status()
+
+        schedule_blocks = [
+            block
+            for block in self._extract_json_blocks(r.text)
+            if block and "Subject" in block[0]
+        ]
+        if not schedule_blocks:
+            raise SourceArgumentNotFoundWithSuggestions("uprn", self._uprn, known_uprns)
+
+        entries = []
+        for item in schedule_blocks[0]:
+            subject = item.get("Subject")
+            date_str = item.get("StartTime")
+            if not subject or not date_str:
+                continue
+            try:
+                date_ = datetime.fromisoformat(date_str).date()
+            except ValueError:
+                _LOGGER.warning("Could not parse date %s", date_str)
+                continue
+
+            entries.append(
+                Collection(date=date_, t=subject, icon=ICON_MAP.get(subject))
             )
 
-        _LOGGER.debug(
-            "Initial tokens — pageSessionId: %s, sessionId: %s, nonce: %s",
-            page_session_id,
-            session_id,
-            nonce,
-        )
-
-        # Step 2: Submit postcode to receive the address selection page
-        submit_url = (
-            f"{_BASE_URL}/apiserver/formsservice/http/processsubmission"
-            f"?pageSessionId={page_session_id}&fsid={session_id}&fsn={nonce}"
-        )
-        payload_postcode = {
-            f"{prefix}_PAGESESSIONID": page_session_id,
-            f"{prefix}_SESSIONID": session_id,
-            f"{prefix}_NONCE": nonce,
-            f"{prefix}_VARIABLES": "",
-            f"{prefix}_PAGENAME": "POSTCODESELECT",
-            f"{prefix}_PAGEINSTANCE": "0",
-            f"{prefix}_POSTCODESELECT_POSTCODE": self._postcode,
-            f"{prefix}_FORMACTION_NEXT": f"{prefix}_POSTCODESELECT_PAGE1NEXT",
-        }
-        response2 = session.post(
-            submit_url, data=payload_postcode, timeout=30, verify=False
-        )
-        response2.raise_for_status()
-        soup2 = BeautifulSoup(response2.text, "html.parser")
-
-        nonce2 = self._get_hidden(soup2, f"{prefix}_NONCE")
-        page_instance = self._get_hidden(soup2, f"{prefix}_PAGEINSTANCE")
-
-        _LOGGER.debug(
-            "Address page nonce: %s, page instance: %s", nonce2, page_instance
-        )
-
-        # Validate that the UPRN exists in the returned address list
-        address_select = soup2.find(
-            "select",
-            {"name": f"{prefix}_ADDRESSSELECT_ADDRESS"},
-        )
-        if address_select:
-            valid_uprns = [
-                opt.get("value", "")
-                for opt in address_select.find_all("option")
-                if opt.get("value")
-            ]
-            if self._uprn not in valid_uprns:
-                raise SourceArgumentNotFound(
-                    "uprn",
-                    self._uprn,
-                )
-
-        # Step 3: Submit UPRN to receive the collection calendar
-        submit_url2 = (
-            f"{_BASE_URL}/apiserver/formsservice/http/processsubmission"
-            f"?pageSessionId={page_session_id}&fsid={session_id}&fsn={nonce2}"
-        )
-        payload_uprn = {
-            f"{prefix}_PAGESESSIONID": page_session_id,
-            f"{prefix}_SESSIONID": session_id,
-            f"{prefix}_NONCE": nonce2,
-            f"{prefix}_VARIABLES": "",
-            f"{prefix}_PAGENAME": "ADDRESSSELECT",
-            f"{prefix}_PAGEINSTANCE": page_instance,
-            f"{prefix}_ADDRESSSELECT_ADDRESS": self._uprn,
-            f"{prefix}_FORMACTION_NEXT": f"{prefix}_ADDRESSSELECT_ADDRESSSELECTNEXTBTN",
-        }
-        response3 = session.post(
-            submit_url2, data=payload_uprn, timeout=30, verify=False
-        )
-        response3.raise_for_status()
-        soup3 = BeautifulSoup(response3.text, "html.parser")
-
-        # Step 4: Parse the calendar
-        return self._parse_calendar(soup3)
-
-    def _parse_calendar(self, soup: BeautifulSoup) -> list[Collection]:
-        """Parse the bin collection calendar from the CALENDAR page."""
-        calendar_div = soup.find(id=lambda x: x and "MAINCALENDAR" in x if x else False)
-        if not calendar_div:
-            _LOGGER.warning("Main calendar element not found in response")
-            return []
-
-        entries: list[Collection] = []
-
-        for month_div in calendar_div.find_all(
-            "div", {"class": "bin-collection__month"}
-        ):
-            h3 = month_div.find("h3")
-            if not h3:
-                continue
-            month_year = h3.get_text(strip=True)  # e.g. "May 2026"
-
-            for item in month_div.find_all("li", {"class": "bin-collection__item"}):
-                day_span = item.find("span", {"class": "bin-collection__number"})
-                type_span = item.find("span", {"class": "bin-collection__type"})
-                if not day_span or not type_span:
-                    continue
-
-                day = day_span.get_text(strip=True)
-                waste_type = type_span.get_text(strip=True)
-
-                try:
-                    collection_date = datetime.strptime(
-                        f"{day} {month_year}", "%d %B %Y"
-                    ).date()
-                except ValueError:
-                    _LOGGER.warning("Could not parse date: %s %s", day, month_year)
-                    continue
-
-                entries.append(
-                    Collection(
-                        date=collection_date,
-                        t=waste_type,
-                        icon=ICON_MAP.get(waste_type),
-                    )
-                )
-
-        _LOGGER.debug("Parsed %d collection entries", len(entries))
         return entries


### PR DESCRIPTION
## Summary

Fixes #4248. Staffordshire Moorlands District Council has once again redesigned their bin-day lookup: `https://www.staffsmoorlands.gov.uk/findyourbinday` no longer serves the GOSS-CMS form the current source depends on. It now 302-redirects to `https://bins.staffsmoorlands.gov.uk/PublicDashboard`, a Bartec Municipal "Public Dashboard" widget — the same platform already used by `highpeak_gov_uk.py` (Staffordshire Moorlands and High Peak share back-office services), `southlanarkshire_gov_uk.py`, and `scotborders_gov_uk.py`.

This re-implements `staffsmoorlands_gov_uk.py`'s `fetch()` against the new postcode-search / select-premises endpoints, following the exact pattern in `highpeak_gov_uk.py`. Public interface (`postcode`, `uprn` params) and both existing `TEST_CASES` are unchanged — the same two UPRNs resolve correctly on the new platform.

## Test plan

- [x] `ruff check --fix` / `ruff format` on the changed file — clean
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] Live test via `test_sources.py -s staffsmoorlands_gov_uk` against both existing `TEST_CASES` — both return entries (43 and 56 collection dates respectively)
- [x] Confirmed no generated files touched in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)