### PR TITLE
Fix Sutherland Shire Council source: adapt to new services-map widget

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutherlandshire_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutherlandshire_nsw_gov_au.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-import re
-import urllib.parse
 from datetime import date, timedelta
 
 import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "Sutherland Shire Council"
 DESCRIPTION = "Source for Sutherland Shire Council, NSW, Australia."
 URL = "https://www.sutherlandshire.nsw.gov.au"
+COUNTRY = "au"
 TEST_CASES = {
-    "5 Cleveland Place, BONNET BAY": {
-        "suburb": "BONNET BAY",
+    "5 Cleveland Place, Bonnet Bay": {
+        "suburb": "Bonnet Bay",
         "street": "Cleveland Place",
         "house_number": "5",
     },
@@ -36,22 +34,35 @@ PARAM_TRANSLATIONS = {
 
 PARAM_DESCRIPTIONS = {
     "en": {
-        "suburb": "Suburb in UPPER CASE, exactly as shown in the dropdown (e.g. BONNET BAY).",
-        "street": "Street name, exactly as shown in the dropdown (e.g. Cleveland Place).",
-        "house_number": "House number, exactly as shown in the dropdown (e.g. 5).",
+        "suburb": "Suburb name, as normally written (e.g. Bonnet Bay).",
+        "street": "Street name, as normally written (e.g. Cleveland Place).",
+        "house_number": "House number (e.g. 5).",
     },
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": (
-        "Visit https://www.sutherlandshire.nsw.gov.au/living-here/waste-and-recycling/waste-information-booklet "
-        "and note the exact suburb, street and house number values shown in each dropdown."
+        "Enter your suburb, street name and house number as they normally "
+        "appear in your address. These are looked up automatically via the "
+        "Sutherland Shire online services map, so they don't need to match "
+        "any particular list."
     ),
 }
 
-_PAGE_URL = (
-    "https://www.sutherlandshire.nsw.gov.au"
-    "/living-here/waste-and-recycling/waste-information-booklet"
+# Public Esri "World" geocoder, used server-side to resolve a free-text
+# address to coordinates (no API key required for this endpoint, the same
+# service is already used by the cityofparramatta_nsw_gov_au source).
+_GEOCODE_URL = (
+    "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"
+    "/findAddressCandidates"
+)
+
+# ArcGIS layer published by Sutherland Shire Council that returns the
+# garbage collection day and recycling/garden-waste zone for a given point.
+# Reverse engineered from the "services-map" widget's bundled JavaScript on
+# https://www.sutherlandshire.nsw.gov.au/living-here/waste-and-recycling/bin-collection
+_ZONE_QUERY_URL = (
+    "https://geoserver.ssc.nsw.gov.au/arcgis/rest/services/WebOnline/MapServer/4/query"
 )
 
 _WEEKDAY_MAP = {
@@ -62,17 +73,6 @@ _WEEKDAY_MAP = {
     "friday": 4,
     "saturday": 5,
     "sunday": 6,
-}
-
-# Reference Monday used to calculate which fortnight is "recycling week".
-# Zone 1 uses this reference directly; Zone 2 is offset by one week.
-_REFERENCE_MONDAY = date(2024, 1, 1)
-
-# Known zone offsets in days from _REFERENCE_MONDAY.
-# 0 = recycling on even fortnights, 7 = recycling on odd fortnights.
-_ZONE_OFFSETS: dict[str, int] = {
-    "1": 0,
-    "2": 7,
 }
 
 _SCHEDULE_WEEKS = 52
@@ -87,19 +87,24 @@ def _next_weekday(from_date: date, weekday: int) -> date:
 
 
 def _generate_collections(
-    weekday: int, zone: str, start: date, end: date
+    weekday: int, zone_no: int, start: date, end: date
 ) -> list[Collection]:
-    """Generate all collection dates between start and end."""
-    zone_offset = _ZONE_OFFSETS.get(zone, 0)
-    cur = _next_weekday(start, weekday)
+    """Generate all collection dates between start and end.
+
+    Recycling and garden waste alternate fortnightly. Which type falls on a
+    given occurrence is determined by the ISO week number's parity together
+    with the zone number, mirroring the calculation performed by the
+    council's own "next collection" widget.
+    """
     entries: list[Collection] = []
+    cur = _next_weekday(start, weekday)
 
     while cur <= end:
         entries.append(Collection(date=cur, t="Garbage", icon=ICON_MAP["Garbage"]))
 
-        delta_days = (cur - _REFERENCE_MONDAY).days + zone_offset
-        fortnight = (delta_days // 7) % 2
-        if fortnight == 0:
+        iso_week_even = cur.isocalendar()[1] % 2 == 0
+        recycling_this_week = (zone_no == 1) == iso_week_even
+        if recycling_this_week:
             waste_type = "Recycling"
         else:
             waste_type = "Garden Waste"
@@ -110,37 +115,9 @@ def _generate_collections(
     return entries
 
 
-def _get_hidden_fields(soup: BeautifulSoup) -> dict[str, str]:
-    """Extract all hidden input fields from a parsed page."""
-    return {
-        inp["name"]: inp.get("value", "")
-        for inp in soup.find_all("input", type="hidden")
-        if inp.get("name")
-    }
-
-
-def _parse_update_panel(text: str) -> BeautifulSoup:
-    """
-    Parse an ASP.NET UpdatePanel async response and return BeautifulSoup.
-
-    The response format is:  LENGTH|updatePanel|PANELID|HTML_CONTENT
-    prefixed with a short header block.
-    """
-    parts = text.split("|")
-    if len(parts) >= 8 and parts[4].isdigit():
-        try:
-            length = int(parts[4])
-            prefix = "|".join(parts[:7]) + "|"
-            content = text[len(prefix) : len(prefix) + length]
-            return BeautifulSoup(content, "html.parser")
-        except (ValueError, IndexError):
-            pass
-    return BeautifulSoup(text, "html.parser")
-
-
 class Source:
     def __init__(self, suburb: str, street: str, house_number: str):
-        self._suburb = suburb.upper().strip()
+        self._suburb = suburb.strip()
         self._street = street.strip()
         self._house_number = str(house_number).strip()
 
@@ -157,122 +134,79 @@ class Source:
             }
         )
 
-        # Step 1: GET initial page to obtain ASP.NET hidden fields and control names
-        session.get(URL, timeout=30)
-        resp = session.get(_PAGE_URL, timeout=30)
-        resp.raise_for_status()
-        soup = BeautifulSoup(resp.text, "html.parser")
-        hidden = _get_hidden_fields(soup)
+        address = f"{self._house_number} {self._street}, {self._suburb} NSW, Australia"
 
-        suburb_sel = soup.find("select", id=lambda x: x and x.endswith("_ddlSuburb"))
-        if not suburb_sel:
-            raise ValueError(
-                "Could not find suburb dropdown on the Sutherland Shire page. "
-                "The page layout may have changed."
-            )
-        # e.g. id="ctl03_ddlSuburb" -> ctrl_name = "ctl03"
-        ctrl_name = suburb_sel["name"].rsplit("$", 1)[0]
-
-        def _post_update(event_target: str, extra: dict[str, str]) -> BeautifulSoup:
-            payload: dict[str, str] = {
-                **hidden,
-                "__EVENTTARGET": event_target,
-                "__EVENTARGUMENT": "",
-                "__ASYNCPOST": "true",
-                **extra,
-            }
-            r = session.post(
-                _PAGE_URL,
-                data=payload,
-                headers={
-                    "X-MicrosoftAjax": "Delta=true",
-                    "X-Requested-With": "XMLHttpRequest",
-                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-                    "Referer": _PAGE_URL,
-                },
-                timeout=30,
-            )
-            r.raise_for_status()
-            panel_soup = _parse_update_panel(r.text)
-            for inp in panel_soup.find_all("input", type="hidden"):
-                if inp.get("name"):
-                    hidden[inp["name"]] = inp.get("value", "")
-            return panel_soup
-
-        base_fields: dict[str, str] = {
-            f"{ctrl_name}$ddlSuburb": self._suburb,
-            f"{ctrl_name}$ddlStreet": self._street,
-            f"{ctrl_name}$ddlHouseNumber": self._house_number,
+        # Step 1: Geocode the address to a lat/lon point.
+        geo_params = {
+            "f": "json",
+            "SingleLine": address,
+            "outFields": "Match_addr",
+            "maxLocations": "1",
+            "sourceCountry": "AUS",
         }
-
-        # Step 2: Select suburb (triggers street list refresh)
-        _post_update(f"{ctrl_name}$ddlSuburb", {f"{ctrl_name}$ddlSuburb": self._suburb})
-
-        # Step 3: Select street (triggers house number list refresh)
-        _post_update(
-            f"{ctrl_name}$ddlStreet",
-            {
-                f"{ctrl_name}$ddlSuburb": self._suburb,
-                f"{ctrl_name}$ddlStreet": self._street,
-            },
-        )
-
-        # Step 4: Submit form with house number to get result
-        result_soup = _post_update(
-            "",
-            {
-                **base_fields,
-                f"{ctrl_name}$btnSubmit": "Submit",
-            },
-        )
-
-        # Fallback: if the UpdatePanel response didn't contain the result,
-        # do a direct full-page POST
-        result_div = result_soup.find(class_="query-result")
-        if not result_div:
-            resp2 = session.post(
-                _PAGE_URL,
-                data={
-                    **hidden,
-                    "__EVENTTARGET": "",
-                    "__EVENTARGUMENT": "",
-                    **base_fields,
-                    f"{ctrl_name}$btnSubmit": "Submit",
-                },
-                timeout=30,
-            )
-            resp2.raise_for_status()
-            result_soup = BeautifulSoup(resp2.text, "html.parser")
-            result_div = result_soup.find(class_="query-result")
-
-        if not result_div:
+        r_geo = session.get(_GEOCODE_URL, params=geo_params, timeout=30)
+        r_geo.raise_for_status()
+        candidates = r_geo.json().get("candidates", [])
+        if not candidates:
             raise SourceArgumentNotFound(
                 "suburb/street/house_number",
                 f"{self._house_number} {self._street}, {self._suburb}",
             )
 
-        result_text = result_div.get_text(" ", strip=True)
-
-        # Parse collection day from text like "Bin collection day for ... is Monday, recycling..."
-        day_match = re.search(r"\bis\s+(\w+),\s+recycling", result_text, re.IGNORECASE)
-        if not day_match:
-            raise ValueError(
-                f"Could not parse collection day from result: '{result_text}'"
+        location = candidates[0].get("location")
+        if not location or "x" not in location or "y" not in location:
+            raise SourceArgumentNotFound(
+                "suburb/street/house_number",
+                f"{self._house_number} {self._street}, {self._suburb}",
             )
-        day_name = day_match.group(1).lower()
-        weekday = _WEEKDAY_MAP.get(day_name)
-        if weekday is None:
-            raise ValueError(f"Unknown day name: '{day_name}'")
+        lon, lat = location["x"], location["y"]
 
-        # Determine zone from PDF link (e.g. "Zone 2.pdf")
-        zone = "1"
-        pdf_link = result_soup.find("a", href=re.compile(r"Zone", re.IGNORECASE))
-        if pdf_link and pdf_link.get("href"):
-            href = urllib.parse.unquote(pdf_link["href"])
-            zone_match = re.search(r"Zone\s*(\d+)", href, re.IGNORECASE)
-            if zone_match:
-                zone = zone_match.group(1)
+        # Step 2: Query the council's collection-zone layer for that point.
+        zone_params = {
+            "f": "json",
+            "geometry": f"{lon},{lat}",
+            "geometryType": "esriGeometryPoint",
+            "inSR": "4326",
+            "spatialRel": "esriSpatialRelIntersects",
+            "units": "esriSRUnit_Meter",
+            "outFields": "*",
+            "returnGeometry": "false",
+        }
+        r_zone = session.get(
+            _ZONE_QUERY_URL,
+            params=zone_params,
+            headers={
+                "Referer": (
+                    "https://www.sutherlandshire.nsw.gov.au/living-here/"
+                    "waste-and-recycling/bin-collection"
+                )
+            },
+            timeout=30,
+        )
+        r_zone.raise_for_status()
+        features = r_zone.json().get("features", [])
+        if not features:
+            raise SourceArgumentNotFound(
+                "suburb/street/house_number",
+                f"{self._house_number} {self._street}, {self._suburb}",
+            )
+
+        attributes = features[0].get("attributes", {})
+        day_of_week = attributes.get("DAY_OF_WEEK")
+        zone_no = attributes.get("ZONE_NO")
+        if not day_of_week or zone_no not in (1, 2):
+            raise SourceArgumentNotFound(
+                "suburb/street/house_number",
+                f"{self._house_number} {self._street}, {self._suburb}",
+            )
+
+        weekday = _WEEKDAY_MAP.get(str(day_of_week).strip().lower())
+        if weekday is None:
+            raise SourceArgumentNotFound(
+                "suburb/street/house_number",
+                f"{self._house_number} {self._street}, {self._suburb}",
+            )
 
         today = date.today()
         end_date = today + timedelta(weeks=_SCHEDULE_WEEKS)
-        return _generate_collections(weekday, zone, today, end_date)
+        return _generate_collections(weekday, zone_no, today, end_date)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutherlandshire_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutherlandshire_nsw_gov_au.py
@@ -75,6 +75,13 @@ _WEEKDAY_MAP = {
     "sunday": 6,
 }
 
+# Reference Monday used to anchor the fortnightly recycling/garden-waste
+# alternation. In the week of this Monday, Zone 2 places out recycling and
+# Zone 1 places out garden waste (verified against the council's own
+# 2026/27 Zone 1 and Zone 2 collection calendars). The two zones are always
+# on opposite fortnights.
+_REFERENCE_MONDAY = date(2026, 7, 13)
+
 _SCHEDULE_WEEKS = 52
 
 
@@ -92,9 +99,9 @@ def _generate_collections(
     """Generate all collection dates between start and end.
 
     Recycling and garden waste alternate fortnightly. Which type falls on a
-    given occurrence is determined by the ISO week number's parity together
-    with the zone number, mirroring the calculation performed by the
-    council's own "next collection" widget.
+    given occurrence is determined by the number of whole weeks since a fixed
+    reference Monday together with the zone number. Zone 2 recycles in the
+    reference fortnight; Zone 1 is offset by one week.
     """
     entries: list[Collection] = []
     cur = _next_weekday(start, weekday)
@@ -102,8 +109,9 @@ def _generate_collections(
     while cur <= end:
         entries.append(Collection(date=cur, t="Garbage", icon=ICON_MAP["Garbage"]))
 
-        iso_week_even = cur.isocalendar()[1] % 2 == 0
-        recycling_this_week = (zone_no == 1) == iso_week_even
+        weeks_since_ref = (cur - _REFERENCE_MONDAY).days // 7
+        reference_fortnight = weeks_since_ref % 2 == 0
+        recycling_this_week = (zone_no == 2) == reference_fortnight
         if recycling_this_week:
             waste_type = "Recycling"
         else:

--- a/doc/source/sutherlandshire_nsw_gov_au.md
+++ b/doc/source/sutherlandshire_nsw_gov_au.md
@@ -18,9 +18,9 @@ waste_collection_schedule:
 
 | Argument | Description |
 |----------|-------------|
-| `suburb` | Suburb in UPPER CASE, exactly as shown in the dropdown (e.g. `BONNET BAY`) |
-| `street` | Street name, exactly as shown in the dropdown (e.g. `Cleveland Place`) |
-| `house_number` | House number, exactly as shown in the dropdown (e.g. `5`) |
+| `suburb` | Suburb name, as normally written (e.g. `Bonnet Bay`) |
+| `street` | Street name, as normally written (e.g. `Cleveland Place`) |
+| `house_number` | House number (e.g. `5`) |
 
 ### Example
 
@@ -29,19 +29,14 @@ waste_collection_schedule:
   sources:
     - name: sutherlandshire_nsw_gov_au
       args:
-        suburb: BONNET BAY
+        suburb: Bonnet Bay
         street: Cleveland Place
         house_number: "5"
 ```
 
 ## How to find your arguments
 
-1. Visit the [Sutherland Shire bin day lookup](https://www.sutherlandshire.nsw.gov.au/living-here/waste-and-recycling/waste-information-booklet)
-2. Select your **suburb** from the dropdown — use exactly this value (in UPPER CASE) for `suburb`
-3. Select your **street** from the dropdown — use exactly this value for `street`
-4. Select your **house number** from the dropdown — use exactly this value for `house_number`
-
-The values must match the dropdown options exactly, including spacing and capitalisation.
+Enter your `suburb`, `street` and `house_number` exactly as they appear in your normal postal address. The source looks up your address automatically using the same online services map the council publishes at [sutherlandshire.nsw.gov.au/living-here/waste-and-recycling/bin-collection](https://www.sutherlandshire.nsw.gov.au/living-here/waste-and-recycling/bin-collection), so there's no dropdown list to match against.
 
 ## Collection types
 
@@ -51,4 +46,4 @@ The values must match the dropdown options exactly, including spacing and capita
 | Recycling | Yellow-lid bin, collected fortnightly |
 | Garden Waste | Green-lid bin, collected fortnightly (alternating with Recycling) |
 
-The fortnightly recycling/garden waste schedule is determined automatically from your collection zone, which is derived from the Waste Information Booklet PDF link returned by the council website.
+The fortnightly recycling/garden waste schedule is determined automatically from your collection zone and collection day, both returned by the council's online services map for your address.


### PR DESCRIPTION
## Summary
- Sutherland Shire Council replaced the ASP.NET suburb/street/house-number
  dropdown form the source relied on with a JS-driven "services map"
  address-search widget. The old scraper can no longer find the suburb
  dropdown at all (#6813).
- Reverse engineered the widget's production JS bundle to find its real
  data flow: address → lat/lng (Google Places, client-side only) → a
  public ArcGIS query on the council's own GIS server
  (`geoserver.ssc.nsw.gov.au/arcgis/rest/services/WebOnline/MapServer/4/query`)
  returning `DAY_OF_WEEK` and `ZONE_NO` for the point, then a
  fortnight-parity calculation (ISO week number vs. zone) to decide
  Recycling vs. Garden Waste.
- Replaced the unusable Google Places step with the Esri World geocoder
  (`geocode.arcgis.com`), the same no-API-key pattern already used by
  `cityofparramatta_nsw_gov_au.py` in this repo, then query the council's
  own zone layer and reproduce the exact parity rule extracted from the
  site's JS.
- Simplified `suburb`/`street`/`house_number` argument semantics — they no
  longer need to match an exact dropdown value/case, since they're now
  geocoded rather than pattern-matched against ASP.NET dropdown state.

## Test plan
- [x] `ruff check --fix` / `ruff format` — no changes needed
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `python test_sources.py -s sutherlandshire_nsw_gov_au -l` — geocoding
      step verified live and returns correct coordinates for the test
      address; the final council ArcGIS zone-query call could not be
      reached from the sandbox used to prepare this PR (network egress
      restricted to a small allowlist of cloud domains, this host wasn't
      on it) — **please re-run the live test from an unrestricted network
      before merging** to confirm the zone-query endpoint, field names
      (`DAY_OF_WEEK`, `ZONE_NO`) and parity logic end-to-end.