### PR TITLE
Add Tandridge District Council (UK) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tandridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tandridge_gov_uk.py
@@ -1,0 +1,174 @@
+from datetime import datetime
+from xml.etree import ElementTree as ET
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+TITLE = "Tandridge District Council"
+DESCRIPTION = "Source for Tandridge District Council, UK, waste collection."
+URL = "https://www.tandridge.gov.uk"
+COUNTRY = "uk"
+
+TEST_CASES = {
+    "14A Station Road East, Oxted": {
+        "postcode": "RH8 0PG",
+        "house_number": "14A",
+    },
+    "22A Station Road East, Oxted": {
+        "postcode": "RH8 0PG",
+        "house_number": "22A",
+    },
+    "No postcode space": {
+        "postcode": "RH80PG",
+        "house_number": "16A",
+    },
+}
+
+ICON_MAP = {
+    "Domestic Waste Collection Service": Icons.GENERAL_WASTE,
+    "Recycling Collection Service": Icons.RECYCLING,
+    "Food Waste Collection Service": Icons.BIO_KITCHEN,
+    "Garden Waste Collection Service": Icons.GARDEN,
+    "Electricals and textiles": Icons.ELECTRONICS,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter your postcode and your house number/name exactly as it appears "
+    "when you look up your address at "
+    "https://tdcws01.tandridge.gov.uk/TDCWebAppsPublic/tfaBranded/408 "
+    "(e.g. '14A').",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "postcode": "Your postcode (e.g. RH8 0PG)",
+        "house_number": "Your house number or name (e.g. 14A)",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "postcode": "Postcode",
+        "house_number": "House number/name",
+    },
+}
+
+_SEARCH_URL = (
+    "https://tdcws01.tandridge.gov.uk/TDCWebAppsPublic/WebServices/"
+    "wsLLPGSearch2018/LLPGQuery_v2_3.asmx?op=SearchByAllAddressDetails"
+)
+_COLLECTIONS_URL = (
+    "https://tdcws01.tandridge.gov.uk/TDCWebAppsPublic/TDCMiddleware/"
+    "RESTAPI/WhiteSpaceAPI/GetCompleteRecordByUPRN"
+)
+
+_NS = {
+    "soap": "http://www.w3.org/2003/05/soap-envelope",
+    "tdc": "http://www.tandridge.gov.uk/Webservices/",
+}
+
+_SEARCH_XML_TEMPLATE = """<?xml version="1.0" encoding="utf-8"?>
+<soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+  <soap12:Body>
+    <SearchByAllAddressDetails xmlns="http://www.tandridge.gov.uk/Webservices/">
+      <SearchAddress></SearchAddress>
+      <SearchTownName></SearchTownName>
+      <SearchLocalityName></SearchLocalityName>
+      <SearchPostCode>{postcode}</SearchPostCode>
+      <SearchReference></SearchReference>
+      <SearchXPos></SearchXPos>
+      <SearchYPos></SearchYPos>
+      <SearchDistance></SearchDistance>
+      <ReturnMaxRecords></ReturnMaxRecords>
+      <MustHaveRefType></MustHaveRefType>
+      <ShowXrefTypes></ShowXrefTypes>
+      <sUseDate></sUseDate>
+      <sSearchAlternatives>1,3,6</sSearchAlternatives>
+      <sPrimaryClassifications></sPrimaryClassifications>
+      <sSecondaryClassifications></sSecondaryClassifications>
+      <sTertiaryClassifications></sTertiaryClassifications>
+      <ShowNonAddressable></ShowNonAddressable>
+      <AllowSearchOrganisations></AllowSearchOrganisations>
+    </SearchByAllAddressDetails>
+  </soap12:Body>
+</soap12:Envelope>"""
+
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+}
+
+
+class Source:
+    def __init__(self, postcode: str, house_number: str):
+        self._postcode = postcode
+        self._house_number = str(house_number)
+
+    def _find_uprn(self, session: requests.Session) -> str:
+        xml_request = _SEARCH_XML_TEMPLATE.format(postcode=self._postcode)
+        r = session.post(
+            _SEARCH_URL,
+            data=xml_request.encode("utf-8"),
+            headers={**_HEADERS, "Content-Type": "text/xml; charset=utf-8"},
+        )
+        r.raise_for_status()
+
+        root = ET.fromstring(r.text)
+        records = root.findall(".//tdc:LLPGRecord", _NS)
+
+        target = self._house_number.strip().lower()
+        candidates: list[tuple[str, str]] = []
+        for record in records:
+            house_part = record.findtext(
+                "tdc:BS7666Format/tdc:HousePart", namespaces=_NS
+            )
+            uprn = record.findtext("tdc:BS7666Format/tdc:UPRN", namespaces=_NS)
+            if not uprn or not house_part:
+                continue
+            candidates.append((house_part.strip(), uprn))
+
+        for house_part, uprn in candidates:
+            if house_part.lower() == target:
+                return uprn
+
+        raise SourceArgumentNotFoundWithSuggestions(
+            "house_number",
+            self._house_number,
+            sorted({house_part for house_part, _ in candidates}),
+        )
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        uprn = self._find_uprn(session)
+
+        r = session.post(
+            _COLLECTIONS_URL,
+            json={"UPRN": uprn},
+            headers={
+                **_HEADERS,
+                "Accept": "application/json, text/javascript, */*; q=0.01",
+                "Content-Type": "application/json",
+            },
+        )
+        r.raise_for_status()
+        data = r.json()
+
+        if not data.get("SuccessFlag"):
+            raise SourceArgumentNotFoundWithSuggestions(
+                "house_number",
+                self._house_number,
+                [],
+            )
+
+        entries = []
+        for item in data.get("lstCollections") or []:
+            service = (item.get("Service") or "").strip()
+            date_str = item.get("Date")
+            if not service or not date_str:
+                continue
+            date = datetime.strptime(date_str, "%d/%m/%Y %H:%M:%S").date()
+            entries.append(Collection(date=date, t=service, icon=ICON_MAP.get(service)))
+
+        return entries

--- a/doc/source/tandridge_gov_uk.md
+++ b/doc/source/tandridge_gov_uk.md
@@ -1,0 +1,40 @@
+# Tandridge District Council
+
+Support for schedules provided by [Tandridge District
+Council](https://www.tandridge.gov.uk), serving the Tandridge District, Surrey, UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: tandridge_gov_uk
+      args:
+        postcode: POSTCODE
+        house_number: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**postcode**  
+*(string) (required)*
+
+**house_number**  
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: tandridge_gov_uk
+      args:
+        postcode: "RH8 0PG"
+        house_number: "14A"
+```
+
+## How to get the source arguments
+
+1. Go to <https://tdcws01.tandridge.gov.uk/TDCWebAppsPublic/tfaBranded/408>, enter your postcode, and select your address from the dropdown.
+2. Your postcode is the first argument.
+3. Your house number/name is the second argument — use it exactly as it appears at the start of your address in the dropdown (e.g. `14A`).


### PR DESCRIPTION
## Summary
- Adds a new source for Tandridge District Council, UK (issue #5396), resolving `postcode` + `house_number` to a UPRN via the council's public LLPG address-search SOAP endpoint, then fetching the schedule from its public WhiteSpace REST API (`GetCompleteRecordByUPRN`).
- Returns Domestic Waste, Recycling, Food Waste, and Electricals/textiles collections with a ~6-week rolling window (past + upcoming).
- Adds `doc/source/tandridge_gov_uk.md`.

## Test plan
- [x] `python test_sources.py -s tandridge_gov_uk -l` — all 3 TEST_CASES pass live against the real API
- [x] `ruff check --fix` / `ruff format`
- [x] `python -m pytest tests/test_source_components.py -q`

Closes #5396