### PR TITLE
Add EBU Ulm (customer "ebu") to AWIDO shared platform

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
@@ -253,6 +253,11 @@ SERVICE_MAP = [
         "service_id": "koenigstein",
     },
     {
+        "title": "EBU Ulm",
+        "url": "https://www.ebu-ulm.de/",
+        "service_id": "ebu",
+    },
+    {
         "title": "Anzing",
         "url": "https://www.lra-ebe.de/",
         "service_id": "ebe",
@@ -463,6 +468,11 @@ TEST_CASES = {
         "customer": "gotha",
         "city": "Drei Gleichen OT Günthersleben",
         "street": "Mittelstr",
+    },
+    "Ulm, Bahnhofplatz": {
+        "customer": "ebu",
+        "city": "Ulm",
+        "street": "Bahnhofplatz",
     },
 }
 


### PR DESCRIPTION
## Summary
- EBU Ulm's dedicated ICS export (`ebu_ulm_de` source / `https://www.ebu-ulm.de/export.php?...`) has stopped returning data (confirmed: HTTP 200 with an empty body).
- EBU now publishes its waste-collection schedule via the AWIDO platform (customer id `ebu`), confirmed working by the issue reporter and a commenter.
- Adds `ebu` to `awido_de.py`'s `SERVICE_MAP` so EBU Ulm shows up in the AWIDO source's customer list / config-flow wizard, and adds a live `TEST_CASES` entry (`Ulm, Bahnhofplatz`).

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed
- [x] `python test_sources.py -s awido_de -l` — new `Ulm, Bahnhofplatz` case returns 196 entries with no errors; existing cases unaffected

Fixes #5349