### PR TITLE
Add Homburg (Saarpfalzkreis) to Mein-Abfallkalender.online

### DIFF
--- a/doc/ics/yaml/mein_abfallkalender_online.yaml
+++ b/doc/ics/yaml/mein_abfallkalender_online.yaml
@@ -114,3 +114,5 @@ extra_info:
     url: https://www.wasserburg.de/
   - title: Erlangen
     url: https://www.erlangen.de/
+  - title: Homburg
+    url: https://www.homburg.de/


### PR DESCRIPTION
## Summary
- Adds Homburg (Saarpfalzkreis, Saarland) to the `extra_info` list of the already-supported `mein-abfallkalender.online` shared ICS platform.
- Verified `https://homburg.mein-abfallkalender.online/` is live and serves the city's waste calendar (the reporter's link issue was simply that Homburg wasn't listed yet, not a broken integration).

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes (9 passed)
- [x] Confirmed `https://homburg.mein-abfallkalender.online/` returns HTTP 200 and matches the expected `mein-abfallkalender.online` page structure
- [x] Confirmed `https://www.homburg.de/` (linked reference URL) returns HTTP 200

Fixes #5089