### PR TITLE
fix(moorabool_vic_gov_au): use curl_cffi to bypass Akamai edge block

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/moorabool_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/moorabool_vic_gov_au.py
@@ -3,10 +3,10 @@
 import datetime
 import json
 from typing import TypedDict
+from urllib.parse import quote
 
-import requests
 from bs4 import BeautifulSoup
-from requests.utils import requote_uri
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import (
     SourceArgAmbiguousWithSuggestions,
@@ -73,7 +73,7 @@ class Source:
 
     @staticmethod
     def search_address(address: str, session: requests.Session) -> ApiResult:
-        q = requote_uri(str(API_URLS["address_search"]).format(address))
+        q = API_URLS["address_search"].format(quote(address))
 
         # Retrieve suburbs
         r = session.get(q)
@@ -81,7 +81,7 @@ class Source:
         return json.loads(r.text)
 
     def fetch(self) -> list[Collection]:
-        session = requests.Session()
+        session = requests.Session(impersonate="chrome")
         session.headers.update(HEADERS)
         locationId = ""
 
@@ -118,7 +118,7 @@ class Source:
             )
 
         # Retrieve the upcoming collections for our property
-        q = requote_uri(str(API_URLS["collection"]).format(locationId))
+        q = API_URLS["collection"].format(quote(str(locationId)))
 
         r = session.get(q)
 


### PR DESCRIPTION
## Summary
- The Moorabool Shire Council waste-services endpoints (`/api/v1/myarea/search` and `/ocapi/Public/myarea/wasteservices`) now respond with HTTP 403 "Access Denied" (Akamai edge WAF) to plain `requests` calls, even with a spoofed User-Agent, causing the source to crash with `json.decoder.JSONDecodeError`.
- Switching to `curl_cffi` with `impersonate="chrome"` restores HTTP 200 JSON responses from both endpoints.
- `requests.utils.requote_uri` is not available on `curl_cffi`, so URL construction now percent-encodes the address / location-id components individually via `urllib.parse.quote`.

Fixes #6826

## Test plan
- [x] `python test_sources.py -s moorabool_vic_gov_au -l` — both test cases (`Border Inn Hotel`, `Bendigo Bank`) return 3 collection entries each with correct dates.
- [x] `python -m pytest tests/test_source_components.py -q` — 9 passed.
- [x] `ruff check --fix` / `ruff format` — clean.