### PR TITLE
Add Scalea to Junker APP source (#5442)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -327,6 +327,7 @@ SERVICE_PROVIDERS = {
     "San Cipriano Po",
     "Stradella",
     "Torre de' Passeri",
+    "Scalea",
 }
 
 
@@ -354,6 +355,7 @@ TEST_CASES = {
         "municipality": "Torre de' Passeri",
         "area": "Utenze domestiche",
     },
+    "Scalea": {"municipality": "Scalea"},
 }
 
 


### PR DESCRIPTION
## Summary
- Closes #5442 — adds the municipality Scalea (CS, Italy) to the Junker APP shared-platform source
- Scalea is already served by the existing differenziata.junkerapp.it/{municipality}/calendario endpoint with no area/zone selection required, so this is a documentation/listing addition to SERVICE_PROVIDERS, plus a TEST_CASES entry — no service-layer code changes

## Test plan
- [x] ruff check --fix / ruff format on the changed file — no changes needed
- [x] python -m pytest tests/test_source_components.py -q — 10 passed
- [x] Live test: python test_sources.py -s junker_app -l — Scalea returns 381 collection entries