### PR TITLE
fix(umweltverbaende_at): skip zones with missing collection dates (#4909)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/umweltverbaende_at.py
@@ -306,6 +306,10 @@ TEST_CASES = {
         "town": "Obernalb",
         "street": "Zum weissen Engel",
     },
+    "Hollabrunn - Zellerndorf": {
+        "district": "hollabrunn",
+        "municipal": "Zellerndorf",
+    },  # regression test for #4909: API returns a zone with a fraktion but no "dates" key
     "Horn": {
         "district": "horn",
         "municipal": "Japons",
@@ -554,7 +558,7 @@ class Source:
 
         entries: list[Collection] = []
         for day in schedule:
-            txt = day.text.strip().split(" \u00a0")
+            txt = day.text.strip().split("  ")
             if len(txt) == 1:
                 txt = day.text.strip().split(" ")
                 txt = [
@@ -877,8 +881,13 @@ class Source:
 
         entries: list[Collection] = []
         for zone in zones:
-            bin_type = zone["fraktion"]
-            for date_dict in zone["dates"]:
+            bin_type = zone.get("fraktion")
+            dates = zone.get("dates")
+            # Some zones (e.g. Zellerndorf/Hollabrunn) are returned by the API
+            # with a fraktion but no "dates" key at all, or an empty one.
+            if not bin_type or not dates:
+                continue
+            for date_dict in dates:
                 date_str = date_dict["date"]
                 date_ = datetime.strptime(date_str, "%Y-%m-%d").date()
                 entries.append(


### PR DESCRIPTION
## Summary
- The Hollabrunn API (and potentially other umweltverbaende_at districts) can return a zone entry with a `fraktion` but no `dates` key at all — this happens for municipals that have multiple `ort` sub-locations (e.g. Zellerndorf) when no `town` is specified, causing the API to return an aggregated/incomplete response.
- `fetch_new()` accessed `zone["dates"]` unconditionally, raising a `KeyError` and crashing the source.
- This PR switches to `zone.get(...)` and skips any zone missing a `fraktion` or `dates`, instead of crashing.
- Added a regression test case `Hollabrunn - Zellerndorf` that reproduces the original crash scenario.

## Test plan
- [x] `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s umweltverbaende_at -l -t` — all test cases pass, including the new `Hollabrunn - Zellerndorf` case (149 entries, no crash).
- [x] `ruff check --fix` / `ruff format` on the changed file.
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed.

Fixes #4909