### PR TITLE
fix(awigo_de): request all waste types together to work around AWIGO API bug

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
@@ -1,5 +1,5 @@
 import re
-import urllib
+import urllib.parse
 
 import requests
 from bs4 import BeautifulSoup
@@ -64,20 +64,20 @@ class Source:
         }
 
         for wt in waste_types:
-            args[f"calendar[{wt}]"] = 1
+            args[f"calendar[{wt}]"] = "1"
 
         r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
 
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, features="html.parser")
-        for option in soup.findAll("option"):
+        for option in soup.find_all("option"):
             if compare_cities(self._ort, option.text):
-                args["calendar[cityID]"] = option.get("value")
+                args["calendar[cityID]"] = str(option.get("value"))
                 break
         if "calendar[cityID]" not in args:
             raise SourceArgumentNotFoundWithSuggestions(
-                "ort", self._ort, [option.text for option in soup.findAll("option")]
+                "ort", self._ort, [option.text for option in soup.find_all("option")]
             )
 
         args["calendar[method]"] = "getStreets"
@@ -86,39 +86,43 @@ class Source:
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, features="html.parser")
-        for option in soup.findAll("option"):
+        for option in soup.find_all("option"):
             if option.text.lower().strip() == self._strasse.lower().strip():
-                args["calendar[streetID]"] = option.get("value")
+                value = option.get("value")
+                if value:
+                    args["calendar[streetID]"] = str(value)
                 break
         if "calendar[streetID]" not in args:
             raise SourceArgumentNotFoundWithSuggestions(
                 "strasse",
                 self._strasse,
-                [option.text for option in soup.findAll("option")],
+                [option.text for option in soup.find_all("option")],
             )
 
-args["calendar[method]"] = "getNumbers"
-r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-r.raise_for_status()
-soup = BeautifulSoup(r.text, features="html.parser")
-        for option in soup.findAll("option"):
+        args["calendar[method]"] = "getNumbers"
+        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, features="html.parser")
+        for option in soup.find_all("option"):
             if option.text.lower().strip().replace(
                 " ", ""
             ) == self._hnr.lower().strip().replace(" ", ""):
-                args["calendar[locationID]"] = option.get("value")
+                value = option.get("value")
+                if value:
+                    args["calendar[locationID]"] = str(value)
                 break
         if "calendar[locationID]" not in args:
             raise SourceArgumentNotFoundWithSuggestions(
-                "hnr", self._hnr, [option.text for option in soup.findAll("option")]
+                "hnr", self._hnr, [option.text for option in soup.find_all("option")]
             )
 
-args["calendar[method]"] = "getICSfile"
-r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-r.raise_for_status()
-ics_url = r.text.strip()
-r = s.get(ics_url)
-r.raise_for_status()
-r.encoding = "utf-8"
+        args["calendar[method]"] = "getICSfile"
+        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+        r.raise_for_status()
+        ics_url = r.text.strip()
+        r = s.get(ics_url)
+        r.raise_for_status()
+        r.encoding = "utf-8"
 
         dates = self._ics.convert(r.text)
         for d in dates:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
@@ -50,69 +50,75 @@ class Source:
         entries = []
         waste_types = ["rest", "paper", "yellow", "brown", "mobile"]
 
-        for active_type in waste_types:
-            s = requests.Session()
-            args = {
-                "legacy_eID": "awigoCalendar",
-                "calendar[method]": "getCities",
-            }
+        # Note: the AWIGO API has a bug where requesting getICSfile with only
+        # a single waste type enabled (e.g. only "rest" or only "paper")
+        # returns an ICS file containing only headers and no events. As soon
+        # as at least two waste types are requested together, it works fine.
+        # We therefore always request all waste types together in a single
+        # call; each ICS event already carries its own waste-type name, so no
+        # server-side filtering is lost by doing this. See GitHub issue #4562.
+        s = requests.Session()
+        args = {
+            "legacy_eID": "awigoCalendar",
+            "calendar[method]": "getCities",
+        }
 
-            for wt in waste_types:
-                args[f"calendar[{wt}]"] = 1 if wt == active_type else 0
+        for wt in waste_types:
+            args[f"calendar[{wt}]"] = 1
 
-            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
 
-            r.raise_for_status()
+        r.raise_for_status()
 
-            soup = BeautifulSoup(r.text, features="html.parser")
-            for option in soup.findAll("option"):
-                if compare_cities(self._ort, option.text):
-                    args["calendar[cityID]"] = option.get("value")
-                    break
-            if "calendar[cityID]" not in args:
-                raise SourceArgumentNotFoundWithSuggestions(
-                    "ort", self._ort, [option.text for option in soup.findAll("option")]
-                )
+        soup = BeautifulSoup(r.text, features="html.parser")
+        for option in soup.findAll("option"):
+            if compare_cities(self._ort, option.text):
+                args["calendar[cityID]"] = option.get("value")
+                break
+        if "calendar[cityID]" not in args:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "ort", self._ort, [option.text for option in soup.findAll("option")]
+            )
 
-            args["calendar[method]"] = "getStreets"
+        args["calendar[method]"] = "getStreets"
 
-            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-            r.raise_for_status()
+        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+        r.raise_for_status()
 
-            soup = BeautifulSoup(r.text, features="html.parser")
-            for option in soup.findAll("option"):
-                if option.text.lower().strip() == self._strasse.lower().strip():
-                    args["calendar[streetID]"] = option.get("value")
-                    break
-            if "calendar[streetID]" not in args:
-                raise SourceArgumentNotFoundWithSuggestions(
-                    "strasse",
-                    self._strasse,
-                    [option.text for option in soup.findAll("option")],
-                )
+        soup = BeautifulSoup(r.text, features="html.parser")
+        for option in soup.findAll("option"):
+            if option.text.lower().strip() == self._strasse.lower().strip():
+                args["calendar[streetID]"] = option.get("value")
+                break
+        if "calendar[streetID]" not in args:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "strasse",
+                self._strasse,
+                [option.text for option in soup.findAll("option")],
+            )
 
-            args["calendar[method]"] = "getNumbers"
-            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-            soup = BeautifulSoup(r.text, features="html.parser")
-            for option in soup.findAll("option"):
-                if option.text.lower().strip().replace(
-                    " ", ""
-                ) == self._hnr.lower().strip().replace(" ", ""):
-                    args["calendar[locationID]"] = option.get("value")
-                    break
-            if "calendar[locationID]" not in args:
-                raise SourceArgumentNotFoundWithSuggestions(
-                    "hnr", self._hnr, [option.text for option in soup.findAll("option")]
-                )
+        args["calendar[method]"] = "getNumbers"
+        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+        soup = BeautifulSoup(r.text, features="html.parser")
+        for option in soup.findAll("option"):
+            if option.text.lower().strip().replace(
+                " ", ""
+            ) == self._hnr.lower().strip().replace(" ", ""):
+                args["calendar[locationID]"] = option.get("value")
+                break
+        if "calendar[locationID]" not in args:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "hnr", self._hnr, [option.text for option in soup.findAll("option")]
+            )
 
-            args["calendar[method]"] = "getICSfile"
-            r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-            r = s.get(r.text)
-            r.encoding = "utf-8"
+        args["calendar[method]"] = "getICSfile"
+        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+        r = s.get(r.text)
+        r.encoding = "utf-8"
 
-            dates = self._ics.convert(r.text)
-            for d in dates:
-                bin_type = d[1].replace("wird abgeholt.", "").strip()
-                entries.append(Collection(d[0], bin_type, ICON_MAP.get(bin_type)))
+        dates = self._ics.convert(r.text)
+        for d in dates:
+            bin_type = d[1].replace("wird abgeholt.", "").strip()
+            entries.append(Collection(d[0], bin_type, ICON_MAP.get(bin_type)))
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
@@ -97,9 +97,10 @@ class Source:
                 [option.text for option in soup.findAll("option")],
             )
 
-        args["calendar[method]"] = "getNumbers"
-        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-        soup = BeautifulSoup(r.text, features="html.parser")
+args["calendar[method]"] = "getNumbers"
+r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+r.raise_for_status()
+soup = BeautifulSoup(r.text, features="html.parser")
         for option in soup.findAll("option"):
             if option.text.lower().strip().replace(
                 " ", ""
@@ -111,10 +112,13 @@ class Source:
                 "hnr", self._hnr, [option.text for option in soup.findAll("option")]
             )
 
-        args["calendar[method]"] = "getICSfile"
-        r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
-        r = s.get(r.text)
-        r.encoding = "utf-8"
+args["calendar[method]"] = "getICSfile"
+r = s.post(API_URL, params=urllib.parse.urlencode(args, safe="[]"))
+r.raise_for_status()
+ics_url = r.text.strip()
+r = s.get(ics_url)
+r.raise_for_status()
+r.encoding = "utf-8"
 
         dates = self._ics.convert(r.text)
         for d in dates:


### PR DESCRIPTION
## Summary
- The AWIGO calendar API has a bug: `getICSfile` returns an ICS payload containing only headers (no events) when only a single waste type is enabled in the request. Requesting two or more types together works correctly.
- `awigo_de.py` previously looped over each waste type and queried them one at a time, so fractions like Restmülltonne (residual waste) and Papiermülltonne (paper) were silently missing from every address's schedule.
- This PR requests all waste types (`rest`, `paper`, `yellow`, `brown`, `mobile`) together in a single call. Each ICS event already carries its own waste-type name (parsed into `bin_type`), so no events are lost and no additional client-side filtering is required.

Fixes #4562

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `python test_sources.py -s awigo_de -l` against all existing TEST_CASES (Bippen, Fürstenau, Melle, Berge) — all pass, all fractions present
- [x] Verified against the exact address reported in #4562 (Bad Laer, Rosenweg, 10) — Restmülltonne and Papiermülltonne entries now present where they were previously missing