### PR TITLE
fix(montecospa_it): remove note-only and duplicate calendar entries

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montecospa_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montecospa_it.py
@@ -78,11 +78,14 @@ class Source:
         self._user_type = user_type
 
     def fetch(self) -> list[Collection]:
+        this_year = date.today().year
         where = {
             "serviceOnline": "1",
+            "language": "it",
             "municipality": self._municipality,
             "serviceZoneName": self._zone,
             "serviceUserClass": self._user_type,
+            "validityYear": {"$in": [this_year, this_year + 1]},
         }
         params = urllib.parse.urlencode({"where": json.dumps(where), "limit": 200})
         r = requests.get(
@@ -93,22 +96,28 @@ class Source:
         r.raise_for_status()
         data = r.json()
 
+        seen: set[tuple[date, str]] = set()
         entries: list[Collection] = []
         for record in data.get("results", []):
-            waste_type_obj = record.get("serviceWasteType") or {}
-            waste_name = (
-                waste_type_obj.get("name", "Unknown")
-                if isinstance(waste_type_obj, dict)
-                else "Unknown"
-            )
+            waste_type_obj = record.get("serviceWasteType")
+            if not isinstance(waste_type_obj, dict):
+                # Records without a waste type are informational notes
+                # (e.g. put-out time instructions), not collection events.
+                continue
+            waste_name = waste_type_obj.get("name") or "Unknown"
             icon = ICON_MAP.get(waste_name)
             calendar = record.get("serviceCalendar") or []
             for day in calendar:
-                if day.get("value") == "x":
-                    try:
-                        d = date.fromisoformat(day["date"])
-                    except (ValueError, KeyError):
-                        continue
-                    entries.append(Collection(date=d, t=waste_name, icon=icon))
+                if day.get("value") != "x":
+                    continue
+                try:
+                    d = date.fromisoformat(day["date"])
+                except (ValueError, KeyError):
+                    continue
+                key = (d, waste_name)
+                if key in seen:
+                    continue
+                seen.add(key)
+                entries.append(Collection(date=d, t=waste_name, icon=icon))
 
         return entries


### PR DESCRIPTION
## Summary

- `montecospa_it` (Monteco S.p.A., Puglia/Basilicata, Italy) was returning bogus `"Unknown"` waste-type entries for records that have no `serviceWasteType` (these are informational notes like put-out-time instructions, not real collection events) — 1865 such entries across the two existing TEST_CASES.
- It could also return duplicated `(date, type)` entries for zones/classes where a `serviceUserClass` (e.g. "Non domestica") matches multiple underlying `serviceUserType` subtypes (generic + a "food category" business subtype) with overlapping calendars.
- Fix: skip records with no `serviceWasteType`, filter by `language`/`validityYear` for correctness, and de-duplicate by `(date, waste name)`.

Found while investigating #4872 (Lecce is already supported by this source since #6510; this fix improves the accuracy of the data returned for that address and all other supported municipalities).

## Test plan

- [x] `ruff check --fix` / `ruff format` — clean
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `python test_sources.py -s montecospa_it -l` — both TEST_CASES pass; entry counts drop from 1149/3228 to 530/991 with zero "Unknown" entries and no duplicate (date, type) pairs within each test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)