### PR TITLE
fix(logan_qld_gov_au): use dict.get to fall through to fallback API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/logan_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/logan_qld_gov_au.py
@@ -46,7 +46,7 @@ class Source:
         )
         data = json.loads(r.text)
 
-        if data["features"]:
+        if data.get("features"):
             collection_day = data["features"][0]["attributes"]["Rubbish_Collection"]
             recycling_week = data["features"][0]["attributes"]["Recycling_Collection"]
             green_waste_week = data["features"][0]["attributes"][
@@ -60,7 +60,7 @@ class Source:
             )
             data = json.loads(r.text)
 
-            if not data["features"]:
+            if not data.get("features"):
                 raise SourceArgumentNotFound(
                     "property_location", self.property_location
                 )


### PR DESCRIPTION
## Summary
Fixes #6842. The primary ArcGIS endpoint `Council_Property_view` no longer exists and now returns `{"error": {"code": 400, "message": "Invalid URL", ...}}` instead of a feature set. Since the code accessed `data["features"]` directly, this raised a `KeyError` and crashed the source before it could reach its own fallback logic (to the still-working `Logan_City_Bin_Collection` endpoint).

Changed both `data["features"]` checks to `data.get("features")` so an error response (missing `"features"` key) is treated the same as an empty result and correctly falls through to the fallback endpoint.

## Test plan
- [x] `python test_sources.py -s logan_qld_gov_au -l` — crash eliminated; fallback endpoint now reached and returns valid collection data for previously-crashing test cases.
- [x] `ruff check --fix` / `ruff format` — clean.
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed.

Reported and fix verified locally by @vaemarr in #6842.