### PR TITLE
docs(static): clarify multi-weekday support for WEEKLY recurrence

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/static.py
@@ -53,6 +53,11 @@ TEST_CASES = {
         "frequency": "WEEKLY",
         "weekdays": "FR",
     },
+    "Recurrence weekly on multiple weekdays": {
+        "type": "Every Tuesday and Thursday",
+        "frequency": "WEEKLY",
+        "weekdays": {"TU": 1, "TH": 1},
+    },
     "Recurrence with exclude date range": {
         "type": "Weekly excluding summer break",
         "frequency": "WEEKLY",

--- a/doc/source/static.md
+++ b/doc/source/static.md
@@ -95,7 +95,9 @@ Used to define the weekday for weekly or monthly frequencies. A weekday is speci
    weekdays: { MO: 1, FR: -2 }
    ```
 
-   The additional numerical argument means the nth occurrence of this weekday in the specified frequency (normally only MONTHLY makes sense here). If frequency is set to `MONTHLY`, `MO: 1` represents the first Monday of the month. `FR: -2` represents the 2nd last Friday of the month.
+   The additional numerical argument means the nth occurrence of this weekday in the specified frequency. If frequency is set to `MONTHLY`, `MO: 1` represents the first Monday of the month. `FR: -2` represents the 2nd last Friday of the month.
+
+   The dictionary format can also be used to select **more than one weekday per week** when `frequency` is `WEEKLY`. In that case the numerical argument is ignored, so `1` is a safe default for every weekday. For example, `weekdays: { TU: 1, TH: 1 }` produces a schedule that recurs every Tuesday **and** every Thursday.
 
    **IMPORTANT**: The colon must be followed by a space!
 
@@ -134,6 +136,20 @@ waste_collection_schedule:
         type: Altpapier
         frequency: WEEKLY
         weekdays: WE
+```
+
+---
+
+Defines a schedule that recurs every Tuesday and every Thursday (e.g. for a watering schedule with two collections per week).
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: static
+      args:
+        type: Watering
+        frequency: WEEKLY
+        weekdays: {TU: 1, TH: 1}
 ```
 
 ---


### PR DESCRIPTION
## Summary
- The `static` source has supported selecting more than one weekday per week since 2023 via the `weekdays` dictionary format (e.g. `weekdays: {TU: 1, TH: 1}`), but the docs implied this was "normally only" useful for MONTHLY frequency, so users didn't discover it.
- Clarifies `doc/source/static.md` to explicitly state the dict format also works for WEEKLY frequency (the numeric argument is ignored in that case), and adds a worked example matching a common "twice a week" use case (e.g. watering days).
- Adds a `TEST_CASES` entry to `static.py` covering `frequency: WEEKLY` with `weekdays: {TU: 1, TH: 1}` as a regression test.

Closes #4844

## Test plan
- [x] `python test_sources.py -s static -l` — new test case returns only Tuesday/Thursday dates
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `ruff check --fix` / `ruff format` — clean