### PR TITLE
Add City of Apopka, FL to ReCollect shared platform

### DIFF
--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -194,6 +194,9 @@ extra_info:
   - title: Newcastle upon Tyne
     url: https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day
     country: uk
+  - title: City of Apopka, FL
+    url: https://www.apopka.gov/319/Solid-Waste
+    country: us
 
 howto:
   en: |
@@ -249,6 +252,7 @@ howto:
     |City of Coquitlam, BC|Canada|[coquitlam.ca](https://www.coquitlam.ca/157/Collection-Calendar-and-Guidelines)|
     |Atlantic Waste Services, GA|USA|[atlanticwaste.com](https://atlanticwaste.com)|
     |Newcastle upon Tyne|UK|[new.newcastle.gov.uk](https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day)|
+    |City of Apopka, FL|USA|[apopka.gov](https://www.apopka.gov/319/Solid-Waste)|
 
     and probably a lot more.
 


### PR DESCRIPTION
## Summary
- City of Apopka, FL has launched ReCollect (`area: CityofApopkaFL`) for household garbage/recycling scheduling, confirmed live via the widget embedded on https://www.apopka.gov/319/Solid-Waste.
- Adds the city to the ReCollect `extra_info` list and "known to work with" table so it shows up in the docs/config wizard.

Closes #4934

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `pre-commit run yamlfmt --files doc/ics/yaml/recollect.yaml` passes with no changes
- [ ] Requester to confirm they can generate a working ICS URL via the widget at https://www.apopka.gov/319/Solid-Waste following the existing ReCollect howto instructions