### PR TITLE
test(hvcgroep_nl): add missing Spaarnelanden test case

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
@@ -46,6 +46,11 @@ TEST_CASES = {
         "house_number": "397",
         "service": "sliedrecht",
     },
+    "Spaarnelanden": {
+        "postal_code": "2013EA",
+        "house_number": "1",
+        "service": "spaarnelanden",
+    },
     "Tollebeek": {"postal_code": "8309AV", "house_number": "1"},
     "Hvcgroep: Tollebeek": {
         "postal_code": "8309AV",


### PR DESCRIPTION
## Summary
- Investigated #4920 (Spaarnelanden / hvcgroep_nl returns empty responses). Confirmed the API endpoints the source uses are unchanged and still match Spaarnelanden's own frontend, and that many valid Haarlem/Zandvoort addresses return real, correct calendar data through this source today.
- Found that `Spaarnelanden` had no dedicated `TEST_CASES` entry despite being a supported `SERVICE_MAP` entry, so there was no regression coverage for this service. This adds one, using a real, verified working address.
- The empty-response reports appear to be address-specific (some addresses genuinely have no personal collection calendar in Spaarnelanden's system, e.g. underground/communal container areas) rather than a systemic bug — see discussion on the issue.

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s hvcgroep_nl -l` — Spaarnelanden test case returns 118 real entries
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed

Closes/relates to #4920 (partial — see issue comment for follow-up needed from reporter).