### PR TITLE
fix(ardsandnorthdown_gov_uk): migrate to new calendarhtml REST endpoint

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ardsandnorthdown_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ardsandnorthdown_gov_uk.py
@@ -22,52 +22,29 @@ ICON_MAP = {
 }
 
 
-API_URL = "https://collections-ardsandnorthdown.azurewebsites.net/WSCollExternal.asmx"
-
-# council seems to always be ARD no matter what the old council was
-PAYLOAD = """<?xml version="1.0" encoding="utf-8" ?>
-<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-    <soap:Body>
-        <getRoundCalendarForUPRN  xmlns="http://webaspx-collections.azurewebsites.net/">
-            <council>ARD</council>
-            <UPRN>{uprn}</UPRN>
-            <from>Chtml</from>
-        </getRoundCalendarForUPRN >
-    </soap:Body>
-</soap:Envelope>
-"""
+API_URL = (
+    "https://ardsandnorthdownbincalendar.azurewebsites.net/api/calendarhtml/{uprn}"
+)
 
 
 class Source:
     def __init__(self, uprn: str | int):
-        self._payload = PAYLOAD.format(uprn=str(uprn).strip())
+        self._uprn = str(uprn).strip()
 
     def fetch(self) -> list[Collection]:
-        # get json file
-        r = requests.post(
-            API_URL,
-            data=self._payload,
-            headers={"Content-Type": "text/xml; charset=utf-8"},
-        )
+        r = requests.get(API_URL.format(uprn=self._uprn))
         r.raise_for_status()
 
-        # xml parser
-        entries: list[Collection] = []
-        # html unescape text
-        text = (
-            (r.text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&"))
-            .split("<getRoundCalendarForUPRNResult>")[-1]
-            .split("</getRoundCalendarForUPRNResult>")[0]
-        )
+        html = r.json().get("calendarHTML", "")
 
-        soup = BeautifulSoup(text, "html.parser")
-        # find b where text start with Key:
+        entries: list[Collection] = []
+
+        soup = BeautifulSoup(html, "html.parser")
+        # find b/strong tag where text starts with "Key:"
 
         self._bin_type_translation: dict[str, str] = {}
 
-        keys = soup.find_all("b")
+        keys = soup.find_all(["b", "strong"])
 
         key = None
         for k in keys:


### PR DESCRIPTION
## Summary
- The council has introduced a new REST endpoint (`ardsandnorthdownbincalendar.azurewebsites.net/api/calendarhtml/{UPRN}`) returning JSON (`{"calendarHTML": "..."}`), which appears to be what the live website widget now uses, replacing the SOAP-based `WSCollExternal.asmx` service.
- The old SOAP endpoint is still functional today, but the new endpoint's HTML wraps the bin-legend labels in `<strong>` instead of `<b>`, so migrating without adjusting the tag lookup would silently break bin-type detection.
- This PR switches the source to the new REST endpoint (simpler GET request, JSON response, no manual SOAP-XML unescaping needed) and widens the legend-tag lookup to match both `<b>` and `<strong>` for resilience.

Fixes #4735

## Test plan
- [x] `python test_sources.py -s ardsandnorthdown_gov_uk -l` — all 3 TEST_CASES pass with entry counts matching pre-change output (94 / 66 / 67 entries).
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed.
- [x] Manually verified both old and new endpoints return equivalent schedule data for all 3 TEST_CASES UPRNs.