### PR TITLE
fix(shellharbourwaste_com_au): bypass Cloudflare block and fix renamed waste-type labels

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/shellharbourwaste_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/shellharbourwaste_com_au.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons
 
 TITLE = "Shellharbour City Council"
@@ -13,15 +13,15 @@ TEST_CASES = {"TestName1": {"zoneID": "Monday A"}, "TestName2": {"zoneID": "Frid
 API_URL = "https://www.shellharbourwaste.com.au/waste-collection"
 
 ICON_MAP = {
-    "Waste": Icons.GENERAL_WASTE,
-    "FOGO": Icons.BIO_KITCHEN,
+    "General Waste": Icons.GENERAL_WASTE,
+    "Garden Waste": Icons.GARDEN,
     "Recycling": Icons.RECYCLING,
 }
 
 
-def findUrl(zoneID):
+def findUrl(zoneID, session):
     # Take Zone ID and find url to parse
-    r = requests.get(
+    r = session.get(
         f"https://www.shellharbourwaste.com.au/wp-json/rb_co/v1/get-waste-url?zone={zoneID}"
     )
     r.raise_for_status()
@@ -34,22 +34,29 @@ class Source:
         self._zoneID = zoneID
 
     def fetch(self):
-        data = {"Referer": "https://www.shellharbourwaste.com.au/find-my-bin-day/"}
-        pageurl = findUrl(self._zoneID)
-        r = requests.get(f"{pageurl}", data=data)
+        session = requests.Session(impersonate="chrome")
+        pageurl = findUrl(self._zoneID, session)
+        r = session.get(
+            pageurl,
+            headers={
+                "Referer": "https://www.shellharbourwaste.com.au/find-my-bin-day/"
+            },
+        )
         r.raise_for_status()
         soup = BeautifulSoup(r.content, "html.parser")
         collections = soup.select("div.waste-block__content")
         entries = []
         for entry in collections:
-            waste_type = entry.find("h3", class_="waste-block__title").text
+            waste_type = entry.find("h3", class_="waste-block__title").text.strip()
+            # Strip trailing bin-colour hint, e.g. "General Waste (Red lid)" -> "General Waste"
+            waste_type = waste_type.split(" (")[0]
             date_string = entry.find("time", class_="waste-block__time").text.strip()
             pickupdate = datetime.strptime(date_string, "%d/%m/%Y")
             entries.append(
                 Collection(
                     date=pickupdate.date(),
-                    t=waste_type.split("/")[0],
-                    icon=ICON_MAP.get(waste_type.split("/")[0]),
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type),
                 )
             )
         return entries


### PR DESCRIPTION
## Summary
- The Shellharbour City Council zone-lookup endpoint (`wp-json/rb_co/v1/get-waste-url`) now returns a Cloudflare "Attention Required" challenge page (HTTP 403) instead of JSON when fetched with plain `requests`, causing `r.json()` to fail with `Expecting value: line 1 column 1 (char 0)` — exactly the error reported in #6841. Switched both HTTP calls to `curl_cffi` with `impersonate="chrome"`, which bypasses the block.
- While fixing, found the provider's HTML has also changed its waste-type labels from a `"Type/Subtype"` format to plain strings with a bin-colour suffix, e.g. `"General Waste (Red lid)"`, `"Garden Waste (Green lid)"`, `"Recycling (Yellow lid)"`. The old `waste_type.split("/")[0]` logic and `ICON_MAP` keys no longer matched, so collection types/icons would have been wrong even after the Cloudflare fix. Updated the parsing to strip the trailing `" (... lid)"` hint and updated `ICON_MAP` keys accordingly (`"Garden Waste"` now maps to `Icons.GARDEN`, matching the site's current wording).

Fixes #6841

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python test_sources.py -s shellharbourwaste_com_au -l` — both TestName1 and TestName2 return 3 correctly dated/typed entries each
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed