### PR TITLE
fix(smiecioplan_pl): add optional building_type param for Gdynia dual-schedule addresses

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/smiecioplan_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/smiecioplan_pl.py
@@ -23,6 +23,18 @@ TEST_CASES = {
         "street": "ABRAHAMA",
         "house": "1",
     },
+    "Gdynia, Zrodlo Marii 19H (multi-family)": {
+        "city": "gdynia",
+        "street": "ŹRÓDŁO MARII",
+        "house": "19H",
+        "building_type": "multi",
+    },
+    "Gdynia, Zrodlo Marii 19H (single-family)": {
+        "city": "gdynia",
+        "street": "ŹRÓDŁO MARII",
+        "house": "19H",
+        "building_type": "single",
+    },
 }
 
 ICON_MAP = {
@@ -69,6 +81,7 @@ PARAM_DESCRIPTIONS = {
         "city": "City name (szczecin, gdansk, gdynia, or sopot).",
         "street": "Street name in uppercase as shown on SmiecioPlan.",
         "house": "House number.",
+        "building_type": "Optional. Some addresses (e.g. in Gdynia) have separate schedules for single-family (single) and multi-family (multi) buildings. Leave empty if your address only has one schedule.",
     },
 }
 
@@ -77,13 +90,18 @@ PARAM_TRANSLATIONS = {
         "city": "City",
         "street": "Street",
         "house": "House Number",
+        "building_type": "Building Type",
     },
     "de": {
         "city": "Stadt",
         "street": "Straße",
         "house": "Hausnummer",
+        "building_type": "Gebäudetyp",
     },
 }
+
+
+BUILDING_TYPES = ("single", "multi")
 
 
 def _get_icon(summary: str) -> str | None:
@@ -95,7 +113,13 @@ def _get_icon(summary: str) -> str | None:
 
 
 class Source:
-    def __init__(self, city: str, street: str, house: str | int):
+    def __init__(
+        self,
+        city: str,
+        street: str,
+        house: str | int,
+        building_type: str | None = None,
+    ):
         if not city:
             raise SourceArgumentRequired("city", "City is required.")
         if not street:
@@ -106,6 +130,14 @@ class Source:
         self._city = city.strip().lower()
         self._street = street.strip().upper()
         self._house = str(house).strip()
+
+        if building_type:
+            building_type = building_type.strip().lower()
+            if building_type not in BUILDING_TYPES:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "building_type", building_type, suggestions=list(BUILDING_TYPES)
+                )
+        self._building_type = building_type or None
 
     def fetch(self) -> list[Collection]:
         # Validate street exists
@@ -149,14 +181,18 @@ class Source:
             )
 
         # Fetch ICS
+        ics_params: dict[str, str] = {
+            "street": self._street,
+            "house": self._house,
+            "city": self._city,
+            "types": "mixed,segregated,bio,bulky",
+        }
+        if self._building_type:
+            ics_params["building_type"] = self._building_type
+
         r = requests.get(
             f"{API_URL}/export/ics",
-            params={
-                "street": self._street,
-                "house": self._house,
-                "city": self._city,
-                "types": "mixed,segregated,bio,bulky",
-            },
+            params=ics_params,
             timeout=30,
         )
         r.raise_for_status()

--- a/doc/source/smiecioplan_pl.md
+++ b/doc/source/smiecioplan_pl.md
@@ -22,6 +22,8 @@ waste_collection_schedule:
 
 **house** *(string) (required)*: House number.
 
+**building_type** *(string) (optional)*: Some addresses (e.g. in Gdynia) have separate schedules for single-family (`single`) and multi-family (`multi`) buildings. Leave empty if your address only has one schedule. If your imported schedule seems to contain duplicate or extra collection dates, try setting this to `single` or `multi` to see which one matches your address on the SmiecioPlan website.
+
 ## Example
 
 ```yaml
@@ -32,4 +34,15 @@ waste_collection_schedule:
         city: "gdansk"
         street: "ABRAHAMA"
         house: "1"
+```
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: smiecioplan_pl
+      args:
+        city: "gdynia"
+        street: "ŹRÓDŁO MARII"
+        house: "19H"
+        building_type: "single"
 ```


### PR DESCRIPTION
## Summary
- Some SmiecioPlan addresses (e.g. in Gdynia) have separate collection schedules for single-family (`single`) and multi-family (`multi`) buildings. The source previously always requested the combined/unfiltered schedule, which returns the union of both variants — producing duplicate and incorrect pickup dates for affected addresses.
- Verified against the live API: requesting `ŹRÓDŁO MARII 19H, Gdynia` without `building_type` returns 635 events, while `building_type=multi` returns 491 and `building_type=single` returns 144 (491 + 144 = 635), confirming the default response is exactly the union of both schedules.
- Adds an optional `building_type` argument (`single` / `multi`) that is only forwarded to the `/export/ics` API call when explicitly set, so cities/addresses that don't use this distinction (e.g. Szczecin, which returns 0 events when `building_type` is sent) are unaffected.
- Adds English/German translations and descriptions for the new parameter, and two new live TEST_CASES covering both building types for a real Gdynia address.

## Test plan
- [x] `ruff check --fix` / `ruff format` on the modified source file
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `python test_sources.py -s smiecioplan_pl -l` — Szczecin (479 entries), Gdynia multi (491 entries), Gdynia single (144 entries) all pass live against the API
- [ ] Reporter (@mariorok) to confirm `building_type: single` now matches their "Jednorodzinna" schedule on smiecioplan.pl

Fixes #6716