### PR TITLE
Add Illertissen example to Knittel Entsorgung ICS platform

### DIFF
--- a/doc/ics/yaml/knittel_entsorgung_com.yaml
+++ b/doc/ics/yaml/knittel_entsorgung_com.yaml
@@ -10,3 +10,5 @@ howto:
 test_cases:
   Nersingen:
     url: https://www.knittel-entsorgung.com/wp-content/uploads/2025/11/NERSINGEN_Nersingen_Leibi_Ober-Unterfahlheim_Strass_2026.ics
+  Illertissen-Ost:
+    url: https://www.knittel-entsorgung.com/wp-content/uploads/2025/11/ILLERTISSEN_Illertissen-OST_2026.ics


### PR DESCRIPTION
## Summary
- Illertissen, Germany (requested in #4835) is already covered by the existing Knittel Entsorgung ICS platform (`doc/ics/yaml/knittel_entsorgung_com.yaml`), it just wasn't documented with an example yet.
- Adds a live, verified ICS URL for the Illertissen-Ost district as a `test_cases` entry, following the same pattern as the existing Nersingen entry.
- Note: Knittel Entsorgung publishes Illertissen as six separate per-district ICS files (Tiefenbach, Betlinshausen, Illertissen-OST, Au, Jedesheim, Illertissen-WEST); users pick the one matching their address from the "Kalenderdatei" popup on https://www.knittel-entsorgung.com/abfuhrkalender-2026/#popup_illertissen_Kalenderdatei.

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes (10 passed)
- [x] Live-tested via `python3 test_sources.py -y knittel_entsorgung_com -l`: both `Nersingen` (30 entries) and `Illertissen-Ost` (38 entries) fetch and parse without errors

Closes #4835