### PR TITLE
Fix haringey_gov_uk source, replacing web-scraping with API calls

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
@@ -24,6 +24,7 @@ SOURCE_CODEOWNERS = ["@marcjay"]
 API = "https://wastecollections.haringey.gov.uk/api"
 COUNCIL_ID = "45"
 
+
 class Source:
     def __init__(self, uprn):
         self._uprn = str(uprn).zfill(12)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 TITLE = "Haringey Council"
@@ -20,40 +19,58 @@ ICON_MAP = {
     "Garden Waste": Icons.GARDEN,
 }
 
+SOURCE_CODEOWNERS = ["@marcjay"]
+
+API = "https://wastecollections.haringey.gov.uk/api"
+COUNCIL_ID = "45"
 
 class Source:
     def __init__(self, uprn):
         self._uprn = str(uprn).zfill(12)
 
     def fetch(self):
-        api_url = f"https://wastecollections.haringey.gov.uk/property/{self._uprn}"
-        response = requests.get(api_url)
+        session = requests.Session()
 
-        soup = BeautifulSoup(response.text, features="html.parser")
-        soup.prettify()
+        # Step 1: resolve the UPRN to the internal point id.
+        address_response = session.post(
+            f"{API}/getAddressByPointId",
+            json={
+                "pointId": self._uprn,
+                "councilId": COUNCIL_ID,
+                "pointType": "PointAddress",
+            },
+        )
+        address_response.raise_for_status()
+        addresses = address_response.json().get("data", [])
+        if not addresses:
+            raise Exception(f"No address found for UPRN {self._uprn}")
+        point_id = addresses[0]["id"]
+
+        # Step 2: fetch the collection schedule for that point id.
+        collection_response = session.post(
+            f"{API}/getCollectionDays",
+            json={
+                "pointId": point_id,
+                "pointType": "PointAddress",
+                "councilId": COUNCIL_ID,
+            },
+        )
+        collection_response.raise_for_status()
+        services = collection_response.json().get("activeServices", [])
 
         entries = []
-
-        service_elements = soup.select(".service-wrapper")
-
-        for service_element in service_elements:
-            service_name = service_element.select(".service-name")[0].text.strip()
-
-            next_service_dates = service_element.select("td.next-service")
-            if len(next_service_dates) == 0:
-                continue
-            next_service_date = next_service_dates[0]
-
-            next_service_date.span.extract()
-
-            entries.append(
-                Collection(
-                    date=datetime.strptime(
-                        next_service_date.text.strip(), "%d/%m/%Y"
-                    ).date(),
-                    t=service_name,
-                    icon=ICON_MAP.get(service_name),
+        for service in services:
+            waste_type = service.get("taskTypeName") or service.get("serviceName")
+            for schedule in service.get("serviceSchedules", []):
+                date_str = schedule.get("currentScheduledDate")
+                if not date_str:
+                    continue
+                entries.append(
+                    Collection(
+                        date=datetime.fromisoformat(date_str).date(),
+                        t=waste_type,
+                        icon=ICON_MAP.get(waste_type),
+                    )
                 )
-            )
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/haringey_gov_uk.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "Haringey Council"
 DESCRIPTION = "Source for haringey.gov.uk services for Haringey Council, UK."
@@ -40,11 +41,12 @@ class Source:
                 "councilId": COUNCIL_ID,
                 "pointType": "PointAddress",
             },
+            timeout=30,
         )
         address_response.raise_for_status()
         addresses = address_response.json().get("data", [])
         if not addresses:
-            raise Exception(f"No address found for UPRN {self._uprn}")
+            raise SourceArgumentNotFound("uprn", self._uprn)
         point_id = addresses[0]["id"]
 
         # Step 2: fetch the collection schedule for that point id.
@@ -55,6 +57,7 @@ class Source:
                 "pointType": "PointAddress",
                 "councilId": COUNCIL_ID,
             },
+            timeout=30,
         )
         collection_response.raise_for_status()
         services = collection_response.json().get("activeServices", [])
@@ -68,7 +71,9 @@ class Source:
                     continue
                 entries.append(
                     Collection(
-                        date=datetime.fromisoformat(date_str).date(),
+                        date=datetime.fromisoformat(
+                            date_str.replace("Z", "+00:00")
+                        ).date(),
                         t=waste_type,
                         icon=ICON_MAP.get(waste_type),
                     )

--- a/doc/source/haringey_gov_uk.md
+++ b/doc/source/haringey_gov_uk.md
@@ -29,11 +29,4 @@ waste_collection_schedule:
 
 
 #### How to find your `UPRN`
-Your uprn is the collection of numbers at the end of the url when viewing your collection schedule on the Haringey Council web site.
-
-For example:  _wastecollections.haringey.gov.uk/property/`000151650618`_
-
-Alternatively, you can discover what your Unique Property Reference Number (UPRN) is by going to https://www.findmyaddress.co.uk/ and entering in your address details.
-
-
-
+You can find your Unique Property Reference Number (UPRN) by going to https://www.findmyaddress.co.uk/search and entering in your address details.


### PR DESCRIPTION
## Summary

- Replace web-scraping of now-defunct waste provider with API calls to new endpoints
- Update documentation

Fixes #6861.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)

Test output:
```
$ python /Users/marcjay/tzdev/hacs_waste_collection_schedule/custom_components/waste_collection_schedule/waste_collect
ion_schedule/test/test_sources.py -s haringey_gov_uk -l
Testing source haringey_gov_uk ...
  found 6 entries for Test_001
    2026-07-15 : Recycling
    2026-07-22 : Recycling
    2026-07-15 : Non-Recyclable Waste
    2026-07-29 : Non-Recyclable Waste
    2026-07-15 : Food Waste
    2026-07-22 : Food Waste
  found 8 entries for Test_002
    2026-07-10 : Recycling
    2026-07-17 : Recycling
    2026-07-03 : Non-Recyclable Waste
    2026-07-17 : Non-Recyclable Waste
    2026-07-10 : Food Waste
    2026-07-17 : Food Waste
    2026-07-10 : Garden Waste
    2026-07-17 : Garden Waste
  found 6 entries for Test_003
    2026-07-10 : Food Waste
    2026-07-17 : Food Waste
    2026-07-10 : Recycling
    2026-07-17 : Recycling
    2026-07-03 : Non-Recyclable Waste
    2026-07-17 : Non-Recyclable Waste
  found 6 entries for Test_004
    2026-07-14 : Non-Recyclable Waste
    2026-07-28 : Non-Recyclable Waste
    2026-07-14 : Food Waste
    2026-07-21 : Food Waste
    2026-07-14 : Recycling
    2026-07-21 : Recycling
```