### PR TITLE
fix(abfallnavi_de): GUI wizard silently fails for Norderstedt due to mismatched suggestion argument names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -236,8 +236,14 @@ class AbfallnaviDe:
         cities = self.get_cities()
         city_id = self._find_in_inverted_dict(cities, city)
         if not city_id:
+            # NOTE: the "argument" passed to SourceArgumentNotFoundWithSuggestions
+            # must match the corresponding Source.__init__ keyword exactly
+            # ("ort"), not some other internal name ("city"). The config flow
+            # UI matches errors/suggestions back to the form field by this
+            # name; a mismatch means the UI silently fails to show any error
+            # or suggestion to the user (see issue #4426).
             raise SourceArgumentNotFoundWithSuggestions(
-                "city", city, list(cities.values())
+                "ort", city, list(cities.values())
             )
         return city_id
 
@@ -255,13 +261,15 @@ class AbfallnaviDe:
         if len(streets) == 1:
             return list(streets.keys())
         if street is None:
+            # NOTE: the "argument" must match the Source.__init__ keyword
+            # exactly ("strasse"), see comment in get_city_id above.
             raise SourceArgumentRequiredWithSuggestions(
-                "street", "street is required of this city", list(streets.values())
+                "strasse", "street is required of this city", list(streets.values())
             )
         matches = [id for id, name in streets.items() if name == street]
         if len(matches) == 0:
             raise SourceArgumentNotFoundWithSuggestions(
-                "street", street, list(streets.values())
+                "strasse", street, list(streets.values())
             )
         return matches
 
@@ -282,15 +290,17 @@ class AbfallnaviDe:
         if len(house_numbers) == 1:
             return next(iter(house_numbers.keys()))
         if house_number is None:
+            # NOTE: the "argument" must match the Source.__init__ keyword
+            # exactly ("hausnummer"), see comment in get_city_id above.
             raise SourceArgumentRequiredWithSuggestions(
-                "house_number",
+                "hausnummer",
                 "house number is required for this street",
                 list(house_numbers.values()),
             )
         house_number_id = self._find_in_inverted_dict(house_numbers, house_number)
         if house_number_id is None:
             raise SourceArgumentNotFoundWithSuggestions(
-                "house_number", house_number, list(house_numbers.values())
+                "hausnummer", house_number, list(house_numbers.values())
             )
 
         return house_number_id

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
@@ -47,6 +47,11 @@ TEST_CASES = {
         "ort": "Norderstedt",
         "strasse": "Distelweg",
     },
+    "nds Norderstedt Friedrichsgaber Weg (house number range as street)": {
+        "service": "nds",
+        "ort": "Norderstedt",
+        "strasse": "Friedrichsgaber Weg 1 - 57",
+    },
     "una Bergkamen, Agnes-Miegel-Str.": {
         "service": "unna",
         "ort": "Bergkamen",


### PR DESCRIPTION
## Summary
- Fixes #4426: the `abfallnavi_de` GUI config wizard silently re-rendered the
  form without any error or suggestions when a street/city/house-number could
  not be resolved (reported for Stadt Norderstedt / "Friedrichsgaber Weg").
- Root cause: `AbfallnaviDe.py` raised `SourceArgumentNotFoundWithSuggestions`
  / `SourceArgumentRequiredWithSuggestions` with argument names `"city"`,
  `"street"`, `"house_number"`, but `Source.__init__` in `abfallnavi_de.py`
  uses `ort`, `strasse`, `hausnummer`. The config flow matches suggestions and
  inline errors back to the form field by this exact name, so the mismatch
  meant both were silently dropped.
- Renamed the raised argument names to match the `Source.__init__` kwargs
  exactly, per the documented contract in `exceptions.py`.
- Added a new TEST_CASE reproducing the underlying data shape that triggered
  this for Norderstedt: large streets there are pre-split by the upstream API
  into house-number-range "street" entries (e.g. "Friedrichsgaber Weg 1 - 57")
  rather than a single street name + separate house-number list.

## Test plan
- [x] `ruff check --fix` / `ruff format` on both changed files
- [x] `python test_sources.py -s abfallnavi_de -l` — all test cases pass,
      including the new Norderstedt/house-number-range case
- [x] `python -m pytest tests/test_source_components.py -q` — passes
- [ ] Reporter to confirm the GUI wizard now shows a usable list of street
      suggestions for Norderstedt addresses like "Friedrichsgaber Weg"