### PR TITLE
fix(schweinfurt_de): showmobile string values ("False") were always truthy

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -152,3 +152,4 @@ Ilkley
 noe
 periode
 Periode
+Aktion

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schweinfurt_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schweinfurt_de.py
@@ -12,17 +12,39 @@ URL = "https://www.schweinfurt.de"
 TEST_CASES = {
     "TestcaseI": {"address": "Ahornstrasse"},
     "TestcaseII": {"address": "Ahornstrasse", "showmobile": "True"},
+    "TestcaseIII": {"address": "Ahornstrasse", "showmobile": "False"},
+    "TestcaseIV": {"address": "Ahornstrasse", "showmobile": False},
 }
 
 _LOGGER = logging.getLogger(__name__)
 
 API_URL = "https://www.schweinfurt.de/leben-freizeit/umwelt/abfallwirtschaft/4427.Aktuelle-Abfuhrtermine-und-Muellkalender.html"
 
+# Titles (or title fragments) that are announcements rather than an actual
+# collection/drop-off event, e.g. "Wertstoffhof geschlossen" (recycling
+# center closed) or "Aktion Kompostverkauf" (compost sale campaign). These
+# are never useful as a "collection" entry, so they are always filtered
+# out, regardless of the `showmobile` setting.
+NON_COLLECTION_KEYWORDS = ["geschlossen", "Aktion Kompostverkauf"]
+
+
+def _to_bool(value) -> bool:
+    """Coerce a bool or a (possibly quoted YAML) string into a bool.
+
+    YAML configs sometimes pass booleans as quoted strings (e.g.
+    `showmobile: "False"`). A naive `bool("False")` evaluates to `True`
+    since any non-empty string is truthy, so this helper normalizes both
+    real booleans and their string representations.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return bool(value)
+
 
 class Source:
     def __init__(self, address, showmobile=False):
         self._address = address
-        self._showmobile = showmobile
+        self._showmobile = _to_bool(showmobile)
 
     def fetch(self):
         headers = {"referer": API_URL}
@@ -58,16 +80,22 @@ class Source:
 
         entries = []
         for entry in data["contents"]:
-            if (
-                "Wertstoffhof" not in data["contents"][entry]["title"]
-                or self._showmobile
+            title = data["contents"][entry]["title"]
+
+            if any(
+                keyword.lower() in title.lower() for keyword in NON_COLLECTION_KEYWORDS
             ):
-                entries.append(
-                    Collection(
-                        datetime.strptime(
-                            data["contents"][entry]["start"], "%Y-%m-%d %H:%M:%S"
-                        ).date(),
-                        data["contents"][entry]["title"],
-                    )
+                continue
+
+            if "Wertstoffhof" in title and not self._showmobile:
+                continue
+
+            entries.append(
+                Collection(
+                    datetime.strptime(
+                        data["contents"][entry]["start"], "%Y-%m-%d %H:%M:%S"
+                    ).date(),
+                    title,
                 )
+            )
         return entries


### PR DESCRIPTION
## Summary
- `showmobile` was stored verbatim from the constructor argument. When passed as a quoted YAML string (e.g. `showmobile: "False"`, as shown in this source's own documentation), `bool("False")` evaluates to `True` in Python, so the "Mobiler Wertstoffhof" filter never actually excluded anything — this is exactly what was reported in #4214.
- Added a `_to_bool()` helper that correctly normalizes both real booleans and their string representations.
- Additionally, always filter out "Wertstoffhof geschlossen" (recycling center closed) and "Aktion Kompostverkauf" (compost sale campaign) entries, since these are announcements rather than actual collection/drop-off events and should never appear as a "Collection", independent of `showmobile`.
- Added regression test cases covering `showmobile` as both a string `"False"` and a real bool `False`.

Fixes #4214

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python test_sources.py -s schweinfurt_de -l` against the live API — confirmed `showmobile: "False"` (string) now correctly excludes mobile Wertstoffhof entries, matching `showmobile: False` (bool)
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed