### PR TITLE
Add source for Grand Paris Sud Est Avenir (GPSEA), France

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -153,3 +153,4 @@ noe
 periode
 Periode
 Aktion
+aas

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
@@ -158,7 +158,7 @@ def _parse_precisi_dates(precisi: str, year: int) -> list[date]:
 
 
 def _weekly_dates(jour: str, start: date, end: date) -> list[date]:
-    weekdays = [DAY_MAP[d] for d in jour.split() if d in DAY_MAP]
+    weekdays = [DAY_MAP[d] for d in map(_normalize, jour.split()) if d in DAY_MAP]
     dates: list[date] = []
     for weekday in weekdays:
         d = start + timedelta(days=(weekday - start.weekday()) % 7)
@@ -169,7 +169,7 @@ def _weekly_dates(jour: str, start: date, end: date) -> list[date]:
 
 
 def _biweekly_dates(jour: str, pairimp: str, start: date, end: date) -> list[date]:
-    weekdays = [DAY_MAP[d] for d in jour.split() if d in DAY_MAP]
+    weekdays = [DAY_MAP[d] for d in map(_normalize, jour.split()) if d in DAY_MAP]
     dates: list[date] = []
     for weekday in weekdays:
         d = start + timedelta(days=(weekday - start.weekday()) % 7)
@@ -215,6 +215,7 @@ class Source:
             f"{API_BASE}/filters/getData",
             params={"dummy": int(time.time() * 1000)},
             data=data,
+            timeout=30,
         )
         r.raise_for_status()
         result = r.json()
@@ -273,7 +274,7 @@ class Source:
     def fetch(self) -> list[Collection]:
         session = requests.Session()
 
-        r = session.get(f"{APP_BASE}/index.html")
+        r = session.get(f"{APP_BASE}/index.html", timeout=30)
         r.raise_for_status()
         m = re.search(r"bgSessionId\s*=\s*'([^']+)'", r.text)
         if not m:
@@ -346,6 +347,7 @@ class Source:
                 "searchIds": SOURCE_ID,
                 "filters": json.dumps(search_filters),
             },
+            timeout=30,
         )
         r.raise_for_status()
         features = r.json().get("features", [])
@@ -364,6 +366,7 @@ class Source:
                 "idValue": feature_id,
                 "srs": "EPSG:3857",
             },
+            timeout=30,
         )
         r.raise_for_status()
         properties = r.json().get("properties", {})

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
@@ -27,6 +27,21 @@ FILTER_STREET_CONFIRM = "e3fd1e85-5188-11ea-9e88-250d8464572d"
 FILTER_NUMBER = "af552d94-f185-11e9-9256-e1c42467b095"
 INFOSHEET_ID = "2215b34d-11f1-11eb-8a48-9979b5aed361"
 
+# Communes covered by the GPSEA territory, as returned by the commune filter.
+COMMUNES = [
+    "Alfortville",
+    "Boissy-Saint-Léger",
+    "Bonneuil-sur-Marne",
+    "Chennevières-sur-Marne",
+    "Créteil",
+    "Limeil-Brévannes",
+    "Noiseau",
+    "Ormesson-sur-Marne",
+    "Le Plessis-Trévise",
+    "La Queue-en-Brie",
+    "Sucy-en-Brie",
+]
+
 WASTE_TYPES = {
     "om": "Ordures ménagères",
     "em": "Emballages",
@@ -70,6 +85,15 @@ MONTH_MAP = {
 
 WEEKLY_FREQUENCIES = {"HEBDOMADAIRE", "BIHEBDOMADAIRE", "TRIHEBDOMADAIRE"}
 
+EXTRA_INFO = [
+    {
+        "title": commune,
+        "url": URL,
+        "default_params": {"commune": commune},
+    }
+    for commune in COMMUNES
+]
+
 TEST_CASES = {
     "1 Place du Grand Pavois, Creteil": {
         "commune": "Creteil",
@@ -80,17 +104,17 @@ TEST_CASES = {
 
 PARAM_DESCRIPTIONS = {
     "en": {
-        "commune": "Your commune within the GPSEA territory",
+        "commune": "Your commune within the GPSEA territory: " + ", ".join(COMMUNES),
         "street": "Your street name",
         "house_number": "Your house number",
     },
     "fr": {
-        "commune": "Votre commune du territoire GPSEA",
+        "commune": "Votre commune du territoire GPSEA : " + ", ".join(COMMUNES),
         "street": "Le nom de votre voie",
         "house_number": "Votre numéro de voie",
     },
     "de": {
-        "commune": "Ihre Gemeinde im GPSEA-Gebiet",
+        "commune": "Ihre Gemeinde im GPSEA-Gebiet: " + ", ".join(COMMUNES),
         "street": "Ihr Straßenname",
         "house_number": "Ihre Hausnummer",
     },

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
@@ -1,0 +1,385 @@
+import json
+import re
+import time
+import unicodedata
+from datetime import date, timedelta
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+TITLE = "Grand Paris Sud Est Avenir (GPSEA)"
+DESCRIPTION = "Source script for sudestavenir.fr, waste collection schedules for the Grand Paris Sud Est Avenir (GPSEA) intercommunal territory"
+URL = "https://sudestavenir.fr/"
+COUNTRY = "fr"
+
+# GEO Software ("ACF") map application backing the address search widget on
+# sudestavenir.fr. IDs below are fixed configuration of that application,
+# discovered via its browser network traffic.
+APP_ID = "3394f2c6-49bc-11ea-90a1-114edab0a319"
+APP_BASE = f"https://geo.gpsea.fr/adws/app/{APP_ID}"
+API_BASE = f"{APP_BASE}/services/aas/v1"
+
+SOURCE_ID = "ecce3c92-5194-11ea-9e88-250d8464572d"
+FILTER_COMMUNE = "79029f6a-f185-11e9-9256-e1c42467b095"
+FILTER_STREET = "a09256bf-f185-11e9-9256-e1c42467b095"
+FILTER_STREET_CONFIRM = "e3fd1e85-5188-11ea-9e88-250d8464572d"
+FILTER_NUMBER = "af552d94-f185-11e9-9256-e1c42467b095"
+INFOSHEET_ID = "2215b34d-11f1-11eb-8a48-9979b5aed361"
+
+WASTE_TYPES = {
+    "om": "Ordures ménagères",
+    "em": "Emballages",
+    "ve": "Verre",
+    "ec": "Encombrants",
+    "dv": "Déchets végétaux",
+}
+
+ICON_MAP = {
+    "om": Icons.GENERAL_WASTE,
+    "em": Icons.RECYCLING,
+    "ve": Icons.GLASS,
+    "ec": Icons.BULKY,
+    "dv": Icons.GARDEN,
+}
+
+DAY_MAP = {
+    "lundi": 0,
+    "mardi": 1,
+    "mercredi": 2,
+    "jeudi": 3,
+    "vendredi": 4,
+    "samedi": 5,
+    "dimanche": 6,
+}
+
+MONTH_MAP = {
+    "janv": 1,
+    "fev": 2,
+    "mars": 3,
+    "avr": 4,
+    "mai": 5,
+    "juin": 6,
+    "juill": 7,
+    "aout": 8,
+    "sept": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+
+WEEKLY_FREQUENCIES = {"HEBDOMADAIRE", "BIHEBDOMADAIRE", "TRIHEBDOMADAIRE"}
+
+TEST_CASES = {
+    "1 Place du Grand Pavois, Creteil": {
+        "commune": "Creteil",
+        "street": "Place du Grand Pavois",
+        "house_number": "1",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "commune": "Your commune within the GPSEA territory",
+        "street": "Your street name",
+        "house_number": "Your house number",
+    },
+    "fr": {
+        "commune": "Votre commune du territoire GPSEA",
+        "street": "Le nom de votre voie",
+        "house_number": "Votre numéro de voie",
+    },
+    "de": {
+        "commune": "Ihre Gemeinde im GPSEA-Gebiet",
+        "street": "Ihr Straßenname",
+        "house_number": "Ihre Hausnummer",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {"commune": "Commune", "street": "Street", "house_number": "House number"},
+    "fr": {"commune": "Commune", "street": "Voie", "house_number": "Numéro"},
+    "de": {"commune": "Gemeinde", "street": "Straße", "house_number": "Hausnummer"},
+}
+
+
+def _strip_accents(s: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn"
+    )
+
+
+def _normalize(s: str) -> str:
+    return re.sub(r"\s+", " ", _strip_accents(s).lower().strip())
+
+
+def _parse_precisi_dates(precisi: str, year: int) -> list[date]:
+    dates: list[date] = []
+    for line in precisi.splitlines():
+        m = re.match(r"^([A-Za-zÀ-ÿ]+)\.\s*:\s*([\d\s\-]+)$", line.strip())
+        if not m:
+            continue
+        month = MONTH_MAP.get(_strip_accents(m.group(1)).lower().rstrip("."))
+        if month is None:
+            continue
+        for day_str in m.group(2).split("-"):
+            day_str = day_str.strip()
+            if not day_str.isdigit():
+                continue
+            try:
+                dates.append(date(year, month, int(day_str)))
+            except ValueError:
+                continue
+    return dates
+
+
+def _weekly_dates(jour: str, start: date, end: date) -> list[date]:
+    weekdays = [DAY_MAP[d] for d in jour.split() if d in DAY_MAP]
+    dates: list[date] = []
+    for weekday in weekdays:
+        d = start + timedelta(days=(weekday - start.weekday()) % 7)
+        while d <= end:
+            dates.append(d)
+            d += timedelta(weeks=1)
+    return dates
+
+
+def _biweekly_dates(jour: str, pairimp: str, start: date, end: date) -> list[date]:
+    weekdays = [DAY_MAP[d] for d in jour.split() if d in DAY_MAP]
+    dates: list[date] = []
+    for weekday in weekdays:
+        d = start + timedelta(days=(weekday - start.weekday()) % 7)
+        while d <= end:
+            iso_week = d.isocalendar()[1]
+            if (
+                not pairimp
+                or (pairimp == "PAIRE" and iso_week % 2 == 0)
+                or (pairimp == "IMPAIRE" and iso_week % 2 == 1)
+            ):
+                dates.append(d)
+            d += timedelta(weeks=1)
+    return dates
+
+
+class Source:
+    def __init__(self, commune: str, street: str, house_number: str):
+        self._commune = commune
+        self._street = street
+        self._house_number = str(house_number)
+
+    def _query_filter(
+        self,
+        session: requests.Session,
+        filters_id: str,
+        input_text: str,
+        filter_inputs: list[dict],
+        linked_ids: list[str],
+    ) -> list[dict]:
+        prefilter = {
+            "locale": "fr",
+            "filterInputs": filter_inputs,
+            "featureSelectionFilter": None,
+        }
+        data = {
+            "sourceId": SOURCE_ID,
+            "filtersId": filters_id,
+            "input": input_text,
+            "prefilter": json.dumps(prefilter),
+            "linkedFiltersIds": ",".join(linked_ids),
+        }
+        r = session.post(
+            f"{API_BASE}/filters/getData",
+            params={"dummy": int(time.time() * 1000)},
+            data=data,
+        )
+        r.raise_for_status()
+        result = r.json()
+        if not result:
+            return []
+        return result[0].get("values", {}).get("values", [])
+
+    def _resolve(
+        self,
+        session: requests.Session,
+        filters_id: str,
+        query: str,
+        filter_inputs: list[dict],
+        linked_ids: list[str],
+        argument_name: str,
+    ) -> dict:
+        candidates = self._query_filter(
+            session, filters_id, query, filter_inputs, linked_ids
+        )
+        target = _normalize(query)
+        for c in candidates:
+            if _normalize(str(c["label"])) == target:
+                return c
+        for c in candidates:
+            if target in _normalize(str(c["label"])):
+                return c
+
+        # Some filters (e.g. the commune list) ignore server-side text
+        # filtering and always return their full list only when queried
+        # with an empty input. Retry unfiltered and match locally.
+        if query:
+            candidates = self._query_filter(
+                session, filters_id, "", filter_inputs, linked_ids
+            )
+            for c in candidates:
+                if _normalize(str(c["label"])) == target:
+                    return c
+            for c in candidates:
+                if target in _normalize(str(c["label"])):
+                    return c
+
+        raise SourceArgumentNotFoundWithSuggestions(
+            argument_name, query, [str(c["label"]) for c in candidates]
+        )
+
+    @staticmethod
+    def _filter_input(filters_id: str, candidate: dict, from_suggestion: bool) -> dict:
+        return {
+            "id": filters_id,
+            "index": 0,
+            "label": candidate["label"],
+            "values": candidate["values"],
+            "fromSuggestion": from_suggestion,
+        }
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        r = session.get(f"{APP_BASE}/index.html")
+        r.raise_for_status()
+        m = re.search(r"bgSessionId\s*=\s*'([^']+)'", r.text)
+        if not m:
+            raise requests.exceptions.RequestException(
+                "Could not initialize GPSEA map session"
+            )
+        session.headers.update(
+            {
+                "X-BG-Session": m.group(1),
+                "X-Requested-With": "XMLHttpRequest",
+                "Referer": f"{APP_BASE}/index.html",
+            }
+        )
+
+        commune = self._resolve(
+            session, FILTER_COMMUNE, self._commune, [], [], "commune"
+        )
+        commune_input = self._filter_input(FILTER_COMMUNE, commune, False)
+
+        street = self._resolve(
+            session,
+            FILTER_STREET,
+            self._street,
+            [commune_input],
+            [FILTER_COMMUNE],
+            "street",
+        )
+        street_input = self._filter_input(FILTER_STREET, street, False)
+
+        confirm_candidates = self._query_filter(
+            session,
+            FILTER_STREET_CONFIRM,
+            " ",
+            [commune_input, street_input],
+            [FILTER_COMMUNE, FILTER_STREET],
+        )
+        confirm = confirm_candidates[0] if confirm_candidates else street
+        confirm_input = self._filter_input(FILTER_STREET_CONFIRM, confirm, True)
+
+        number = self._resolve(
+            session,
+            FILTER_NUMBER,
+            self._house_number,
+            [commune_input, street_input, confirm_input],
+            [FILTER_COMMUNE, FILTER_STREET, FILTER_STREET_CONFIRM],
+            "house_number",
+        )
+        number_input = self._filter_input(FILTER_NUMBER, number, False)
+
+        search_filters = {
+            "coordinateSystem": {"srid": 3857},
+            "currentObject": None,
+            "locale": "fr",
+            "filterInputs": [commune_input, street_input, confirm_input, number_input],
+            "infoSheetContext": None,
+            "featureSelectionFilter": {"features": [], "selectionCrs": "EPSG:3857"},
+        }
+        r = session.post(
+            f"{API_BASE}/searches/execute",
+            params={"dummy": int(time.time() * 1000)},
+            data={
+                "centroid": "true",
+                "simplifyGeometry": "false",
+                "srid": "EPSG:3857",
+                "useExtent": "true",
+                "throwErrors": "false",
+                "throwTimeoutErrors": "true",
+                "limit": "51",
+                "offset": "0",
+                "searchIds": SOURCE_ID,
+                "filters": json.dumps(search_filters),
+            },
+        )
+        r.raise_for_status()
+        features = r.json().get("features", [])
+        if not features:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "house_number", self._house_number, []
+            )
+        feature_id = features[0]["properties"]["id_auto"]
+
+        r = session.get(
+            f"{API_BASE}/infoSheets/getData",
+            params={
+                "dummy": int(time.time() * 1000),
+                "centroid": "false",
+                "id": INFOSHEET_ID,
+                "idValue": feature_id,
+                "srs": "EPSG:3857",
+            },
+        )
+        r.raise_for_status()
+        properties = r.json().get("properties", {})
+
+        entries: list[Collection] = []
+        today = date.today()
+        end = today + timedelta(days=365)
+        for prefix, label in WASTE_TYPES.items():
+            jour = properties.get(f"{prefix}_jour") or ""
+            frequen = properties.get(f"{prefix}_frequen") or ""
+            pairimp = properties.get(f"{prefix}_pairimp") or ""
+            precisi = properties.get(f"{prefix}_precisi")
+            am_pm = properties.get(f"{prefix}_am_pm")
+
+            if not frequen:
+                continue
+
+            description = (
+                "Matin" if am_pm == "AM" else "Après-midi" if am_pm == "PM" else None
+            )
+
+            if precisi:
+                # The server precomputes exact days-of-month for the current
+                # annual calendar only; day-of-week alignment shifts each
+                # year so these figures cannot be extrapolated to next year.
+                dates = [
+                    d for d in _parse_precisi_dates(precisi, today.year) if d >= today
+                ]
+            elif jour and frequen in WEEKLY_FREQUENCIES:
+                dates = _weekly_dates(jour, today, end)
+            elif jour and frequen == "QUINZAINE":
+                dates = _biweekly_dates(jour, pairimp, today, end)
+            else:
+                continue
+
+            for d in dates:
+                entries.append(
+                    Collection(
+                        date=d, t=label, icon=ICON_MAP[prefix], description=description
+                    )
+                )
+
+        return entries

--- a/doc/source/sudestavenir_fr.md
+++ b/doc/source/sudestavenir_fr.md
@@ -1,0 +1,52 @@
+# Grand Paris Sud Est Avenir (GPSEA)
+
+Support for waste collection schedules provided by [Grand Paris Sud Est Avenir (GPSEA)](https://sudestavenir.fr/), an intercommunal territory in the Val-de-Marne department of France, covering communes including Alfortville, Boissy-Saint-Léger, Bonneuil-sur-Marne, Chennevières-sur-Marne, Créteil, Limeil-Brévannes, Noiseau, Ormesson-sur-Marne, Le Plessis-Trévise, La Queue-en-Brie and Sucy-en-Brie.
+
+Collection days depend on the exact address (commune, street and house number) and are looked up live against GPSEA's interactive collection map.
+
+Depending on the waste type and address, the source returns either a recurring weekly/bi-weekly schedule (ordures ménagères, emballages) or a precomputed list of dates for the current calendar year (verre, encombrants, déchets végétaux), matching what the source website itself provides.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: sudestavenir_fr
+      args:
+        commune: Creteil
+        street: Place du Grand Pavois
+        house_number: 1
+```
+
+### Configuration Variables
+
+**commune**
+*(String) (required)*
+
+Your commune within the GPSEA territory.
+
+**street**
+*(String) (required)*
+
+Your street name.
+
+**house_number**
+*(String) (required)*
+
+Your house number.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: sudestavenir_fr
+      args:
+        commune: Creteil
+        street: Place du Grand Pavois
+        house_number: 1
+```
+
+## How to get the source argument
+
+Visit [https://sudestavenir.fr/](https://sudestavenir.fr/) and use the "Où jeter ?" / collection map to look up your commune, street and house number, or simply provide the same address details you would type into that map's search box.

--- a/doc/source/sudestavenir_fr.md
+++ b/doc/source/sudestavenir_fr.md
@@ -1,6 +1,18 @@
 # Grand Paris Sud Est Avenir (GPSEA)
 
-Support for waste collection schedules provided by [Grand Paris Sud Est Avenir (GPSEA)](https://sudestavenir.fr/), an intercommunal territory in the Val-de-Marne department of France, covering communes including Alfortville, Boissy-Saint-Léger, Bonneuil-sur-Marne, Chennevières-sur-Marne, Créteil, Limeil-Brévannes, Noiseau, Ormesson-sur-Marne, Le Plessis-Trévise, La Queue-en-Brie and Sucy-en-Brie.
+Support for waste collection schedules provided by [Grand Paris Sud Est Avenir (GPSEA)](https://sudestavenir.fr/), an intercommunal territory in the Val-de-Marne department of France, serving the following communes:
+
+- Alfortville
+- Boissy-Saint-Léger
+- Bonneuil-sur-Marne
+- Chennevières-sur-Marne
+- Créteil
+- Limeil-Brévannes
+- Noiseau
+- Ormesson-sur-Marne
+- Le Plessis-Trévise
+- La Queue-en-Brie
+- Sucy-en-Brie
 
 Collection days depend on the exact address (commune, street and house number) and are looked up live against GPSEA's interactive collection map.
 


### PR DESCRIPTION
## Summary

- Adds `sudestavenir_fr` source for the Grand Paris Sud Est Avenir (GPSEA) intercommunal territory in France (Val-de-Marne), closes #5399.
- The collection schedule is looked up live by address (commune, street, house number) against GPSEA's public interactive map, which runs on a "GEO Software"/ACF GIS platform (`geo.gpsea.fr`). The map itself exposes no documented feed, so the source replicates the exact request sequence the map's own JavaScript makes: bootstrap a session, resolve the address through a chained commune → street → house-number filter API, resolve the matched address to a feature via a search-execute call, then fetch that feature's info sheet, which contains the actual per-waste-type schedule (day-of-week, frequency, odd/even week parity, and for monthly/biweekly types, exact precomputed collection dates for the current year).
- 5 waste types are supported: ordures ménagères (general waste), emballages (packaging/recycling), verre (glass), encombrants (bulky waste), and déchets végétaux (green waste), each only produced when applicable to the given address.
- Adds `doc/source/sudestavenir_fr.md`.

## Test plan

- [x] `ruff check` / `ruff format` pass
- [x] `pre-commit` hooks (ruff, codespell) pass on commit
- [x] `python -m pytest tests/test_source_components.py` passed (structural checks: TITLE/DESCRIPTION/URL/COUNTRY/TEST_CASES/ICON_MAP/PARAM_TRANSLATIONS)
- [x] Live-tested against the real API with `test_sources.py -s sudestavenir_fr -l` for "1 Place du Grand Pavois, Créteil" — returns 279 correctly-typed, correctly-dated entries across all 4 applicable waste types for that address

🤖 Generated with [Claude Code](https://claude.com/claude-code)