### PR TITLE
Add City of Moreton Bay (QLD) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/moretonbay_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/moretonbay_qld_gov_au.py
@@ -1,0 +1,198 @@
+from datetime import date, timedelta
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "City of Moreton Bay"
+DESCRIPTION = "Source for City of Moreton Bay, Queensland, Australia."
+URL = "https://www.moretonbay.qld.gov.au"
+COUNTRY = "au"
+
+TEST_CASES = {
+    "25 Pumicestone Street, Bellara": {
+        "house_number": "25",
+        "street_name": "Pumicestone",
+        "suburb": "Bellara",
+    },
+    "74 North Street, Woorim": {
+        "house_number": 74,
+        "street_name": "North Street",
+        "suburb": "Woorim",
+    },
+    "8 Irene Street, Redcliffe": {
+        "house_number": "8",
+        "street_name": "Irene",
+        "suburb": "Redcliffe",
+    },
+}
+
+SOURCE_CODEOWNERS = ["@CRZTFR"]
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "house_number": "House number",
+        "street_name": "Street name",
+        "suburb": "Suburb",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "house_number": "The house/unit number, e.g. '25'",
+        "street_name": "The street name, e.g. 'Pumicestone' or 'Pumicestone Street'",
+        "suburb": "The suburb, e.g. 'Bellara'",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Enter your house number, street name and suburb exactly as they "
+        "appear on the City of Moreton Bay bin-day lookup at "
+        "https://www.moretonbay.qld.gov.au/Services/Waste-Recycling/Collections/Bin-Days. "
+        "The street name may be given with or without its street type "
+        "(e.g. 'Pumicestone' or 'Pumicestone Street')."
+    ),
+}
+
+# Public ArcGIS feature layer published on the City of Moreton Bay open-data
+# portal (datahub.moretonbay.qld.gov.au → "Property Waste Collection Days and
+# Recycle Weeks"). Each property parcel carries its collection weekday
+# (Bin_Day) and its recycling fortnight (Recycle_Week = "WEEK 1"/"WEEK 2").
+API_URL = (
+    "https://services-ap1.arcgis.com/152ojN3Ts9H3cdtl/arcgis/rest/services/"
+    "MBRC_Waste/FeatureServer/0/query"
+)
+
+ICON_MAP = {
+    "General Waste": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "Garden Organics": Icons.GARDEN,
+}
+
+_WEEKDAYS = {
+    "MONDAY": 0,
+    "TUESDAY": 1,
+    "WEDNESDAY": 2,
+    "THURSDAY": 3,
+    "FRIDAY": 4,
+    "SATURDAY": 5,
+    "SUNDAY": 6,
+}
+
+# Monday that starts a council "WEEK 1" recycling fortnight. Anchored to the
+# council bin-day lookup: a WEEK 1 property (25 Pumicestone Street, Bellara)
+# has its recycling collected Thu 16 Jul 2026, so the week of Mon 13 Jul 2026
+# is WEEK 1. Queensland does not observe daylight saving, so this fixed
+# fortnight parity stays correct all year. _week1_offset(d) == 0 means d falls
+# in a council "WEEK 1"; == 1 means "WEEK 2".
+WEEK1_REFERENCE = date(2026, 7, 13)
+
+_WEEKS_AHEAD = 12  # how many weekly general-waste events to emit
+
+
+def _week1_offset(d: date) -> int:
+    return ((d - WEEK1_REFERENCE).days // 7) % 2
+
+
+def _next_weekday(today: date, weekday: int) -> date:
+    return today + timedelta(days=(weekday - today.weekday()) % 7)
+
+
+class Source:
+    def __init__(self, house_number, street_name: str, suburb: str):
+        self._house_number = str(house_number).strip()
+        self._street_name = street_name.strip().upper()
+        self._suburb = suburb.strip().upper()
+
+    def _query(self) -> list[dict]:
+        # Escape single quotes to keep the ArcGIS WHERE clause well-formed.
+        house = self._house_number.replace("'", "''")
+        street = self._street_name.replace("'", "''")
+        suburb = self._suburb.replace("'", "''")
+        where = (
+            f"House_No='{house}' "
+            f"AND UPPER(Road) LIKE '%{street}%' "
+            f"AND UPPER(Suburb)='{suburb}'"
+        )
+        params = {
+            "where": where,
+            "outFields": "ADDRESS,Bin_Day,Recycle_Week",
+            "returnGeometry": "false",
+            "f": "json",
+        }
+        r = requests.get(API_URL, params=params, timeout=30)
+        r.raise_for_status()
+        return [f["attributes"] for f in r.json().get("features", [])]
+
+    def fetch(self) -> list[Collection]:
+        features = self._query()
+
+        if not features:
+            # Offer nearby house numbers on the same street/suburb as hints.
+            suggestions = self._suggestions()
+            raise SourceArgumentNotFoundWithSuggestions(
+                "house_number",
+                self._house_number,
+                suggestions,
+            )
+
+        attrs = features[0]
+        bin_day = (attrs.get("Bin_Day") or "").strip().upper()
+        recycle_week = (attrs.get("Recycle_Week") or "").strip().upper()
+
+        weekday = _WEEKDAYS.get(bin_day)
+        if weekday is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "house_number", self._house_number, []
+            )
+
+        today = date.today()
+        entries: list[Collection] = []
+
+        # General waste: weekly on the collection weekday.
+        d = _next_weekday(today, weekday)
+        for _ in range(_WEEKS_AHEAD):
+            entries.append(Collection(d, "General Waste", ICON_MAP["General Waste"]))
+            d += timedelta(weeks=1)
+
+        # Recycling: fortnightly on the collection weekday, in the property's
+        # recycle week. Garden organics is fortnightly on the opposite week.
+        recycle_offset = 0 if recycle_week == "WEEK 1" else 1
+        garden_offset = 1 - recycle_offset
+
+        for name, offset in (
+            ("Recycling", recycle_offset),
+            ("Garden Organics", garden_offset),
+        ):
+            d = _next_weekday(today, weekday)
+            if _week1_offset(d) != offset:
+                d += timedelta(weeks=1)
+            for _ in range(_WEEKS_AHEAD // 2):
+                entries.append(Collection(d, name, ICON_MAP[name]))
+                d += timedelta(weeks=2)
+
+        return entries
+
+    def _suggestions(self) -> list[str]:
+        street = self._street_name.replace("'", "''")
+        suburb = self._suburb.replace("'", "''")
+        params = {
+            "where": (f"UPPER(Road) LIKE '%{street}%' AND UPPER(Suburb)='{suburb}'"),
+            "outFields": "ADDRESS",
+            "returnGeometry": "false",
+            "returnDistinctValues": "true",
+            "f": "json",
+        }
+        try:
+            r = requests.get(API_URL, params=params, timeout=30)
+            r.raise_for_status()
+            return [
+                f["attributes"]["ADDRESS"]
+                for f in r.json().get("features", [])
+                if f["attributes"].get("ADDRESS")
+            ][:10]
+        except requests.RequestException:
+            return []

--- a/doc/source/moretonbay_qld_gov_au.md
+++ b/doc/source/moretonbay_qld_gov_au.md
@@ -1,0 +1,48 @@
+# City of Moreton Bay
+
+Support for schedules provided by [City of Moreton Bay](https://www.moretonbay.qld.gov.au/), Queensland, Australia.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: moretonbay_qld_gov_au
+      args:
+        house_number: HOUSE_NUMBER
+        street_name: STREET_NAME
+        suburb: SUBURB
+```
+
+### Configuration Variables
+
+**house_number**  
+*(string) (required)*
+
+**street_name**  
+*(string) (required)*  
+May be given with or without the street type, e.g. `Pumicestone` or `Pumicestone Street`.
+
+**suburb**  
+*(string) (required)*  
+The suburb, e.g. `Bellara`. Required to disambiguate street names that appear in more than one suburb.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: moretonbay_qld_gov_au
+      args:
+        house_number: "25"
+        street_name: Pumicestone
+        suburb: Bellara
+```
+
+## How to get the source arguments
+
+Enter your address at the [City of Moreton Bay bin-day lookup](https://www.moretonbay.qld.gov.au/Services/Waste-Recycling/Collections/Bin-Days) to confirm the exact street name and suburb. Then supply the house number, street name and suburb as the source arguments.
+
+## Notes
+
+General waste (red bin) is collected weekly. Recycling (yellow bin) and garden organics (lime green bin) are each collected fortnightly on the same weekday, on alternating weeks. Data is sourced from the council's public open-data feed (property waste collection days and recycle weeks).


### PR DESCRIPTION
## Description

Adds a new source for **City of Moreton Bay**, Queensland, Australia.

Moreton Bay is the largest Australian LGA (~532,000 residents) that was not yet covered by any existing source (verified against the source directory and the `impactapps_com_au` aggregator council list).

## Data source

Per-property collection data comes from the council's **public ArcGIS open-data feed** (published on `datahub.moretonbay.qld.gov.au` as *"Property Waste Collection Days and Recycle Weeks"*, layer `MBRC_Waste/FeatureServer/0`). No login, no scraping of the Cloudflare/Akamai-protected main site.

Each property carries its collection weekday (`Bin_Day`) and recycling fortnight (`Recycle_Week` = WEEK 1 / WEEK 2). The source queries by house number + street name + suburb.

## Collection model

- **General waste** (red) — weekly
- **Recycling** (yellow) — fortnightly, on the property's recycle week
- **Garden organics** (green) — fortnightly, on the alternating week

The Week 1/Week 2 fortnight parity is anchored to a known datapoint from the council's own bin-day lookup (documented in a code comment). Queensland does not observe daylight saving, so the fixed parity holds year-round.

## Testing

- `TEST_CASES` verified live against the ArcGIS feed.
- Output cross-checked against the council bin-day lookup for `25 Pumicestone Street, Bellara` (general waste + recycling Thu 16/7/2026, garden organics Thu 23/7/2026 — matches exactly).
- `tests/test_source_components.py` passes (10/10).
- `ruff check` / `ruff format` clean.
- `doc/source/moretonbay_qld_gov_au.md` included.