### PR TITLE
docs(recycleapp_be): document Ivago (Gent) coverage, add test case

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recycleapp_be.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recycleapp_be.py
@@ -41,6 +41,11 @@ TEST_CASES = {
         "street": "Abelendreef",
         "house_number": 1,
     },
+    "9040 Gent (Ivago), Krekelberg 1": {
+        "postcode": 9040,
+        "street": "Krekelberg",
+        "house_number": 1,
+    },
     "8700 Abeelstraat 1": {
         "postcode": 8700,
         "street": "Abeelstraat",

--- a/doc/source/recycleapp_be.md
+++ b/doc/source/recycleapp_be.md
@@ -2,6 +2,8 @@
 
 Support for schedules provided by [Recycle / recycleapp.be](https://www.recycleapp.be/).
 
+This source works for any Belgian municipality on the Fost Plus / RecycleApp.be platform — including local operators that present their own branded collection calendar on top of the same backend, e.g. [Ivago](https://www.ivago.be/) (Gent). If your local waste operator isn't listed by name anywhere in this repo, try this source with your postcode/street/house number before requesting a new one — it likely already works.
+
 ## Configuration via configuration.yaml
 
 ```yaml


### PR DESCRIPTION
## Summary
- Ivago's Gent collection calendar runs on the same Fost Plus / RecycleApp.be backend already supported by the generic `recycleapp_be` source — no core logic changes needed.
- Adds a verified test case for Gent/Ivago (postcode 9040, Krekelberg 1) confirmed live against the API (20 collection entries returned, including one literally labeled "Glas (IVAGO)").
- Adds a short doc note to `doc/source/recycleapp_be.md` so future searches for "Ivago" or "Gent" find this generic source, since it has no per-municipality documentation.

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check` / `ruff format` clean on the edited source file
- [x] New test case verified live against the RecycleApp.be API for postcode 9040, street Krekelberg, house_number 1

Closes #5034