### PR TITLE
Add source for Mildura Rural City Council (VIC, AU)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mildura_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mildura_vic_gov_au.py
@@ -1,0 +1,120 @@
+import json
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+from curl_cffi import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+TITLE = "Mildura Rural City Council"
+DESCRIPTION = "Source for Mildura Rural City Council waste collection."
+URL = "https://www.mildura.vic.gov.au"
+TEST_CASES = {
+    "Stockmans Drive": {"street_address": "1 Stockmans Drive, Irymple VIC 3498"},
+    "Deakin Avenue": {"street_address": "76 Deakin Avenue, Mildura VIC 3500"},
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street_address": "Full street address including suburb and postcode, e.g. '1 Stockmans Drive, Irymple VIC 3498'",
+    }
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Go to <https://www.mildura.vic.gov.au/Explore/My-Neighbourhood> and make sure your address matches the auto-complete suggestions."
+}
+
+API_URLS = {
+    "address_search": "https://www.mildura.vic.gov.au/api/v1/myarea/search",
+    "collection": "https://www.mildura.vic.gov.au/ocapi/Public/myarea/wasteservices",
+}
+
+HEADERS = {
+    "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+    "accept": "text/plain, */*; q=0.01",
+    "Referer": "https://www.mildura.vic.gov.au/Services/Waste-and-Recycling/My-bins/Find-your-bin-day",
+    "X-Requested-With": "XMLHttpRequest",
+}
+
+ICON_MAP = {
+    "Organics Waste": Icons.BIO_KITCHEN,
+    "Landfill Waste": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "Glass": Icons.GLASS,
+}
+
+
+class Source:
+    def __init__(self, street_address: str):
+        self._street_address = street_address
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session(impersonate="chrome")
+
+        # Step 1: search for the address to get its geolocation id
+        r = session.get(
+            API_URLS["address_search"],
+            params={"keywords": self._street_address},
+            headers=HEADERS,
+        )
+        r.raise_for_status()
+
+        data = json.loads(r.text)
+
+        items = data.get("Items") or []
+        if not items:
+            raise SourceArgumentNotFound(
+                "street_address",
+                self._street_address,
+                "Check your address at https://www.mildura.vic.gov.au/Explore/My-Neighbourhood",
+            )
+
+        location_id = items[0]["Id"]
+
+        # Step 2: retrieve the upcoming collections for the property
+        r = session.get(
+            API_URLS["collection"],
+            params={"geolocationid": location_id, "ocsvclang": "en-AU"},
+            headers=HEADERS,
+        )
+        r.raise_for_status()
+
+        data = json.loads(r.text)
+
+        response_content = data["responseContent"]
+
+        soup = BeautifulSoup(response_content, "html.parser")
+        services = soup.find_all("div", attrs={"class": "waste-services-result"})
+
+        entries = []
+
+        for item in services:
+            date_text = item.find("div", attrs={"class": "next-service"})
+            if date_text is None:
+                continue
+
+            date_format = "%a %d/%m/%Y"
+
+            try:
+                cleaned_date_text = (
+                    date_text.text.replace("\r", "").replace("\n", "").strip()
+                )
+                date = datetime.strptime(cleaned_date_text, date_format).date()
+            except ValueError:
+                # Non-date entries, e.g. "Bin Collection Area: You are in Area 1"
+                continue
+
+            waste_type_h3 = item.find("h3")
+            if waste_type_h3 is None:
+                continue
+            waste_type = waste_type_h3.text.strip()
+
+            entries.append(
+                Collection(
+                    date=date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type, Icons.GENERAL_WASTE),
+                )
+            )
+
+        return entries

--- a/doc/source/mildura_vic_gov_au.md
+++ b/doc/source/mildura_vic_gov_au.md
@@ -1,0 +1,43 @@
+# Mildura Rural City Council
+
+Support for schedules provided by [Mildura Rural City Council](https://www.mildura.vic.gov.au/Services/Waste-and-Recycling/My-bins/Find-your-bin-day).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mildura_vic_gov_au
+      args:
+        street_address: STREET_ADDRESS
+```
+
+### Configuration Variables
+
+**street_address**  
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mildura_vic_gov_au
+      args:
+        street_address: 1 Stockmans Drive, Irymple VIC 3498
+```
+
+## How to get the source arguments
+
+Visit the [Mildura Rural City Council - My Neighbourhood](https://www.mildura.vic.gov.au/Explore/My-Neighbourhood) page and search for your address. The street address used to configure hacs_waste_collection_schedule should match the address shown in the autocomplete suggestions, including suburb and postcode.
+
+## Collection types
+
+The following waste types are returned by this source:
+
+| Type | Icon |
+|------|------|
+| Organics Waste | mdi:food-apple |
+| Landfill Waste | mdi:trash-can |
+| Recycling | mdi:recycle |
+| Glass | mdi:bottle-soda |


### PR DESCRIPTION
## Summary
- Adds a new source for Mildura Rural City Council (VIC, Australia), fulfilling #5043.
- Uses the same Granicus/OpenCities "My Neighbourhood" address-search + `ocapi/Public/myarea/wasteservices` API already used by several other Australian council sources in this repo (e.g. Hume, Moorabool, Warrnambool).
- Requires `curl_cffi` (`impersonate="chrome"`) since the site is behind Akamai bot protection and rejects plain `requests`.

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python test_sources.py -s mildura_vic_gov_au -l` returns live collection data for two independent addresses

Closes #5043