### PR TITLE
fix(hausmuell_info): correctly detect "no match" search responses

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hausmuell_info.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hausmuell_info.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ICS import ICS
 
 TITLE = "hausmüll.info"
@@ -242,8 +243,20 @@ class Source:
         to_return = [i.strip() for i in ids if i.strip().isdigit()]
         return to_return
 
+    def _has_result(self, response_text: str) -> bool:
+        """Check whether a search response actually contains a matching entry.
+
+        The API returns a `<li>` with an `onclick` attribute for a real match,
+        and either an empty `<ul>` or a `<li>Keinen Eintrag gefunden</li>`
+        (no `onclick`) when nothing matches.
+        """
+        li = BeautifulSoup(response_text, "html.parser").find("li")
+        if not li:
+            return False
+        return bool(li.get("onclick"))
+
     def request_all(
-        self, url: str, data: dict, params: dict, error_message: str
+        self, url: str, data: dict, params: dict, argument: str, value: str
     ) -> requests.Response:
         """Request url with data if not successful retry with different kinds of replaced special chars.
 
@@ -251,23 +264,24 @@ class Source:
             url (str): url to request
             data (dict): data to send
             params (dict): params to send
-            error_message (str): error message to raise if all requests fail
+            argument (str): name of the source argument being searched for (as in Source.__init__)
+            value (str): value of that source argument, used for the error message
 
         Raises:
-            Exception: if all requests fail
+            SourceArgumentNotFound: if all requests fail to find a match
 
         Returns:
             requests.Response: the successful response
         """
         r = requests.post(url, data=data, params=params)
-        if "kein Eintrag gefunden" not in r.text and not r.text.strip() == "<ul></ul>":
+        if self._has_result(r.text):
             return r
         r = requests.post(
             url,
             data=replace_special_chars_args(data),
             params=replace_special_chars_args(params),
         )
-        if "kein Eintrag gefunden" not in r.text and not r.text.strip() == "<ul></ul>":
+        if self._has_result(r.text):
             return r
         r = requests.post(
             url,
@@ -276,9 +290,9 @@ class Source:
             ),
             params=replace_special_chars_args(params),
         )
-        if "kein Eintrag gefunden" not in r.text and not r.text.strip() == "<ul></ul>":
+        if self._has_result(r.text):
             return r
-        raise Exception(error_message)
+        raise SourceArgumentNotFound(argument, value)
 
     def fetch(self):
         args = {
@@ -316,7 +330,8 @@ class Source:
                 self._search_url + "search_orte.php",
                 args,
                 {"input": self._ort, "ort_id": "0"},
-                "Ort provided but not found in search results.",
+                "ort",
+                self._ort,
             )
 
             ids = self._get_elemts(r.text)
@@ -329,7 +344,8 @@ class Source:
                 self._search_url + "search_ortsteile.php",
                 args,
                 {"input": self._ortsteil, "ort_id": args["ort_id"]},
-                "Ortsteil provided but not found in search results.",
+                "ortsteil",
+                self._ortsteil,
             )
 
             ids = self._get_elemts(r.text)
@@ -345,7 +361,8 @@ class Source:
                 self._search_url + "search_strassen.php",
                 args,
                 {"input": self._strasse, "str_id": "0", "ort_id": args["ort_id"]},
-                "Strasse provided but not found in search results.",
+                "strasse",
+                self._strasse,
             )
             ids = self._get_elemts(r.text)
             args["hidden_id_str"] = args["str_id"] = ids[0]
@@ -358,7 +375,8 @@ class Source:
                 self._search_url + "search_hnr.php",
                 args,
                 {"input": self._hausnummer, "hnr_id": "0", "str_id": args["str_id"]},
-                "hausnummer provided but not found in search results.",
+                "hausnummer",
+                self._hausnummer,
             )
 
             ids = self._get_elemts(r.text)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hausmuell_info.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hausmuell_info.py
@@ -250,10 +250,12 @@ class Source:
         and either an empty `<ul>` or a `<li>Keinen Eintrag gefunden</li>`
         (no `onclick`) when nothing matches.
         """
-        li = BeautifulSoup(response_text, "html.parser").find("li")
-        if not li:
-            return False
-        return bool(li.get("onclick"))
+        return (
+            BeautifulSoup(response_text, "html.parser").find(
+                "li", attrs={"onclick": True}
+            )
+            is not None
+        )
 
     def request_all(
         self, url: str, data: dict, params: dict, argument: str, value: str


### PR DESCRIPTION
## Summary
- `Source.request_all()` in `hausmuell_info.py` detected a failed/empty search response by checking for the literal strings `"kein Eintrag gefunden"` and `"<ul></ul>"`. Live testing against `wesel.hausmuell.info` shows the real API responses are `"Keinen Eintrag gefunden"` (capitalized, plural) and `"<ul class = 'proposalList'></ul>"` — neither matches the checked literals, so every first-attempt response was (incorrectly) treated as successful, the retry-with-special-chars fallback never ran, and a real "not found" case fell through to a generic, unhelpful `ValueError("No Valid response, please check your configuration.")`.
- Replaced the broken string checks with `_has_result()`, which parses the response and checks for an `onclick` attribute on the matched `<li>` (the same signal `_get_elemts()` already relies on).
- `request_all()` now raises `SourceArgumentNotFound(argument, value)` instead of a generic `Exception`, giving a clear, argument-specific message.

Fixes #5189

## Test plan
- [x] `python test_sources.py -s hausmuell_info -l` — all 13 existing `TEST_CASES` still pass with identical entry counts.
- [x] Manually reproduced the reported error live against `wesel.hausmuell.info` with `ort="Wesel"` (the value from the bug report) and confirmed it now raises `SourceArgumentNotFound: We could not find values for the argument 'ort' with the value 'Wesel', please check the spelling and try again.` instead of the opaque generic error.
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed.