### PR TITLE
fix(rd4_nl): add house_number_extension parameter support

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rd4_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rd4_nl.py
@@ -24,9 +24,15 @@ API_URL = "https://data.rd4.nl/api/v1/waste-calendar"
 
 
 class Source:
-    def __init__(self, postal_code: str, house_number: str | int):
+    def __init__(
+        self,
+        postal_code: str,
+        house_number: str | int,
+        house_number_extension: str | None = None,
+    ):
         self._postal_code: str = postal_code
         self._house_number: str | int = house_number
+        self._house_number_extension: str | None = house_number_extension
 
     def fetch(self) -> list[Collection]:
         now = datetime.now()
@@ -59,6 +65,9 @@ class Source:
             "house_number": self._house_number,
             "year": year,
         }
+
+        if self._house_number_extension:
+            args["house_number_extension"] = self._house_number_extension
 
         # get json file
         r = requests.get(API_URL, params=args)

--- a/doc/source/rd4_nl.md
+++ b/doc/source/rd4_nl.md
@@ -11,7 +11,7 @@ waste_collection_schedule:
       args:
         postal_code: POSTAL CODE (postcode)
         house_number: "HOUSE NUMBER (huisnummer)"
-        
+        house_number_extension: "HOUSE NUMBER EXTENSION (toevoeging, optional)"
 ```
 
 ### Configuration Variables
@@ -22,6 +22,10 @@ waste_collection_schedule:
 **house_number**  
 *(String | Integer) (required)*
 
+**house_number_extension**  
+*(String) (optional)*  
+House number extension (toevoeging), e.g. `"A"`, `"B"`, `"bis"`. Only needed if your address has an extension.
+
 ## Example
 
 ```yaml
@@ -31,7 +35,18 @@ waste_collection_schedule:
       args:
         postal_code: 6417 AT
         house_number: "32"
-        
+```
+
+With house number extension:
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: rd4_nl
+      args:
+        postal_code: 6417 AT
+        house_number: "32"
+        house_number_extension: "A"
 ```
 
 ## How to get the source argument


### PR DESCRIPTION
## Summary

- Add `house_number_extension: str | None = None` optional parameter to `rd4_nl.Source.__init__()`
- Pass it through to the `data.rd4.nl` API only when a non-empty value is provided
- Update `doc/source/rd4_nl.md` to document the new parameter and add a YAML example with it

Closes #5032.

## Test plan

- [x] Existing test case `6417 AT 32` still returns entries (no regression)
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `ruff check --fix` + `ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)