### PR TITLE
Add Landkreis Reutlingen (Wannweil) to abfall.io GraphQL source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -10,4 +10,9 @@ SERVICE_MAP = [
         "service_id": "1c230a689579b6d3ddb9ceb5a56c6072",
         "country": "at",
     },
+    {
+        "title": "Landkreis Reutlingen",
+        "url": "https://www.kreis-reutlingen.de/",
+        "service_id": "15f69fab91c4cae50d9dbb5bcfd383f0",
+    },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -57,6 +57,10 @@ TEST_CASES = {
         "key": "1c230a689579b6d3ddb9ceb5a56c6072",
         "idHouseNumber": 31972,
     },
+    "Landkreis Reutlingen, Wannweil, Bahnhofstraße 5": {
+        "key": "15f69fab91c4cae50d9dbb5bcfd383f0",
+        "idHouseNumber": 58444,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Adds Landkreis Reutlingen to the `abfall_io_graphql` shared-platform `SERVICE_MAP`, resolving #6880 (Wannweil, Germany source request).
- The provider's collection-schedule page (kreis-reutlingen.de) embeds the abfall.io v3 widget with service key `15f69fab91c4cae50d9dbb5bcfd383f0`, which is not usable with the legacy `abfall_io` source (401) but works with the existing v3 GraphQL implementation.
- Adds a `TEST_CASES` entry for Bahnhofstraße 5, Wannweil (the example address from the issue) to exercise this provider in CI.
- Since the key covers the whole Landkreis (not just Wannweil), this also enables every other municipality in Landkreis Reutlingen via the same `key`.

## Test plan
- [x] `ruff check --fix` / `ruff format` on both changed files
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] Live test: `python test_sources.py -s abfall_io_graphql -l` returns 39 real collection entries for the new Wannweil test case, and all pre-existing test cases still pass

Closes #6880