### PR TITLE
Add Viborg (Revas) to Affaldonline source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
@@ -117,6 +117,12 @@ AFFALDONLINE_MUNICIPALITIES = {
         "parser": "default",
         "values": "Nørregade|69||||7100|Vejle|16285351|16285351|0",
     },
+    "viborg": {
+        "title": "Revas (Viborg Kommune)",
+        "url": "https://www.revas.dk/",
+        "parser": "default",
+        "values": "Hjultorvet|1||||8800|Viborg|8228245|8739|0",
+    },
 }
 
 EXTRA_INFO = [

--- a/doc/source/affaldonline_dk.md
+++ b/doc/source/affaldonline_dk.md
@@ -47,6 +47,7 @@ Go to the Affaldonline site for your municipality:
 - [Silkeborg](https://www.affaldonline.dk/kalender/silkeborg/)
 - [Sorø](https://www.affaldonline.dk/kalender/soroe/)
 - [Vejle](https://www.affaldonline.dk/kalender/vejle/)
+- [Viborg (Revas)](https://www.affaldonline.dk/kalender/viborg/)
 
 Open the developer console in your browser.
 


### PR DESCRIPTION
## Summary
- Adds Viborg Kommune (waste operator "Revas") to the existing `affaldonline_dk` shared source, which already covers several Danish municipalities served by the Affaldonline platform.
- Viborg's `showInfo.php` response uses the same format already handled by the "default" parser, verified against a live address.

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed source file
- [x] Live-fetched Viborg data via `test_sources.py`: returned correct entries (`Mad`, `Rest` on the same date) for a real Viborg address
- [x] `python -m pytest tests/test_source_components.py -q` passes

Closes #5681