### PR TITLE
feat(source): add CEM Ambiente (cem_ambiente_it)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cem_ambiente_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cem_ambiente_it.py
@@ -1,0 +1,227 @@
+from datetime import datetime
+from difflib import get_close_matches
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+TITLE = "CEM Ambiente"
+DESCRIPTION = "Source for CEM Ambiente (CEM FACILE), covering municipalities in the Milano / Monza e Brianza / Lodi area of Italy."
+URL = "https://www.cemambiente.it"
+COUNTRY = "it"
+
+API_URL = "https://cemfacile.cemambiente.it"
+
+EXTRA_INFO = [
+    {"title": "Agrate Brianza", "country": "it"},
+    {"title": "Aicurzio", "country": "it"},
+    {"title": "Arcore", "country": "it"},
+    {"title": "Basiano", "country": "it"},
+    {"title": "Bellinzago Lombardo", "country": "it"},
+    {"title": "Bellusco", "country": "it"},
+    {"title": "Bernareggio", "country": "it"},
+    {"title": "Borgo San Giovanni", "country": "it"},
+    {"title": "Brugherio", "country": "it"},
+    {"title": "Burago Di Molgora", "country": "it"},
+    {"title": "Busnago", "country": "it"},
+    {"title": "Bussero", "country": "it"},
+    {"title": "Cambiago", "country": "it"},
+    {"title": "Camparada", "country": "it"},
+    {"title": "Caponago", "country": "it"},
+    {"title": "Carnate", "country": "it"},
+    {"title": "Carpiano", "country": "it"},
+    {"title": "Carugate", "country": "it"},
+    {"title": "Casaletto Lodigiano", "country": "it"},
+    {"title": "Casalmaiocco", "country": "it"},
+    {"title": "Caselle Lurani", "country": "it"},
+    {"title": "Cassano D'Adda", "country": "it"},
+    {"title": "Cassina De' Pecchi", "country": "it"},
+    {"title": "Cavenago Di Brianza", "country": "it"},
+    {"title": "Cernusco Sul Naviglio", "country": "it"},
+    {"title": "Cerro Al Lambro", "country": "it"},
+    {"title": "Cervignano D'Adda", "country": "it"},
+    {"title": "Cologno Monzese", "country": "it"},
+    {"title": "Colturano", "country": "it"},
+    {"title": "Comazzo", "country": "it"},
+    {"title": "Concorezzo", "country": "it"},
+    {"title": "Cornate D'Adda", "country": "it"},
+    {"title": "Correzzana", "country": "it"},
+    {"title": "Dresano", "country": "it"},
+    {"title": "Gessate", "country": "it"},
+    {"title": "Gorgonzola", "country": "it"},
+    {"title": "Grezzago", "country": "it"},
+    {"title": "Inzago", "country": "it"},
+    {"title": "Lesmo", "country": "it"},
+    {"title": "Liscate", "country": "it"},
+    {"title": "Macherio", "country": "it"},
+    {"title": "Masate", "country": "it"},
+    {"title": "Massalengo", "country": "it"},
+    {"title": "Mediglia", "country": "it"},
+    {"title": "Melegnano", "country": "it"},
+    {"title": "Melzo", "country": "it"},
+    {"title": "Merlino", "country": "it"},
+    {"title": "Mezzago", "country": "it"},
+    {"title": "Mulazzano", "country": "it"},
+    {"title": "Ornago", "country": "it"},
+    {"title": "Pantigliate", "country": "it"},
+    {"title": "Paullo", "country": "it"},
+    {"title": "Pessano Con Bornago", "country": "it"},
+    {"title": "Pozzo D'Adda", "country": "it"},
+    {"title": "Pozzuolo Martesana", "country": "it"},
+    {"title": "Rodano", "country": "it"},
+    {"title": "Roncello", "country": "it"},
+    {"title": "Ronco Briantino", "country": "it"},
+    {"title": "Salerano sul Lambro", "country": "it"},
+    {"title": "San Zenone Al Lambro", "country": "it"},
+    {"title": "Sant'Angelo Lodigiano", "country": "it"},
+    {"title": "Settala", "country": "it"},
+    {"title": "Sordio", "country": "it"},
+    {"title": "Sulbiate", "country": "it"},
+    {"title": "Torrevecchia Pia", "country": "it"},
+    {"title": "Trezzano Rosa", "country": "it"},
+    {"title": "Trezzo Sull'Adda", "country": "it"},
+    {"title": "Tribiano", "country": "it"},
+    {"title": "Truccazzano", "country": "it"},
+    {"title": "Usmate Velate", "country": "it"},
+    {"title": "Vaprio D'Adda", "country": "it"},
+    {"title": "Vedano Al Lambro", "country": "it"},
+    {"title": "Vignate", "country": "it"},
+    {"title": "Villasanta", "country": "it"},
+    {"title": "Vimercate", "country": "it"},
+    {"title": "Vimodrone", "country": "it"},
+    {"title": "Vizzolo Predabissi", "country": "it"},
+]
+
+TEST_CASES = {
+    "Vimodrone, Via Aldo Moro": {"city": "Vimodrone", "street": "Via Aldo Moro"},
+    "Cologno Monzese, Via Cadore": {"city": "Cologno Monzese", "street": "Via Cadore"},
+    "Vimercate, Via Cesare Battisti": {
+        "city": "Vimercate",
+        "street": "Via Cesare Battisti",
+    },
+}
+
+ICON_MAP = {
+    "UMI": Icons.BIO_KITCHEN,  # Raccolta Umido (food waste)
+    "VER": Icons.GARDEN,  # Raccolta Verde (garden waste)
+    "CAR": Icons.PAPER,  # Raccolta Carta
+    "VET": Icons.GLASS,  # Raccolta Vetro
+    "MUL": Icons.PLASTIC_PACKAGING,  # Raccolta Multipak (plastic + metal)
+    "APL": Icons.PLASTIC_PACKAGING,  # Raccolta Altre Plastiche
+    "SEC": Icons.GENERAL_WASTE,  # Raccolta Secco
+    "ECU": Icons.GENERAL_WASTE,  # Raccolta Ecuosacco
+    "STP": Icons.GENERAL_WASTE,  # Raccolta Ecuosacco puntuale
+}
+
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter the municipality (comune) and street (via) exactly as they are "
+    "known to CEM Ambiente, e.g. as shown on https://www.cemambiente.it/cemfacile/. "
+    "If the exact spelling isn't found, the error message will list the closest "
+    "matching street names for your municipality.",
+    "it": "Inserisci il comune e la via esattamente come sono indicati da CEM "
+    "Ambiente, ad esempio come mostrato su https://www.cemambiente.it/cemfacile/. "
+    "Se l'ortografia esatta non viene trovata, il messaggio di errore elencherà le "
+    "vie più simili per il tuo comune.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "city": "The municipality served by CEM Ambiente (e.g. 'Vimodrone').",
+        "street": "The street name as listed by CEM Ambiente for the selected "
+        "municipality (e.g. 'Via Aldo Moro').",
+    },
+    "it": {
+        "city": "Il comune servito da CEM Ambiente (ad esempio 'Vimodrone').",
+        "street": "Il nome della via come indicato da CEM Ambiente per il comune "
+        "selezionato (ad esempio 'Via Aldo Moro').",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "city": "City",
+        "street": "Street",
+    },
+    "it": {
+        "city": "Comune",
+        "street": "Via",
+    },
+}
+
+
+class Source:
+    def __init__(self, city: str, street: str):
+        self._city: str = city
+        self._street: str = street
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        r = session.post(f"{API_URL}/public/listComuni", json={})
+        r.raise_for_status()
+        comuni = r.json().get("body", [])
+
+        comune = next(
+            (
+                c
+                for c in comuni
+                if str(c.get("nome", "")).casefold() == self._city.strip().casefold()
+            ),
+            None,
+        )
+        if comune is None:
+            all_names = [c.get("nome", "") for c in comuni]
+            suggestions = get_close_matches(self._city, all_names, n=5, cutoff=0.4)
+            raise SourceArgumentNotFoundWithSuggestions(
+                "city", self._city, suggestions or sorted(all_names)
+            )
+
+        id_siunet = comune["idSiunet"]
+
+        r = session.post(f"{API_URL}/public/listVie", json={"idSiunet": id_siunet})
+        r.raise_for_status()
+        vie = r.json().get("body", [])
+
+        via = next(
+            (
+                v
+                for v in vie
+                if str(v.get("nome", "")).casefold() == self._street.strip().casefold()
+            ),
+            None,
+        )
+        if via is None:
+            all_streets = [v.get("nome", "") for v in vie]
+            suggestions = get_close_matches(self._street, all_streets, n=5, cutoff=0.4)
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street", self._street, suggestions or sorted(all_streets)
+            )
+
+        r = session.post(
+            f"{API_URL}/public/getCalendario",
+            json={
+                "idSiunet": id_siunet,
+                "idVia": via["idVia"],
+                "nomeVia": via["nome"],
+            },
+        )
+        r.raise_for_status()
+        servizi = r.json().get("body", [])
+
+        entries: list[Collection] = []
+        for item in servizi:
+            date_str = item.get("data")
+            servizio = item.get("servizio")
+            if not date_str or not servizio:
+                continue
+
+            date = datetime.fromisoformat(date_str).date()
+
+            tipologia = item.get("tipologiaServizio") or ""
+            code = tipologia.split(" - ")[0].strip()
+            icon = ICON_MAP.get(code)
+
+            entries.append(Collection(date=date, t=servizio, icon=icon))
+
+        return entries

--- a/doc/source/cem_ambiente_it.md
+++ b/doc/source/cem_ambiente_it.md
@@ -1,0 +1,52 @@
+# CEM Ambiente
+
+Support for waste collection schedules provided by [CEM Ambiente](https://www.cemambiente.it) (CEM FACILE), covering municipalities in the Milano / Monza e Brianza / Lodi area of Italy.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cem_ambiente_it
+      args:
+        city: "Vimodrone"
+        street: "Via Aldo Moro"
+```
+
+### Configuration Variables
+
+**city**
+*(string) (required)*
+
+The municipality (comune) served by CEM Ambiente, e.g. `Vimodrone`.
+
+**street**
+*(string) (required)*
+
+The street name (via) as listed by CEM Ambiente for the selected municipality, e.g. `Via Aldo Moro`.
+
+## How to find your city and street
+
+1. Open [https://www.cemambiente.it/cemfacile/](https://www.cemambiente.it/cemfacile/) and select your municipality and street to confirm the exact spelling used by CEM Ambiente.
+2. Use those exact values for `city` and `street` in your configuration.
+3. If the spelling doesn't match exactly, the integration will raise an error listing the closest matching names it found for your municipality.
+
+## Supported municipalities
+
+Agrate Brianza, Aicurzio, Arcore, Basiano, Bellinzago Lombardo, Bellusco, Bernareggio, Borgo San Giovanni, Brugherio, Burago Di Molgora, Busnago, Bussero, Cambiago, Camparada, Caponago, Carnate, Carpiano, Carugate, Casaletto Lodigiano, Casalmaiocco, Caselle Lurani, Cassano D'Adda, Cassina De' Pecchi, Cavenago Di Brianza, Cernusco Sul Naviglio, Cerro Al Lambro, Cervignano D'Adda, Cologno Monzese, Colturano, Comazzo, Concorezzo, Cornate D'Adda, Correzzana, Dresano, Gessate, Gorgonzola, Grezzago, Inzago, Lesmo, Liscate, Macherio, Masate, Massalengo, Mediglia, Melegnano, Melzo, Merlino, Mezzago, Mulazzano, Ornago, Pantigliate, Paullo, Pessano Con Bornago, Pozzo D'Adda, Pozzuolo Martesana, Rodano, Roncello, Ronco Briantino, Salerano sul Lambro, San Zenone Al Lambro, Sant'Angelo Lodigiano, Settala, Sordio, Sulbiate, Torrevecchia Pia, Trezzano Rosa, Trezzo Sull'Adda, Tribiano, Truccazzano, Usmate Velate, Vaprio D'Adda, Vedano Al Lambro, Vignate, Villasanta, Vimercate, Vimodrone, Vizzolo Predabissi.
+
+## Bin types returned
+
+| Provider `tipologiaServizio` prefix | Meaning | Icon |
+|---|---|---|
+| UMI | Raccolta Umido (food/organic waste) | `Icons.BIO_KITCHEN` |
+| VER | Raccolta Verde (garden waste) | `Icons.GARDEN` |
+| CAR | Raccolta Carta (paper) | `Icons.PAPER` |
+| VET | Raccolta Vetro (glass) | `Icons.GLASS` |
+| MUL | Raccolta Multipak (plastic + metal packaging) | `Icons.PLASTIC_PACKAGING` |
+| APL | Raccolta Altre Plastiche (other plastics) | `Icons.PLASTIC_PACKAGING` |
+| SEC | Raccolta Secco (residual/general waste) | `Icons.GENERAL_WASTE` |
+| ECU / STP | Raccolta Ecuosacco (branded residual-waste bag) | `Icons.GENERAL_WASTE` |
+| MAN / SPA / CES / MER | Street sweeping, litter-bin emptying, market cleaning (not household collection) | no icon |
+
+The returned collection type (`t`) is the human-readable description reported by CEM Ambiente (e.g. `raccolta UMIDO`, `Spazzamento manuale`), not the prefix itself.


### PR DESCRIPTION
## Summary
- Adds a new source for CEM Ambiente, using the public CEM FACILE JSON API (`cemfacile.cemambiente.it/public/{listComuni,listVie,getCalendario}`) that backs https://www.cemambiente.it/cemfacile/
- Covers ~77 municipalities in the Milano / Monza e Brianza / Lodi area of Italy (full list in `EXTRA_INFO` and `doc/source/cem_ambiente_it.md`)
- No login or Cloudflare bypass needed; endpoints return structured JSON directly
- Unknown city/street inputs raise `SourceArgumentNotFoundWithSuggestions` with the closest matching names (via `difflib.get_close_matches`)

Closes #6871

## Test plan
- [x] `ruff check --fix` / `ruff format` on the new source file
- [x] `python test_sources.py -s cem_ambiente_it -l` — verified live against Vimodrone/Via Aldo Moro (the address from the issue), Cologno Monzese/Via Cadore, and Vimercate/Via Cesare Battisti
- [x] `python -m pytest tests/test_source_components.py -q`