### PR TITLE
Add Prince George's County, MD source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/prince_georges_county_md_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/prince_georges_county_md_us.py
@@ -1,0 +1,149 @@
+from datetime import date, timedelta
+
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import (
+    ArcGisError,
+    geocode,
+    query_feature_layer,
+)
+
+TITLE = "Prince George's County, MD"
+DESCRIPTION = (
+    "Source for Prince George's County, Maryland curbside trash, recycling, "
+    "bulky trash, and yard trim collection."
+)
+URL = "https://www.princegeorgescountymd.gov/departments-offices/environment/waste-recycling/residential-collections"
+COUNTRY = "us"
+
+TEST_CASES = {
+    "6807 McCormick Rd, Upper Marlboro": {
+        "address": "6807 McCormick Rd, Upper Marlboro, MD"
+    },
+    "2607 Haney Ave, Suitland": {"address": "2607 Haney Ave, Suitland, MD"},
+}
+
+ICON_MAP = {
+    "Trash": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "Bulky Trash": Icons.BULKY,
+    "Yard Trim": Icons.GARDEN,
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Full street address including city and state (e.g. '1301 McCormick Dr, Upper Marlboro, MD')",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+# Prince George's County Department of the Environment "Once-A-Week"
+# residential collection lookup layer. This is the same FeatureLayer that
+# backs the County's own public "Waste Collection Services" address tool
+# linked from the Residential Collections page (URL above).
+TRASH_LAYER_URL = (
+    "https://gisent.princegeorgescountymd.gov/gisonline/rest/services/"
+    "DoE/RRD_PROP_TRASH/MapServer/0"
+)
+
+WEEKDAYS = {
+    "Monday": 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+    "Saturday": 5,
+    "Sunday": 6,
+}
+
+WEEKS_AHEAD = 26
+
+# Fields on the layer that hold a weekly day-of-service name. The
+# Wood-and-Tree-Debris field is intentionally excluded because it is always
+# "Call 311 to Schedule" (an on-demand service, not a recurring weekly
+# pickup), and there is no reliable "day" to project forward.
+DAY_FIELDS = {
+    "Trash_Day_of_Service1": "Trash",
+    "Trash_Day_of_Service2": "Trash",
+    "Recycle_Day_of_Service": "Recycling",
+    "Bulky_Day_of_Service": "Bulky Trash",
+    "Yard_Day_of_Service": "Yard Trim",
+}
+
+OUT_FIELDS = ",".join({*DAY_FIELDS, "Address"})
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        try:
+            location = geocode(self._address)
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        try:
+            features = query_feature_layer(
+                TRASH_LAYER_URL,
+                geometry=location,
+                out_fields=OUT_FIELDS,
+            )
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        attrs = self._select_feature(features)
+
+        entries: list[Collection] = []
+        seen_days: dict[str, set[str]] = {}
+        for field, waste_type in DAY_FIELDS.items():
+            day_name = (attrs.get(field) or "").strip().title()
+            if day_name not in WEEKDAYS:
+                continue
+            # Avoid duplicate weekly entries when Trash_Day_of_Service1 and
+            # Trash_Day_of_Service2 happen to name the same weekday.
+            seen = seen_days.setdefault(waste_type, set())
+            if day_name in seen:
+                continue
+            seen.add(day_name)
+            entries += self._weekly_dates(day_name, waste_type)
+
+        if not entries:
+            # The property was found but is not enrolled in any
+            # County-collected waste service (e.g. commercial/private-hauler
+            # address), so there is nothing meaningful to report.
+            raise SourceArgumentNotFound("address", self._address)
+
+        return entries
+
+    def _select_feature(self, features: list[dict]) -> dict:
+        # A point that falls exactly on a shared parcel-boundary vertex can
+        # intersect more than one polygon. Prefer the feature whose Address
+        # starts with the same house number as the requested address.
+        house_number = "".join(
+            ch for ch in self._address.split()[0] if ch.isdigit()
+        ).lstrip("0")
+        if house_number:
+            for attrs in features:
+                found_address = (attrs.get("Address") or "").strip()
+                found_house_number = found_address.split(" ")[0].lstrip("0")
+                if found_house_number == house_number:
+                    return attrs
+        return features[0]
+
+    @staticmethod
+    def _weekly_dates(day_name: str, waste_type: str) -> list[Collection]:
+        weekday = WEEKDAYS[day_name]
+        today = date.today()
+        days_ahead = (weekday - today.weekday()) % 7
+        next_date = today + timedelta(days=days_ahead)
+        icon = ICON_MAP.get(waste_type)
+        return [
+            Collection(date=next_date + timedelta(weeks=i), t=waste_type, icon=icon)
+            for i in range(WEEKS_AHEAD)
+        ]

--- a/doc/source/prince_georges_county_md_us.md
+++ b/doc/source/prince_georges_county_md_us.md
@@ -1,0 +1,45 @@
+# Prince George's County, MD
+
+Support for schedules provided by [Prince George's County, MD](https://www.princegeorgescountymd.gov/departments-offices/environment/waste-recycling/residential-collections).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: prince_georges_county_md_us
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Full street address including city and state.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: prince_georges_county_md_us
+      args:
+        address: 6807 McCormick Rd, Upper Marlboro, MD
+```
+
+## How to get the source arguments
+
+Use your full street address including city and state (e.g. "6807 McCormick Rd, Upper Marlboro, MD"). The source geocodes the address via the ArcGIS World Geocoder and then queries the County's residential collection lookup layer — the same data that backs the County's own [online address tool](http://princegeorges.maps.arcgis.com/apps/webappviewer/index.html?id=7e1968cf75524789a2fd131afe6ea6b4) — to determine your collection days.
+
+Returned collection types:
+
+- **Trash** — weekly, for all County-collected residential customers.
+- **Recycling** — weekly, for addresses eligible for County recycling service.
+- **Bulky Trash** — weekly, on the same day as regular trash (up to 4 items, no appointment needed).
+- **Yard Trim** — weekly, always on Monday, year-round.
+
+Addresses that are not enrolled in County-collected waste service (e.g. commercial properties or addresses using a private hauler) will raise an error, since there is no County collection schedule to report.
+
+Note: Collection days are reported as a fixed weekly pickup day and do not account for holiday shifts. Curbside electronics/scrap-metal and appliance/white-goods pickups are by appointment only and are not covered by this source.


### PR DESCRIPTION
## Summary
- Adds a new source for Prince George's County, MD, covering weekly Trash, Recycling, Bulky Trash (same-day as trash, up to 4 items), and Yard Trim (Mondays year-round) collection.
- Resolves free-text addresses via the Esri World Geocoder, then queries the County's public "Once-A-Week Collection" ArcGIS layer (`DoE/RRD_PROP_TRASH`) — the same layer that backs the County's own public address-lookup tool linked from its residential collections page.
- Reuses the existing shared `waste_collection_schedule/service/ArcGis.py` helpers (`geocode`, `query_feature_layer`), following the pattern established by `alexandria_va_us.py`.
- Disambiguates boundary-vertex spatial-query ties by matching the returned parcel's house number back against the input address.
- Excludes the Wood-and-Tree-Debris field, since it is always "Call 311 to Schedule" (on-demand, not a recurring weekly pickup).

Closes #5576

## Test plan
- [x] \`ruff check\` / \`ruff format --check\` pass
- [x] \`python -m pytest tests/test_source_components.py -q\` passes (10/10)
- [x] Verified \`fetch()\` logic end-to-end for both TEST_CASES addresses (correct weekly Trash/Recycling/Bulky/Yard days) and for a non-serviced address (correctly raises \`SourceArgumentNotFound\`)
- [ ] \`python test_sources.py -s prince_georges_county_md_us -l\` — please re-run in CI/reviewer environment to confirm live network access to \`gisent.princegeorgescountymd.gov\` (blocked from the triage sandbox's egress; verified functionally via a read-proxy instead, see PR discussion)