### PR TITLE
feat(source): add City of Yarra, VIC, AU (yarracity_vic_gov_au)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
@@ -1,0 +1,143 @@
+from datetime import date, timedelta
+
+from dateutil.easter import easter
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import (
+    ArcGisError,
+    geocode,
+    get_next_n_dates,
+    most_recent_weekday,
+    query_feature_layer,
+)
+
+TITLE = "City of Yarra"
+DESCRIPTION = "Source for City of Yarra waste collection."
+URL = "https://www.yarracity.vic.gov.au"
+COUNTRY = "au"
+TEST_CASES = {
+    "Fitzroy Town Hall": {"address": "201 Napier Street, Fitzroy VIC 3065"},
+    "Richmond Town Hall": {"address": "333 Bridge Road, Richmond VIC 3121"},
+}
+SOURCE_CODEOWNERS = ["@yeaaaaaahh"]
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Enter your full street address including suburb and postcode, "
+        "e.g. '333 Bridge Road, Richmond VIC 3121'."
+    ),
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": (
+            "Full street address within the City of Yarra, "
+            "including suburb and postcode"
+        ),
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+ICON_MAP = {
+    "Rubbish": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "Glass": Icons.GLASS,
+    "FOGO": Icons.BIO_KITCHEN,
+}
+
+MAP_SERVER_URL = (
+    "https://yccgis-prd.esriaustraliaonline.com.au/arcgis/rest/services/"
+    "Waste_Services/CW_FC_PRD_Waste_Collection/MapServer"
+)
+GLASS_LAYER_URL = f"{MAP_SERVER_URL}/0"
+WASTE_LAYER_URL = f"{MAP_SERVER_URL}/1"
+
+WEEKS_AHEAD = 52
+
+_WEEKDAYS = {
+    "Monday": 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+    "Saturday": 5,
+    "Sunday": 6,
+}
+
+
+def _holiday_shift(d: date) -> date:
+    # Council rule: collections run on all public holidays except Good Friday
+    # and Christmas Day, when the collection happens one day later.
+    if d == easter(d.year) - timedelta(days=2) or d == date(d.year, 12, 25):
+        return d + timedelta(days=1)
+    return d
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        try:
+            location = geocode(f"{self._address}, Victoria, Australia")
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        try:
+            waste = query_feature_layer(
+                WASTE_LAYER_URL,
+                geometry=location,
+                out_fields="collection_day,recycling_anchor_date",
+            )[0]
+            glass = query_feature_layer(
+                GLASS_LAYER_URL,
+                geometry=location,
+                out_fields="anchor_date,frequency_days",
+            )[0]
+        except ArcGisError as e:
+            raise SourceArgumentNotFound(
+                "address",
+                self._address,
+                "the address must be within the City of Yarra.",
+            ) from e
+
+        day_name = waste["collection_day"]
+        if day_name not in _WEEKDAYS:
+            raise ValueError(f"Unexpected collection day: {day_name!r}")
+
+        entries = []
+
+        # Rubbish and FOGO are collected weekly on the property's collection day.
+        for d in get_next_n_dates(
+            most_recent_weekday(_WEEKDAYS[day_name]), WEEKS_AHEAD, timedelta(days=7)
+        ):
+            d = _holiday_shift(d)
+            entries.append(Collection(d, "Rubbish", ICON_MAP["Rubbish"]))
+            entries.append(Collection(d, "FOGO", ICON_MAP["FOGO"]))
+
+        # Recycling alternates fortnightly between zones; the layer's anchor
+        # date fixes this property's phase. DateOnly fields are ISO strings.
+        for d in get_next_n_dates(
+            date.fromisoformat(waste["recycling_anchor_date"]),
+            WEEKS_AHEAD // 2,
+            timedelta(days=14),
+        ):
+            entries.append(
+                Collection(_holiday_shift(d), "Recycling", ICON_MAP["Recycling"])
+            )
+
+        # Glass runs on its own cycle (currently every 28 days) with an
+        # independent per-polygon anchor.
+        for d in get_next_n_dates(
+            date.fromisoformat(glass["anchor_date"]),
+            WEEKS_AHEAD // 4,
+            timedelta(days=int(glass["frequency_days"])),
+        ):
+            entries.append(Collection(_holiday_shift(d), "Glass", ICON_MAP["Glass"]))
+
+        return entries

--- a/doc/source/yarracity_vic_gov_au.md
+++ b/doc/source/yarracity_vic_gov_au.md
@@ -1,0 +1,60 @@
+# City of Yarra
+
+Support for schedules provided by [City of Yarra](https://www.yarracity.vic.gov.au/residents/bins-waste-recycling-and-cleansing/recycling-and-rubbish/bin-collection), Victoria, Australia.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: yarracity_vic_gov_au
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**  
+*(string) (required)*
+
+Full street address within the City of Yarra, including suburb and postcode.
+
+For a residential address you can keep the value out of source control by storing it in Home Assistant `secrets.yaml` and referencing it with `!secret`.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: yarracity_vic_gov_au
+      args:
+        address: 333 Bridge Road, Richmond VIC 3121
+```
+
+## How to get the source arguments
+
+Use your address as you would enter it in the council's [bin collection lookup](https://www.yarracity.vic.gov.au/residents/bins-waste-recycling-and-cleansing/recycling-and-rubbish/bin-collection). Include the suburb and postcode for reliable matching.
+
+Collection types returned:
+
+- **Rubbish** — weekly
+- **FOGO** (Food Organics and Garden Organics) — weekly, same day as Rubbish
+- **Recycling** — fortnightly, same day as Rubbish
+- **Glass** — every four weeks
+
+A household without a FOGO bin can hide that type with the standard customisation:
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: yarracity_vic_gov_au
+      args:
+        address: 333 Bridge Road, Richmond VIC 3121
+      customize:
+        - type: FOGO
+          show: false
+```
+
+## Public holidays
+
+Collections run as normal on public holidays except Good Friday and Christmas Day, when the collection happens one day later. The source applies this shift automatically. One-off service changes announced by the council (for example severe weather disruptions) are not reflected.


### PR DESCRIPTION
## Summary

Adds a source for the City of Yarra (inner Melbourne, Victoria, Australia).

- Geocodes the configured address with the shared `service/ArcGis.py` helpers and
  intersects the point with the council's public waste-collection MapServer layers.
- The waste layer provides the weekly collection day and the fortnightly recycling
  anchor date; the glass layer provides the independent four-weekly glass anchor
  and frequency, so all schedules follow the live council data.
- Returns **Rubbish** and **FOGO** (weekly), **Recycling** (fortnightly) and
  **Glass** (four-weekly). Households without a FOGO bin can hide that type via
  the standard `customize` option (shown in the doc page).
- Applies the council's standing public-holiday rule, following the approach of
  `subiaco_wa_gov_au`: collections due on Good Friday or Christmas Day happen one
  day later; all other public holidays run as normal.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (10 passed)
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/yarracity_vic_gov_au.md` created
- [x] TEST_CASES use real, publicly accessible addresses (not my own) — Fitzroy Town Hall and Richmond Town Hall; both verified live (143 entries each)