### PR TITLE
docs(installation): warn that fetch_time/day_switch_time must be quoted

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -101,12 +101,26 @@ waste_collection_schedule:
 | Parameter | Type | Requirement | Description |
 |-----|-----|-----|-----|
 | sources | list | required | Contains information for the service provider being used. For details see [Attributes for sources](#attributes-for-sources) |
-| fetch_time | time | optional | representation of the time of day in "HH:MM" that Home Assistant polls service provider for latest collection schedule. If no time is provided, the default of "01:00" is used |
+| fetch_time | time | optional | representation of the time of day in `"HH:MM"` (**must be quoted**, see note below) that Home Assistant polls service provider for latest collection schedule. If no time is provided, the default of "01:00" is used |
 | fetch_interval_days | int | optional | fetch interval in days. If set to `1` (default), behavior stays unchanged and fetching happens daily at `fetch_time` (plus optional random offset). If set to `>1`, data is fetched every _n_ days. |
 | random_fetch_time_offset | int | optional | randomly offsets the `fetch_time` by up to _int_ minutes. Can be used to distribute Home Assistant fetch commands over a longer time frame to avoid peak loads at service providers |
-| day_switch_time | time | optional | time of the day in "HH:MM" that Home Assistant dismisses the current entry and moves to the next entry. If no time if provided, the default of "10:00" is used. |
+| day_switch_time | time | optional | time of the day in `"HH:MM"` (**must be quoted**, see note below) that Home Assistant dismisses the current entry and moves to the next entry. If no time if provided, the default of "10:00" is used. |
 | separator | string | optional | Used to join entries if the multiple values for a single day are returned by the source. If no value is entered, the default of ", " is used |
 | day_offset | int | optional | Offset in days to add to the collection date (can be negative). If no value is entered, the default of 0 is used |
+
+> **Note: always quote `fetch_time` and `day_switch_time`**
+>
+> Home Assistant's YAML loader follows the legacy YAML 1.1 spec, which parses an unquoted `H:MM` value as a **sexagesimal (base-60) number** rather than a string whenever the hour starts with a non-zero digit. For example, an unquoted `fetch_time: 10:00` is silently read as the integer `600` (10 × 60 + 0), which then fails validation with an error like `Invalid time specified: 600`. Times with a leading zero on the hour (e.g. `09:59`) happen to be unaffected, which is why this only seems to break for times from `10:00` onward.
+>
+> To avoid this, always wrap these values in quotes so they are parsed as strings:
+>
+> ```yaml
+> waste_collection_schedule:
+>   fetch_time: "10:00"
+>   day_switch_time: "18:30"
+> ```
+>
+> This is a characteristic of the YAML 1.1 parser used by Home Assistant/PyYAML, not something this integration can change on its own.
 
 ## Attributes for _sources_
 


### PR DESCRIPTION
## Summary
- `fetch_time` and `day_switch_time` are `time`-typed YAML config values documented as `"HH:MM"`, but the table examples were unquoted, inviting the exact YAML 1.1 sexagesimal-parsing pitfall reported in #5065 (unquoted `fetch_time: 10:00` is parsed by PyYAML as the integer `600`, not the string `"10:00"`, breaking Home Assistant's `cv.time` validator).
- Added an explicit "must be quoted" callout to both parameter table rows in `doc/installation.md`, plus a note block explaining the root cause (YAML 1.1 vs 1.2 sexagesimal resolver) with a concrete quoted example.
- No code changes — see discussion on #6876, where the maintainers decided against a parser-side workaround in favor of documenting correct YAML usage.

Refs #5065

## Test plan
- [x] Confirmed `doc/installation.md` is hand-maintained (not touched by `update_docu_links.py`)
- [x] `grep -rn "HH:MM" --include="*.md" .` shows only the corrected lines
- [x] `python -m pytest tests/test_source_components.py -q` passes (docs-only change)