### PR TITLE
feat(source): add Timrå kommun waste collection (timra_se)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/timra_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/timra_se.py
@@ -1,0 +1,140 @@
+from datetime import date
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "Timrå kommun"
+DESCRIPTION = "Source for Timrå kommun (Sweden) waste collection."
+URL = "https://www.timra.se"
+COUNTRY = "se"
+TEST_CASES = {
+    "Aspen 195": {"address": "Aspen 195"},
+    "Tuna 112": {"address": "Tuna 112"},
+    "Torsboda 130": {"address": "Torsboda 130"},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Enter the property address exactly as shown on the Timrå kommun "
+        "waste collection map (Belägenhetsadress), e.g. 'Aspen 195'. You can "
+        "look up the address at https://kartor.timra.se/portal/apps/experiencebuilder/experience/?id=186668f9efeb458c926d85a978fe85de"
+    ),
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": (
+            "Property address as used by Timrå kommun (Belägenhetsadress), "
+            "e.g. 'Aspen 195'."
+        ),
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Address",
+    },
+}
+
+ICON_MAP = {
+    "Fyrfackskärl 1": Icons.RECYCLING,
+    "Fyrfackskärl 2": Icons.GENERAL_WASTE,
+}
+
+# The webmap defines which hosted FeatureServer layer currently holds the
+# waste collection data. Resolving it dynamically (instead of hardcoding the
+# FeatureServer URL, which is suffixed with a publish date and is expected to
+# change when Timrå kommun refreshes the schedule for a new year) keeps the
+# source working without code changes across those refreshes.
+PORTAL_WEBMAP_DATA_URL = (
+    "https://kartor.timra.se/portal/sharing/rest/content/items/"
+    "f77cab36aa3043d0b9dfeaeb679a23bd/data"
+)
+
+
+def _get_feature_layer_url(session: requests.Session) -> str:
+    r = session.get(PORTAL_WEBMAP_DATA_URL, params={"f": "json"}, timeout=30)
+    r.raise_for_status()
+    layers = r.json().get("operationalLayers", [])
+    return str(layers[0]["url"])
+
+
+def _parse_dates(value: str | None) -> list[date]:
+    if not value:
+        return []
+    year = date.today().year
+    dates = []
+    for part in value.replace("\r", "").replace("\n", "").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        day_str, month_str = part.split("/")
+        dates.append(date(year, int(month_str), int(day_str)))
+    return dates
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        feature_layer_url = _get_feature_layer_url(session)
+
+        escaped = self._address.replace("'", "''")
+        features = self._query(
+            session,
+            feature_layer_url,
+            f"UPPER(beladress) = UPPER('{escaped}')",
+            "beladress,karl1,karl2",
+        )
+
+        if len(features) > 1:
+            raise SourceArgAmbiguousWithSuggestions(
+                "address",
+                self._address,
+                sorted({f["beladress"] for f in features}),
+            )
+
+        if not features:
+            similar = self._query(
+                session,
+                feature_layer_url,
+                f"UPPER(beladress) LIKE UPPER('%{escaped}%')",
+                "beladress",
+            )
+            suggestions = sorted({f["beladress"] for f in similar})[:10]
+            raise SourceArgumentNotFoundWithSuggestions(
+                "address", self._address, suggestions
+            )
+
+        feature = features[0]
+
+        entries = []
+        for d in _parse_dates(feature.get("karl1")):
+            entries.append(Collection(d, "Fyrfackskärl 1", ICON_MAP["Fyrfackskärl 1"]))
+        for d in _parse_dates(feature.get("karl2")):
+            entries.append(Collection(d, "Fyrfackskärl 2", ICON_MAP["Fyrfackskärl 2"]))
+
+        return entries
+
+    @staticmethod
+    def _query(
+        session: requests.Session, feature_layer_url: str, where: str, out_fields: str
+    ) -> list[dict]:
+        r = session.get(
+            f"{feature_layer_url.rstrip('/')}/query",
+            params={
+                "where": where,
+                "outFields": out_fields,
+                "returnGeometry": "false",
+                "f": "json",
+            },
+            timeout=30,
+        )
+        r.raise_for_status()
+        return [f["attributes"] for f in r.json().get("features", [])]

--- a/doc/source/timra_se.md
+++ b/doc/source/timra_se.md
@@ -1,0 +1,41 @@
+# Timrå kommun
+
+Support for schedules provided by [Timrå kommun](https://www.timra.se/), serving the municipality of Timrå, Sweden.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: timra_se
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)* : Property address (Belägenhetsadress) as used by Timrå kommun, e.g. `"Aspen 195"`.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: timra_se
+      args:
+        address: "Aspen 195"
+```
+
+## How to get the source argument
+
+Enter the property address exactly as shown on the [Timrå kommun waste collection map](https://kartor.timra.se/portal/apps/experiencebuilder/experience/?id=186668f9efeb458c926d85a978fe85de), e.g. `"Aspen 195"`. If the address cannot be found, the error message will list similar addresses to help you find the correct spelling.
+
+## Notes
+
+Timrå kommun uses a "fyrfack" (four-compartment) collection system with two bins per property:
+
+- **Fyrfackskärl 1** — collected roughly every 4 weeks.
+- **Fyrfackskärl 2** — collected roughly every 2 weeks.
+
+The exact waste fractions held in each bin are not exposed by the underlying data source, so both bins are reported using their generic names.


### PR DESCRIPTION
## Summary
- Adds a new source for Timrå kommun, Sweden (`timra_se`), closing #5541.
- Queries Timrå kommun's public ArcGIS FeatureServer directly by property address (`Belägenhetsadress`), returning collection dates for the two "fyrfack" (four-compartment) bins used in the municipality.
- The FeatureServer URL is resolved dynamically from the parent Web Map item at fetch-time (rather than hardcoded) since the underlying hosted layer name is date-stamped and expected to change when the municipality republishes for a new year.
- Includes `doc/source/timra_se.md`.

## Test plan
- [x] `ruff check --fix` / `ruff format` — clean
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `python test_sources.py -s timra_se -l` — all 3 TEST_CASES pass (36 entries each, dates verified against the raw API response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)