### PR TITLE
fix(abfallkalender_prezero_network): remove Willich, no longer served by PreZero

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallkalender_prezero_network.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallkalender_prezero_network.py
@@ -17,11 +17,6 @@ EXTRA_INFO = [
         "url": "https://abfallkalender.prezero.network/bad-oeynhausen",
         "default_params": {"city": "bad-oeynhausen"},
     },
-    {
-        "title": "Willich",
-        "url": "https://abfallkalender.prezero.network/willich",
-        "default_params": {"city": "willich"},
-    },
 ]
 
 TEST_CASES = {
@@ -32,16 +27,6 @@ TEST_CASES = {
     "Bad Oeynhausen Ackerstraße": {
         "street": "Ackerstraße",
         "house_number": "2",
-    },
-    "Willich Aachener Straße": {
-        "city": "willich",
-        "street": "Aachener Straße",
-        "house_number": "1",
-    },
-    "Willich Ahornweg": {
-        "city": "willich",
-        "street": "Ahornweg",
-        "house_number": "5",
     },
 }
 
@@ -69,20 +54,20 @@ PARAM_TRANSLATIONS = {
 
 PARAM_DESCRIPTIONS = {
     "de": {
-        "city": "Stadt-Kennung (Standard: 'bad-oeynhausen'; unterstützte Werte: 'bad-oeynhausen', 'willich')",
+        "city": "Stadt-Kennung (Standard und einzig unterstützter Wert: 'bad-oeynhausen')",
         "street": "Straßenname (z.B. 'Aalstraße')",
         "house_number": "Hausnummer (z.B. '1')",
     },
     "en": {
-        "city": "City identifier (default: 'bad-oeynhausen'; supported values: 'bad-oeynhausen', 'willich')",
+        "city": "City identifier (default and only supported value: 'bad-oeynhausen')",
         "street": "Street name (e.g. 'Aalstraße')",
         "house_number": "House number (e.g. '1')",
     },
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
-    "de": "Geben Sie Ihre Straße und Hausnummer ein. Die Stadt ist standardmäßig auf Bad Oeynhausen eingestellt (unterstützt: Bad Oeynhausen, Willich).",
-    "en": "Enter your street and house number. The city defaults to Bad Oeynhausen (supported: Bad Oeynhausen, Willich).",
+    "de": "Geben Sie Ihre Straße und Hausnummer ein. Diese Quelle unterstützt derzeit nur Bad Oeynhausen.",
+    "en": "Enter your street and house number. This source currently only supports Bad Oeynhausen.",
 }
 
 

--- a/doc/source/abfallkalender_prezero_network.md
+++ b/doc/source/abfallkalender_prezero_network.md
@@ -4,7 +4,11 @@ Support for schedules provided by [PreZero](https://abfallkalender.prezero.netwo
 
 Currently supported cities:
 - **Bad Oeynhausen** - [abfallkalender.prezero.network/bad-oeynhausen](https://abfallkalender.prezero.network/bad-oeynhausen)
-- **Willich** - [abfallkalender.prezero.network/willich](https://abfallkalender.prezero.network/willich)
+
+> **Note:** Willich was previously served by PreZero, but PreZero no longer serves Willich (the
+> `abfallkalender.prezero.network/willich` page now returns 404). Willich's waste collection is
+> covered by the [AbfallNavi (RegioIT.de)](abfallnavi_de.md) source via Kreis Viersen
+> (`service: viersen`, `ort: Willich`).
 
 ## Configuration via configuration.yaml
 
@@ -33,7 +37,7 @@ House number as a string (e.g., "1", "12a").
 **city**
 *(string) (optional)*
 
-City identifier from the PreZero URL. Defaults to `bad-oeynhausen`. Supported values: `bad-oeynhausen`, `willich`.
+City identifier from the PreZero URL. Defaults to `bad-oeynhausen`. Currently the only supported value is `bad-oeynhausen`.
 
 ## Examples
 
@@ -48,29 +52,12 @@ waste_collection_schedule:
         house_number: "1"
 ```
 
-### Willich
-
-```yaml
-waste_collection_schedule:
-  sources:
-    - name: abfallkalender_prezero_network
-      args:
-        street: Aachener Straße
-        house_number: "1"
-        city: willich
-```
-
 ## How to Find Your Configuration
 
 ### For Bad Oeynhausen
 1. Go to [https://abfallkalender.prezero.network/bad-oeynhausen](https://abfallkalender.prezero.network/bad-oeynhausen)
 2. Enter your street name and house number on the website to verify they are correct
 3. Use these exact values in your configuration (the city parameter is already set to Bad Oeynhausen by default)
-
-### For Willich
-1. Go to [https://abfallkalender.prezero.network/willich](https://abfallkalender.prezero.network/willich)
-2. Enter your street name and house number on the website to verify they are correct
-3. Use these exact values in your configuration with `city: willich`
 
 ## Waste Types
 


### PR DESCRIPTION
## Summary
- PreZero's calendar for Willich is dead (`abfallkalender.prezero.network/willich` returns 404); the
  city's waste contract moved PreZero → Remondis → Lankes Entsorgung during 2026, and PreZero simply
  dropped Willich from their site.
- Removes the Willich `EXTRA_INFO` entry, TEST_CASES, and related translations/doc text from
  `abfallkalender_prezero_network.py`, since there is no live PreZero endpoint left to fetch from.
- Willich is already fully covered by the existing `abfallnavi_de` source (Kreis Viersen,
  `service: viersen`), verified live with 308 returned collection entries for a Willich address.
  Updated `doc/source/abfallkalender_prezero_network.md` to point Willich users there.

Fixes #6896

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed source file
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `python test_sources.py -s abfallkalender_prezero_network -l` — remaining Bad Oeynhausen test cases pass
- [x] Verified `abfallnavi_de` (`service=viersen`, `ort=Willich`) returns live collection data for Willich