### PR TITLE
Add source for Waikato District Council, New Zealand

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/waikato_district_council_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/waikato_district_council_govt_nz.py
@@ -1,0 +1,154 @@
+import re
+from datetime import datetime, timedelta
+
+import requests
+from waste_collection_schedule import (
+    Collection,  # type: ignore[attr-defined]
+    Icons,
+)
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "Waikato District Council"
+DESCRIPTION = (
+    "Source for Waikato District Council kerbside rubbish and recycling "
+    "collection, New Zealand."
+)
+URL = "https://www.waikatodistrict.govt.nz/"
+COUNTRY = "nz"
+
+TEST_CASES = {
+    "Rotowaro, Monday": {"address": "42B Mahuta Station Road, Rotowaro"},
+    "Raglan, Tuesday": {"address": "90 Upper Wainui Road, Raglan"},
+    "Tuakau, Tuesday": {"address": "11 Gordon Paul Place, Tuakau"},
+    "Pokeno, Thursday": {"address": "53 Market Street, Pokeno"},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter your address as it appears on the council's rubbish and "
+    "recycling collection page, e.g. '18 Example Drive, Huntly'. If the "
+    "address cannot be found uniquely, the error message will list the "
+    "closest matches known to the council."
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Address",
+    }
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Street address within the Waikato District, e.g. "
+        "'18 Example Drive, Huntly'.",
+    }
+}
+
+API_URL = "https://www.waikatodistrict.govt.nz/widgetApi/RubbishAndRecyclingCollections/search"
+
+COLLECTION_TYPE = "Rubbish and Recycling"
+
+ICON_MAP = {
+    COLLECTION_TYPE: Icons.GENERAL_WASTE,
+}
+
+# Number of weeks of weekly collections to generate.
+WEEKS_AHEAD = 26
+
+# Cap the disambiguation suggestions returned to the user.
+MAX_SUGGESTIONS = 10
+
+WEEKDAYS = {
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+}
+
+# Collection areas / days that don't have a fixed weekly kerbside collection
+# (e.g. monthly resource-recovery drop-off points, self-service transfer
+# stations, or properties outside the serviced area).
+NO_WEEKLY_SERVICE_DAYS = {"", "selfservice", "monthlydropoff"}
+
+# The API's search matches on a punctuation-free string; strip commas etc.
+_PUNCTUATION_RE = re.compile(r"[,\n\r]+")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _normalize(address: str) -> str:
+    address = _PUNCTUATION_RE.sub(" ", address)
+    address = _WHITESPACE_RE.sub(" ", address)
+    return address.strip().lower()
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address: str = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        query = _normalize(self._address)
+
+        r = requests.get(API_URL, params={"address": query}, timeout=30)
+        r.raise_for_status()
+        results = r.json()
+
+        # Deduplicate by normalized address, keeping the first record and the
+        # original (nicely cased) address string for suggestions.
+        unique: dict[str, dict] = {}
+        for entry in results:
+            raw_address = entry.get("address")
+            if not raw_address:
+                continue
+            key = _normalize(raw_address)
+            unique.setdefault(key, entry)
+
+        if not unique:
+            raise SourceArgumentNotFoundWithSuggestions("address", self._address, [])
+
+        exact = unique.get(query)
+        if exact is not None:
+            target = exact
+        elif len(unique) == 1:
+            target = next(iter(unique.values()))
+        else:
+            suggestions = sorted(e["address"] for e in unique.values())
+            raise SourceArgumentNotFoundWithSuggestions(
+                "address", self._address, suggestions[:MAX_SUGGESTIONS]
+            )
+
+        collection_day = (target.get("collectionDay") or "").strip().lower()
+        collection_area = target.get("collectionArea")
+        next_date_str = target.get("nextDate")
+
+        if (
+            collection_day in NO_WEEKLY_SERVICE_DAYS
+            or collection_day not in WEEKDAYS
+            or collection_area in (None, "None")
+            or not next_date_str
+        ):
+            raise SourceArgumentNotFound(
+                "address",
+                self._address,
+                message_addition=(
+                    "this address does not have a fixed weekly rubbish and "
+                    "recycling collection day (it may use a monthly drop-off "
+                    "point, a self-service transfer station, or no kerbside "
+                    "service). Please check the council's website."
+                ),
+            )
+
+        next_date = datetime.fromisoformat(next_date_str).date()
+
+        return [
+            Collection(
+                date=next_date + timedelta(weeks=i),
+                t=COLLECTION_TYPE,
+                icon=ICON_MAP[COLLECTION_TYPE],
+            )
+            for i in range(WEEKS_AHEAD)
+        ]

--- a/doc/source/waikato_district_council_govt_nz.md
+++ b/doc/source/waikato_district_council_govt_nz.md
@@ -1,0 +1,41 @@
+# Waikato District Council
+
+Support for schedules provided by [Waikato District Council](https://www.waikatodistrict.govt.nz/), serving the Waikato District, New Zealand.
+
+The source queries the council's public rubbish and recycling collection address search and returns the next 26 weeks of collections for the property.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+        - name: waikato_district_council_govt_nz
+          args:
+            address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**  
+*(String) (required)*  
+Your street address within the Waikato District, including the town, e.g. `18 Example Drive, Huntly`.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+        - name: waikato_district_council_govt_nz
+          args:
+            address: 18 Example Drive, Huntly
+```
+
+## How to get the source argument
+
+Visit the council's [rubbish and recycling collection](https://www.waikatodistrict.govt.nz/services-facilities/rubbish-and-recycling/rubbish-and-recycling-services/rubbish-and-recycling-collection) page and search for your property using the address search box. Use the same address as the `address` argument, including the town/suburb if the street name is ambiguous. If the address cannot be matched uniquely, the integration's error message will list the closest known addresses.
+
+## Notes / Limitations
+
+- Rubbish, glass/mixed recycling, paper and card (and, in some areas, food scraps) are collected together on the same weekly kerbside day, so a single combined "Rubbish and Recycling" entry is returned per collection day.
+- Properties served by a monthly resource-recovery drop-off point, a self-service transfer station, or with no kerbside service, are not supported — the council's own page does not provide a fixed weekly day for these either.
+- The council's data does not encode public-holiday adjustments beyond the very next collection date, so collections further in the future that are shifted around New Zealand public holidays may not be reflected exactly. This limitation is shared with other New Zealand sources.


### PR DESCRIPTION
## Summary
- Adds a new source for Waikato District Council (`waikato_district_council_govt_nz`), New Zealand, resolving #5226.
- Queries the council's public `widgetApi/RubbishAndRecyclingCollections/search` JSON endpoint by street address and returns 26 weeks of the combined weekly "Rubbish and Recycling" kerbside collection day, anchored on the API's authoritative `nextDate`.
- Addresses served by a monthly drop-off point, a self-service transfer station, or with no kerbside service raise a clear `SourceArgumentNotFound` instead of silently returning nothing.
- Ambiguous or unmatched addresses raise `SourceArgumentNotFoundWithSuggestions` with the closest known addresses from the council's own database.

## Test plan
- [x] `ruff check --fix` / `ruff format` on the new source file
- [x] Live test against the real API: `python test_sources.py -s waikato_district_council_govt_nz -l` — all 4 test cases return 26 entries each
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `doc/source/waikato_district_council_govt_nz.md` created manually