### PR TITLE
feat(ics): add Gemeinde Neuberg, Germany

### DIFF
--- a/doc/ics/yaml/neuberg_de.yaml
+++ b/doc/ics/yaml/neuberg_de.yaml
@@ -1,0 +1,16 @@
+---
+title: Gemeinde Neuberg
+url: https://neuberg.eu/
+country: de
+howto:
+  en: |
+    - Go to <https://neuberg.eu/leben-und-wohnen/abfallkalender>.
+    - Scroll down to the download section and right-click on the entry titled `Abfallkalender <year>` (the one linking to a file ending in `.ICS`) and copy the link address.
+    - Use this link as the `url` parameter.
+  de: |
+    - Öffnen Sie <https://neuberg.eu/leben-und-wohnen/abfallkalender>.
+    - Scrollen Sie zum Download-Bereich und klicken Sie mit der rechten Maustaste auf den Eintrag `Abfallkalender <Jahr>` (der auf eine Datei mit der Endung `.ICS` verweist) und kopieren Sie die Link-Adresse.
+    - Verwenden Sie diesen Link als `url`-Parameter.
+test_cases:
+  Neuberg:
+    url: https://neuberg.eu/output/download.php?fid=3502.1370.1.ICS


### PR DESCRIPTION
## Summary
- Adds Gemeinde Neuberg (Main-Kinzig-Kreis, Hesse, Germany) to the shared ICS/iCal source via a new `doc/ics/yaml/neuberg_de.yaml` entry.
- Neuberg publishes a single, publicly accessible, static `.ICS` calendar for the whole municipality (no address/street selection required).

Closes #3646

## Test plan
- [x] `python test_sources.py -y neuberg_de -l` — fetched 43 collection entries (Sondermüll, Restmüll/3 Wochen, Restmüll/6 Wochen, Bioabfälle, Altpapier, Gelber Sack) with real dates.
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed.
- [x] `yamlfmt` — no formatting diff.