### PR TITLE
Add Stadt Tengen (Germany) as a new ICS provider

### DIFF
--- a/doc/ics/yaml/tengen_de.yaml
+++ b/doc/ics/yaml/tengen_de.yaml
@@ -1,0 +1,12 @@
+---
+title: Stadt Tengen
+url: https://www.tengen.de
+country: de
+howto:
+  en: |
+    - Go to <https://www.tengen.de/service+_+rathaus/buergerservice/abfallentsorgung/abfallkalender>.
+    - Click on `Alle Termine des Abfallkalenders in meinen Kalender (z. B. Outlook) übernehmen (.ics-Datei)` and copy the link.
+    - Use this link as the `url` parameter. This feed already covers the whole municipality (Tengen and Wiechs a.R.) and does not require an address.
+test_cases:
+  Tengen:
+    url: https://www.tengen.de/site/Tengen/zmservice/2266403/ical/vevent.ics


### PR DESCRIPTION
## Summary
- Adds `doc/ics/yaml/tengen_de.yaml` so the generic `ics` source can be used to fetch collection schedules for Stadt Tengen (Baden-Württemberg, Germany).
- The town publishes a single combined iCal feed at `https://www.tengen.de/site/Tengen/zmservice/2266403/ical/vevent.ics` covering all waste types (Biomüll, Papier, Restmüll, Grüner Punkt, Problemstoff, Kühlgeräteabfuhr) and both localities (Tengen, Wiechs a.R.) — no address parameter required.
- Note: the URL originally reported in #3634 (`/pb/site/Tengen-2018/...`) pointed at a retired CMS instance and now returns 503; the feed has moved to `/site/Tengen/...` on the current site, which is what's used here.

Closes #3634

## Test plan
- [x] `python test_sources.py -y tengen_de -l` — found 40 entries with correctly typed waste categories
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `pre-commit run yamlfmt --files doc/ics/yaml/tengen_de.yaml` — passed