### PR TITLE
Add Gemeinde Hille (Germany) to ICS shared platform

### DIFF
--- a/doc/ics/yaml/hille_de.yaml
+++ b/doc/ics/yaml/hille_de.yaml
@@ -1,0 +1,19 @@
+---
+title: Gemeinde Hille
+url: https://www.hille.de
+howto:
+  en: |
+    - Go to <https://www.hille.de/Wirtschaft-Wohnen/Wohnen/Abfallkalender/>.
+    - Find the `ICS` download link matching your `Abfuhrbezirk` (collection district). Reminders are not needed for Home Assistant, so the `Ohne Erinnerung` (without reminder) files are recommended.
+    - Right click the matching link and select `copy link` to get the URL.
+    - Use this link as the `url` parameter.
+  de: |
+    - Gehen Sie auf <https://www.hille.de/Wirtschaft-Wohnen/Wohnen/Abfallkalender/>.
+    - Suchen Sie den `ICS`-Download-Link für Ihren Abfuhrbezirk. Erinnerungen werden für Home Assistant nicht benötigt, daher werden die Dateien "Ohne Erinnerung" empfohlen.
+    - Klicken Sie mit der rechten Maustaste auf den passenden Link und wählen Sie `Link kopieren`, um die URL zu erhalten.
+    - Verwenden Sie diesen Link als `url`-Parameter.
+test_cases:
+  Bezirk 1:
+    url: https://www.hille.de/media/custom/3015_1711_1.ICS
+  Bezirk 2:
+    url: https://www.hille.de/media/custom/3015_1712_1.ICS


### PR DESCRIPTION
## Summary
- Gemeinde Hille (NRW, Germany) publishes static, publicly accessible ICS calendar files per collection district (`Abfuhrbezirk`) on its own website.
- Adds a new `doc/ics/yaml/hille_de.yaml` entry so residents can configure the generic ICS source with a direct link, instead of needing a bespoke source module.
- Picked the "Ohne Erinnerung" (without reminder) variant for each district since the ICS source only reads `SUMMARY`/`DTSTART` and ignores `VALARM` reminders.

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes (10 passed)
- [x] `python test_sources.py -y hille_de -l -t` returns real, distinct upcoming entries for both `Bezirk 1` and `Bezirk 2` test cases (36 entries each)

Closes #3526