### PR TITLE
Add source: Předměřice nad Labem (predmerice_nad_labem_cz)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/predmerice_nad_labem_cz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/predmerice_nad_labem_cz.py
@@ -1,0 +1,69 @@
+"""Source for Předměřice nad Labem, Czech Republic."""
+
+import re
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+
+TITLE = "Předměřice nad Labem"
+DESCRIPTION = "Source for Předměřice nad Labem, Czech Republic."
+URL = "https://www.predmericenl.cz/odpady"
+COUNTRY = "cz"
+
+TEST_CASES = {
+    "Předměřice nad Labem": {},
+}
+
+SOURCE_CODEOWNERS = ["@ArzykDev"]
+
+ICON_MAP = {
+    "Směsný komunální odpad": Icons.GENERAL_WASTE,
+    "Plasty": Icons.PLASTIC_PACKAGING,
+    "Papír a lepenky": Icons.PAPER,
+}
+
+# Header cell carries a 6-digit waste-catalogue code prefix, e.g.
+# "200301 Směsný komunální odpad" — capture the name after the code.
+WASTE_TYPE_RE = re.compile(r"^\d{6}\s+(.+)$")
+DATE_RE = re.compile(r"^\d{2}\.\d{2}\.\d{4}$")
+
+
+class Source:
+    def __init__(self):
+        pass
+
+    def fetch(self) -> list[Collection]:
+        r = requests.get(URL, timeout=30)
+        r.raise_for_status()
+        r.encoding = "utf-8"
+
+        soup = BeautifulSoup(r.text, "html.parser")
+        tables = soup.find_all("table", class_="svozovy_plan")
+        if not tables:
+            raise ValueError("No collection schedule tables found on the page.")
+
+        entries: list[Collection] = []
+        for table in tables:
+            waste_type = None
+            for td in table.find_all("td"):
+                text = td.get_text(strip=True)
+                match = WASTE_TYPE_RE.match(text)
+                if match:
+                    waste_type = match.group(1)
+                    break
+            if waste_type is None:
+                continue
+
+            icon = ICON_MAP.get(waste_type)
+            for td in table.find_all("td"):
+                text = td.get_text(strip=True)
+                if DATE_RE.match(text):
+                    date = datetime.strptime(text, "%d.%m.%Y").date()
+                    entries.append(Collection(date=date, t=waste_type, icon=icon))
+
+        if not entries:
+            raise ValueError("No collection dates found on the page.")
+
+        return entries

--- a/doc/source/predmerice_nad_labem_cz.md
+++ b/doc/source/predmerice_nad_labem_cz.md
@@ -1,0 +1,31 @@
+# Předměřice nad Labem
+
+Support for waste collection schedules provided by [Předměřice nad Labem](https://www.predmericenl.cz/odpady), Czech Republic.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: predmerice_nad_labem_cz
+```
+
+### Configuration Variables
+
+None. The schedule is village-wide, so this source takes no arguments.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: predmerice_nad_labem_cz
+```
+
+## Bin types returned
+
+| Provider description       | Returned type              | Icon                     |
+|----------------------------|----------------------------|--------------------------|
+| Směsný komunální odpad     | Směsný komunální odpad     | `Icons.GENERAL_WASTE`    |
+| Plasty                     | Plasty                     | `Icons.PLASTIC_PACKAGING`|
+| Papír a lepenky            | Papír a lepenky            | `Icons.PAPER`            |


### PR DESCRIPTION
## Add source: Předměřice nad Labem (predmerice_nad_labem_cz)

Adds waste collection support for the village of Předměřice nad Labem,
Czech Republic.

### Provider
- Website: https://www.predmericenl.cz/odpady
- Collections operated by Marius Pedersen / Hradecké služby a.s.
- The village publishes no ICS/iCal or JSON feed — the schedule lives in
  three HTML tables (`table.svozovy_plan`) that are hand-updated once a
  year. This source scrapes those tables.

### Configuration
No arguments. The schedule is village-wide with no per-address lookup, so
the source takes no parameters and there is a single empty test case.

### Waste streams returned
| Provider description   | Icon                     |
|------------------------|--------------------------|
| Směsný komunální odpad | `Icons.GENERAL_WASTE`    |
| Plasty                 | `Icons.PLASTIC_PACKAGING`|
| Papír a lepenky        | `Icons.PAPER`            |

### Testing
- `pytest tests/test_source_components.py` — passes.
- Live `test_sources.py -s predmerice_nad_labem_cz` — 65 entries
  (26 mixed + 26 plastics + 13 paper for 2026).

The parser loops over all `svozovy_plan` tables and matches the waste type
by its 6-digit catalogue-code prefix, so an added stream (e.g. bio) won't
break it.
