### PR TITLE
Add source: East Suffolk Council (eastsuffolk_gov_uk)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastsuffolk_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastsuffolk_gov_uk.py
@@ -1,0 +1,147 @@
+import datetime
+import re
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.AchieveForms import init_session, run_lookup
+
+TITLE = "East Suffolk Council"
+DESCRIPTION = "Source for East Suffolk Council, UK."
+URL = "https://www.eastsuffolk.gov.uk"
+TEST_CASES = {
+    "106 Mill Lane, Felixstowe, IP11 2LL": {"uprn": "100091126543"},
+    "82 Mill Lane, Felixstowe, IP11 2LL": {"uprn": 100091126520},
+}
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Find your UPRN by visiting "
+        "https://my.eastsuffolk.gov.uk/service/Bin_collection_dates_finder "
+        "and searching for your address. Your UPRN can also be found at "
+        "https://www.findmyaddress.co.uk/."
+    )
+}
+PARAM_TRANSLATIONS = {
+    "en": {
+        "uprn": "UPRN",
+    }
+}
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number (UPRN) for your address.",
+    }
+}
+COUNTRY = "uk"
+
+BASE_URL = "https://my.eastsuffolk.gov.uk"
+SERVICE_URL = f"{BASE_URL}/service/Bin_collection_dates_finder"
+AUTH_URL = f"{BASE_URL}/authapi/isauthenticated"
+API_URL = f"{BASE_URL}/apibroker/runLookup"
+HOSTNAME = "my.eastsuffolk.gov.uk"
+
+AUTH_LOOKUP_ID = "59e73f8bd860c"
+COLLECTIONS_LOOKUP_ID = "68f900a32e7a4"
+
+ICON_MAP = {
+    "PAPER": Icons.PAPER,
+    "CARDBOARD": Icons.PAPER,
+    "FOOD": Icons.BIO_KITCHEN,
+    "GENERAL": Icons.GENERAL_WASTE,
+    "RESIDUAL": Icons.GENERAL_WASTE,
+    "RECYCLING": Icons.RECYCLING,
+    "GARDEN": Icons.GARDEN,
+}
+
+# Strip the leading emoji glyph that the API embeds in front of the label,
+# e.g. "\U0001F4F0  Paper and cardboard - standard bin" -> "Paper and
+# cardboard - standard bin"
+LEADING_EMOJI_RE = re.compile(r"^[^A-Za-z]+")
+
+
+def _get_icon(waste_type: str) -> str | None:
+    upper = waste_type.upper()
+    for key, icon in ICON_MAP.items():
+        if key in upper:
+            return icon
+    return None
+
+
+class Source:
+    def __init__(self, uprn: str | int):
+        self._uprn = str(uprn).strip()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update({"User-Agent": "Mozilla/5.0"})
+
+        sid = init_session(session, SERVICE_URL, AUTH_URL, HOSTNAME)
+
+        auth_result = run_lookup(
+            session,
+            API_URL,
+            sid,
+            AUTH_LOOKUP_ID,
+            {"Details": {"bartecMode": {"value": "Live"}}},
+        )
+        auth_rows = (
+            auth_result.get("integration", {}).get("transformed", {}).get("rows_data")
+        )
+        auth_token = ""
+        if isinstance(auth_rows, dict):
+            auth_token = auth_rows.get("0", {}).get("AuthenticateResponse", "")
+
+        if not auth_token:
+            raise SourceArgumentNotFound("uprn", self._uprn)
+
+        today = datetime.date.today()
+        end_date = today + datetime.timedelta(days=90)
+
+        col_result = run_lookup(
+            session,
+            API_URL,
+            sid,
+            COLLECTIONS_LOOKUP_ID,
+            {
+                "Details": {
+                    "bartecMode": {"value": "Live"},
+                    "AuthenticateResponse": {"value": auth_token},
+                    "finalUPRN": {"value": self._uprn},
+                    "minimum_date": {"value": today.strftime("%Y-%m-%dT00:00:00")},
+                    "maximum_date": {"value": end_date.strftime("%Y-%m-%dT00:00:00")},
+                }
+            },
+        )
+        rows = col_result.get("integration", {}).get("transformed", {}).get("rows_data")
+
+        if not isinstance(rows, dict) or not rows:
+            raise SourceArgumentNotFound("uprn", self._uprn)
+
+        entries = []
+        for row in rows.values():
+            date_str = row.get("CollectionDateFormatted", "").strip()
+            if not date_str:
+                continue
+            try:
+                collection_date = datetime.datetime.strptime(
+                    date_str, "%d/%m/%Y"
+                ).date()
+            except ValueError:
+                continue
+
+            waste_type = LEADING_EMOJI_RE.sub(
+                "", row.get("CollectionTypeDescriptive", "")
+            ).strip()
+            if not waste_type:
+                waste_type = row.get("CollectionType", "").strip()
+            if not waste_type:
+                continue
+
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=waste_type,
+                    icon=_get_icon(waste_type),
+                )
+            )
+
+        return entries

--- a/doc/source/eastsuffolk_gov_uk.md
+++ b/doc/source/eastsuffolk_gov_uk.md
@@ -1,0 +1,35 @@
+# East Suffolk Council
+
+Support for schedules provided by [East Suffolk Council](https://www.eastsuffolk.gov.uk), UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: eastsuffolk_gov_uk
+      args:
+        uprn: UPRN
+```
+
+### Configuration Variables
+
+**uprn**
+*(string) (required)*
+
+Your Unique Property Reference Number (UPRN).
+
+## How to find your UPRN
+
+1. Visit the [East Suffolk bin collection dates finder](https://my.eastsuffolk.gov.uk/service/Bin_collection_dates_finder) and search for your address.
+2. Alternatively, look up your address at [findmyaddress.co.uk](https://www.findmyaddress.co.uk/).
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: eastsuffolk_gov_uk
+      args:
+        uprn: "YOUR_UPRN_HERE"
+```


### PR DESCRIPTION
## Summary
- Adds a new source for East Suffolk Council, UK, fetching bin collection dates from their public "Bin collection dates finder" (AchieveForms/Bartec-based), keyed by UPRN.
- Reuses the existing shared `waste_collection_schedule.service.AchieveForms` helper for the session handshake and lookup calls, consistent with other AchieveForms sources in the repo (e.g. `tendring_gov_uk.py`, `eastcambs_gov_uk.py`).
- Closes #5183.

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] Live test via `test_sources.py -s eastsuffolk_gov_uk -l` against both TEST_CASES, confirming real collection dates and waste types (including a Garden waste subscription) are returned
- [x] `doc/source/eastsuffolk_gov_uk.md` added