### PR TITLE
Fix communitywastedisposal_com: honor call-to-schedule flag and week-of-month ordinals

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/communitywastedisposal_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/communitywastedisposal_com.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, timedelta
 
 import requests
 from dateutil.rrule import FR, MO, SA, SU, TH, TU, WE, WEEKLY, rrule
-from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ArcGis import (
     ArcGisError,
@@ -22,6 +22,7 @@ COUNTRY = "us"
 TEST_CASES = {
     "Forney TX": {"address": "100 Princeton Cir, Forney, TX 75126"},
     "Allen TX": {"address": "123 Main St, Allen, TX 75002"},
+    "Keller TX": {"address": "2016 Willis Ln, Keller, TX, 76248, USA"},
 }
 
 PARAM_DESCRIPTIONS = {
@@ -37,13 +38,29 @@ PARAM_TRANSLATIONS = {
 }
 
 LAYER_CONFIG = {
-    0: {"type": "HHW", "icon": "mdi:delete-sweep"},
-    1: {"type": "Recycling", "icon": "mdi:recycle"},
-    2: {"type": "Trash", "icon": "mdi:trash-can-outline"},
-    3: {"type": "Bulk Waste", "icon": "mdi:package-variant"},
-    4: {"type": "Yard Waste", "icon": "mdi:leaf"},
-    5: {"type": "Compost", "icon": "mdi:compost"},
+    0: {"type": "HHW"},
+    1: {"type": "Recycling"},
+    2: {"type": "Trash"},
+    3: {"type": "Bulk Waste"},
+    4: {"type": "Yard Waste"},
+    5: {"type": "Compost"},
 }
+
+ICON_MAP = {
+    "HHW": Icons.HAZARDOUS,
+    "Recycling": Icons.RECYCLING,
+    "Trash": Icons.GENERAL_WASTE,
+    "Bulk Waste": Icons.BULKY,
+    "Yard Waste": Icons.GARDEN,
+    "Compost": Icons.ORGANIC,
+}
+
+# Fields (name differs in case between layers) that flag a waste stream as
+# "call to schedule" rather than an automatic recurring pickup. When set to
+# "Yes" the ArcGIS route data still carries a PickupDay/Frequency/TimingWeek
+# combination, but it does not represent an actual recurring collection date
+# -- the resident has to call CWD to arrange it. See #5072.
+CALL_TO_SCHEDULE_FIELDS = ("CallToSche", "CalltoSche")
 
 WEEKDAY_MAP = {
     "Monday": MO,
@@ -67,6 +84,11 @@ STR_TO_WEEKDAY = {
 
 FEATURE_BASE = "https://services3.arcgis.com/xeSJphIgrY4QfLVq/arcgis/rest/services/CWD_Routes_View/FeatureServer"
 GEOCODE_URL = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"
+
+
+def _week_of_month(d: date) -> int:
+    """Return the 1-based ordinal occurrence of d's weekday within its month."""
+    return ((d.day - 1) // 7) + 1
 
 
 class Source:
@@ -177,12 +199,32 @@ class Source:
         )
         all_dates = [d.date() for d in rule]
 
-        if "1st" in timing_week:
-            dates = [d for d in all_dates if d.day <= 7]
+        # TimingWeek can contain one or more ordinals, e.g. "1st", "3rd",
+        # "1st and 3rd" or "2nd and 4th". Whenever it gives us an explicit
+        # ordinal, honor it precisely (regardless of the -- sometimes
+        # inconsistent -- Frequency label) instead of only special-casing
+        # "1st" and silently falling back to "every single week" for
+        # anything else, which previously produced e.g. a collection every
+        # week for streams that only occur on the 2nd/4th week of the month.
+        ordinals = [int(n) for n in re.findall(r"\d+", timing_week)]
+
+        if ordinals:
+            dates = [d for d in all_dates if _week_of_month(d) in ordinals]
         elif "biweekly" in frequency:
-            dates = [d for i, d in enumerate(all_dates) if d.isocalendar()[1] % 2 == 1]
-        else:
+            dates = [d for d in all_dates if d.isocalendar()[1] % 2 == 1]
+        elif not frequency or frequency in ("na", "weekly"):
+            # Blank/"NA"/"Weekly" -- either explicitly weekly, or no
+            # cadence info at all (in which case a weekly cadence on the
+            # given PickupDay is the best available assumption, matching
+            # prior behavior).
             dates = all_dates
+        else:
+            # Frequency is "Monthly"/"BiMonthly"/"Calendar" (or something
+            # else unrecognised) but TimingWeek doesn't tell us which
+            # week(s) of the month apply. There is no way to derive that
+            # from the public route data alone, so skip rather than guess
+            # and show a wrong (e.g. weekly) schedule. See #5072.
+            dates = []
 
         return [
             (
@@ -215,6 +257,19 @@ class Source:
                 continue
 
             attrs = features[0]
+
+            # Some streams (typically HHW, and occasionally Bulk/Yard Waste)
+            # are "call to schedule" rather than an automatic recurring
+            # pickup: the route data still carries a PickupDay/Frequency, but
+            # residents must call CWD to arrange collection. Don't surface
+            # those as if they were a fixed recurring date. See #5072.
+            if any(
+                isinstance(attrs.get(field), str)
+                and attrs[field].strip().lower() == "yes"
+                for field in CALL_TO_SCHEDULE_FIELDS
+            ):
+                continue
+
             pickup_days = [
                 d.strip()
                 for key in ("PickupDay1", "PickupDay2")
@@ -236,7 +291,7 @@ class Source:
                         Collection(
                             date=collection_date,
                             t=config["type"],
-                            icon=config["icon"],
+                            icon=ICON_MAP.get(config["type"]),
                         )
                     )
 

--- a/doc/source/communitywastedisposal_com.md
+++ b/doc/source/communitywastedisposal_com.md
@@ -33,4 +33,8 @@ waste_collection_schedule:
 
 Visit the [CWD View My Schedule](https://www.communitywastedisposal.com/view-my-schedule/) page and enter your address to verify your service area and collection days.
 
-Supported cities include: Addison, Allen, Anna, Balch Springs, Blue Ridge, Celina, Crandall, Fairview, Farmersville, Fate, Forney, Frisco, Garland, Heath, Josephine, Kaufman, Lavon, Lucas, McKinney, McLendon-Chisholm, Melissa, Murphy, Nevada, Parker, Plano, Princeton, Prosper, Richardson, Rockwall, Rowlett, Royse City, Sachse, Seagoville, Southlake, St. Paul, Talty, Terrell, and Wylie.
+Supported cities include: Addison, Allen, Anna, Balch Springs, Blue Ridge, Celina, Crandall, Fairview, Farmersville, Fate, Forney, Frisco, Garland, Heath, Josephine, Kaufman, Keller, Lavon, Lucas, McKinney, McLendon-Chisholm, Melissa, Murphy, Nevada, Parker, Plano, Princeton, Prosper, Richardson, Rockwall, Rowlett, Royse City, Sachse, Seagoville, Southlake, St. Paul, Talty, Terrell, and Wylie.
+
+## Limitations
+
+Some waste streams are "call to schedule" rather than an automatic recurring pickup (e.g. Household Hazardous Waste in most zones) — these are not returned, since there is no fixed recurring date to report. Likewise, some Monthly/BiMonthly streams don't specify which week of the month they fall on in CWD's public route data; those are also omitted rather than guessed.


### PR DESCRIPTION
## Summary
- Community Waste Disposal (CWD) (`communitywastedisposal_com`) already covers Keller, TX (#5072) — no new source is needed. While verifying the reporter's address I found the source was showing several waste streams as bogus weekly collections.
- Some CWD streams (most commonly Household Hazardous Waste) are "call to schedule" — the route data still carries a PickupDay/Frequency, but residents must call CWD to arrange pickup. The source ignored this flag and displayed them as an automatic weekly collection anyway.
- Monthly/BiMonthly streams whose route data doesn't specify which week of the month applies were also silently defaulted to "every week" instead of being omitted.
- This PR: skips call-to-schedule streams, correctly parses all `TimingWeek` ordinals (`1st`/`2nd`/`3rd`/`4th`, incl. combinations like `"2nd and 4th"`) instead of only special-casing `"1st"`, skips truly ambiguous Monthly/BiMonthly streams instead of guessing, adds a Keller TX test case, and moves `ICON_MAP` onto the canonical `Icons` enum.

## Test plan
- [x] `python custom_components/.../test/test_sources.py -s communitywastedisposal_com -l` — Forney/Allen/Keller all return sane, correctly-typed entries; the previously-bogus weekly HHW/Bulk/Yard entries for call-to-schedule or ambiguous-cadence streams are gone.
- [x] `python custom_components/.../test/test_sources.py -s communitywastedisposal_com -d` — double-fetch determinism check passes.
- [x] `python -m pytest tests/test_source_components.py -q` — passes.
- [x] `ruff check --fix` / `ruff format` — clean.

Closes #5072