### PR TITLE
fix(mijnafvalwijzer_nl): scope date/type lookup to each year's own div

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mijnafvalwijzer_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mijnafvalwijzer_nl.py
@@ -85,12 +85,18 @@ class Source:
         types_list = []
         for year in years:
             year_int = int(year.get("id")[-4:])
-            dates = soup.find_all("span", class_="span-line-break")
+            # Scope the date/type lookup to this year's own container.
+            # Searching the whole page (`soup`) here pulls in the
+            # dates/types of *every* year present on the page for *each*
+            # year iteration, duplicating entries and mislabeling half of
+            # them with the wrong year whenever two "jaar-XXXX" blocks are
+            # present at once (e.g. around a year boundary). See GH #5064.
+            dates = year.find_all("span", class_="span-line-break")
             for date in dates:
                 date_day.append(int(date.string.split()[1]))
                 date_month.append(dict_month[date.string.split()[2]])
                 date_year.append(year_int)
-            types = soup.find_all("span", class_="afvaldescr")
+            types = year.find_all("span", class_="afvaldescr")
             for type in types:
                 types_list.append(type.string)
 


### PR DESCRIPTION
## Summary
- `Source.fetch()` looped over each `jaar-XXXX` year container but queried
  `soup.find_all(...)` (the whole page) instead of `year.find_all(...)`
  (the current year's own element) for dates and waste types.
- When mijnafvalwijzer.nl renders two year blocks at once (e.g. around a
  year boundary, showing remaining days of the current year plus all of
  next year), this caused every date to be collected twice and tagged
  with both years — producing duplicate, mislabeled calendar entries.
- Fix: scope both `find_all` calls to the per-year `year` element.

Fixes #5064

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python test_sources.py -s mijnafvalwijzer_nl -l` — 4/5 TEST_CASES pass (Tilburg fails with a pre-existing, unrelated 404 from a stale postcode/number test fixture, confirmed present on unpatched master too)
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] Reproduced the bug with a synthetic two-year page (duplicating the current single `jaar-2026` block into `jaar-2025`+`jaar-2026`): old code produced 116 duplicated/mislabeled entries, fixed code produces the correct 58 unique entries