### PR TITLE
feat(source): add Southend-on-Sea City Council waste collection (southend_gov_uk)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southend_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southend_gov_uk.py
@@ -1,0 +1,65 @@
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentRequired
+from waste_collection_schedule.service.uk_cloud9_apps import Cloud9Client
+
+TITLE = "Southend-on-Sea City Council"
+DESCRIPTION = (
+    "Source for southend.gov.uk services for Southend-on-Sea City Council, UK."
+)
+URL = "https://www.southend.gov.uk"
+COUNTRY = "uk"
+TEST_CASES = {
+    "Test_001": {"uprn": 100090691871},
+    "Test_002": {"uprn": "100090700485"},
+    "Test_003": {
+        "postcode": "SS3 9JD",
+        "address": "38 Thorpedene Gardens, Shoeburyness",
+    },
+}
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "You can find your UPRN by visiting [Find My Address](https://www.findmyaddress.co.uk) and entering your address details."
+}
+PARAM_TRANSLATIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number (UPRN)",
+        "postcode": "Postcode (legacy, use UPRN instead)",
+        "address": "Address (legacy, use UPRN instead)",
+    }
+}
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number (UPRN)",
+        "postcode": "Postcode (legacy, use UPRN instead)",
+        "address": "Address (legacy, use UPRN instead)",
+    }
+}
+ICON_MAP = {
+    "garden": Icons.GARDEN,
+    "food": Icons.BIO_KITCHEN,
+    "recycl": Icons.RECYCLING,
+    "refuse": Icons.GENERAL_WASTE,
+}
+
+
+class Source:
+    def __init__(
+        self,
+        uprn: str | int | None = None,
+        postcode: str | None = None,
+        address: str | None = None,
+    ):
+        self._client = Cloud9Client("southend", icon_keywords=ICON_MAP)
+        self._uprn = str(uprn) if uprn else None
+        self._postcode = postcode
+        self._address = address
+
+    def fetch(self) -> list[Collection]:
+        if self._uprn:
+            return self._client.fetch_by_uprn(self._uprn)
+        if not self._postcode:
+            raise SourceArgumentRequired("uprn", "Provide a UPRN or postcode + address")
+        return self._client.fetch_by_address(
+            postcode=self._postcode,
+            address_string=self._address or "",
+            argument_name="postcode",
+        )

--- a/doc/source/southend_gov_uk.md
+++ b/doc/source/southend_gov_uk.md
@@ -1,0 +1,49 @@
+# Southend-on-Sea City Council
+
+Support for schedules provided by [Southend-on-Sea City Council](https://www.southend.gov.uk), UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: southend_gov_uk
+      args:
+        uprn: UNIQUE_PROPERTY_REFERENCE_NUMBER
+```
+
+### Configuration Variables
+
+**uprn**
+*(string) (required)*
+
+**postcode**
+*(string) (optional) (legacy, use UPRN instead)*
+
+**address**
+*(string) (optional) (legacy, use UPRN instead)*
+
+## Example using UPRN
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: southend_gov_uk
+      args:
+        uprn: "100090691871"
+```
+
+## Example using postcode and address (legacy)
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: southend_gov_uk
+      args:
+        postcode: "SS3 9JD"
+        address: "38 Thorpedene Gardens, Shoeburyness"
+```
+
+#### How to get the source argument
+
+An easy way to discover your Unique Property Reference Number (UPRN) is by going to https://www.findmyaddress.co.uk/ and entering in your address details.


### PR DESCRIPTION
## Summary
- Adds a new source for Southend-on-Sea City Council, UK, closing #4852.
- Southend recently migrated collection lookups to a "Southend Waste" mobile app built on the Cloud9 Technologies platform, the same backend already used by `arun_gov_uk`, `northherts_gov_uk`, and `rugby_gov_uk`. This source reuses the shared `Cloud9Client` service with authority `southend`.
- Supports lookup by UPRN (preferred) or legacy postcode + address.

## Test plan
- [x] `ruff check --fix` / `ruff format` on the new source file
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `python test_sources.py -s southend_gov_uk -l` — all 3 TEST_CASES return live collection data
- [x] Added `doc/source/southend_gov_uk.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)