### PR TITLE
feat(source): add Surf Coast Shire, VIC, AU (surf_coast_vic_gov_au)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/surf_coast_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/surf_coast_vic_gov_au.py
@@ -1,0 +1,198 @@
+import logging
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+from ..service.WhatBinDay import WhatBinDayService
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "Surf Coast Shire"
+DESCRIPTION = "Source for Surf Coast Shire (VIC) waste collection."
+URL = "https://www.surfcoast.vic.gov.au"
+COUNTRY = "au"
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Visit the Surf Coast Shire 'Bin collection calendars' page "
+        "(https://www.surfcoast.vic.gov.au/Property/Waste-and-recycling/Kerbside-bins/Bin-collection-calendars), "
+        "search for your address, and enter the street number, street name, "
+        "suburb and postcode exactly as they appear (suburb must be in "
+        "Title Case, e.g. 'Torquay', not 'TORQUAY')."
+    )
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street_number": "Street number (e.g. '20')",
+        "street_name": "Street name (e.g. 'Bell Street')",
+        "suburb": "Suburb, in Title Case (e.g. 'Torquay')",
+        "post_code": "Postcode (e.g. '3228')",
+    }
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "street_number": "Street number",
+        "street_name": "Street name",
+        "suburb": "Suburb",
+        "post_code": "Post code",
+    }
+}
+
+TEST_CASES = {
+    "Bell Street Torquay": {
+        "street_number": "20",
+        "street_name": "Bell Street",
+        "suburb": "Torquay",
+        "post_code": "3228",
+    },
+    "Mountjoy Parade Lorne": {
+        "street_number": "1",
+        "street_name": "Mountjoy Parade",
+        "suburb": "Lorne",
+        "post_code": "3232",
+    },
+    "Noble Street Anglesea": {
+        "street_number": "1",
+        "street_name": "Noble Street",
+        "suburb": "Anglesea",
+        "post_code": "3230",
+    },
+}
+
+
+ICON_MAP = {
+    "WasteBin": Icons.GENERAL_WASTE,
+    "RecycleBin": Icons.RECYCLING,
+    "GreenBin": Icons.ORGANIC,
+    "GlassBin": Icons.GLASS,
+}
+
+BIN_NAMES = {
+    "WasteBin": "General waste (landfill)",
+    "RecycleBin": "Recycling",
+    "GreenBin": "Food and garden waste",
+    "GlassBin": "Glass",
+}
+
+
+class Source:
+    def __init__(
+        self, street_number: str, street_name: str, suburb: str, post_code: str
+    ):
+        self.street_number = str(street_number)
+        self.street_name = str(street_name)
+        # Surf Coast Shire's WhatBinDay backend matches the suburb name
+        # case-sensitively against its own dataset (e.g. "Torquay", not
+        # "TORQUAY"), so normalise user input to Title Case.
+        self.suburb = str(suburb).strip().title()
+        self.post_code = str(post_code)
+
+        self._service = WhatBinDayService(
+            location_key=(
+                f"{self.street_number}_{self.street_name}_"
+                f"{self.suburb}_{self.post_code}"
+            ),
+            icon_map=ICON_MAP,
+            bin_names=BIN_NAMES,
+            app_package="com.socketsoftware.whatbinday.surfcoast",
+        )
+
+    def _geocode(self) -> dict:
+        """Resolve the address to coordinates via Nominatim.
+
+        Surf Coast Shire's roster lookup requires coordinates close to the
+        actual property (unlike some other WhatBinDay-backed councils, a
+        generic/default coordinate does not resolve to any bin service),
+        so we geocode the full address first.
+        """
+        query = (
+            f"{self.street_number} {self.street_name}, "
+            f"{self.suburb} VIC {self.post_code}, Australia"
+        )
+        response = requests.get(
+            NOMINATIM_URL,
+            params={
+                "q": query,
+                "format": "json",
+                "limit": "1",
+                "countrycodes": "au",
+            },
+            headers={"User-Agent": "hacs_waste_collection_schedule"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        results = response.json()
+        if not results:
+            raise SourceArgumentNotFound("street_name", self.street_name)
+
+        return {
+            "lat": float(results[0]["lat"]),
+            "lng": float(results[0]["lon"]),
+        }
+
+    def _build_location_data(self, coordinates: dict) -> dict:
+        """Build the WhatBinDay address payload.
+
+        The shared WhatBinDayService.build_address_data() helper uses the
+        same string for both the state's long_name and short_name. Surf
+        Coast Shire's backend requires the full state name ("Victoria") as
+        the long_name, so the payload is built manually here instead of
+        via that helper.
+        """
+        formatted_address = (
+            f"{self.street_number} {self.street_name}, "
+            f"{self.suburb} VIC {self.post_code}, Australia"
+        )
+        return {
+            "address_components": [
+                {
+                    "long_name": self.street_number,
+                    "short_name": self.street_number,
+                    "types": ["street_number"],
+                },
+                {
+                    "long_name": self.street_name,
+                    "short_name": self.street_name,
+                    "types": ["route"],
+                },
+                {
+                    "long_name": self.suburb,
+                    "short_name": self.suburb,
+                    "types": ["locality", "political"],
+                },
+                {
+                    "long_name": self.post_code,
+                    "short_name": self.post_code,
+                    "types": ["postal_code"],
+                },
+                {
+                    "long_name": "Victoria",
+                    "short_name": "VIC",
+                    "types": ["administrative_area_level_1", "political"],
+                },
+                {
+                    "long_name": "Australia",
+                    "short_name": "AU",
+                    "types": ["country", "political"],
+                },
+            ],
+            "formatted_address": formatted_address,
+            "geometry": {
+                "location": coordinates,
+                "location_type": "APPROXIMATE",
+            },
+        }
+
+    def fetch(self) -> list[Collection]:
+        coordinates = self._geocode()
+        location_data = self._build_location_data(coordinates)
+
+        entries = self._service.get_collection_schedule(location_data)
+        if not entries:
+            raise SourceArgumentNotFound("street_name", self.street_name)
+        return entries

--- a/doc/source/surf_coast_vic_gov_au.md
+++ b/doc/source/surf_coast_vic_gov_au.md
@@ -1,0 +1,54 @@
+# Surf Coast Shire, VIC
+
+Support for schedules provided by [Surf Coast Shire Bin collection calendars](https://www.surfcoast.vic.gov.au/Property/Waste-and-recycling/Kerbside-bins/Bin-collection-calendars), the same lookup used by the official SCRRApp ([Apple](https://apps.apple.com/au/app/scrrapp/id1547443364) / [Google Play](https://play.google.com/store/apps/details?id=com.socketsoftware.whatbinday.surfcoast)).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: surf_coast_vic_gov_au
+      args:
+        street_number: STREET_NUMBER
+        street_name: STREET_NAME
+        suburb: SUBURB
+        post_code: POST_CODE
+```
+
+### Configuration Variables
+
+**street_number**  
+*(string) (required)*
+
+**street_name**  
+*(string) (required)*
+
+**suburb**  
+*(string) (required)*
+
+Must be entered in Title Case (e.g. `Torquay`), not upper case (`TORQUAY`) — the upstream lookup matches suburb names case-sensitively.
+
+**post_code**  
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: surf_coast_vic_gov_au
+      args:
+        street_number: "20"
+        street_name: "Bell Street"
+        suburb: "Torquay"
+        post_code: "3228"
+```
+
+## How to get the source arguments
+
+1. Visit the [Bin collection calendars](https://www.surfcoast.vic.gov.au/Property/Waste-and-recycling/Kerbside-bins/Bin-collection-calendars) page and search for your address to confirm it is serviced.
+2. Enter the street number, street name, suburb and postcode of your address. The suburb must be in Title Case (e.g. `Lorne`, `Anglesea`, `Torquay`) exactly as it appears on the council's own address list.
+
+## Notes
+
+This source geocodes the supplied address via [OpenStreetMap Nominatim](https://nominatim.openstreetmap.org/) and then queries the same public WhatBinDay API used by the SCRRApp mobile app. A very small number of addresses may not resolve to a coordinate precise enough for the upstream lookup to match a serviced address (this appears to affect a handful of properties even in the mobile app itself), in which case the source will raise an error asking you to check the address.


### PR DESCRIPTION
## Summary
- Adds `surf_coast_vic_gov_au` source for Surf Coast Shire, VIC, Australia, using the same public WhatBinDay API (`api.whatbinday.com`) that backs the council's official SCRRApp mobile app (app package `com.socketsoftware.whatbinday.surfcoast`).
- Reuses the shared `WhatBinDayService` (already used by `kingston_vic_gov_au.py` and `lismore_city_nsw_gov_au.py`) for device registration and result parsing — no changes made to that shared file.
- Surf Coast's backend requires the address state `long_name` to be `"Victoria"` (not `"VIC"`) and matches suburb names case-sensitively, so the address payload is built directly in this source rather than via `WhatBinDayService.build_address_data()`.
- Adds a new `GlassBin` → `Icons.GLASS` mapping (a bin type not seen in the existing WhatBinDay sources).
- Adds `doc/source/surf_coast_vic_gov_au.md`.

Closes #4971

## Test plan
- [x] `ruff check --fix` / `ruff format` — clean
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed
- [x] `python test_sources.py -s surf_coast_vic_gov_au -l` — all 3 TEST_CASES pass live (236–238 entries each)