### PR TITLE
Fix 7 wrong council website domains in impactapps_com_au source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
@@ -217,7 +217,7 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
     {
         "name": "Brisbane City Council",
         "url": "https://brisbane.waste-info.com.au",
-        "website": "https://www.brisbane.nsw.gov.au",
+        "website": "https://www.brisbane.qld.gov.au",
     },
     {
         "name": "Burwood City Council",
@@ -227,12 +227,12 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
     {
         "name": "Campbeltown City Council",
         "url": "https://campbelltown.waste-info.com.au",
-        "website": "https://www.campbelltown.vic.gov.au",
+        "website": "https://www.campbelltown.nsw.gov.au",
     },
     {
         "name": "City of Canada Bay Council",
         "url": "https://canada-bay.waste-info.com.au",
-        "website": "https://www.canadabay.vic.gov.au",
+        "website": "https://www.canadabay.nsw.gov.au",
     },
     {
         "name": "Cowra Council",
@@ -242,7 +242,7 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
     {
         "name": "Cumberland City Council",
         "url": "https://cumberland.waste-info.com.au",
-        "website": "https://www.cumberland.vic.gov.au",
+        "website": "https://www.cumberland.nsw.gov.au",
     },
     {
         "name": "Forbes Shire Council",
@@ -257,7 +257,7 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
     {
         "name": "Lithgow City Council",
         "url": "https://lithgow.waste-info.com.au",
-        "website": "https://www.lithgow.nsw.gov.au",
+        "website": "https://council.lithgow.com/",
     },
     {
         "name": "Livingstone Shire Council",
@@ -282,7 +282,7 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
     {
         "name": "Port Stephens Council",
         "url": "https://port-stephens.waste-info.com.au",
-        "website": "https://www.portstephens.vic.gov.au",
+        "website": "https://www.portstephens.nsw.gov.au",
     },
     {
         "name": "Port Macquarie Hastings Council",
@@ -317,7 +317,7 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
     {
         "name": "Wollongong City Council",
         "url": "https://wollongong.waste-info.com.au",
-        "website": "https://www.wollongong.vic.gov.au",
+        "website": "https://www.wollongong.nsw.gov.au",
     },
     {
         "name": "Gympie Regional Council",


### PR DESCRIPTION
## Summary
- Brisbane City Council's \`website\` pointed to a \`.nsw.gov.au\` domain — Brisbane is in Queensland, real domain is \`brisbane.qld.gov.au\`
- Campbelltown, Canada Bay, Cumberland, Port Stephens, and Wollongong councils' \`website\` all pointed to \`.vic.gov.au\` domains — all five are actually in NSW
- Lithgow City Council's \`website\` (\`lithgow.nsw.gov.au\`) doesn't resolve at all — the council's real site is \`council.lithgow.com\`

The \`url\` field (used for the actual waste-info.com.au API calls this source makes) is unaffected — only \`website\`, the reference link to each council's own official site, was wrong.

## How found
Building a per-scan "data sourced from X" attribution feature in a downstream app that surfaces \`website\` to end users. Verified every corrected domain resolves and is the right council (direct HTTP check, cross-referenced against Wikipedia's infobox for a couple that didn't respond directly from my network) before fixing.

## Test plan
- [x] File still parses (valid Python)
- [x] Diff is minimal — exactly the 7 wrong \`website\` values changed, nothing else touched
- [x] Confirmed all 7 corrected domains resolve and match the real council