### PR TITLE
fix(ecoharmonogram_pl): disambiguate single/multi-family schedules for multi-id streets

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import re
-from typing import cast
+from typing import ClassVar, cast
 
 from ..collection import Collection
 from ..exceptions import (
@@ -17,6 +17,7 @@ from ..service.EcoHarmonogramPL import (
     Schedule,
     ScheduleDescription,
     SchedulePeriod,
+    ScheduleResponse,
     Street,
     StreetResponse,
     Town,
@@ -68,7 +69,7 @@ PARAM_DESCRIPTIONS = {
         "house_number": "House number",
         "district": "District",
         "language": "Language for waste type names (pl, en, uk, ru)",
-        "additional_sides_matcher": "Additional matcher for collection sides",
+        "additional_sides_matcher": "Additional matcher for collection sides. Also used to pick between single-family ('Zabudowa jednorodzinna') and multi-family ('Zabudowa wielorodzinna') schedules for streets that offer both.",
         "community": "Community",
         "g1": GROUP_DESCRIPTION_EN,
         "g2": GROUP_DESCRIPTION_EN,
@@ -156,11 +157,19 @@ TEST_CASES = {
         "house_number": "1",
         "district": "Zawiercie",
     },
-    "Case for multi id separated with comma": {
+    "Case for multi id separated with comma (single-family)": {
         "town": "Zabrze",
         "street": "Leśna",
         "district": "Zabrze",
         "house_number": "1",
+        "additional_sides_matcher": "Zabudowa jednorodzinna",
+    },
+    "Case for multi id separated with comma (multi-family)": {
+        "town": "Zabrze",
+        "street": "Leśna",
+        "district": "Zabrze",
+        "house_number": "1",
+        "additional_sides_matcher": "Zabudowa wielorodzinna",
     },
     "Case for multiple schedules for the same house": {
         "town": "Nadolice Wielkie",
@@ -466,59 +475,161 @@ class Source:
 
         return streets
 
+    # Some towns (e.g. Zabrze) encode single-family ("jednorodzinna") vs
+    # multi-family ("wielorodzinna") housing as two different schedule ids
+    # for what looks like a single street. The `sides` field returned for
+    # those ids is identical (it just holds the district name), so it can't
+    # be used to tell them apart. The only reliable signal we've found is
+    # the housing-type letter encoded in the response's top-level `name`
+    # field, e.g. "Hjb_15;Hjmb_17;..." (single-family) vs "Hwb_9;Hwmb_15;..."
+    # (multi-family).
+    _HOUSING_TYPE_LABELS: ClassVar[dict[str, str]] = {
+        "j": "Zabudowa jednorodzinna",
+        "w": "Zabudowa wielorodzinna",
+    }
+
+    @classmethod
+    def _derive_housing_type_label(cls, schedules_response: ScheduleResponse) -> str:
+        """Best-effort housing-type label derived from the schedule-name prefix.
+
+        Returns "" when the response doesn't match the known "Hj"/"Hw"
+        prefix pattern, i.e. when it can't be used to disambiguate.
+        """
+        name = schedules_response.get("name") or ""
+        first_token = name.split(";", 1)[0]
+        match = re.match(r"^H([jw])", first_token)
+        if not match:
+            return ""
+        return cls._HOUSING_TYPE_LABELS[match.group(1)]
+
+    def _append_schedule_entries(
+        self, schedules_response: ScheduleResponse, entries: list[Collection]
+    ) -> None:
+        schedules_raw = schedules_response["schedules"]
+        schedules_descriptions_dict = dict[str, ScheduleDescription]()
+        schedules_descriptions_raw = schedules_response["scheduleDescription"]
+
+        for sd in schedules_descriptions_raw:
+            schedules_descriptions_dict[sd["id"]] = sd
+
+        schedules: list[ScheduleWithName] = []
+        for sr in schedules_raw:
+            z: ScheduleWithName = cast(ScheduleWithName, sr.copy())
+            z["name"] = schedules_descriptions_dict[sr["scheduleDescriptionId"]]["name"]
+            schedules.append(z)
+
+        for sch in schedules:
+            days = sch["days"].split(";")
+            month = sch["month"]
+            year = sch["year"]
+            for d in days:
+                d = d.strip()
+                if not d:
+                    continue
+                try:
+                    dmy = datetime.date(int(year), int(month), int(d))
+                except ValueError:
+                    _LOGGER.warning(
+                        "ecoharmonogram_pl: skipping invalid date %s-%s-%s for %s",
+                        year,
+                        month,
+                        d,
+                        sch["name"],
+                    )
+                    continue
+                name = sch["name"]
+                if not self._entry_exists(dmy, name, entries):
+                    entries.append(Collection(dmy, name))
+
     def _create_entries(self, sp: SchedulePeriod, town: Town) -> list[Collection]:
         streets = self._get_streets_with_group(sp, town)
         streets_list = self._filter_streets_by_house_number(streets["streets"])
 
         entries: list[Collection] = []
         for street in streets_list:
-            for streetId in street["id"].split(","):
+            street_ids = street["id"].split(",")
+
+            if len(street_ids) == 1:
+                # Fast path: unchanged legacy behaviour for the common case.
                 schedules_response = self._ecoharmonogram_pl.fetch_schedules(
-                    sp, streetId
+                    sp, street_ids[0]
                 )
-                schedules_raw = schedules_response["schedules"]
                 if (
                     self.additional_sides_matcher_input.lower()
                     in schedules_response["street"]["sides"].lower()
                 ):
-                    schedules_descriptions_dict = dict[str, ScheduleDescription]()
-                    schedules_descriptions_raw = schedules_response[
-                        "scheduleDescription"
-                    ]
-
-                    for sd in schedules_descriptions_raw:
-                        schedules_descriptions_dict[sd["id"]] = sd
-
-                    schedules: list[ScheduleWithName] = []
-                    for sr in schedules_raw:
-                        z: ScheduleWithName = cast(ScheduleWithName, sr.copy())
-                        z["name"] = schedules_descriptions_dict[
-                            sr["scheduleDescriptionId"]
-                        ]["name"]
-                        schedules.append(z)
-
-                    for sch in schedules:
-                        days = sch["days"].split(";")
-                        month = sch["month"]
-                        year = sch["year"]
-                        for d in days:
-                            d = d.strip()
-                            if not d:
-                                continue
-                            try:
-                                dmy = datetime.date(int(year), int(month), int(d))
-                            except ValueError:
-                                _LOGGER.warning(
-                                    "ecoharmonogram_pl: skipping invalid date %s-%s-%s for %s",
-                                    year,
-                                    month,
-                                    d,
-                                    sch["name"],
-                                )
-                                continue
-                            name = sch["name"]
-                            if not self._entry_exists(dmy, name, entries):
-                                entries.append(Collection(dmy, name))
+                    self._append_schedule_entries(schedules_response, entries)
                 if self.additional_sides_matcher_input == "":
                     return entries
+                continue
+
+            # A single street entry bundles multiple ids (e.g. Zabrze splits
+            # single-family and multi-family housing into two ids for the
+            # same street name). Fetch all of them up front so we can decide
+            # whether `sides` already disambiguates them.
+            fetched: list[tuple[str, ScheduleResponse]] = [
+                (streetId, self._ecoharmonogram_pl.fetch_schedules(sp, streetId))
+                for streetId in street_ids
+            ]
+            sides_by_id = [resp["street"]["sides"] for _, resp in fetched]
+
+            if len({s.lower() for s in sides_by_id}) > 1:
+                # `sides` differs between ids - keep existing behaviour and
+                # let additional_sides_matcher filter on it as before.
+                for _streetId, schedules_response in fetched:
+                    if (
+                        self.additional_sides_matcher_input.lower()
+                        not in schedules_response["street"]["sides"].lower()
+                    ):
+                        continue
+                    self._append_schedule_entries(schedules_response, entries)
+                if self.additional_sides_matcher_input == "":
+                    return entries
+                continue
+
+            # `sides` is identical (or empty) for every id, so it can't
+            # disambiguate them. Fall back to the housing-type label derived
+            # from the schedule name.
+            derived_labels = [
+                self._derive_housing_type_label(resp) for _, resp in fetched
+            ]
+            distinct_derived = {d for d in derived_labels if d}
+
+            if len(distinct_derived) <= 1:
+                # No known housing-type split detected - preserve legacy
+                # behaviour and merge everything (e.g. Nadolice Wielkie,
+                # where multiple ids for the same house are genuinely meant
+                # to be combined into a single calendar).
+                for _streetId, schedules_response in fetched:
+                    self._append_schedule_entries(schedules_response, entries)
+                if self.additional_sides_matcher_input == "":
+                    return entries
+                continue
+
+            # Multiple genuinely different housing types were found for this
+            # street - require the user to pick one via
+            # additional_sides_matcher instead of silently merging them.
+            if self.additional_sides_matcher_input == "":
+                raise SourceArgumentRequiredWithSuggestions(
+                    "additional_sides_matcher",
+                    "this street has separate schedules for single-family and "
+                    "multi-family housing, please select one",
+                    distinct_derived,
+                )
+
+            matched_any = False
+            for (_streetId, schedules_response), label in zip(
+                fetched, derived_labels, strict=True
+            ):
+                if self.additional_sides_matcher_input.lower() != label.lower():
+                    continue
+                matched_any = True
+                self._append_schedule_entries(schedules_response, entries)
+
+            if not matched_any:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "additional_sides_matcher",
+                    self.additional_sides_matcher_input,
+                    distinct_derived,
+                )
         return entries


### PR DESCRIPTION
## Summary
- Fixes #6922: for streets like Zabrze's "Leśna" where the API returns two comma-separated street ids (one for single-family / "jednorodzinna" housing, one for multi-family / "wielorodzinna"), the source used to either merge both schedules into one calendar or silently pick whichever id came first, since the `sides` field (normally used to disambiguate via `additional_sides_matcher`) is identical for both ids in these cases.
- Adds a fallback disambiguation signal derived from the schedule response's `name` field prefix (`Hj...` = single-family, `Hw...` = multi-family), reusing the existing `additional_sides_matcher` parameter so users can select "Zabudowa jednorodzinna" or "Zabudowa wielorodzinna" for affected streets — consistent with how other towns already use that parameter.
- This fallback only activates when `sides` can't already disambiguate the ids **and** a genuine Hj/Hw split is detected, so towns that legitimately merge multiple ids into a single house's calendar (e.g. the existing "Nadolice Wielkie" test case) are unaffected.

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] `python -m pytest tests/test_source_components.py -q` passes (10 passed)
- [x] Offline unit-level verification against mocked API responses shaped like the issue's evidence, confirming: ambiguous case now raises a clear `SourceArgumentRequiredWithSuggestions`/`SourceArgumentNotFoundWithSuggestions`, correct filtering per housing type, and unaffected legacy-merge behavior for unrelated multi-id towns
- [ ] Live `test_sources.py -s ecoharmonogram_pl -l` — not runnable from CI/dev sandbox (the API appears to return empty responses to non-Polish IPs); would appreciate a maintainer or the reporter re-testing with the new `additional_sides_matcher` values against their real Zabrze address