### PR TITLE
fix(config_flow): surface WASTE_TYPES in the UI language (v3 beta feedback)

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -295,12 +295,19 @@ def _build_schema_from_params(
 def _get_waste_types_for_customize(source_cls) -> list[str]:
     """Get waste type names from WASTE_TYPES for customization.
 
-    Returns waste_type.id strings for new-style sources.
+    Returns each canonical WasteType's name in the active display language, so
+    the names match the labels ``Collection.type`` produces at fetch time.
+    Returning the English name regardless of the UI language made the config
+    flow offer an English duplicate of every type already fetched under its
+    localised name, which then became an empty extra sensor (v3 beta feedback,
+    #6561).
     """
+    from waste_collection_schedule.waste_types import display_name
+
     waste_types = getattr(source_cls, "WASTE_TYPES", None)
     if not waste_types:
         return []
-    return [wt.names.get("en", wt.id) for wt in waste_types]
+    return [display_name(wt) for wt in waste_types]
 
 
 def get_customize_schema(defaults: dict[str, Any] | None = None):
@@ -939,6 +946,13 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
             # During reconfigure the existing entry already owns this unique_id;
             # skipping the check prevents HA from aborting and creating a duplicate.
             self._abort_if_unique_id_configured()
+
+        # Collection labels are localised to the HA UI language at fetch time;
+        # align the display language here so the types offered and auto-created
+        # during setup match what the entry will show once running (#6561).
+        from waste_collection_schedule.waste_types import set_display_language
+
+        set_display_language(self.hass.config.language)
 
         try:
             instance = await self.hass.async_add_executor_job(

--- a/tests/test_new_architecture.py
+++ b/tests/test_new_architecture.py
@@ -2334,6 +2334,32 @@ class TestDisplayLanguage:
             # Restore the default so other tests keep seeing English labels.
             w.set_display_language("en")
 
+    def test_waste_type_ui_name_matches_collection_type(self):
+        """The name the config flow offers for a WASTE_TYPE must match the
+        label its Collections carry at runtime.
+
+        The config flow surfaces a source's WASTE_TYPES via
+        ``waste_types.display_name`` (localised). Hardcoding the English name
+        instead (the pre-fix behaviour) meant a non-English instance was offered
+        an English duplicate of a type already fetched under its localised name,
+        which then became an empty extra sensor (v3 beta feedback, #6561).
+        """
+        from waste_collection_schedule import waste_types as w
+        from waste_collection_schedule.collection import Collection
+
+        day = datetime.date(2026, 1, 1)
+        try:
+            w.set_display_language("de")
+            for wt in (w.GENERAL_WASTE, w.RECYCLABLES, w.PAPER):
+                offered = w.display_name(wt)  # what the config flow now offers
+                fetched = Collection(date=day, waste_type=wt).type
+                assert offered == fetched
+                # And it must not be the English name a German instance would
+                # never produce (the phantom-sensor cause).
+                assert offered != wt.names["en"]
+        finally:
+            w.set_display_language("en")
+
 
 class TestConfigParamValidation:
     """Defaults, alternatives, and validate() rules for ConfigParam."""


### PR DESCRIPTION
Fixes #6925. Feedback from @meilon trialling the v3 beta (#6561).

## Problem

`Collection.type` localises canonical `WasteType` labels to the Home Assistant UI language (`waste_types.display_name`, set from `hass.config.language`). But the config flow surfaced a source's `WASTE_TYPES` by their hardcoded English names (`wt.names["en"]`).

The config flow unions the fetched types (localised) with those English names, and when the user does not configure sensors manually the finish step auto-creates one sensor per resulting type. On a non-English instance the English names never match any fetched collection, so each becomes an empty sensor.

@meilon saw this on a German instance of `awb_es_de`: the correct German sensors with data, plus 3 empty English ones (`Recycling`, `Paper & Cardboard`, `General Waste`).

## Fix

- Surface `WASTE_TYPES` through `display_name` (localised) instead of the hardcoded English name, so the offered names match the labels collections actually carry.
- Set the display language at the start of the config-flow fetch, so the types offered and auto-created during setup match what the running entry shows regardless of whether another entry has already been set up in the process.

With both, the union de-duplicates and the phantom sensors disappear.

## Verification

Reproduced offline against the `awb_es_de` cassette with the display language set to German: fetched `[Biomüll, Wertstoffe, Restmüll, Altpapier, Warentauschtag]`, phantom English `[Recycling, Paper & Cardboard, General Waste]`; after the fix, zero phantoms.

Added a regression test (`TestDisplayLanguage.test_waste_type_ui_name_matches_collection_type`) asserting the offered name equals the runtime `Collection.type` under a non-English language. `ruff`, `ruff-format` and `mypy` pass.

## Out of scope

The related `awb_es_de` Restmüll cadence merge (2-weekly and 4-weekly collapsed into one type) is tracked separately in #6926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
