### PR TITLE
Add Le Cotentin (Cherbourg-en-Cotentin) to publidata_fr

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -51,6 +51,11 @@ TEST_CASES = {
         "insee_code": "54304",
         "instance_id": 1436,
     },
+    "Le Cotentin, Cherbourg-en-Cotentin": {
+        "address": "435 rue Maxime-Laubeuf",
+        "insee_code": "50129",
+        "instance_id": 1011,
+    },
     # "Saumur Val de Loire, Allones": {
     # "address": "5 rue du Bellay",
     # "insee_code": "49002",
@@ -292,6 +297,11 @@ EXTRA_INFO = [
         "url": "https://mhdd.grandnancy.eu/",
         "default_params": {"instance_id": 1436},
     },
+    {
+        "title": "Le Cotentin",
+        "url": "https://dechets.lecotentin.fr/",
+        "default_params": {"instance_id": 1011},
+    },
 ]
 
 _CALENDAR_DAY_VERY_ABBR = {
@@ -515,9 +525,9 @@ class Source:
         Parse a part of the opening_hours string and return the corresponding kwargs to rrule constructor.
 
         Example:
-            "Sep-Nov" -> {"bymonth": [9, 10, 11]}
-            "We[2,4]" -> {"byweekday": WE(2), WE(4)}
-            "2024-2025" -> {"dtstart": datetime(2024, 1, 1, tzinfo=timezone.utc), "until": datetime(2025, 12, 31, tzinfo=timezone.utc)}
+            "Sep-Nov" -&gt; {"bymonth": [9, 10, 11]}
+            "We[2,4]" -&gt; {"byweekday": WE(2), WE(4)}
+            "2024-2025" -&gt; {"dtstart": datetime(2024, 1, 1, tzinfo=timezone.utc), "until": datetime(2025, 12, 31, tzinfo=timezone.utc)}
         """
         if self._is_year(part):
             return self._parse_year(part)


### PR DESCRIPTION
## Summary
- Adds Le Cotentin (instance_id 1011) to the Publidata generic source's `EXTRA_INFO` and `TEST_CASES`, covering Cherbourg-en-Cotentin and surrounding communes on the Cotentin peninsula.
- Resolved the instance_id by geocoding the example address from the issue and cross-referencing the Publidata search API against the widget slug used on https://dechets.lecotentin.fr/a8VOMt60xY/calendar/.

## Test plan
- [x] `python test_sources.py -s publidata_fr -l` — live-fetches all test cases including the new "Le Cotentin, Cherbourg-en-Cotentin" case; returns weekly household-waste and packaging collection dates with no errors.
- [x] `python -m pytest tests/test_source_components.py -q` — 10 passed.
- [x] `ruff check --fix` / `ruff format` — clean.

Closes #5129