### PR TITLE
fix(awb_es_de): let a household pick its Restmüll collection interval (v3 beta feedback)

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -242,8 +242,18 @@ def _build_schema_from_params(
             elif field_name in pre_filled:
                 description = {"suggested_value": pre_filled[field_name]}
 
-            options = dependent_options.get(field_name) or error_suggestions.get(
-                field_name
+            # A plain "select" (dropdown) carries its own fixed option list;
+            # dependent/cascading selects have theirs fetched into
+            # dependent_options above.
+            select_options = (
+                list(param.options)
+                if param.widget == "select" and param.options
+                else None
+            )
+            options = (
+                dependent_options.get(field_name)
+                or error_suggestions.get(field_name)
+                or select_options
             )
             default = param.defaults.get(field_name)
             optional = param_optional or default is not None

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/config_params.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/config_params.py
@@ -76,6 +76,12 @@ class ConfigParam:
     # provided rather than every field.
     groups: tuple[tuple[str, ...], ...] = ()
 
+    # For a "select" widget (``dropdown``): the fixed option list the config
+    # flow renders as a dropdown. Empty for other widgets. The selector keeps
+    # custom_value on and ``validate`` does not enforce membership, so a value
+    # outside the list is still accepted.
+    options: list[str] = field(default_factory=list)
+
 
 def _title(field_name: str, label: str | None) -> str:
     """A field's display label: the explicit ``label`` or a Title-Cased name."""
@@ -302,6 +308,7 @@ def dropdown(
             "en": {field_name: display},
         },
         required=not optional,
+        options=list(options),
     )
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_es_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_es_de.py
@@ -9,24 +9,53 @@ pair. When no ICS link is found, the legacy source's city/street
 autocomplete-validation calls are preserved so a bad argument is reported
 with suggestions rather than a generic "not found".
 
-"Biotonne" and "Papiertonne" already resolve against the standard German
-aliases. "Gelbe/r Sack/Tonne", "Papiersammlung (Vereine)" and the two
-"Restmüll ...-wöchentlich" cadence labels are Esslingen-specific phrasings
-mapped explicitly.
+"Papiertonne" already resolves against the standard German aliases (to the
+same PAPER that "Papiersammlung (Vereine)" is mapped to). "Biotonne",
+"Gelbe/r Sack/Tonne" and the two "Restmüll ...-wöchentlich" cadence labels are
+mapped explicitly: the Esslingen-specific phrasings would not otherwise
+resolve, and mapping "Biotonne" (which would resolve by alias) declares ORGANIC
+in the source's WASTE_TYPES rather than leaving it to runtime alias resolution.
+
+The one calendar carries both the 2-weekly and the 4-weekly general-waste
+series, and a household follows one of them. The optional ``restmuell_cadence``
+argument keeps only the chosen series, so the general-waste sensor shows a
+single household's collection dates rather than both cadences merged.
 """
 
 from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
 from waste_collection_schedule.base_source import BaseSource
-from waste_collection_schedule.config_params import city, street
+from waste_collection_schedule.config_params import city, dropdown, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _SEARCH_URL = "https://www.awb-es.de/statics/abfallplus/search.json.php"
 _CALENDAR_URL = "https://www.awb-es.de/abfuhr/abfuhrtermine/__Abfuhrtermine.html"
+
+# Esslingen publishes both the 2-weekly and the 4-weekly general-waste
+# (Restmüll) series in one calendar; a household is on one of them. When the
+# resident picks their cadence the other series is dropped, so the general-waste
+# sensor shows only their own collection dates.
+_CADENCES = ("2-wöchentlich", "4-wöchentlich")
+
+
+def _is_unselected_restmuell(summary: str, cadence: str) -> bool:
+    """True if ``summary`` is a Restmüll cadence line other than ``cadence``.
+
+    A plain "Restmüll" line (no cadence) and every non-Restmüll type are kept.
+    """
+    low = summary.lower()
+    if "restmüll" not in low:
+        return False
+    return any(c in low and c != cadence.lower() for c in _CADENCES)
 
 
 def _suggestions(session, search: str, parent: str, kind: str) -> list[str]:
@@ -62,10 +91,17 @@ class Source(BaseSource):
     PARAMS = (
         city(field="city"),
         street(field="street", optional=True),
+        dropdown(
+            "restmuell_cadence",
+            list(_CADENCES),
+            label="Restmüll collection interval",
+            optional=True,
+        ),
     )
 
     transform = ICSTransformer(
         type_value_map={
+            "biotonne": ORGANIC,
             "gelbe/r sack/tonne": RECYCLABLES,
             "papiersammlung (vereine)": PAPER,
             "restmüll 2-wöchentlich": GENERAL_WASTE,
@@ -73,8 +109,13 @@ class Source(BaseSource):
         }
     )
 
-    def __init__(self, city: str, street: "str | None" = None):
-        super().__init__(city=city, street=street)
+    def __init__(
+        self,
+        city: str,
+        street: "str | None" = None,
+        restmuell_cadence: "str | None" = None,
+    ):
+        super().__init__(city=city, street=street, restmuell_cadence=restmuell_cadence)
 
     def retrieve(self, source):
         session = source.session
@@ -112,7 +153,11 @@ class Source(BaseSource):
 
     def parse(self, raw, source):
         ics_parser = IcsParser()
+        cadence = source.params.get("restmuell_cadence")
         entries = []
         for response in raw:
-            entries.extend(ics_parser(response, source))
+            for date, summary in ics_parser(response, source):
+                if cadence and _is_unselected_restmuell(summary, cadence):
+                    continue
+                entries.append((date, summary))
         return entries

--- a/tests/test_new_architecture.py
+++ b/tests/test_new_architecture.py
@@ -2169,6 +2169,9 @@ class TestConfigParams:
         p = dropdown("region", ["North", "South"])
         assert p.widget == "select"
         assert "region" in p.fields
+        # Options are stored so the config flow can render the dropdown; a
+        # select that dropped them rendered as a free-text field instead.
+        assert p.options == ["North", "South"]
 
     def test_text_field(self):
         from waste_collection_schedule.config_params import text_field
@@ -2333,6 +2336,35 @@ class TestDisplayLanguage:
         finally:
             # Restore the default so other tests keep seeing English labels.
             w.set_display_language("en")
+
+
+class TestAwbEsDeCadence:
+    """awb_es_de keeps only the resident's Restmüll cadence (#6926).
+
+    The Esslingen calendar carries both the 2-weekly and the 4-weekly
+    general-waste series; a household follows one. The optional
+    ``restmuell_cadence`` argument drops the other so the general-waste sensor
+    is not the two cadences merged.
+    """
+
+    def test_helper_drops_only_the_other_cadence(self):
+        from waste_collection_schedule.source.awb_es_de import (
+            _is_unselected_restmuell,
+        )
+
+        assert _is_unselected_restmuell("Restmüll 2-wöchentlich", "4-wöchentlich")
+        assert not _is_unselected_restmuell("Restmüll 4-wöchentlich", "4-wöchentlich")
+        # A plain Restmüll line and every non-Restmüll type are always kept.
+        assert not _is_unselected_restmuell("Restmüll", "4-wöchentlich")
+        assert not _is_unselected_restmuell("Biotonne", "4-wöchentlich")
+
+    def test_cadence_is_an_optional_dropdown(self):
+        from waste_collection_schedule.source.awb_es_de import Source
+
+        cadence = next(p for p in Source.PARAMS if "restmuell_cadence" in p.fields)
+        assert cadence.widget == "select"
+        assert cadence.options == ["2-wöchentlich", "4-wöchentlich"]
+        assert cadence.required is False
 
 
 class TestConfigParamValidation:


### PR DESCRIPTION
Fixes #6926. Feedback from @meilon trialling the v3 beta (#6561).

## Problem

AWB Esslingen publishes both a 2-weekly and a 4-weekly general-waste (Restmüll) series in a single ICS calendar. A household is on one cadence, not both. The migrated source mapped both `Restmüll 2-wöchentlich` and `Restmüll 4-wöchentlich` to a single `GENERAL_WASTE`, so a 4-weekly household saw the two cadences merged into one general-waste sensor with no way to keep only its own dates.

## Fix

Add an optional `restmuell_cadence` dropdown (`2-wöchentlich` / `4-wöchentlich`). When set, the unselected Restmüll series is dropped in `parse` before the transform, leaving one clean general-waste sensor. When unset, both are kept (unchanged behaviour), so existing configurations are unaffected.

Verified offline against the `awb_es_de` cassette (dates are the recurring events expanded over the next year):

| `restmuell_cadence` | 2-weekly events | 4-weekly events | other types |
|---|---|---|---|
| unset | 12 | 6 | unchanged |
| `2-wöchentlich` | 12 | 0 | unchanged |
| `4-wöchentlich` | 0 | 6 | unchanged |

## Two related fixes this surfaced

1. **`config_params.dropdown()` discarded its options.** `ConfigParam` had no `options` field, so a plain `select` never received its list and rendered as a free-text box (affecting every `dropdown(...)` on the branch: eggelsberg_at, hohokus_nj_us, isaac_qld_gov_au, kalamunda_wa_gov_au, felixdorf_gv_at, ics, ecoharmonogram_pl). Options are now stored on `ConfigParam` and rendered as a real dropdown (`custom_value` stays on, so a value outside the list is still accepted).
2. **`awb_es_de` returned an undeclared waste type.** Its auto-derived `WASTE_TYPES` omitted `ORGANIC`, because `Biotonne` resolved through the shared aliases rather than the map, so `test_waste_types_are_declared` failed for this source. `Biotonne` is now mapped to `ORGANIC` explicitly; the resolved output is unchanged, but the type is declared.

## Tests

`ruff`, `ruff-format`, `mypy` pass. Added `TestAwbEsDeCadence` (cadence filter + dropdown declaration) and extended `test_dropdown` to assert options are stored. The full `awb_es_de` source-validation set now passes (previously 2 failures on the undeclared `organic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
