### PR TITLE
feat: add shared service/OpenCities.py client for MyArea/OpenCities councils (batch 0/5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ If a site returns 403 with regular `requests`, switch to `curl_cffi` — it bypa
 - ❌ `if __name__ == "__main__":` blocks or standalone-script boilerplate.
 - ❌ Dummy parameters (e.g. `_`) just to satisfy the config GUI.
 - ❌ Login-required sources. The project only supports publicly accessible endpoints.
-- ❌ Sources for providers already covered by a shared platform — check `recollect.yaml`, `mein_abfallkalender_online.yaml`, `recyclecoach_com.py`'s `EXTRA_INFO` list, `c_trace_de`, and the other shared platforms first.
+- ❌ Sources for providers already covered by a shared platform — check `recollect.yaml`, `mein_abfallkalender_online.yaml`, `recyclecoach_com.py`'s `EXTRA_INFO` list, `c_trace_de`, `service/OpenCities.py` (OpenCities/MyArea council CMS widget — `api/v1/myarea/search` + `ocapi/Public/myarea/wasteservices` endpoints), and the other shared platforms first.
 
 ---
 
@@ -178,7 +178,7 @@ These are the issues that come up most often in PR review. Avoid them and your P
 2. **Generated files in the diff**. See list above. Revert before pushing.
 3. **Missing `doc/source/<id>.md`**. Required for every new source; create it manually.
 4. **Hardcoded data**. Fetch live; do not paste a schedule.
-5. **Provider already covered by a shared platform** (Recollect, RecycleCoach, ICS YAML, Publidata, IntraMaps, etc.). Check first.
+5. **Provider already covered by a shared platform** (Recollect, RecycleCoach, ICS YAML, Publidata, IntraMaps, OpenCities/MyArea, etc.). Check first.
 6. **Generic `Exception`**. Use `SourceArgumentNotFound` / `SourceArgumentNotFoundWithSuggestions`.
 7. **403 from a Cloudflare site**. Switch to `curl_cffi`.
 8. **Login-required**. Not supported — the project only consumes public endpoints.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -1,0 +1,271 @@
+"""Shared client for councils running the "OpenCities"/"MyArea" widget.
+
+Many AU/NZ council websites expose the same two endpoints on their own
+domain (the widget behind e.g. https://www.logan.qld.gov.au/MyLogan):
+
+- ``GET <domain>/api/v1/myarea/search[fuzzy]`` — address search, returning
+  JSON ``{"Items": [{"Id": "<geolocation-guid>", "AddressSingleLine": ...}]}``
+  (a handful of legacy deployments return XML instead).
+- ``GET <domain>/ocapi/Public/myarea/wasteservices`` — given a
+  ``geolocationid``, returns ``{"success": bool, "responseContent": "<html>"}``
+  where the HTML is a series of ``<article>``/``div.waste-services-result``
+  blocks, each with an ``<h3>`` (waste type) and a ``.next-service`` element
+  (next collection date).
+
+This module centralises that flow behind :class:`OpenCitiesClient` so
+per-council source files stay a thin ``OpenCitiesConfig`` + ``Source`` shim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Literal
+
+import requests
+from bs4 import BeautifulSoup
+from curl_cffi import requests as curl_cffi_requests
+
+from waste_collection_schedule import Collection
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+)
+
+DEFAULT_DATE_FORMAT = "%a %d/%m/%Y"
+
+
+@dataclass(frozen=True)
+class OpenCitiesConfig:
+    """Per-council configuration for :class:`OpenCitiesClient`."""
+
+    domain: str
+    """Council base URL, e.g. ``"https://www.ballina.nsw.gov.au"`` (no trailing slash)."""
+
+    argument_name: str = "address"
+    """Exact ``Source.__init__`` kwarg name, used in raised exceptions."""
+
+    search_fuzzy: bool = False
+    """Use ``/api/v1/myarea/searchfuzzy`` instead of ``/api/v1/myarea/search``."""
+
+    max_results: int | None = None
+    """Optional ``maxresults`` query param on the search request."""
+
+    search_response_format: Literal["json", "xml", "json_then_xml"] = "json"
+    """Search response format. ``"json_then_xml"`` tries JSON, falls back to XML."""
+
+    page_link: str | None = None
+    """Optional ``pageLink`` query param required by some council instances."""
+
+    ocsvclang: str = "en-AU"
+
+    use_curl_cffi: bool = False
+    """Use curl_cffi (Chrome impersonation) to bypass Akamai/Incapsula bot protection."""
+
+    impersonate: str = "chrome"
+
+    warm_up_url: str | None = None
+    """A page fetched once, lazily, before the first API request (session/cookie priming)."""
+
+    date_format: str = DEFAULT_DATE_FORMAT
+
+    icon_keywords: dict[str, Any] | None = None
+    """Lower-cased waste-type substring -> icon, checked in insertion order."""
+
+    strip_type_suffixes: tuple[str, ...] = ()
+    """Suffixes (case-insensitive) stripped from parsed waste-type labels, e.g. ``("collection",)``."""
+
+    headers: dict[str, str] | None = None
+
+    timeout: int = 30
+
+    strict_address_matching: bool = True
+    """
+    If True (default), multiple search results are disambiguated by exact
+    (case/space-insensitive) match against ``AddressSingleLine``, raising
+    ``SourceArgAmbiguousWithSuggestions`` when that's not conclusive. Set to
+    False only for legacy XML search responses that carry no address text at
+    all, where the first result is the only option.
+    """
+
+
+class OpenCitiesClient:
+    def __init__(self, config: OpenCitiesConfig) -> None:
+        self._cfg = config
+        self._session = self._build_session()
+        self._geolocation_id: str | None = None
+        self._warmed_up = False
+
+    # ---- public API ---------------------------------------------------
+
+    def fetch(
+        self, address: str | None = None, geolocation_id: str | None = None
+    ) -> list[Collection]:
+        """Resolve collections for an address, or directly for a geolocation id.
+
+        When resolving from ``address``, the geolocation id is cached across
+        calls (HA polls ``fetch()`` repeatedly) so only the first call pays
+        for the address search. If a cached id later fails, it is re-resolved
+        once and the wasteservices call retried.
+        """
+        if geolocation_id is not None:
+            return self.fetch_by_geolocation_id(geolocation_id)
+
+        if address is None:
+            raise ValueError("Either address or geolocation_id must be provided")
+
+        used_cache = self._geolocation_id is not None
+        if not used_cache:
+            self._geolocation_id = self.resolve_geolocation_id(address)
+
+        try:
+            return self.fetch_by_geolocation_id(self._geolocation_id)  # type: ignore[arg-type]
+        except SourceArgumentNotFound:
+            if not used_cache:
+                raise
+            self._geolocation_id = self.resolve_geolocation_id(address)
+            return self.fetch_by_geolocation_id(self._geolocation_id)
+
+    def resolve_geolocation_id(self, address: str) -> str:
+        self._ensure_warmed_up()
+        items = self._search(address)
+        return self._select_address(address, items)
+
+    def fetch_by_geolocation_id(self, geolocation_id: str) -> list[Collection]:
+        self._ensure_warmed_up()
+        params: dict[str, str] = {
+            "geolocationid": geolocation_id,
+            "ocsvclang": self._cfg.ocsvclang,
+        }
+        if self._cfg.page_link:
+            params["pageLink"] = self._cfg.page_link
+        response = self._get(
+            f"{self._cfg.domain}/ocapi/Public/myarea/wasteservices", params
+        )
+        data = response.json()
+        if not data.get("success", True) or not data.get("responseContent"):
+            raise SourceArgumentNotFound(self._cfg.argument_name, geolocation_id)
+        return self._parse_wasteservices_html(data["responseContent"])
+
+    # ---- internals ------------------------------------------------------
+
+    def _build_session(self):
+        if self._cfg.use_curl_cffi:
+            session = curl_cffi_requests.Session(impersonate=self._cfg.impersonate)
+        else:
+            session = requests.Session()
+        if self._cfg.headers:
+            session.headers.update(self._cfg.headers)
+        return session
+
+    def _get(self, url: str, params: dict[str, Any] | None = None):
+        response = self._session.get(url, params=params, timeout=self._cfg.timeout)
+        response.raise_for_status()
+        return response
+
+    def _ensure_warmed_up(self) -> None:
+        if self._warmed_up or not self._cfg.warm_up_url:
+            return
+        self._get(self._cfg.warm_up_url)
+        self._warmed_up = True
+
+    def _search(self, address: str) -> list[dict[str, Any]]:
+        path = "searchfuzzy" if self._cfg.search_fuzzy else "search"
+        params: dict[str, Any] = {"keywords": address}
+        if self._cfg.max_results is not None:
+            params["maxresults"] = self._cfg.max_results
+        response = self._get(f"{self._cfg.domain}/api/v1/myarea/{path}", params)
+
+        fmt = self._cfg.search_response_format
+        if fmt == "xml":
+            return self._parse_search_xml(response.text)
+        if fmt == "json_then_xml":
+            try:
+                return response.json().get("Items") or []
+            except ValueError:
+                return self._parse_search_xml(response.text)
+        return response.json().get("Items") or []
+
+    @staticmethod
+    def _parse_search_xml(text: str) -> list[dict[str, Any]]:
+        soup = BeautifulSoup(text, "xml")
+        items: list[dict[str, Any]] = []
+        for result in soup.find_all("PhysicalAddressSearchResult"):
+            id_el = result.find("Id")
+            if id_el and id_el.text.strip():
+                item: dict[str, Any] = {"Id": id_el.text.strip()}
+                address_el = result.find("AddressSingleLine")
+                if address_el and address_el.text.strip():
+                    item["AddressSingleLine"] = address_el.text.strip()
+                items.append(item)
+        return items
+
+    def _select_address(self, address: str, items: list[dict[str, Any]]) -> str:
+        if not items:
+            raise SourceArgumentNotFound(self._cfg.argument_name, address)
+        if len(items) == 1 or not self._cfg.strict_address_matching:
+            return items[0]["Id"]
+
+        normalized = address.lower().replace(" ", "")
+        exact = [
+            item
+            for item in items
+            if item.get("AddressSingleLine", "").lower().replace(" ", "") == normalized
+        ]
+        if len(exact) == 1:
+            return exact[0]["Id"]
+
+        if not any(item.get("AddressSingleLine") for item in items):
+            # No address text to disambiguate with (e.g. legacy XML results) —
+            # fall back to the first match rather than crash.
+            return items[0]["Id"]
+
+        suggestions = [item.get("AddressSingleLine", item["Id"]) for item in items]
+        raise SourceArgAmbiguousWithSuggestions(
+            self._cfg.argument_name, address, suggestions
+        )
+
+    def _parse_wasteservices_html(self, html: str) -> list[Collection]:
+        soup = BeautifulSoup(html, "html.parser")
+        entries: list[Collection] = []
+        for block in soup.select("article, div.waste-services-result"):
+            title = block.select_one("h3")
+            next_service = block.select_one(".next-service")
+            if title is None or next_service is None:
+                continue
+
+            waste_type = title.get_text(" ", strip=True)
+            for suffix in self._cfg.strip_type_suffixes:
+                if waste_type.lower().endswith(suffix.lower()):
+                    waste_type = waste_type[: -len(suffix)].strip()
+
+            date_text = next_service.get_text(" ", strip=True)
+            if not date_text:
+                continue
+            collection_date = self._parse_date(date_text)
+            if collection_date is None:
+                continue
+
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=waste_type,
+                    icon=self._resolve_icon(waste_type),
+                )
+            )
+        return entries
+
+    def _parse_date(self, text: str) -> date | None:
+        try:
+            return datetime.strptime(text, self._cfg.date_format).date()
+        except ValueError:
+            return None
+
+    def _resolve_icon(self, label: str) -> Any | None:
+        if not self._cfg.icon_keywords:
+            return None
+        lowered = label.lower()
+        for keyword, icon in self._cfg.icon_keywords.items():
+            if keyword.lower() in lowered:
+                return icon
+        return None

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -561,6 +561,344 @@ def test_uk_cloud9_client_requires_api_domains() -> None:
         assert "At least one API domain" in str(err)
 
 
+class _OpenCitiesResponse:
+    def __init__(self, *, json_data=None, text="", json_error=False):
+        self._json_data = json_data
+        self.text = text
+        self._json_error = json_error
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        if self._json_error:
+            raise ValueError("invalid json")
+        return self._json_data
+
+
+class _OpenCitiesSession:
+    def __init__(self, responder) -> None:
+        self.headers: dict[str, str] = {}
+        self.calls: list[tuple[str, dict | None]] = []
+        self._responder = responder
+
+    def get(self, url, params=None, timeout=None):
+        self.calls.append((url, params))
+        return self._responder(url, params)
+
+
+def _opencities_module():
+    return import_module("waste_collection_schedule.service.OpenCities")
+
+
+def test_opencities_client_resolves_single_address_result() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+
+    def responder(url, params):
+        assert "/api/v1/myarea/search" in url
+        return _OpenCitiesResponse(
+            json_data={"Items": [{"Id": "abc-123", "AddressSingleLine": "1 Main St"}]}
+        )
+
+    client._session = _OpenCitiesSession(responder)
+
+    assert client.resolve_geolocation_id("1 Main St") == "abc-123"
+
+
+def test_opencities_client_raises_ambiguous_with_suggestions_on_multiple_matches() -> (
+    None
+):
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={
+                "Items": [
+                    {"Id": "a", "AddressSingleLine": "1 Main St, Northtown"},
+                    {"Id": "b", "AddressSingleLine": "1 Main St, Southtown"},
+                ]
+            }
+        )
+    )
+
+    try:
+        client.resolve_geolocation_id("1 Main St")
+        raise AssertionError("Expected SourceArgAmbiguousWithSuggestions")
+    except module.SourceArgAmbiguousWithSuggestions as err:
+        assert list(err.suggestions) == [
+            "1 Main St, Northtown",
+            "1 Main St, Southtown",
+        ]
+
+
+def test_opencities_client_selects_exact_match_among_multiple_results() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={
+                "Items": [
+                    {"Id": "a", "AddressSingleLine": "5 Other St, Southtown"},
+                    {"Id": "b", "AddressSingleLine": "  1 main st, northtown  "},
+                ]
+            }
+        )
+    )
+
+    assert client.resolve_geolocation_id("1 main st, northtown") == "b"
+
+
+def test_opencities_client_raises_not_found_on_empty_search() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(json_data={"Items": []})
+    )
+
+    try:
+        client.resolve_geolocation_id("nowhere")
+        raise AssertionError("Expected SourceArgumentNotFound")
+    except module.SourceArgumentNotFound:
+        pass
+
+
+def test_opencities_client_uses_searchfuzzy_and_maxresults_when_configured() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", search_fuzzy=True, max_results=1
+    )
+    client = module.OpenCitiesClient(config)
+    session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(json_data={"Items": [{"Id": "a"}]})
+    )
+    client._session = session
+
+    client.resolve_geolocation_id("1 Main St")
+
+    url, params = session.calls[0]
+    assert url == "https://example.invalid/api/v1/myarea/searchfuzzy"
+    assert params == {"keywords": "1 Main St", "maxresults": 1}
+
+
+def test_opencities_client_includes_page_link_param_when_configured() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", page_link="/some/page"
+    )
+    client = module.OpenCitiesClient(config)
+    session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": "<p>no services</p>"}
+        )
+    )
+    client._session = session
+
+    client.fetch_by_geolocation_id("abc")
+
+    _, params = session.calls[0]
+    assert params is not None
+    assert params["pageLink"] == "/some/page"
+
+
+def test_opencities_client_parses_wasteservices_html_into_collections() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    html = (
+        "<article><h3>General Waste</h3>"
+        '<div class="next-service">Mon 01/02/2027</div></article>'
+        "<article><h3>Recycling</h3>"
+        '<div class="next-service">Tue 02/02/2027</div></article>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert [(e.date.isoformat(), e.type) for e in entries] == [
+        ("2027-02-01", "General Waste"),
+        ("2027-02-02", "Recycling"),
+    ]
+
+
+def test_opencities_client_resolves_icon_via_keywords() -> None:
+    from waste_collection_schedule import Icons
+
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid",
+        icon_keywords={
+            "general waste": Icons.GENERAL_WASTE,
+            "recycling": Icons.RECYCLING,
+        },
+    )
+    client = module.OpenCitiesClient(config)
+    html = (
+        "<article><h3>General Waste</h3>"
+        '<div class="next-service">Mon 01/02/2027</div></article>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert entries[0].icon == Icons.GENERAL_WASTE
+
+
+def test_opencities_client_skips_entries_missing_next_service_date() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    html = (
+        '<article><h3>General Waste</h3><div class="next-service"></div></article>'
+        "<article><h3>Recycling</h3>"
+        '<div class="next-service">Tue 02/02/2027</div></article>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert [e.type for e in entries] == ["Recycling"]
+
+
+def test_opencities_client_retries_once_on_stale_cached_geolocation_id() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+
+    search_calls = {"count": 0}
+    html = (
+        "<article><h3>General Waste</h3>"
+        '<div class="next-service">Mon 01/02/2027</div></article>'
+    )
+
+    def responder(url, params):
+        if "myarea/search" in url:
+            search_calls["count"] += 1
+            return _OpenCitiesResponse(json_data={"Items": [{"Id": "fresh-id"}]})
+        # wasteservices: fail for the stale cached id, succeed for the fresh one
+        if params.get("geolocationid") == "stale-id":
+            return _OpenCitiesResponse(json_data={"success": False})
+        return _OpenCitiesResponse(json_data={"success": True, "responseContent": html})
+
+    client._session = _OpenCitiesSession(responder)
+    client._geolocation_id = "stale-id"
+
+    entries = client.fetch(address="1 Main St")
+
+    assert search_calls["count"] == 1
+    assert [e.type for e in entries] == ["General Waste"]
+    assert client._geolocation_id == "fresh-id"
+
+
+def test_opencities_client_bypasses_search_when_geolocation_id_given_directly() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": "<p>no services</p>"}
+        )
+    )
+    client._session = session
+
+    client.fetch(geolocation_id="abc")
+
+    assert all("myarea/search" not in url for url, _ in session.calls)
+
+
+def test_opencities_client_fires_warm_up_url_once_before_first_request() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", warm_up_url="https://example.invalid/warm"
+    )
+    client = module.OpenCitiesClient(config)
+    session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": "<p>no services</p>"}
+        )
+    )
+    client._session = session
+
+    client.fetch_by_geolocation_id("abc")
+    client.fetch_by_geolocation_id("abc")
+
+    warm_up_calls = [url for url, _ in session.calls if url.endswith("/warm")]
+    assert len(warm_up_calls) == 1
+
+
+def test_opencities_client_falls_back_from_json_to_xml_search_response() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", search_response_format="json_then_xml"
+    )
+    client = module.OpenCitiesClient(config)
+    xml = (
+        "<Results><PhysicalAddressSearchResult>"
+        "<Id>xml-id</Id><AddressSingleLine>1 Main St</AddressSingleLine>"
+        "</PhysicalAddressSearchResult></Results>"
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(json_error=True, text=xml)
+    )
+
+    assert client.resolve_geolocation_id("1 Main St") == "xml-id"
+
+
+def test_opencities_client_parses_xml_only_search_response() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid",
+        search_response_format="xml",
+        strict_address_matching=False,
+    )
+    client = module.OpenCitiesClient(config)
+    xml = (
+        "<Results><PhysicalAddressSearchResult>"
+        "<Id>xml-id</Id></PhysicalAddressSearchResult></Results>"
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(text=xml)
+    )
+
+    assert client.resolve_geolocation_id("1 Main St") == "xml-id"
+
+
+def test_opencities_client_uses_curl_cffi_session_when_configured(monkeypatch) -> None:
+    module = _opencities_module()
+    created_with = {}
+
+    class _FakeCurlSession:
+        def __init__(self, impersonate=None):
+            created_with["impersonate"] = impersonate
+            self.headers: dict[str, str] = {}
+
+    monkeypatch.setattr(module.curl_cffi_requests, "Session", _FakeCurlSession)
+
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", use_curl_cffi=True
+    )
+    client = module.OpenCitiesClient(config)
+
+    assert isinstance(client._session, _FakeCurlSession)
+    assert created_with["impersonate"] == "chrome"
+
+
 def test_mzv_rotenburg_route_filter_without_location() -> None:
     module = _get_module("mzv_rotenburg_bebra_de")
 


### PR DESCRIPTION
## Summary

37 source files independently hand-roll the same "OpenCities"/"MyArea" council-CMS flow:

- `GET <domain>/api/v1/myarea/search[fuzzy]` — address search
- `GET <domain>/ocapi/Public/myarea/wasteservices` — collection dates as an HTML fragment

The duplication has drifted: inconsistent `curl_cffi` bot-protection, bare `Exception` raises in some, missing `timeout=`, and only 1-2 sources (`hobartcity_com_au.py`, `moorabool_vic_gov_au.py`) implementing geolocation-id caching or ambiguous-address-match suggestions instead of blindly taking the first search result.

This is **batch 0 of 6** in a phased migration: land the shared `OpenCitiesConfig`/`OpenCitiesClient` client and its unit tests first, with **no source files touched yet**, so the abstraction gets reviewed before ~33 follow-on sources depend on its shape. Follow-up PRs will migrate sources in small batches (easiest "modern" sources first, then the mechanical old-style family, then the trickiest 4-field-address/XML family last), each independently reviewable and live-tested.

## What's in this PR

- `service/OpenCities.py` — new client, structurally modeled on `service/uk_cloud9_apps.py` (stateful client class, raises `SourceArgumentNotFound`/`SourceArgAmbiguousWithSuggestions` directly). Config dataclass covers the variance found across the 37 sources: curl_cffi vs plain requests, `search` vs `searchfuzzy`, JSON vs XML vs JSON-then-XML search responses, optional `pageLink`, optional warm-up GET, geolocation-id caching + stale-retry, and ambiguous-address-match suggestions (made the default behavior instead of blind `Items[0]`).
- 15 `test_opencities_*` unit tests in `tests/test_source_components.py`, following the existing `test_uk_cloud9_client_*` monkeypatch style.
- CLAUDE.md: added OpenCities/MyArea to the "shared platform, check first" checklist so future new-source contributors don't add a 38th near-duplicate.

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [x] Documentation update
- [x] Other (new shared service module, no source files migrated yet)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (25 passed)
- [x] `ruff check --fix` / `ruff format` / `mypy --ignore-missing-imports --explicit-package-bases` clean (pre-commit hooks pass)
- [x] No generated files in diff
- [x] Not applicable: no new source `.py`/`doc/source/*.md` in this PR — client only