### PR TITLE
refactor: migrate 6 OpenCities sources onto shared service/OpenCities.py (batch 1/5)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -88,6 +88,14 @@ class OpenCitiesConfig:
     all, where the first result is the only option.
     """
 
+    require_date_precise: bool = False
+    """
+    If True, only wasteservices blocks additionally carrying a
+    ``date-precise`` CSS class are parsed, skipping vague/recurring entries
+    with no concrete next date (some council deployments, e.g. Shoalhaven,
+    mix both kinds of block in the same response).
+    """
+
 
 class OpenCitiesClient:
     def __init__(self, config: OpenCitiesConfig) -> None:
@@ -225,10 +233,31 @@ class OpenCitiesClient:
             self._cfg.argument_name, address, suggestions
         )
 
+    @staticmethod
+    def _select_top_level(soup: BeautifulSoup, selector: str) -> list[Any]:
+        """soup.select(), but drop matches nested inside another match.
+
+        Some council deployments wrap a matching ``<article>`` inside a
+        matching ``div.waste-services-result`` (or vice versa); selecting
+        both tags would otherwise double-count every entry.
+        """
+        candidates = soup.select(selector)
+        candidate_ids = {id(candidate) for candidate in candidates}
+        return [
+            candidate
+            for candidate in candidates
+            if not any(id(parent) in candidate_ids for parent in candidate.parents)
+        ]
+
     def _parse_wasteservices_html(self, html: str) -> list[Collection]:
         soup = BeautifulSoup(html, "html.parser")
         entries: list[Collection] = []
-        for block in soup.select("article, div.waste-services-result"):
+        selector = (
+            "div.waste-services-result.date-precise"
+            if self._cfg.require_date_precise
+            else "article, div.waste-services-result"
+        )
+        for block in self._select_top_level(soup, selector):
             title = block.select_one("h3")
             next_service = block.select_one(".next-service")
             if title is None or next_service is None:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ballina_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ballina_nsw_gov_au.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Ballina Shire Council"
 DESCRIPTION = "Source for Ballina Shire Council, NSW, Australia."
@@ -18,8 +17,6 @@ TEST_CASES = {
     "1 Grant St, Ballina NSW 2478": {"address": "1 Grant St, Ballina NSW 2478"}
 }
 
-SEARCH_URL = "https://www.ballina.nsw.gov.au/api/v1/myarea/searchfuzzy"
-COLLECTION_URL = "https://www.ballina.nsw.gov.au/ocapi/Public/myarea/wasteservices"
 PAGE_LINK = "/$8a878053-5e29-431d-896b-8c79ce08799f$/Residents/Waste-and-Recycling/Bin-Collection-Day"
 
 HEADERS = {
@@ -41,83 +38,20 @@ ICON_MAP = {
     "garden organics": Icons.GARDEN,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.ballina.nsw.gov.au",
+    search_fuzzy=True,
+    max_results=1,
+    page_link=PAGE_LINK,
+    headers=HEADERS,
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
     def __init__(self, address: str):
         self._address = " ".join(address.split())
-        self._session = requests.Session()
-        self._session.headers.update(HEADERS)
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        geolocation_id = self._get_geolocation_id()
-        response = self._session.get(
-            COLLECTION_URL,
-            params={
-                "geolocationid": geolocation_id,
-                "ocsvclang": "en-AU",
-                "pageLink": PAGE_LINK,
-            },
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        html_content = response.json().get("responseContent", "")
-        if not html_content:
-            raise SourceArgumentNotFound("address", self._address)
-
-        return self._parse_entries(html_content)
-
-    def _get_geolocation_id(self) -> str:
-        response = self._session.get(
-            SEARCH_URL,
-            params={"keywords": self._address, "maxresults": "1"},
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        items = response.json().get("Items", [])
-        if not items:
-            raise SourceArgumentNotFound("address", self._address)
-
-        geolocation_id = items[0].get("Id")
-        if not geolocation_id:
-            raise SourceArgumentNotFound("address", self._address)
-
-        return geolocation_id
-
-    def _parse_entries(self, html: str) -> list[Collection]:
-        soup = BeautifulSoup(html, "html.parser")
-        entries: list[Collection] = []
-
-        for result in soup.select(".waste-services-result"):
-            title = result.find("h3")
-            next_service = result.select_one(".next-service")
-            if title is None or next_service is None:
-                continue
-
-            waste_type = title.get_text(" ", strip=True)
-            date_text = next_service.get_text(" ", strip=True)
-            try:
-                collection_date = datetime.strptime(date_text, "%a %d/%m/%Y").date()
-            except ValueError:
-                continue
-
-            entries.append(
-                Collection(
-                    date=collection_date,
-                    t=waste_type,
-                    icon=self._guess_icon(waste_type),
-                )
-            )
-
-        if not entries:
-            raise SourceArgumentNotFound("address", self._address)
-
-        return entries
-
-    def _guess_icon(self, waste_type: str) -> str | None:
-        lower = waste_type.lower()
-        for key, icon in ICON_MAP.items():
-            if key in lower:
-                return icon
-        return None
+        return self._client.fetch(address=self._address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cassowarycoast_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cassowarycoast_qld_gov_au.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
-from bs4 import BeautifulSoup
-from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Cassowary Coast Regional Council"
 DESCRIPTION = (
@@ -21,10 +20,6 @@ TEST_CASES = {
     "10 Bombala Street, Mourilyan": {"address": "10 Bombala Street, Mourilyan, 4858"},
 }
 
-SEARCH_URL = "https://www.cassowarycoast.qld.gov.au/api/v1/myarea/searchfuzzy"
-COLLECTION_URL = (
-    "https://www.cassowarycoast.qld.gov.au/ocapi/Public/myarea/wasteservices"
-)
 PAGE_LINK = "/Waste-Water-and-Roads/Waste-and-Recycling/Kerbside-Collection"
 
 HEADERS = {
@@ -55,85 +50,21 @@ PARAM_TRANSLATIONS = {
     },
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.cassowarycoast.qld.gov.au",
+    search_fuzzy=True,
+    max_results=1,
+    page_link=PAGE_LINK,
+    headers=HEADERS,
+    use_curl_cffi=True,
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
     def __init__(self, address: str):
         self._address = " ".join(address.split())
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        session = requests.Session(impersonate="chrome")
-        session.headers.update(HEADERS)
-
-        geolocation_id = self._get_geolocation_id(session)
-
-        response = session.get(
-            COLLECTION_URL,
-            params={
-                "geolocationid": geolocation_id,
-                "ocsvclang": "en-AU",
-                "pageLink": PAGE_LINK,
-            },
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        html_content = response.json().get("responseContent", "")
-        if not html_content:
-            raise SourceArgumentNotFound("address", self._address)
-
-        return self._parse_entries(html_content)
-
-    def _get_geolocation_id(self, session) -> str:
-        response = session.get(
-            SEARCH_URL,
-            params={"keywords": self._address, "maxresults": "1"},
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        items = response.json().get("Items", [])
-        if not items:
-            raise SourceArgumentNotFound("address", self._address)
-
-        geolocation_id = items[0].get("Id")
-        if not geolocation_id:
-            raise SourceArgumentNotFound("address", self._address)
-
-        return geolocation_id
-
-    def _parse_entries(self, html: str) -> list[Collection]:
-        soup = BeautifulSoup(html, "html.parser")
-        entries: list[Collection] = []
-
-        for result in soup.select(".waste-services-result"):
-            title = result.find("h3")
-            next_service = result.select_one(".next-service")
-            if title is None or next_service is None:
-                continue
-
-            waste_type = title.get_text(" ", strip=True)
-            date_text = next_service.get_text(" ", strip=True)
-            try:
-                collection_date = datetime.strptime(date_text, "%a %d/%m/%Y").date()
-            except ValueError:
-                continue
-
-            entries.append(
-                Collection(
-                    date=collection_date,
-                    t=waste_type,
-                    icon=self._guess_icon(waste_type),
-                )
-            )
-
-        if not entries:
-            raise SourceArgumentNotFound("address", self._address)
-
-        return entries
-
-    def _guess_icon(self, waste_type: str) -> str | None:
-        lower = waste_type.lower()
-        for key, icon in ICON_MAP.items():
-            if key in lower:
-                return icon
-        return None
+        return self._client.fetch(address=self._address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiama_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiama_nsw_gov_au.py
@@ -9,8 +9,8 @@ DESCRIPTION = "Source script for kiama.nsw.gov.au"
 URL = "https://kiama.nsw.gov.au"
 COUNTRY = "au"
 TEST_CASES = {
-    "TestName1": {"geolocationid": "38da9173-322a-43fd-953b-3b51803dbe94"},
-    "TestName2": {"geolocationid": "f2c04fcf-e3d3-424e-aa90-1d365bbf0130"},
+    "TestName1": {"geolocationid": "3e54d9b4-e0b8-41cf-8518-d48c1cc5407b"},
+    "TestName2": {"geolocationid": "0d96e409-7a81-4ccb-a0d8-d8435e066182"},
 }
 
 ICON_MAP = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiama_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kiama_nsw_gov_au.py
@@ -1,8 +1,8 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Kiama City Council"
 DESCRIPTION = "Source script for kiama.nsw.gov.au"
@@ -12,8 +12,6 @@ TEST_CASES = {
     "TestName1": {"geolocationid": "38da9173-322a-43fd-953b-3b51803dbe94"},
     "TestName2": {"geolocationid": "f2c04fcf-e3d3-424e-aa90-1d365bbf0130"},
 }
-
-API_URL = "https://www.kiama.nsw.gov.au/ocapi/Public/myarea/wasteservices"
 
 ICON_MAP = {
     "Urban garbage": Icons.GENERAL_WASTE,
@@ -31,62 +29,17 @@ Look for a network call to the wasteservices endpoint, it will have geolocationi
 This GUID is what you need, it is unique to your service address.""",
 }
 
-
-def parse_date(date_str):
-    """Convert date string like 'Fri 20/6/2025' to date object."""
-    try:
-        # Parse date string (format: 'Fri DD/M/YYYY')
-        return datetime.strptime(date_str, "%a %d/%m/%Y").date()
-    except ValueError:
-        return f"Invalid date format: {date_str}"
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.kiama.nsw.gov.au",
+    argument_name="geolocationid",
+    icon_keywords=ICON_MAP,
+)
 
 
 class Source:
-    def __init__(self, geolocationid):
+    def __init__(self, geolocationid: str):
         self._geolocationid = geolocationid
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        data = {
-            "Referer": "https://www.kiama.nsw.gov.au/Services/Waste-and-recycling/Find-my-bin-collection-dates"
-        }
-
-        pageurl = f"https://www.kiama.nsw.gov.au/ocapi/Public/myarea/wasteservices?geolocationid={self._geolocationid}&ocsvclang=en-AU"
-        response = requests.get(f"{pageurl}", data=data)
-        response.raise_for_status()
-        # Parse JSON to get HTML content
-        data = response.json()
-        if not data.get("success") or "responseContent" not in data:
-            raise ValueError("Invalid JSON response structure")
-
-        html_content = data["responseContent"]
-
-        # Parse HTML with BeautifulSoup
-        soup = BeautifulSoup(html_content, "html.parser")
-
-        # Find all waste service result articles
-        results = soup.find_all("div", class_="waste-services-result")
-        entries = []
-        if results:
-            for result in results:
-                # Get bin type from <h3>
-                bin_type = result.find("h3")
-                bin_type = bin_type.get_text(strip=True) if bin_type else "Unknown"
-
-                # Get next service date from <div class="next-service">
-                next_service = result.find("div", class_="next-service")
-                day = (
-                    next_service.get_text(strip=True)
-                    if next_service
-                    else "No date provided"
-                )
-
-                # Only print if a date is available
-                if day and day != "":
-                    entries.append(
-                        Collection(
-                            date=parse_date(day),
-                            t=bin_type,
-                            icon=ICON_MAP.get(bin_type),
-                        )
-                    )
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(geolocation_id=self._geolocationid)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lanecove_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lanecove_nsw_gov_au.py
@@ -1,11 +1,7 @@
-import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
-from waste_collection_schedule.exceptions import (
-    SourceArgumentNotFound,
-    SourceArgumentNotFoundWithSuggestions,
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
 )
 
 TITLE = "Lane Cove Council"
@@ -42,11 +38,6 @@ PARAM_TRANSLATIONS = {
     },
 }
 
-API_URLS = {
-    "search": "https://www.lanecove.nsw.gov.au/api/v1/myarea/search",
-    "collection": "https://www.lanecove.nsw.gov.au/ocapi/Public/myarea/wasteservices",
-}
-
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
     "Accept": "text/plain, */*; q=0.01",
@@ -54,56 +45,18 @@ HEADERS = {
     "X-Requested-With": "XMLHttpRequest",
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.lanecove.nsw.gov.au",
+    headers=HEADERS,
+    icon_keywords=ICON_MAP,
+    use_curl_cffi=True,
+)
+
 
 class Source:
     def __init__(self, address: str):
         self._address = address
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        s = requests.Session()
-        s.headers.update(HEADERS)
-
-        r = s.get(API_URLS["search"], params={"keywords": self._address})
-        r.raise_for_status()
-        data = r.json()
-
-        items = data.get("Items", [])
-        if not items:
-            raise SourceArgumentNotFound("address", self._address)
-
-        if len(items) > 1:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "address",
-                self._address,
-                [item["AddressSingleLine"] for item in items],
-            )
-
-        geoid = items[0]["Id"]
-
-        r = s.get(
-            API_URLS["collection"],
-            params={"geolocationid": geoid, "ocsvclang": "en-AU"},
-        )
-        r.raise_for_status()
-
-        html = r.json()["responseContent"]
-        soup = BeautifulSoup(html, "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.find("h3").get_text(strip=True)
-
-            next_date_str = article.find("div", class_="next-service").get_text(
-                strip=True
-            )
-            next_date = datetime.datetime.strptime(next_date_str, "%a %d/%m/%Y").date()
-
-            icon = None
-            for key, value in ICON_MAP.items():
-                if key in waste_type:
-                    icon = value
-                    break
-
-            entries.append(Collection(date=next_date, t=waste_type, icon=icon))
-
-        return entries
+        return self._client.fetch(address=self._address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/shoalhaven_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/shoalhaven_nsw_gov_au.py
@@ -1,12 +1,8 @@
-import datetime
-import logging
-import re
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
-
-_LOGGER = logging.getLogger(__name__)
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Shoalhaven City Council"
 DESCRIPTION = "Source script for shoalhaven.nsw.gov.au"
@@ -22,10 +18,9 @@ TEST_CASES = {
     "Station St, NOWRA": {"geolocation_id": "984061de-cd63-43f4-bbd3-694b4e8af4d5"},
 }
 
-API_BASE_URL = "https://www.shoalhaven.nsw.gov.au/ocapi/Public/myarea/wasteservices"
 ICON_MAP = {
-    "GENERAL WASTE": Icons.GENERAL_WASTE,
-    "RECYCLING": Icons.RECYCLING,
+    "general waste": Icons.GENERAL_WASTE,
+    "recycling": Icons.RECYCLING,
 }
 
 # ### Arguments affecting the configuration GUI ####
@@ -55,6 +50,13 @@ PARAM_TRANSLATIONS = {
 
 # ### End of arguments affecting the configuration GUI ####
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.shoalhaven.nsw.gov.au",
+    argument_name="geolocation_id",
+    icon_keywords=ICON_MAP,
+    require_date_precise=True,
+)
+
 
 class Source:
     def __init__(self, geolocation_id: str):
@@ -64,81 +66,7 @@ class Source:
         :param geolocation_id: The unique ID for the address to fetch waste services for.
         """
         self._geolocation_id = geolocation_id
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        """
-        Fetch the waste collection schedule from the Shoalhaven City Council API.
-
-        :return: A list of Collection objects, each representing a waste collection.
-        :raises Exception: If the API call fails or no collection schedules are found.
-        """
-        session = requests.Session()
-        params = {"geolocationid": self._geolocation_id, "ocsvclang": "en-AU"}
-
-        # Make the API request
-        r = session.get(API_BASE_URL, params=params)
-        r.raise_for_status()  # Raise an exception for HTTP errors (e.g., 404, 500)
-
-        data = r.json()
-
-        # Check if the API call was successful based on the JSON response
-        if not data.get("success"):
-            raise Exception(
-                f"API call was not successful: {data.get('responseContent', 'No specific error message provided by API.')}"
-            )
-
-        # The actual content is embedded as an HTML string within 'responseContent'
-        html_content = data["responseContent"]
-        soup = BeautifulSoup(html_content, "html.parser")
-
-        entries = []  # List to store parsed collection schedules
-
-        # Find all HTML blocks that represent a waste service result with a precise date.
-        # This regex targets divs with both "waste-services-result" and "date-precise" classes.
-        waste_service_blocks = soup.find_all(
-            "div", class_=re.compile(r"\bwaste-services-result\b.*\bdate-precise\b")
-        )
-
-        for block in waste_service_blocks:
-            waste_type_tag = block.find("h3")
-            next_service_tag = block.find("div", class_="next-service")
-
-            # These tags should always be present for blocks with 'date-precise'
-            if waste_type_tag and next_service_tag:
-                waste_type = waste_type_tag.get_text(strip=True).upper()
-                next_service_text = next_service_tag.get_text(strip=True)
-
-                # Extract the date using a regular expression.
-                # The 'date-precise' class implies a date will be present.
-                match = re.search(r"(\d{1,2}/\d{1,2}/\d{4})", next_service_text)
-                if match:
-                    date_str = match.group(1)
-                    collection_date = datetime.datetime.strptime(
-                        date_str, "%d/%m/%Y"
-                    ).date()
-
-                    entries.append(
-                        Collection(
-                            date=collection_date,
-                            t=waste_type,
-                            icon=ICON_MAP.get(waste_type),
-                        )
-                    )
-                else:
-                    # This case should ideally not be hit if 'date-precise' filtering works as expected.
-                    _LOGGER.warning(
-                        f"Warning: 'date-precise' block '{waste_type}' did not contain a parseable date: '{next_service_text}'"
-                    )
-            else:
-                # This case should also not be hit with the refined find_all.
-                _LOGGER.warning(
-                    f"Warning: 'date-precise' block missing h3 or next-service div: {block}"
-                )
-
-        if not entries:
-            # If no collection schedules were successfully parsed, raise an error.
-            raise Exception(
-                "No collection schedules found. Please check your Geolocation ID and ensure the API is returning valid data for your address."
-            )
-
-        return entries
+        return self._client.fetch(geolocation_id=self._geolocation_id)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/willoughby_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/willoughby_nsw_gov_au.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-import datetime
-import logging
 import re
 
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import (
-    SourceArgumentNotFound,
-    SourceArgumentNotFoundWithSuggestions,
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
 )
 
 TITLE = "Willoughby City Council"
@@ -47,141 +43,25 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": "Visit the Willoughby City Council waste service dates page, search for your address, and use the address text as shown by the lookup.",
 }
 
-BASE_URL = "https://www.willoughby.nsw.gov.au"
-PAGE_URL = (
-    f"{BASE_URL}/Residents/Waste-and-recycling/"
-    "Household-bin-services/Waste-and-street-sweeping-services"
-)
-
-API_URLS = {
-    "address_search": f"{BASE_URL}/api/v1/myarea/search",
-    "collection": f"{BASE_URL}/ocapi/Public/myarea/wasteservices",
-}
-
 HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
     ),
     "Accept": "application/json, text/javascript, */*; q=0.01",
-    "Referer": PAGE_URL,
+    "Referer": (
+        f"{URL}/Residents/Waste-and-recycling/"
+        "Household-bin-services/Waste-and-street-sweeping-services"
+    ),
     "X-Requested-With": "XMLHttpRequest",
 }
 
-_LOGGER = logging.getLogger(__name__)
-
-
-class Source:
-    def __init__(self, address: str):
-        self._address = address.strip()
-
-    def fetch(self) -> list[Collection]:
-        session = requests.Session()
-        session.headers.update(HEADERS)
-
-        # Establish cookies/session before the AJAX calls.
-        try:
-            session.get(PAGE_URL, timeout=30)
-        except requests.RequestException:
-            _LOGGER.debug(
-                "Could not preload Willoughby page; continuing with API calls"
-            )
-
-        geolocation_id = self._get_geolocation_id(session)
-        html = self._get_waste_services_html(session, geolocation_id)
-
-        entries = self._parse_entries(html)
-        entries.sort(key=lambda entry: entry.date)
-        return entries
-
-    def _get_geolocation_id(self, session: requests.Session) -> str:
-        response = session.get(
-            API_URLS["address_search"],
-            params={"keywords": self._address},
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        data = response.json()
-        items = data.get("Items") or []
-        if not items:
-            raise SourceArgumentNotFound("address", self._address)
-
-        if len(items) > 1:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "address",
-                self._address,
-                [item.get("AddressSingleLine", "") for item in items],
-            )
-
-        geolocation_id = items[0].get("Id")
-        if not geolocation_id:
-            raise SourceArgumentNotFound("address", self._address)
-
-        return geolocation_id
-
-    def _get_waste_services_html(
-        self, session: requests.Session, geolocation_id: str
-    ) -> str:
-        response = session.get(
-            API_URLS["collection"],
-            params={
-                "geolocationid": geolocation_id,
-                "ocsvclang": "en-AU",
-            },
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        data = response.json()
-        if not data.get("success", False):
-            message = (
-                data.get("message")
-                or data.get("error")
-                or data.get("responseMessage")
-                or "Willoughby waste services API returned success=false"
-            )
-            raise RuntimeError(message)
-
-        return data.get("responseContent") or ""
-
-    @staticmethod
-    def _parse_entries(html: str) -> list[Collection]:
-        soup = BeautifulSoup(html, "html.parser")
-        entries: list[Collection] = []
-        seen: set[tuple[datetime.date, str]] = set()
-
-        service_items = soup.select("article, div.waste-services-result")
-
-        for item in service_items:
-            waste_type_el = item.find("h3")
-            date_el = item.find(class_="next-service")
-
-            if not waste_type_el or not date_el:
-                continue
-
-            waste_type = _normalise_waste_type(waste_type_el.get_text(" ", strip=True))
-            date_text = date_el.get_text(" ", strip=True)
-            date = _parse_date(date_text)
-
-            if not date:
-                _LOGGER.debug("Could not parse Willoughby date text: %s", date_text)
-                continue
-
-            key = (date, waste_type)
-            if key in seen:
-                continue
-
-            seen.add(key)
-            entries.append(
-                Collection(
-                    date=date,
-                    t=waste_type,
-                    icon=ICON_MAP.get(waste_type, "mdi:trash-can"),
-                )
-            )
-
-        return entries
+_CONFIG = OpenCitiesConfig(
+    domain=URL,
+    headers=HEADERS,
+    icon_keywords=ICON_MAP,
+    use_curl_cffi=True,
+)
 
 
 def _normalise_waste_type(text: str) -> str:
@@ -202,36 +82,27 @@ def _normalise_waste_type(text: str) -> str:
     return text
 
 
-def _parse_date(text: str) -> datetime.date | None:
-    text = re.sub(r"\s+", " ", text.replace("\xa0", " ")).strip()
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+        self._client = OpenCitiesClient(_CONFIG)
 
-    formats = (
-        "%a %d/%m/%Y",
-        "%A %d/%m/%Y",
-        "%d/%m/%Y",
-        "%a %d %B %Y",
-        "%A %d %B %Y",
-        "%d %B %Y",
-    )
+    def fetch(self) -> list[Collection]:
+        raw_entries = self._client.fetch(address=self._address)
 
-    for date_format in formats:
-        try:
-            return datetime.datetime.strptime(text, date_format).date()
-        except ValueError:
-            pass
-
-    slash_match = re.search(r"\b\d{1,2}/\d{1,2}/\d{4}\b", text)
-    if slash_match:
-        try:
-            return datetime.datetime.strptime(slash_match.group(0), "%d/%m/%Y").date()
-        except ValueError:
-            pass
-
-    long_match = re.search(r"\b\d{1,2}\s+[A-Za-z]+\s+\d{4}\b", text)
-    if long_match:
-        try:
-            return datetime.datetime.strptime(long_match.group(0), "%d %B %Y").date()
-        except ValueError:
-            pass
-
-    return None
+        entries: list[Collection] = []
+        seen: set[tuple[object, str]] = set()
+        for entry in raw_entries:
+            waste_type = _normalise_waste_type(entry.type)
+            key = (entry.date, waste_type)
+            if key in seen:
+                continue
+            seen.add(key)
+            entries.append(
+                Collection(
+                    date=entry.date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type),
+                )
+            )
+        return entries

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -729,6 +729,25 @@ def test_opencities_client_parses_wasteservices_html_into_collections() -> None:
     ]
 
 
+def test_opencities_client_does_not_double_count_nested_article_in_result_div() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    html = (
+        '<div class="waste-services-result"><article><h3>General Waste</h3>'
+        '<div class="next-service">Mon 01/02/2027</div></article></div>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert len(entries) == 1
+
+
 def test_opencities_client_resolves_icon_via_keywords() -> None:
     from waste_collection_schedule import Icons
 
@@ -774,6 +793,29 @@ def test_opencities_client_skips_entries_missing_next_service_date() -> None:
     entries = client.fetch_by_geolocation_id("abc")
 
     assert [e.type for e in entries] == ["Recycling"]
+
+
+def test_opencities_client_filters_by_date_precise_class_when_configured() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", require_date_precise=True
+    )
+    client = module.OpenCitiesClient(config)
+    html = (
+        '<div class="waste-services-result date-precise"><h3>General Waste</h3>'
+        '<div class="next-service">Mon 01/02/2027</div></div>'
+        '<div class="waste-services-result"><h3>Recycling</h3>'
+        '<div class="next-service">Every fortnight</div></div>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert [e.type for e in entries] == ["General Waste"]
 
 
 def test_opencities_client_retries_once_on_stale_cached_geolocation_id() -> None:


### PR DESCRIPTION
## Summary

Batch 1 of the phased OpenCities/MyArea consolidation started in #6934: migrates the 6 easiest sources onto `OpenCitiesClient` instead of each hand-rolling the search → geolocation-id → wasteservices flow.

- `kiama_nsw_gov_au.py`, `shoalhaven_nsw_gov_au.py` — geolocation-id-only councils (no search step), exercise `fetch(geolocation_id=...)` in isolation.
- `ballina_nsw_gov_au.py`, `lanecove_nsw_gov_au.py`, `willoughby_nsw_gov_au.py`, `cassowarycoast_qld_gov_au.py` — address-search councils, introduce `search_fuzzy`, `max_results`, `page_link`, custom `headers`, and curl_cffi one at a time.

### Client fixes/extensions found while migrating these six

- **Nested-block double-counting bug**: some council HTML wraps a matching `<article>` inside a matching `div.waste-services-result` (confirmed live on Ballina and Cassowary Coast) — the client's original `"article, div.waste-services-result"` selector matched both, double-counting every entry. Fixed by only keeping the outermost match of a nested pair (`OpenCitiesClient._select_top_level`), with a regression test.
- **`OpenCitiesConfig.require_date_precise`** (new field): Shoalhaven's wasteservices response mixes precise-date blocks with vague/recurring ones in the same payload and only wants the former — a genuine behavioral difference from every other migrated council, not just style, so it's a config flag rather than hardcoded logic.
- **lanecove/willoughby now need curl_cffi**: confirmed via a raw HTTP replay of each source's *pre-migration* code that both now 403 under plain `requests` (Akamai/Incapsula), so this migration bundles the `curl_cffi` fix per the project's existing "403 → curl_cffi" convention rather than leaving them broken.

### Note on kiama

Both of `kiama_nsw_gov_au.py`'s hardcoded `TEST_CASES` geolocation IDs return `"No collection services found for this address"` from the live API today — verified by replaying the exact pre-migration HTTP request, so this is pre-existing stale test-fixture data, not something this migration caused. Not fixed here (would require a fresh real address, out of scope for a refactor PR).

## Type of change

- [ ] New source
- [x] Bug fix / source fix (nested-block double-counting; lanecove/willoughby curl_cffi 403 fix)
- [ ] Documentation update
- [x] Other (migration onto shared service/OpenCities.py client)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (27 passed)
- [x] `ruff check --fix` / `ruff format` / `mypy --ignore-missing-imports --explicit-package-bases` clean (pre-commit hooks pass)
- [x] No generated files in diff
- [x] Live-tested each of the 6 sources via `test_sources.py -s <name> -l` against the real API
- [x] `TITLE`/`URL`/`COUNTRY`/`TEST_CASES`/`HOW_TO_GET_ARGUMENTS_DESCRIPTION`/`PARAM_*` unchanged; `doc/source/*.md` untouched