### PR TITLE
fix(config_flow): use class TITLE on the reconfigure path (#6938)

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -1255,7 +1255,15 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
         schema, module = await self.__get_arg_schema(
             source, config_entry.data["args"], args_input, include_title=False
         )
-        title = module.TITLE
+        # New-style (BaseSource) sources declare TITLE on the Source class rather
+        # than at module level, so resolve it safely instead of reading
+        # module.TITLE directly (which raises AttributeError for those sources).
+        source_cls = getattr(module, "Source", None)
+        title: str = (
+            getattr(source_cls, "TITLE", None)
+            or getattr(module, "TITLE", source)
+            or source
+        )
         errors: dict[str, str] = {}
         description_placeholders: dict[str, str] = self._get_description_placeholders(
             source


### PR DESCRIPTION
## Problem

Reconfigure crashes with `AttributeError` for every new-style (`BaseSource`) source.

`async_step_reconfigure` read the display title with `title = module.TITLE`. New-style sources declare `TITLE` on the `Source` class, not at module level, so this raised `AttributeError` on the reconfigure path before the form could render. Legacy module-level sources were unaffected.

## Fix

Resolve the title the same safe way the rest of the flow already does: read `TITLE` from the `Source` class first, then fall back to a module-level `TITLE`, then to the source name.

```python
source_cls = getattr(module, "Source", None)
title: str = (
    getattr(source_cls, "TITLE", None)
    or getattr(module, "TITLE", source)
    or source
)
```

## Tests

There is no Home Assistant test harness in this repo (`homeassistant` is not a test dependency, so `config_flow.py` cannot be imported under pytest), and no existing config-flow tests to extend. No automated test was added for that reason. The change is a one-line title resolution mirroring the existing pattern; `pre-commit` `ruff`, `ruff-format` and `mypy` all pass on the changed file.

Fixes #6938

🤖 Generated with [Claude Code](https://claude.com/claude-code)