### PR TITLE
fix(config_flow): reset per-flow state instead of sharing a class dict (#6939)

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -5,7 +5,7 @@ import logging
 import types
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, ClassVar, Literal, TypedDict, Union, cast, get_origin
+from typing import Any, Literal, TypedDict, Union, cast, get_origin
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -524,12 +524,24 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
     _country: str | None = None
     _source: str | None = None
 
-    _options: ClassVar[dict] = {}
     # Not a ClassVar: the empty dict is only a per-instance "not yet
     # initialized" sentinel; _async_setup_sources() below rebinds it to the
     # shared _SOURCES cache on first use.
     _sources: dict[str, list[SourceDict]] = {}  # noqa: RUF012
     _error_suggestions: dict[str, list[Any]]
+
+    def __init__(self) -> None:
+        """Give each config-flow run its own mutable state.
+
+        ``_options`` used to be a class-level dict shared by every flow
+        instance. Because the flow only ever mutates it in place (via
+        ``update()`` and item assignment) and never rebinds it at the start
+        of a run, a second "add integration" in the same process inherited
+        the first run's sensors and customisations, and ``finish()`` then
+        passed that shared dict on by reference. Binding it per instance
+        keeps successive runs independent.
+        """
+        self._options: dict[str, Any] = {}
 
     async def _async_setup_sources(self) -> None:
         if len(self._sources) > 0:


### PR DESCRIPTION
## Cause

`WasteCollectionConfigFlow._options` was declared as a class-level `ClassVar[dict] = {}`. The flow only ever mutates it in place (`self._options.update(...)`, `self._options[...] = ...`) and never rebinds it at the start of a run, so a single dict is shared by every flow instance in the Home Assistant process.

As a result, a second "add integration" run inherits the first run's `CONF_SENSORS` and `CONF_CUSTOMIZE`, and `finish()` then passes that shared dict on to the new config entry by reference.

## Fix

Give each config-flow instance its own `_options` dict via `__init__`, so successive runs stay independent.

The other per-flow mutable state (`sensors`, `_customize_index`, `_customize_types`, `_fetched_types`, `_error_suggestions`) is already instance-only: it is either lazily rebound or guarded with `hasattr`, so it does not share this flaw and is left as-is. `WasteCollectionOptionsFlow` is a separate class with its own `_options` and is unaffected.

## Testing

`homeassistant` is not installed in the repo's test environment and there is no HA-level config-flow test harness (no hass fixtures / `pytest-homeassistant-custom-component`), so `config_flow.py` cannot be imported under pytest. No automated test was added for this reason. `pre-commit run ruff ruff-format mypy` on the changed file all pass.

Fixes #6939

🤖 Generated with [Claude Code](https://claude.com/claude-code)