### PR TITLE
fix: apply per-type customisation to pipeline sources (#6936)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -18,10 +18,32 @@ def _is_glob(key: str) -> bool:
     return any(ch in key for ch in _GLOB_CHARS)
 
 
+def _match_customize_keys(
+    customize: dict[str, "Customize"], keys: list[str]
+) -> "Customize | None":
+    """Return the Customize entry matching any of ``keys``.
+
+    An exact key match always wins and is tried for every candidate key (in the
+    order given) before any glob is considered, so an exact match on one key can
+    never be shadowed by a glob match on another. If no candidate matches
+    exactly, each candidate is matched against every customize key that contains
+    an fnmatch glob wildcard (``*``, ``?`` or ``[...]``); the first such glob key
+    in definition order wins. Matching is case-sensitive, like the exact lookup.
+    """
+    for key in keys:
+        c = customize.get(key)
+        if c is not None:
+            return c
+    for pattern, candidate in customize.items():
+        if _is_glob(pattern) and any(fnmatch.fnmatchcase(k, pattern) for k in keys):
+            return candidate
+    return None
+
+
 def match_customize(
     customize: dict[str, "Customize"], waste_type: str
 ) -> "Customize | None":
-    """Return the Customize entry for a waste type.
+    """Return the Customize entry for a single waste-type key.
 
     An exact key match always wins. If no exact key exists, the waste type is
     matched against any customize key that contains an fnmatch glob wildcard
@@ -29,13 +51,7 @@ def match_customize(
     glob key (in definition order) is used. Matching is case-sensitive, like
     the exact lookup.
     """
-    c = customize.get(waste_type)
-    if c is not None:
-        return c
-    for key, candidate in customize.items():
-        if _is_glob(key) and fnmatch.fnmatchcase(waste_type, key):
-            return candidate
-    return None
+    return _match_customize_keys(customize, [waste_type])
 
 
 class Fetchable(Protocol):
@@ -104,25 +120,48 @@ class Customize:
 
 
 def _get_customize_key(entry: Collection) -> str:
-    """Get the key to look up in the customize dict.
+    """Primary key used to look an entry up in the customize dict.
 
-    New-style sources: use waste_type.id (e.g. "general_waste")
-    Legacy sources: use the display string (e.g. "Refuse")
+    New-style sources: the canonical ``WasteType.id`` (e.g. "general_waste"),
+    which is stable and locale-independent.
+    Legacy sources: the display string (e.g. "Refuse").
     """
     if isinstance(entry, LegacyCollection):
         return entry.type
     return entry.waste_type.id
 
 
+def _customize_keys(entry: Collection) -> list[str]:
+    """Candidate keys to look an entry up in the customize dict.
+
+    Legacy sources are only ever matched by their display string, exactly as
+    before. New-style (pipeline) sources are matched by their canonical
+    ``WasteType.id`` first, then by the localised display name as a fallback.
+
+    The display-name fallback is what actually fixes per-type customisation for
+    pipeline sources (issue #6936): the config flow presents, stores and builds
+    sensors from the display labels the user sees, so every customize key the UI
+    writes is a display name, never an id. Accepting both keys lets that stored
+    customisation apply while keeping the id as the preferred, locale-independent
+    key (and the one the library's own tests assert). User-typed fnmatch globs,
+    also written against the displayed labels, keep working for the same reason.
+    """
+    if isinstance(entry, LegacyCollection):
+        return [entry.type]
+    # id preferred; de-duplicate in case it equals the display name (e.g. an
+    # English preserved label).
+    return list(dict.fromkeys([entry.waste_type.id, entry.type]))
+
+
 def filter_function(entry: Collection, customize: dict[str, Customize]):
-    c = match_customize(customize, _get_customize_key(entry))
+    c = _match_customize_keys(customize, _customize_keys(entry))
     if c is None:
         return True
     return c.show
 
 
 def customize_function(entry: Collection, customize: dict[str, Customize]):
-    c = match_customize(customize, _get_customize_key(entry))
+    c = _match_customize_keys(customize, _customize_keys(entry))
     if c is not None:
         if c.alias is not None:
             entry.set_type(c.alias)

--- a/tests/test_new_architecture.py
+++ b/tests/test_new_architecture.py
@@ -3266,6 +3266,158 @@ class TestSourceShellCustomize:
         customize_function(c, customize)
         assert c.type == "General Bin"
 
+    # --- Regression tests for #6936 -----------------------------------------
+    # The config flow presents, stores and builds sensors from the display
+    # labels a user sees, so every customize key written by the UI for a
+    # pipeline source is a display name, never a WasteType.id. Customisation
+    # keyed by the display name must therefore apply to new-style sources.
+
+    def test_customize_applies_alias_by_display_name_6936(self):
+        from waste_collection_schedule.collection import Collection
+        from waste_collection_schedule.source_shell import (
+            Customize,
+            customize_function,
+        )
+        from waste_collection_schedule.waste_types import GENERAL_WASTE
+
+        c = Collection(date=datetime.date(2026, 1, 1), waste_type=GENERAL_WASTE)
+        # Keyed by the display label ("General Waste"), not the id.
+        customize = {"General Waste": Customize("General Waste", alias="Bin Day")}
+        customize_function(c, customize)
+        assert c.type == "Bin Day"
+
+    def test_customize_applies_icon_by_display_name_6936(self):
+        from waste_collection_schedule.collection import Collection
+        from waste_collection_schedule.source_shell import (
+            Customize,
+            customize_function,
+        )
+        from waste_collection_schedule.waste_types import GENERAL_WASTE
+
+        c = Collection(date=datetime.date(2026, 1, 1), waste_type=GENERAL_WASTE)
+        customize = {"General Waste": Customize("General Waste", icon="mdi:custom-bin")}
+        customize_function(c, customize)
+        assert c.icon == "mdi:custom-bin"
+
+    def test_filter_hides_by_display_name_6936(self):
+        from waste_collection_schedule.collection import Collection
+        from waste_collection_schedule.source_shell import Customize, filter_function
+        from waste_collection_schedule.waste_types import GENERAL_WASTE
+
+        c = Collection(date=datetime.date(2026, 1, 1), waste_type=GENERAL_WASTE)
+        customize = {"General Waste": Customize("General Waste", show=False)}
+        assert filter_function(c, customize) is False
+
+    def test_customize_glob_matches_display_name_6936(self):
+        from waste_collection_schedule.collection import Collection
+        from waste_collection_schedule.source_shell import (
+            Customize,
+            customize_function,
+        )
+        from waste_collection_schedule.waste_types import GENERAL_WASTE
+
+        c = Collection(date=datetime.date(2026, 1, 1), waste_type=GENERAL_WASTE)
+        # Globs are typed by the user against the labels shown in the UI.
+        customize = {"General *": Customize("General *", alias="Rubbish")}
+        customize_function(c, customize)
+        assert c.type == "Rubbish"
+
+    def test_customize_exact_id_still_wins_over_glob_6936(self):
+        from waste_collection_schedule.collection import Collection
+        from waste_collection_schedule.source_shell import (
+            Customize,
+            customize_function,
+        )
+        from waste_collection_schedule.waste_types import GENERAL_WASTE
+
+        c = Collection(date=datetime.date(2026, 1, 1), waste_type=GENERAL_WASTE)
+        # An exact key (the canonical id) must win over a glob on another key.
+        customize = {
+            "*": Customize("*", alias="Catch-all"),
+            "general_waste": Customize("general_waste", alias="Exact"),
+        }
+        customize_function(c, customize)
+        assert c.type == "Exact"
+
+    def test_customize_legacy_ignores_ad_hoc_id_6936(self):
+        from waste_collection_schedule.collection import LegacyCollection
+        from waste_collection_schedule.source_shell import (
+            Customize,
+            customize_function,
+        )
+
+        # Legacy entries must only be matched by their display string, never by
+        # the internal ad-hoc "legacy_..." id.
+        c = LegacyCollection(date=datetime.date(2026, 1, 1), t="Refuse")
+        customize = {"legacy_Refuse": Customize("legacy_Refuse", alias="Wrong")}
+        customize_function(c, customize)
+        assert c.type == "Refuse"  # unchanged
+
+    def test_shell_fetch_applies_display_name_customisation_6936(self):
+        """End-to-end: a pipeline source with customisation stored by display
+        name has its alias applied and its hidden type filtered out."""
+        from waste_collection_schedule.collection import Collection
+        from waste_collection_schedule.source_shell import Customize, SourceShell
+        from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
+
+        class _FakeSource:
+            def fetch(self):
+                return [
+                    Collection(
+                        date=datetime.date(2026, 1, 1), waste_type=GENERAL_WASTE
+                    ),
+                    Collection(date=datetime.date(2026, 1, 2), waste_type=RECYCLABLES),
+                ]
+
+        customize = {
+            "General Waste": Customize("General Waste", alias="Rubbish Bin"),
+            "Recycling": Customize("Recycling", show=False),
+        }
+        shell = SourceShell(
+            source=_FakeSource(),
+            customize=customize,
+            title="Test",
+            description="",
+            url=None,
+            calendar_title=None,
+            unique_id="test",
+            day_offset=0,
+        )
+        shell.fetch()
+        types = [e.type for e in shell._entries]
+        assert types == ["Rubbish Bin"]  # aliased, and Recycling hidden
+
+    def test_shell_fetch_applies_customisation_legacy_6936(self):
+        """The same end-to-end path still works for legacy sources keyed by the
+        display string."""
+        from waste_collection_schedule.collection import LegacyCollection
+        from waste_collection_schedule.source_shell import Customize, SourceShell
+
+        class _FakeLegacySource:
+            def fetch(self):
+                return [
+                    LegacyCollection(date=datetime.date(2026, 1, 1), t="Refuse"),
+                    LegacyCollection(date=datetime.date(2026, 1, 2), t="Recycling"),
+                ]
+
+        customize = {
+            "Refuse": Customize("Refuse", alias="General Bin"),
+            "Recycling": Customize("Recycling", show=False),
+        }
+        shell = SourceShell(
+            source=_FakeLegacySource(),
+            customize=customize,
+            title="Test",
+            description="",
+            url=None,
+            calendar_title=None,
+            unique_id="test",
+            day_offset=0,
+        )
+        shell.fetch()
+        types = [e.type for e in shell._entries]
+        assert types == ["General Bin"]
+
     def test_day_offset(self):
         from waste_collection_schedule.collection import Collection
         from waste_collection_schedule.source_shell import apply_day_offset


### PR DESCRIPTION
## Cause

Per-type customisation (alias, custom icon/picture, hide via `show=False`, dedicated calendars) was a silent no-op for every new-style (pipeline) source.

The config flow presents, stores and builds sensors from the display labels a user sees, so every customize key the UI writes for a pipeline source is a **display name** (e.g. `"General Waste"`, or the localised `"Restmüll"`). The lookup in `source_shell.py`, however, matched new-style entries only by their **canonical `WasteType.id`** (e.g. `"general_waste"`). A display name never equals an id, so `match_customize` always returned `None` and the customisation was ignored.

Legacy sources were unaffected: they key on the display string on both the store and lookup sides.

## Fix

Match a new-style entry against **both** keys: its canonical `WasteType.id` first (the preferred, locale-independent key, and the one the library's own tests assert), then its localised display name as a fallback. This makes the customisation the UI actually stores apply — across the setup, reconfigure and YAML paths at once — and keeps user-typed fnmatch globs working, since those too are written against the displayed labels. Exact matches still win over globs across both candidate keys.

Legacy sources are unchanged: matched by their display string only, never by the internal ad-hoc `"legacy_..."` id.

## Design decision

The whole config surface (flow selection, stored keys, sensor collection-type keys, globs) is expressed in display names; the lookup was the only place speaking exclusively in ids. Broadening the lookup fixes the bug at a single seam in the core library, entirely within `source_shell.py`, without rewriting that display-name-based surface across two config-flow classes (and without breaking user-typed globs). It stays forward-compatible with a future move to id-based storage: the id remains the preferred key, so if the config flow is later upgraded to store ids, the same lookup keeps working with no further change.

### Possible follow-up (out of scope)

True locale-independent storage would require the config flow (setup **and** reconfigure) plus the sensor `collection_types` keys to store `WasteType.id` rather than display names. That is a larger, cross-cutting change and is deliberately not attempted here for a release blocker.

## Tests

Adds regression tests to `tests/test_new_architecture.py` exercising `SourceShell` with display-name-keyed customisation for a pipeline source (alias, icon, hide, glob, exact-wins-over-glob, and an end-to-end `fetch()`), and confirming legacy behaviour is unchanged. `pre-commit` (`ruff`, `ruff-format`, `mypy`) and `pytest tests/test_new_architecture.py` pass.

Fixes #6936

🤖 Generated with [Claude Code](https://claude.com/claude-code)
