### PR TITLE
refactor: migrate 6 more OpenCities sources onto shared client (batch 2/5)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -67,6 +67,14 @@ class OpenCitiesConfig:
     warm_up_url: str | None = None
     """A page fetched once, lazily, before the first API request (session/cookie priming)."""
 
+    warm_up_before: Literal["search", "wasteservices"] = "search"
+    """
+    When the (one-off) warm-up GET fires: before the address search
+    (default), or after it — right before the wasteservices call, which
+    also covers the direct ``geolocation_id`` bypass path where no search
+    ever happens.
+    """
+
     date_format: str = DEFAULT_DATE_FORMAT
 
     icon_keywords: dict[str, Any] | None = None
@@ -135,12 +143,14 @@ class OpenCitiesClient:
             return self.fetch_by_geolocation_id(self._geolocation_id)
 
     def resolve_geolocation_id(self, address: str) -> str:
-        self._ensure_warmed_up()
+        if self._cfg.warm_up_before == "search":
+            self._ensure_warmed_up()
         items = self._search(address)
         return self._select_address(address, items)
 
     def fetch_by_geolocation_id(self, geolocation_id: str) -> list[Collection]:
-        self._ensure_warmed_up()
+        if self._cfg.warm_up_before == "wasteservices":
+            self._ensure_warmed_up()
         params: dict[str, str] = {
             "geolocationid": geolocation_id,
             "ocsvclang": self._cfg.ocsvclang,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/banyule_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/banyule_vic_gov_au.py
@@ -1,12 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-from bs4 import BeautifulSoup
-from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons
-from waste_collection_schedule.exceptions import (
-    SourceArgumentExceptionMultiple,
+from waste_collection_schedule.exceptions import SourceArgumentExceptionMultiple
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
 )
 
 TITLE = "Banyule City Council"
@@ -22,30 +18,25 @@ TEST_CASES = {
     "Thursday B": {"street_address": "35 Para Road, MONTMORENCY"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "green waste": Icons.GARDEN,
     "recycling": Icons.RECYCLING,
 }
 
-
-class SourceConfigurationError(ValueError):
-    pass
-
-
-class SourceParseError(ValueError):
-    pass
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.banyule.vic.gov.au",
+    use_curl_cffi=True,
+    impersonate="chrome124",
+    warm_up_url="https://www.banyule.vic.gov.au/Waste-environment/Waste-recycling/Bin-collection-services",
+    warm_up_before="wasteservices",
+    icon_keywords=ICON_MAP,
+    # Without an explicit Accept header the search endpoint returns XML
+    # instead of JSON.
+    headers={"Accept": "application/json"},
+)
 
 
 class Source:
-    OC_GEOLOCATION_SEARCH_URL = "https://www.banyule.vic.gov.au/api/v1/myarea/search"
-
-    OC_SESSION_URL = "https://www.banyule.vic.gov.au/Waste-environment/Waste-recycling/Bin-collection-services"
-    OC_CALENDAR_URL = "https://www.banyule.vic.gov.au/ocapi/Public/myarea/wasteservices"
-
-    OC_RE_DATE_STR = re.compile(r"[^\s]+\s(\d{1,2}/\d{1,2}/\d{4})")
-
     def __init__(
         self,
         street_address: str | None = None,
@@ -59,96 +50,9 @@ class Source:
 
         self._street_address = street_address
         self._geolocation_id = geolocation_id
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        # Use curl_cffi session to bypass Incapsula bot protection
-        session = requests.Session(impersonate="chrome124")
-
-        geolocation_id = self._geolocation_id
-        if geolocation_id is None:
-            # Search for geolocation ID
-            geolocation_response = session.get(
-                self.OC_GEOLOCATION_SEARCH_URL,
-                params={"keywords": self._street_address, "maxresults": 1},
-                headers={"Accept": "application/json"},
-            )
-            geolocation_response.raise_for_status()
-
-            # Pull ID from results
-            geolocation_result = geolocation_response.json()
-            _LOGGER.debug(f"Search response: {geolocation_response!r}")
-
-            if "success" in geolocation_result and not geolocation_result["success"]:
-                raise SourceParseError(
-                    "Unspecified server-side error when searching address"
-                )
-
-            if (
-                "Items" not in geolocation_result
-                or geolocation_result["Items"] is None
-                or len(geolocation_result["Items"]) < 1
-            ):
-                raise SourceParseError(
-                    "Expected list of locations from address search, got empty or missing list"
-                )
-
-            geolocation_data = geolocation_result["Items"][0]
-
-            if "Id" not in geolocation_data:
-                raise SourceParseError(
-                    "Location in address search result but missing geolocation ID"
-                )
-
-            geolocation_id = geolocation_data["Id"]
-            _LOGGER.info(
-                f"Address {self._street_address} mapped to geolocation ID {geolocation_id}"
-            )
-
-        calendar_request = session.get(self.OC_SESSION_URL)
-        calendar_request.raise_for_status()
-
-        calendar_request = session.get(
-            self.OC_CALENDAR_URL,
-            params={"geolocationid": geolocation_id, "ocsvclang": "en-AU"},
+        return self._client.fetch(
+            address=self._street_address, geolocation_id=self._geolocation_id
         )
-        calendar_request.raise_for_status()
-
-        calendar_result = calendar_request.json()
-        _LOGGER.debug(f"Calendar response: {calendar_result!r}")
-
-        if "success" in calendar_result and not calendar_result["success"]:
-            raise SourceParseError(
-                "Unspecified server-side error when getting calendar"
-            )
-
-        # Extract entries from bundled HTML
-        calendar_parser = BeautifulSoup(
-            calendar_result["responseContent"], "html.parser"
-        )
-
-        pickup_entries = []
-
-        for element in calendar_parser.find_all("article"):
-            _LOGGER.debug(f"Parsing collection: {element!r}")
-
-            waste_type = element.h3.string
-
-            # Extract and parse collection date
-            waste_date_match = self.OC_RE_DATE_STR.match(
-                element.find(class_="next-service").string.strip()
-            )
-
-            if waste_date_match is None:
-                continue
-
-            waste_date = datetime.strptime(waste_date_match[1], "%d/%m/%Y").date()
-
-            # Base icon on type
-            waste_icon = ICON_MAP.get(waste_type.lower())
-
-            pickup_entries.append(Collection(waste_date, waste_type, waste_icon))
-            _LOGGER.info(
-                f"Collection for {waste_type} (icon: {waste_icon}) on {waste_date}"
-            )
-
-        return pickup_entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cambridge_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cambridge_wa_gov_au.py
@@ -1,12 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-from bs4 import BeautifulSoup
-from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons
-from waste_collection_schedule.exceptions import (
-    SourceArgumentExceptionMultiple,
+from waste_collection_schedule.exceptions import SourceArgumentExceptionMultiple
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
 )
 
 TITLE = "Town of Cambridge (WA)"
@@ -17,8 +13,6 @@ TEST_CASES = {
     "Cambridge Library": {"street_address": "99 The Boulevard, FLOREAT 6014"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "general waste": Icons.GENERAL_WASTE,
     "green waste": Icons.GARDEN,
@@ -26,27 +20,19 @@ ICON_MAP = {
     "recycling": Icons.RECYCLING,
 }
 
-
-class SourceConfigurationError(ValueError):
-    pass
-
-
-class SourceParseError(ValueError):
-    pass
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.cambridge.wa.gov.au",
+    use_curl_cffi=True,
+    warm_up_url="https://www.cambridge.wa.gov.au/Residents/Waste-Recycling/Find-My-Bin-Day",
+    warm_up_before="wasteservices",
+    icon_keywords=ICON_MAP,
+    # Without an explicit Accept header the search endpoint returns XML
+    # instead of JSON.
+    headers={"Accept": "application/json"},
+)
 
 
 class Source:
-    OC_GEOLOCATION_SEARCH_URL = "https://www.cambridge.wa.gov.au/api/v1/myarea/search"
-
-    OC_SESSION_URL = (
-        "https://www.cambridge.wa.gov.au/Residents/Waste-Recycling/Find-My-Bin-Day"
-    )
-    OC_CALENDAR_URL = (
-        "https://www.cambridge.wa.gov.au/ocapi/Public/myarea/wasteservices"
-    )
-
-    OC_RE_DATE_STR = re.compile(r"[^\s]+\s(\d{1,2}/\d{1,2}/\d{4})")
-
     def __init__(
         self,
         street_address: str | None = None,
@@ -60,96 +46,9 @@ class Source:
 
         self._street_address = street_address
         self._geolocation_id = geolocation_id
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        # Use curl_cffi session to bypass Incapsula bot protection
-        session = requests.Session(impersonate="chrome")
-
-        geolocation_id = self._geolocation_id
-        if geolocation_id is None:
-            # Search for geolocation ID
-            geolocation_response = session.get(
-                self.OC_GEOLOCATION_SEARCH_URL,
-                params={"keywords": self._street_address, "maxresults": 1},
-                headers={"Accept": "application/json"},
-            )
-            geolocation_response.raise_for_status()
-
-            # Pull ID from results
-            geolocation_result = geolocation_response.json()
-            _LOGGER.debug(f"Search response: {geolocation_response!r}")
-
-            if "success" in geolocation_result and not geolocation_result["success"]:
-                raise SourceParseError(
-                    "Unspecified server-side error when searching address"
-                )
-
-            if (
-                "Items" not in geolocation_result
-                or geolocation_result["Items"] is None
-                or len(geolocation_result["Items"]) < 1
-            ):
-                raise SourceParseError(
-                    "Expected list of locations from address search, got empty or missing list"
-                )
-
-            geolocation_data = geolocation_result["Items"][0]
-
-            if "Id" not in geolocation_data:
-                raise SourceParseError(
-                    "Location in address search result but missing geolocation ID"
-                )
-
-            geolocation_id = geolocation_data["Id"]
-            _LOGGER.info(
-                f"Address {self._street_address} mapped to geolocation ID {geolocation_id}"
-            )
-
-        calendar_request = session.get(self.OC_SESSION_URL)
-        calendar_request.raise_for_status()
-
-        calendar_request = session.get(
-            self.OC_CALENDAR_URL,
-            params={"geolocationid": geolocation_id, "ocsvclang": "en-AU"},
+        return self._client.fetch(
+            address=self._street_address, geolocation_id=self._geolocation_id
         )
-        calendar_request.raise_for_status()
-
-        calendar_result = calendar_request.json()
-        _LOGGER.debug(f"Calendar response: {calendar_result!r}")
-
-        if "success" in calendar_result and not calendar_result["success"]:
-            raise SourceParseError(
-                "Unspecified server-side error when getting calendar"
-            )
-
-        # Extract entries from bundled HTML
-        calendar_parser = BeautifulSoup(
-            calendar_result["responseContent"], "html.parser"
-        )
-
-        pickup_entries = []
-
-        for element in calendar_parser.find_all("article"):
-            _LOGGER.debug(f"Parsing collection: {element!r}")
-
-            waste_type = element.h3.string
-
-            # Extract and parse collection date
-            waste_date_match = self.OC_RE_DATE_STR.match(
-                element.find(class_="next-service").string.strip()
-            )
-
-            if waste_date_match is None:
-                continue
-
-            waste_date = datetime.strptime(waste_date_match[1], "%d/%m/%Y").date()
-
-            # Base icon on type
-            waste_icon = ICON_MAP.get(waste_type.lower())
-
-            pickup_entries.append(Collection(waste_date, waste_type, waste_icon))
-            _LOGGER.info(
-                f"Collection for {waste_type} (icon: {waste_icon}) on {waste_date}"
-            )
-
-        return pickup_entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hobartcity_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hobartcity_com_au.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-from typing import TypedDict
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
-from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "City of Hobart "
 DESCRIPTION = "Source for City of Hobart"
@@ -25,89 +23,23 @@ ICON_MAP = {
     "fogo": Icons.BIO_KITCHEN,
 }
 
-SEARCH_URL = "https://www.hobartcity.com.au/api/v1/myarea/search"
-API_URL = "https://www.hobartcity.com.au/ocapi/Public/myarea/wasteservices"
-API_PARAMS = {
-    "geolocationid": "",  # filled in later
-    "ocsvclang": "en-AU",
-    "pageLink": "/$720cfbd8-df7e-4b88-bf92-e218d51ee173$/Residents/Waste-and-recycling/When-is-my-bin-collected",
-}
-
 PARAM_DESCRIPTIONS = {
     "en": {
         "address": "The address should exactly match the address autocompleted by the website: https://www.hobartcity.com.au/Residents/Waste-and-recycling/When-is-my-bin-collected",
     }
 }
 
-
-class Address(TypedDict):
-    Id: str
-    AddressSingleLine: str
-    MunicipalSubdivision: str
-    Distance: int
-    Score: float
-    LatLon: None
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.hobartcity.com.au",
+    page_link="/$720cfbd8-df7e-4b88-bf92-e218d51ee173$/Residents/Waste-and-recycling/When-is-my-bin-collected",
+    icon_keywords=ICON_MAP,
+)
 
 
 class Source:
     def __init__(self, address: str) -> None:
-        self._address: str = address
-        self._address_id: str | None = None
-
-    def _fetch_address_id(self) -> None:
-        args = {"keywords": self._address}
-        r = requests.get(SEARCH_URL, params=args)
-        r.raise_for_status()
-        addresses: list[Address] = r.json()["Items"]
-        if len(addresses) == 1:
-            self._address_id = addresses[0]["Id"]
-            return
-
-        for address in addresses:
-            if address["AddressSingleLine"].lower().replace(
-                " ", ""
-            ) == self._address.lower().replace(" ", ""):
-                self._address_id = address["Id"]
-                return
-        raise SourceArgumentNotFoundWithSuggestions(
-            argument="address",
-            value=self._address,
-            suggestions=[a["AddressSingleLine"] for a in addresses],
-        )
+        self._address = address
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        fresh = False
-        if not self._address_id:
-            self._fetch_address_id()
-            fresh = True
-        try:
-            return self.get_collections()
-        except Exception as e:
-            if fresh:
-                raise e
-            return self.get_collections()
-
-    def get_collections(self) -> list[Collection]:
-        if not self._address_id:
-            raise ValueError("Address ID not set")  # this should never happen
-        params = API_PARAMS.copy()
-        params["geolocationid"] = self._address_id
-        r = requests.get(API_URL, params=params)
-        r.raise_for_status()
-        data = r.json()
-        if data["success"] is False:
-            raise ValueError("API request failed")
-
-        soup = BeautifulSoup(data["responseContent"], "html.parser")
-        entries = []
-        for article in soup.select("article"):
-            bin_type = article.select_one("h3").text.strip()
-            date_tag = article.select_one("div.next-service").text.strip()
-            if not date_tag:  # Skip entries with empty dates (e.g., calendar download)
-                continue
-            # Wed 4/12/2024
-            date_ = datetime.strptime(date_tag, "%a %d/%m/%Y").date()
-            icon = ICON_MAP.get(bin_type.lower().split("/")[0])
-            entries.append(Collection(date=date_, t=bin_type, icon=icon))
-
-        return entries
+        return self._client.fetch(address=self._address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/logan_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/logan_qld_gov_au.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
-from bs4 import BeautifulSoup
-from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Logan City Council"
 DESCRIPTION = "Source for Logan City Council rubbish collection."
@@ -42,9 +41,6 @@ PARAM_DESCRIPTIONS = {
     },
 }
 
-SEARCH_URL = "https://www.logan.qld.gov.au/api/v1/myarea/search"
-COLLECTION_URL = "https://www.logan.qld.gov.au/ocapi/Public/myarea/wasteservices"
-
 HEADERS = {
     "accept": "application/json, text/javascript, */*; q=0.01",
     "referer": URL + "/MyLogan",
@@ -62,98 +58,21 @@ ICON_MAP = {
     "green waste": Icons.ORGANIC,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.logan.qld.gov.au",
+    argument_name="property_location",
+    max_results=1,
+    headers=HEADERS,
+    use_curl_cffi=True,
+    date_format="%A %d %B %Y",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
     def __init__(self, property_location: str):
         self._property_location = " ".join(property_location.split())
-        # The property's geolocation id is a stable per-property GUID. Cache it
-        # after the first lookup so subsequent (daily) fetches only need the
-        # single wasteservices call instead of the address search as well.
-        self._geolocation_id: str | None = None
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        # The council site sits behind Akamai bot protection, so impersonate a
-        # real browser (plain requests get a 403 Access Denied).
-        session = requests.Session(impersonate="chrome")
-        session.headers.update(HEADERS)
-
-        if self._geolocation_id is not None:
-            # Reuse the cached property id and skip the address search.
-            try:
-                return self._fetch_services(session, self._geolocation_id)
-            except SourceArgumentNotFound:
-                # Cached id may have gone stale; fall through to re-resolve.
-                self._geolocation_id = None
-
-        self._geolocation_id = self._get_geolocation_id(session)
-        return self._fetch_services(session, self._geolocation_id)
-
-    def _fetch_services(self, session, geolocation_id: str) -> list[Collection]:
-        response = session.get(
-            COLLECTION_URL,
-            params={"geolocationid": geolocation_id, "ocsvclang": "en-AU"},
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        html_content = response.json().get("responseContent", "")
-        if not html_content:
-            raise SourceArgumentNotFound("property_location", self._property_location)
-
-        return self._parse_entries(html_content)
-
-    def _get_geolocation_id(self, session) -> str:
-        response = session.get(
-            SEARCH_URL,
-            params={"keywords": self._property_location, "maxresults": "1"},
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        items = response.json().get("Items", [])
-        if not items:
-            raise SourceArgumentNotFound("property_location", self._property_location)
-
-        geolocation_id = items[0].get("Id")
-        if not geolocation_id:
-            raise SourceArgumentNotFound("property_location", self._property_location)
-
-        return geolocation_id
-
-    def _parse_entries(self, html: str) -> list[Collection]:
-        soup = BeautifulSoup(html, "html.parser")
-        entries: list[Collection] = []
-
-        for result in soup.select(".waste-services-result"):
-            title = result.find("h3")
-            next_service = result.select_one(".next-service")
-            if title is None or next_service is None:
-                continue
-
-            waste_type = title.get_text(" ", strip=True)
-            date_text = next_service.get_text(" ", strip=True)
-            try:
-                # e.g. "Monday 20 July 2026"
-                collection_date = datetime.strptime(date_text, "%A %d %B %Y").date()
-            except ValueError:
-                continue
-
-            entries.append(
-                Collection(
-                    date=collection_date,
-                    t=waste_type,
-                    icon=self._guess_icon(waste_type),
-                )
-            )
-
-        if not entries:
-            raise SourceArgumentNotFound("property_location", self._property_location)
-
-        return entries
-
-    def _guess_icon(self, waste_type: str) -> str | None:
-        lower = waste_type.lower()
-        for key, icon in ICON_MAP.items():
-            if key in lower:
-                return icon
-        return None
+        return self._client.fetch(address=self._property_location)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mildura_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mildura_vic_gov_au.py
@@ -1,10 +1,8 @@
-import json
-from datetime import datetime
-
-from bs4 import BeautifulSoup
-from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Mildura Rural City Council"
 DESCRIPTION = "Source for Mildura Rural City Council waste collection."
@@ -24,11 +22,6 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": "Go to <https://www.mildura.vic.gov.au/Explore/My-Neighbourhood> and make sure your address matches the auto-complete suggestions."
 }
 
-API_URLS = {
-    "address_search": "https://www.mildura.vic.gov.au/api/v1/myarea/search",
-    "collection": "https://www.mildura.vic.gov.au/ocapi/Public/myarea/wasteservices",
-}
-
 HEADERS = {
     "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
     "accept": "text/plain, */*; q=0.01",
@@ -43,78 +36,19 @@ ICON_MAP = {
     "Glass": Icons.GLASS,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.mildura.vic.gov.au",
+    argument_name="street_address",
+    headers=HEADERS,
+    use_curl_cffi=True,
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
     def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        session = requests.Session(impersonate="chrome")
-
-        # Step 1: search for the address to get its geolocation id
-        r = session.get(
-            API_URLS["address_search"],
-            params={"keywords": self._street_address},
-            headers=HEADERS,
-        )
-        r.raise_for_status()
-
-        data = json.loads(r.text)
-
-        items = data.get("Items") or []
-        if not items:
-            raise SourceArgumentNotFound(
-                "street_address",
-                self._street_address,
-                "Check your address at https://www.mildura.vic.gov.au/Explore/My-Neighbourhood",
-            )
-
-        location_id = items[0]["Id"]
-
-        # Step 2: retrieve the upcoming collections for the property
-        r = session.get(
-            API_URLS["collection"],
-            params={"geolocationid": location_id, "ocsvclang": "en-AU"},
-            headers=HEADERS,
-        )
-        r.raise_for_status()
-
-        data = json.loads(r.text)
-
-        response_content = data["responseContent"]
-
-        soup = BeautifulSoup(response_content, "html.parser")
-        services = soup.find_all("div", attrs={"class": "waste-services-result"})
-
-        entries = []
-
-        for item in services:
-            date_text = item.find("div", attrs={"class": "next-service"})
-            if date_text is None:
-                continue
-
-            date_format = "%a %d/%m/%Y"
-
-            try:
-                cleaned_date_text = (
-                    date_text.text.replace("\r", "").replace("\n", "").strip()
-                )
-                date = datetime.strptime(cleaned_date_text, date_format).date()
-            except ValueError:
-                # Non-date entries, e.g. "Bin Collection Area: You are in Area 1"
-                continue
-
-            waste_type_h3 = item.find("h3")
-            if waste_type_h3 is None:
-                continue
-            waste_type = waste_type_h3.text.strip()
-
-            entries.append(
-                Collection(
-                    date=date,
-                    t=waste_type,
-                    icon=ICON_MAP.get(waste_type, Icons.GENERAL_WASTE),
-                )
-            )
-
-        return entries
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/moorabool_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/moorabool_vic_gov_au.py
@@ -1,16 +1,7 @@
-# Highly inspired by the Blacktown source
-
-import datetime
-import json
-from typing import TypedDict
-from urllib.parse import quote
-
-from bs4 import BeautifulSoup
-from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons
-from waste_collection_schedule.exceptions import (
-    SourceArgAmbiguousWithSuggestions,
-    SourceArgumentNotFoundWithSuggestions,
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
 )
 
 TITLE = "Moorabool Shire Council"
@@ -31,11 +22,6 @@ TEST_CASES = {
     },
 }
 
-API_URLS = {
-    "address_search": "https://www.moorabool.vic.gov.au/api/v1/myarea/search?keywords={}",
-    "collection": "https://www.moorabool.vic.gov.au/ocapi/Public/myarea/wasteservices?geolocationid={}&ocsvclang=en-AU",
-}
-
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
     "Accept": "text/plain, */*; q=0.01",
@@ -50,119 +36,19 @@ ICON_MAP = {
     "Green waste": Icons.GARDEN,
 }
 
-
-class ApiItem(TypedDict):
-    Id: str
-    AddressSingleLine: str
-    MunicipalSubdivision: str
-    Distance: int
-    Score: float
-    LatLon: tuple[int, int]
-
-
-class ApiResult(TypedDict):
-    Items: list[ApiItem]
-    Offset: int
-    Limit: int
-    Total: int
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.moorabool.vic.gov.au",
+    headers=HEADERS,
+    use_curl_cffi=True,
+    icon_keywords=ICON_MAP,
+    strip_type_suffixes=("collection",),
+)
 
 
 class Source:
     def __init__(self, address: str):
         self.address = address
-
-    @staticmethod
-    def search_address(address: str, session: requests.Session) -> ApiResult:
-        q = API_URLS["address_search"].format(quote(address))
-
-        # Retrieve suburbs
-        r = session.get(q)
-
-        return json.loads(r.text)
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        session = requests.Session(impersonate="chrome")
-        session.headers.update(HEADERS)
-        locationId = ""
-
-        data = self.search_address(self.address, session)
-
-        if len(data["Items"]) > 1:
-            raise SourceArgAmbiguousWithSuggestions(
-                "address",
-                self.address,
-                [item["AddressSingleLine"] for item in data["Items"]],
-            )
-        if len(data["Items"]) == 0:
-            splitted_address = self.address.split()
-            data = self.search_address(
-                (
-                    (splitted_address[0] + splitted_address[1][:4])
-                    if len(splitted_address) > 1
-                    else splitted_address[0]
-                ),
-                session,
-            )
-            raise SourceArgumentNotFoundWithSuggestions(
-                "address",
-                self.address,
-                [item["AddressSingleLine"] for item in data["Items"]],
-            )
-
-        # Find the ID for our suburb
-        locationId = data["Items"][0]["Id"]
-
-        if locationId == 0:
-            raise ValueError(
-                f"Unable to find location ID for {self.address}, maybe you misspelled your address?"
-            )
-
-        # Retrieve the upcoming collections for our property
-        q = API_URLS["collection"].format(quote(str(locationId)))
-
-        r = session.get(q)
-
-        col_data = json.loads(r.text)
-
-        responseContent = col_data["responseContent"]
-
-        soup = BeautifulSoup(responseContent, "html.parser")
-        services = soup.select("div.waste-services-result")
-
-        entries = []
-
-        for item in services:
-            # test if <div> contains a valid date. If not, is is not a collection item.
-            date_text = item.select_one("div.next-service")
-            if not date_text:
-                continue
-
-            date_format = "%a %d/%m/%Y"
-
-            try:
-                # Strip carriage returns and newlines out of the HTML content
-                cleaned_date_text = (
-                    date_text.text.replace("\r", "").replace("\n", "").strip()
-                )
-
-                # Parse the date
-                date = datetime.datetime.strptime(cleaned_date_text, date_format).date()
-
-            except ValueError:
-                continue
-
-            waste_type_h3 = item.select_one("h3")
-
-            if not waste_type_h3:
-                continue
-            waste_type = waste_type_h3.text.strip().removesuffix("collection").strip()
-
-            entries.append(
-                Collection(
-                    date=date,
-                    t=waste_type,
-                    icon=ICON_MAP.get(waste_type, "mdi:trash-can"),
-                )
-            )
-
-        return entries
+        return self._client.fetch(address=self.address)

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -864,10 +864,14 @@ def test_opencities_client_bypasses_search_when_geolocation_id_given_directly() 
     assert all("myarea/search" not in url for url, _ in session.calls)
 
 
-def test_opencities_client_fires_warm_up_url_once_before_first_request() -> None:
+def test_opencities_client_fires_warm_up_url_once_before_wasteservices_when_configured() -> (
+    None
+):
     module = _opencities_module()
     config = module.OpenCitiesConfig(
-        domain="https://example.invalid", warm_up_url="https://example.invalid/warm"
+        domain="https://example.invalid",
+        warm_up_url="https://example.invalid/warm",
+        warm_up_before="wasteservices",
     )
     client = module.OpenCitiesClient(config)
     session = _OpenCitiesSession(
@@ -882,6 +886,40 @@ def test_opencities_client_fires_warm_up_url_once_before_first_request() -> None
 
     warm_up_calls = [url for url, _ in session.calls if url.endswith("/warm")]
     assert len(warm_up_calls) == 1
+
+
+def test_opencities_client_fires_warm_up_url_before_search_by_default() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", warm_up_url="https://example.invalid/warm"
+    )
+    client = module.OpenCitiesClient(config)
+    session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(json_data={"Items": [{"Id": "abc"}]})
+    )
+    client._session = session
+
+    client.resolve_geolocation_id("1 Main St")
+
+    assert [url for url, _ in session.calls[:1]] == ["https://example.invalid/warm"]
+
+
+def test_opencities_client_does_not_warm_up_before_wasteservices_by_default() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", warm_up_url="https://example.invalid/warm"
+    )
+    client = module.OpenCitiesClient(config)
+    session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": "<p>no services</p>"}
+        )
+    )
+    client._session = session
+
+    client.fetch_by_geolocation_id("abc")
+
+    assert all("/warm" not in url for url, _ in session.calls)
 
 
 def test_opencities_client_falls_back_from_json_to_xml_search_response() -> None:


### PR DESCRIPTION
## Summary

Batch 2 of the phased OpenCities/MyArea consolidation (batch 0: #6934, batch 1: #6946): migrates `hobartcity_com_au.py`, `moorabool_vic_gov_au.py`, `banyule_vic_gov_au.py`, `cambridge_wa_gov_au.py`, `mildura_vic_gov_au.py`, and `logan_qld_gov_au.py` (itself only recently migrated to OpenCities in #6920) onto `OpenCitiesClient`.

These six were picked because between them they exercise the client-side variance not yet covered by batch 1: curl_cffi, the `geolocation_id` bypass kwarg alongside address search, a non-default `date_format`, and hand-rolled caching/ambiguous-address-match logic (hobartcity, moorabool, logan) that the shared client's defaults now subsume.

### Client extensions added while migrating (found via live-testing, not assumed upfront)

- **`OpenCitiesConfig.strip_type_suffixes`** — moorabool strips a `"collection"` suffix some labels carry.
- **`OpenCitiesConfig.warm_up_before`** (`"search"` or `"wasteservices"`) — banyule and cambridge fire their warm-up GET *after* resolving a geolocation id (via search or the direct bypass) and *before* the wasteservices call. The client originally always warmed up before search; this needed to be configurable, not hardcoded, since different councils need different ordering.
- **Explicit `Accept: application/json` header for banyule/cambridge** — their search endpoints silently return XML instead of JSON without it (confirmed by replaying the raw HTTP request both with and without the header). Added via the existing `headers` config field rather than extending `search_response_format`, since it's an Accept-header quirk rather than a deployment that only emits XML.

### Note on Cambridge's "duplicate" entry

`Cambridge Library` (`99 The Boulevard, FLOREAT 6014`) returns 4 entries with two identical "General Waste / Wed 22/7/2026" rows. Verified via a raw HTTP replay that the API's own `wasteservices` response genuinely contains two identical `<article>` blocks for that address — this is upstream duplicate data, not a client regression (pre-migration code, which also just iterated every `<article>`, would have produced the same duplicate).

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [x] Other (migration onto shared service/OpenCities.py client + client extensions)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (29 passed)
- [x] `ruff check --fix` / `ruff format` / `mypy --ignore-missing-imports --explicit-package-bases` clean (pre-commit hooks pass)
- [x] No generated files in diff
- [x] Live-tested each of the 6 sources via `test_sources.py -s <name> -l` against the real API
- [x] `TITLE`/`URL`/`COUNTRY`/`TEST_CASES`/`HOW_TO_GET_ARGUMENTS_DESCRIPTION`/`PARAM_*` unchanged; `doc/source/*.md` untouched