### PR TITLE
refactor: migrate 7 mechanical-family OpenCities sources (batch 3a/5)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -87,13 +87,21 @@ class OpenCitiesConfig:
 
     timeout: int = 30
 
-    strict_address_matching: bool = True
+    strict_address_matching: bool = False
     """
-    If True (default), multiple search results are disambiguated by exact
-    (case/space-insensitive) match against ``AddressSingleLine``, raising
-    ``SourceArgAmbiguousWithSuggestions`` when that's not conclusive. Set to
-    False only for legacy XML search responses that carry no address text at
-    all, where the first result is the only option.
+    If False (default), the first (highest-ranked) search result is always
+    used, trusting the API's own relevance ranking -- this matches how the
+    vast majority of council deployments behave today. If True, multiple
+    search results are instead disambiguated by exact (case/space-
+    insensitive) match against ``AddressSingleLine``, raising
+    ``SourceArgAmbiguousWithSuggestions`` when that's not conclusive. Only
+    enable this for councils whose original implementation already did its
+    own such disambiguation (e.g. Hobart, Moorabool) -- for most councils
+    it does more harm than good, since a user's address rarely matches the
+    server's canonical ``AddressSingleLine`` formatting byte-for-byte (e.g.
+    missing a state abbreviation or punctuation the server adds), which
+    would otherwise turn a normal, correctly-resolved top hit into a hard
+    "ambiguous" failure.
     """
 
     require_date_precise: bool = False

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hobartcity_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hobartcity_com_au.py
@@ -33,6 +33,7 @@ _CONFIG = OpenCitiesConfig(
     domain="https://www.hobartcity.com.au",
     page_link="/$720cfbd8-df7e-4b88-bf92-e218d51ee173$/Residents/Waste-and-recycling/When-is-my-bin-collected",
     icon_keywords=ICON_MAP,
+    strict_address_matching=True,
 )
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mansfield_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mansfield_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Mansfield Shire Council"
 DESCRIPTION = "Source for Mansfield Shire Council rubbish collection."
@@ -14,71 +12,23 @@ TEST_CASES = {
     "Mansfield Zoo": {"street_address": "1064 Mansfield-Woods Point Road, Mansfield"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "General Waste": Icons.GENERAL_WASTE,
     "Recycling": Icons.RECYCLING,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.mansfield.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.mansfield.vic.gov.au/Community/Residents/Waste-Recycling/Check-My-Bin-Day",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.mansfield.vic.gov.au/Community/Residents/Waste-Recycling/Check-My-Bin-Day"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.mansfield.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.mansfield.vic.gov.au/Community/Residents/Waste-Recycling/Check-My-Bin-Day"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.mansfield.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string
-            if next_pickup is None:
-                continue
-            date_match = re.search(r"\d{1,2}\/\d{1,2}\/\d{4}", next_pickup)
-            if date_match:
-                next_pickup_date = datetime.strptime(
-                    date_match.group(0), "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maroondah_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maroondah_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-from bs4 import BeautifulSoup
-from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Maroondah City Council"
 DESCRIPTION = "Source for Maroondah City Council. Finds both green waste and general recycling dates."
@@ -33,8 +31,6 @@ TEST_CASES = {
     "Friday - Area B": {"address": "61 Timms Avenue, KILSYTH 3137"},  # Friday - Area B
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "General waste": Icons.GENERAL_WASTE,
     "Food and Garden organics": Icons.BIO_KITCHEN,
@@ -52,64 +48,19 @@ HEADERS = {
     "X-Requested-With": "XMLHttpRequest",
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.maroondah.vic.gov.au",
+    use_curl_cffi=True,
+    headers=HEADERS,
+    warm_up_url="https://www.maroondah.vic.gov.au/Residents-property/Waste-rubbish/Waste-collection-schedule",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, address):
+    def __init__(self, address: str):
         self._street_address = address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session(impersonate="chrome")
-        session.headers.update(HEADERS)
-
-        response = session.get(
-            "https://www.maroondah.vic.gov.au/Residents-property/Waste-rubbish/Waste-collection-schedule"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.maroondah.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.maroondah.vic.gov.au/Residents-property/Waste-rubbish/Waste-collection-schedule"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.maroondah.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = (
-                article.find("div", {"class": "next-service"}).getText().strip()
-            )
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Melton City Council"
 DESCRIPTION = "Source for Melton City Council rubbish collection."
@@ -16,81 +14,27 @@ TEST_CASES = {
     "Wednesday B": {"street_address": "17 KEYNES CIRCUIT FRASER RISE 3336"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "Food and Green Waste": Icons.BIO_KITCHEN,
     "Hard Waste": Icons.BULKY,
     "Recycling": Icons.RECYCLING,
 }
 
+HEADERS = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "}
+
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.melton.vic.gov.au",
+    argument_name="street_address",
+    headers=HEADERS,
+    warm_up_url="https://www.melton.vic.gov.au/My-Area",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-        headers = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "}
-        session.headers.update(headers)
-
-        response = session.get("https://www.melton.vic.gov.au/Home")
-        response = session.get("https://www.melton.vic.gov.au/Home")
-        response.raise_for_status()
-
-        response = session.get("https://www.melton.vic.gov.au/My-Area")
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.melton.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.melton.vic.gov.au/My-Area"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.melton.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").getText().strip()
-
-            if not re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                pattern = r"\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(0?[1-9]|[12][0-9]|3[01])/(0?[1-9]|1[0-2])/\d{4}\b"
-                date_match = re.search(pattern, next_pickup, re.IGNORECASE)
-
-                if date_match:
-                    next_pickup = date_match.group(0) if date_match else None
-
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/moorabool_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/moorabool_vic_gov_au.py
@@ -42,6 +42,7 @@ _CONFIG = OpenCitiesConfig(
     use_curl_cffi=True,
     icon_keywords=ICON_MAP,
     strip_type_suffixes=("collection",),
+    strict_address_matching=True,
 )
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/moyne_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/moyne_vic_gov_au.py
@@ -1,17 +1,13 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Moyne Shire Council"
 DESCRIPTION = "Source for Moyne Shire Council rubbish collection."
 URL = "https://www.moyne.vic.gov.au"
 TEST_CASES = {"Test": {"street_address": "1 Cox Street, PORT FAIRY, 3284"}}
-
-_LOGGER = logging.getLogger(__name__)
 
 ICON_MAP = {
     "Landfill": Icons.GENERAL_WASTE,
@@ -20,64 +16,18 @@ ICON_MAP = {
     "Glass Only": Icons.GLASS,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.moyne.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.moyne.vic.gov.au/Your-property/Waste-and-recycling/Kerbside-collection-dates",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.moyne.vic.gov.au/Your-property/Waste-and-recycling/Kerbside-collection-dates"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.moyne.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.moyne.vic.gov.au/Your-property/Waste-and-recycling/Kerbside-collection-dates"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.moyne.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string
-            if next_pickup is None:
-                continue
-            date_match = re.search(r"\d{1,2}\/\d{1,2}\/\d{4}", next_pickup)
-            if date_match:
-                next_pickup_date = datetime.strptime(
-                    date_match.group(0), "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mrsc_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mrsc_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Macedon Ranges Shire Council"
 DESCRIPTION = "Source for Macedon Ranges Shire Council rubbish collection."
@@ -14,69 +12,24 @@ TEST_CASES = {
     "ALDI Gisborne": {"street_address": "45 Aitken Street, Gisborne"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "FOGO bin": Icons.BIO_KITCHEN,
     "Recycling bin": Icons.RECYCLING,
     "Glass-only bin": Icons.GLASS,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.mrsc.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.mrsc.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.mrsc.vic.gov.au/Live-Work/Bins-Rubbish-Recycling/Bins-and-collection-days/Bin-collection-days"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.mrsc.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string.strip()
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nillumbik_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nillumbik_vic_gov_au.py
@@ -1,17 +1,13 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Nillumbik Shire Council"
 DESCRIPTION = "Source for Nillumbik Shire Council rubbish collection."
 URL = "https://www.nillumbik.vic.gov.au"
 TEST_CASES = {"Test": {"street_address": "11 Sunnyside Crescent, WATTLE GLEN, 3096"}}
-
-_LOGGER = logging.getLogger(__name__)
 
 ICON_MAP = {
     "Food and Green Waste": Icons.BIO_KITCHEN,
@@ -19,61 +15,18 @@ ICON_MAP = {
     "Recycling": Icons.RECYCLING,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.nillumbik.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.nillumbik.vic.gov.au/Residents/Waste-and-recycling/Bin-collection/Check-my-bin-day",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.nillumbik.vic.gov.au/Residents/Waste-and-recycling/Bin-collection/Check-my-bin-day"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.nillumbik.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.nillumbik.vic.gov.au/Residents/Waste-and-recycling/Bin-collection/Check-my-bin-day"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.nillumbik.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string.strip()
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stonnington_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stonnington_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Stonnington City Council"
 DESCRIPTION = "Source for Stonnington City Council rubbish collection."
@@ -14,69 +12,24 @@ TEST_CASES = {
     "Malvern Library": {"street_address": "1255 High Street, Malvern"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "Food and Green Waste": Icons.BIO_KITCHEN,
     "Hard Waste": Icons.BULKY,
     "Recycling": Icons.RECYCLING,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.stonnington.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.stonnington.vic.gov.au/Services/Waste-and-recycling",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.stonnington.vic.gov.au/Services/Waste-and-recycling"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.stonnington.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.stonnington.vic.gov.au/Services/Waste-and-recycling"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.stonnington.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string.strip()
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -611,7 +611,9 @@ def test_opencities_client_raises_ambiguous_with_suggestions_on_multiple_matches
     None
 ):
     module = _opencities_module()
-    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", strict_address_matching=True
+    )
     client = module.OpenCitiesClient(config)
     client._session = _OpenCitiesSession(
         lambda url, params: _OpenCitiesResponse(
@@ -636,7 +638,9 @@ def test_opencities_client_raises_ambiguous_with_suggestions_on_multiple_matches
 
 def test_opencities_client_selects_exact_match_among_multiple_results() -> None:
     module = _opencities_module()
-    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", strict_address_matching=True
+    )
     client = module.OpenCitiesClient(config)
     client._session = _OpenCitiesSession(
         lambda url, params: _OpenCitiesResponse(
@@ -650,6 +654,28 @@ def test_opencities_client_selects_exact_match_among_multiple_results() -> None:
     )
 
     assert client.resolve_geolocation_id("1 main st, northtown") == "b"
+
+
+def test_opencities_client_trusts_top_search_result_by_default() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={
+                "Items": [
+                    {"Id": "a", "AddressSingleLine": "1 Main St, Northtown"},
+                    {"Id": "b", "AddressSingleLine": "1 Main St, Southtown"},
+                ]
+            }
+        )
+    )
+
+    # With strict_address_matching left at its default (False), the
+    # highest-ranked result is used even though it doesn't textually match
+    # the query -- avoids turning normal fuzzy-search hits (e.g. missing a
+    # state abbreviation) into a hard "ambiguous" failure.
+    assert client.resolve_geolocation_id("1 Main St, Somewhere Else") == "a"
 
 
 def test_opencities_client_raises_not_found_on_empty_search() -> None:


### PR DESCRIPTION
## Summary

Batch 3a of the phased OpenCities/MyArea consolidation (batches 0-2: #6934, #6946, #6951): migrates the "mechanical old-style" family — `mansfield_vic_gov_au.py`, `maroondah_vic_gov_au.py`, `melton_vic_gov_au.py`, `moyne_vic_gov_au.py`, `mrsc_vic_gov_au.py`, `nillumbik_vic_gov_au.py`, `stonnington_vic_gov_au.py` — onto `OpenCitiesClient`. These all previously copy-pasted the same warm-up-GET → search → wasteservices flow with a bare `raise Exception(...)` on no results.

### Real bug fixed in the shared client: `strict_address_matching` default was wrong

`OpenCitiesConfig.strict_address_matching` defaulted to `True` (added in #6951 for hobartcity/moorabool parity), meaning any multi-result search that didn't textually match the query's `AddressSingleLine` byte-for-byte raised a hard "ambiguous" failure — instead of trusting the search API's own top-ranked result. Live-testing this batch caught two real instances: `moyne_vic_gov_au`'s and `maroondah_vic_gov_au`'s own `TEST_CASES` addresses omit a state abbreviation the server's `AddressSingleLine` adds, so the *correct* top-ranked result was being rejected as "ambiguous" purely on a formatting mismatch.

Flipped the default to `False` (trust the top search result — how the vast majority of these ~20 councils' original code already behaved) and made strict matching an explicit opt-in, now set on `hobartcity_com_au.py` and `moorabool_vic_gov_au.py` (the only two sources whose original hand-written code actually implemented this disambiguation themselves). Re-verified every previously-migrated batch-1/2 source still passes its live test with the new default.

### Two pre-existing outages found (documented, not fixed here)

- **`mansfield.vic.gov.au`** has moved off OpenCities entirely onto a Drupal 11 site — `/api/v1/myarea/search` now 404s regardless of implementation (confirmed via a raw replay of the pre-migration request).
- **`melton.vic.gov.au`**'s wasteservices endpoint returns `{"success": false}` even when replaying the *exact* pre-migration request sequence (the address search itself succeeds and returns a valid geolocation id, but the second call fails server-side).

Both are unrelated to this refactor — same failure occurs with the original, unmigrated code. Not something a client change can fix.

## Type of change

- [ ] New source
- [x] Bug fix / source fix (`strict_address_matching` default)
- [ ] Documentation update
- [x] Other (migration onto shared service/OpenCities.py client)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (30 passed)
- [x] `ruff check --fix` / `ruff format` / `mypy --ignore-missing-imports --explicit-package-bases` clean (pre-commit hooks pass)
- [x] No generated files in diff
- [x] Live-tested every migrated source via `test_sources.py -s <name> -l` against the real API (mansfield/melton confirmed as pre-existing outages, not regressions)
- [x] `TITLE`/`URL`/`COUNTRY`/`TEST_CASES`/`HOW_TO_GET_ARGUMENTS_DESCRIPTION`/`PARAM_*` unchanged; `doc/source/*.md` untouched