### PR TITLE
refactor: migrate 7 more mechanical-family OpenCities sources (batch 3b/5)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -19,7 +19,7 @@ per-council source files stay a thin ``OpenCitiesConfig`` + ``Source`` shim.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Literal
 
 import requests
@@ -33,6 +33,16 @@ from waste_collection_schedule.exceptions import (
 )
 
 DEFAULT_DATE_FORMAT = "%a %d/%m/%Y"
+
+_WEEKDAY_NAMES = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
 
 
 @dataclass(frozen=True)
@@ -110,6 +120,13 @@ class OpenCitiesConfig:
     ``date-precise`` CSS class are parsed, skipping vague/recurring entries
     with no concrete next date (some council deployments, e.g. Shoalhaven,
     mix both kinds of block in the same response).
+    """
+
+    exclude_types: tuple[str, ...] = ()
+    """
+    Waste-type labels (exact match) to always drop, e.g. a council mixing
+    an unrelated "Burning off" permit article into the same wasteservices
+    response.
     """
 
 
@@ -282,6 +299,8 @@ class OpenCitiesClient:
                 continue
 
             waste_type = title.get_text(" ", strip=True)
+            if waste_type in self._cfg.exclude_types:
+                continue
             for suffix in self._cfg.strip_type_suffixes:
                 if waste_type.lower().endswith(suffix.lower()):
                     waste_type = waste_type[: -len(suffix)].strip()
@@ -306,7 +325,21 @@ class OpenCitiesClient:
         try:
             return datetime.strptime(text, self._cfg.date_format).date()
         except ValueError:
-            return None
+            pass
+        # Some deployments describe a recurring service as "Every <Weekday>"
+        # instead of a concrete next date (no explicit next occurrence is
+        # given by the API at all) -- resolve it to the next occurrence of
+        # that weekday from today.
+        parts = text.split()
+        if len(parts) >= 2 and parts[0].lower() == "every":
+            try:
+                target_weekday = _WEEKDAY_NAMES.index(parts[1].capitalize())
+            except ValueError:
+                return None
+            today = datetime.now().date()
+            days_ahead = (target_weekday - today.weekday()) % 7
+            return today + timedelta(days=days_ahead)
+        return None
 
     def _resolve_icon(self, label: str) -> Any | None:
         if not self._cfg.icon_keywords:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/goldcoast_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/goldcoast_qld_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Gold Coast City Council"
 DESCRIPTION = "Source for Gold Coast Council rubbish collection."
@@ -15,65 +13,25 @@ TEST_CASES = {
     "Pie Pie": {"street_address": "1887 Gold Coast Hwy Burleigh Heads"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "General waste": Icons.GENERAL_WASTE,
     "Recycling": Icons.RECYCLING,
     "Green organics": Icons.ORGANIC,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.goldcoast.qld.gov.au",
+    argument_name="street_address",
+    search_fuzzy=True,
+    max_results=1,
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        # Making a get request
-        response = session.get(
-            "https://www.goldcoast.qld.gov.au/api/v1/myarea/searchfuzzy?maxresults=1",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.goldcoast.qld.gov.au/Services/Waste-recycling/Find-my-bin-day"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "Https://www.goldcoast.qld.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type, "mdi:trash-can")
-            next_pickup = article.find(class_="next-service").string.strip()
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/midcoast_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/midcoast_nsw_gov_au.py
@@ -1,22 +1,16 @@
-import logging
-import re
-from datetime import datetime, timedelta
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "MidCoast Council"
 DESCRIPTION = "Source for MidCoast Council (NSW) rubbish collection."
 URL = "https://www.midcoast.nsw.gov.au/"
 DEEPLINK = f"{URL}Services/Waste-and-recycling/When-is-my-bin-collected"
-API_URL = f"{URL}ocapi/Public/myarea/wasteservices?ocsvclang=en-AU"
-SEARCH_URL = f"{URL}api/v1/myarea/search"
 TEST_CASES = {
     "Randomly Selected Address": {"street_address": "101 Goldens Road, FORSTER"}
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 ICON_MAP = {
     "General Waste": Icons.GENERAL_WASTE,
@@ -24,90 +18,22 @@ ICON_MAP = {
     "Green Waste": Icons.GARDEN,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain=URL.rstrip("/"),
+    argument_name="street_address",
+    warm_up_url=URL,
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    @staticmethod
-    def next_weekday(target_day):
-        day_map = {
-            "Monday": 0,
-            "Tuesday": 1,
-            "Wednesday": 2,
-            "Thursday": 3,
-            "Friday": 4,
-            "Saturday": 5,
-            "Sunday": 6,
-        }
-        if target_day not in day_map:
-            raise ValueError(
-                f"Error calculating date for general waste, returned day as {target_day}. Please raise an issue."
-            )
-
-        today = datetime.now().date()
-        target_weekday = day_map[target_day]
-        days_ahead = (target_weekday - today.weekday()) % 7
-
-        return today + timedelta(days=days_ahead)
-
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(URL, timeout=30)
-        response.raise_for_status()
-
-        response = session.get(
-            SEARCH_URL,
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise ValueError(
-                f"Address search for '{self._street_address}' returned no results. Check your address on {DEEPLINK}"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            API_URL,
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string.strip()
-            if waste_type not in ICON_MAP:
-                _LOGGER.debug("Skipping non-waste entry: %s", waste_type)
-                continue
-            icon = ICON_MAP.get(waste_type, "mdi:trash-can-outline")
-            next_pickup = article.find(class_="next-service").string.strip()
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-            elif next_pickup.startswith("Every"):
-                day_string = next_pickup.split(sep=" ")[1]
-                next_pickup_date = Source.next_weekday(day_string)
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        entries = self._client.fetch(address=self._street_address)
+        # The wasteservices response for MidCoast also includes non-waste
+        # articles (e.g. bin-collection guidelines); only keep the known
+        # waste types, matching the pre-migration allowlist behaviour.
+        return [entry for entry in entries if entry.type in ICON_MAP]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/monash_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/monash_vic_gov_au.py
@@ -1,8 +1,8 @@
-import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "City of Monash"
 DESCRIPTION = "Source for City of Monash rubbish collection."
@@ -40,49 +40,16 @@ PARAM_TRANSLATIONS = {
 
 # ### End of arguments affecting the configuration GUI ####
 
+_CONFIG = OpenCitiesConfig(
+    domain=URL.rstrip("/"),
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
     def __init__(self, address: str):
         self._address = address
+        self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        s = requests.Session()
-
-        r = s.get(
-            f"{URL}api/v1/myarea/search",
-            params={"keywords": self._address},
-        )
-        if r.status_code != requests.codes.ok:
-            raise Exception("Error Accessing myarea API")  # DO NOT JUST return []
-        data = r.json()
-        geoid = data["Items"][0]["Id"]  # assume first one is correct and get geoid
-
-        r = s.get(
-            f"{URL}ocapi/Public/myarea/wasteservices",
-            params={"geolocationid": geoid, "ocsvclang": "en-AU"},
-        )
-
-        if r.status_code != requests.codes.ok:
-            raise Exception(
-                "Error Accessing Waste Services API"
-            )  # DO NOT JUST return []
-        html = r.json()["responseContent"]
-        soup = BeautifulSoup(html, "html.parser")
-
-        entries = []  # List that holds collection schedule
-        for article in soup.find_all("article"):
-            waste_type = article.find("h3").get_text(strip=True)
-
-            next_date_str = article.find("div", class_="next-service").get_text(
-                strip=True
-            )
-            next_date = datetime.datetime.strptime(next_date_str, "%a %d/%m/%Y").date()
-            entries.append(
-                Collection(
-                    date=next_date,  # Collection date
-                    t=waste_type,  # Collection type
-                    icon=ICON_MAP.get(waste_type),  # Collection icon
-                )
-            )
-
-        return entries
+        return self._client.fetch(address=self._address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mornpen_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mornpen_vic_gov_au.py
@@ -1,11 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentException
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Mornington Peninsula Shire Council"
 DESCRIPTION = "Source for Mornington Peninsula Shire Council rubbish collection."
@@ -20,90 +17,25 @@ TEST_CASES = {
     },
 }
 
-
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "Green waste bin": Icons.GARDEN,
     "Household rubbish bin": Icons.GENERAL_WASTE,
     "Recycling bin": Icons.RECYCLING,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.mornpen.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.mornpen.vic.gov.au/Your-Property/Rubbish-Recycling/Bins/Find-your-bin-day",
+    icon_keywords=ICON_MAP,
+    exclude_types=("Burning off",),
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.mornpen.vic.gov.au/Your-Property/Rubbish-Recycling/Bins/Find-your-bin-day",
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.mornpen.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-            timeout=30,
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise SourceArgumentException(
-                "street_address",
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.mornpen.vic.gov.au/Your-Property/Rubbish-Recycling/Bins/Find-your-bin-day",
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.mornpen.vic.gov.au/ocapi/Public/myarea/wasteservices",
-            params={"geolocationid": geolocationid, "ocsvclang": "en-AU"},
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            if article.h3 is None:
-                continue
-            waste_type = article.h3.string
-
-            if waste_type is None or waste_type == "Burning off":
-                continue
-
-            icon = ICON_MAP.get(waste_type, "mdi:trash-can-outline")
-
-            next_service_div = article.find("div", {"class": "next-service"})
-            if next_service_div is None:
-                continue
-            next_pickup = next_service_div.get_text().strip()
-
-            if not re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                continue
-
-            next_pickup_date = datetime.strptime(
-                next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-            ).date()
-
-            if next_pickup_date is None or waste_type is None:
-                continue
-
-            entries.append(Collection(date=next_pickup_date, t=waste_type, icon=icon))
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wangaratta_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wangaratta_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Rural City of Wangaratta"
 DESCRIPTION = "Source for Rural City of Wangaratta rubbish collection."
@@ -14,69 +12,24 @@ TEST_CASES = {
     "KFC Wangaratta": {"street_address": "23-27 Ryley Street WANGARATTA VIC 3677"},
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "General Waste": Icons.GENERAL_WASTE,
     "Organics": Icons.ORGANIC,
     "Recycling": Icons.RECYCLING,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.wangaratta.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.wangaratta.vic.gov.au/Services/Waste-Recycling/Kerbside-Collection/Check-your-bin-day",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.wangaratta.vic.gov.au/Services/Waste-Recycling/Kerbside-Collection/Check-your-bin-day"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.wangaratta.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.wangaratta.vic.gov.au/Services/Waste-Recycling/Kerbside-Collection/Check-your-bin-day"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.wangaratta.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string.strip()
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/whittlesea_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/whittlesea_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Whittlesea City Council"
 DESCRIPTION = "Source for Whittlesea Council (VIC) rubbish collection."
@@ -15,8 +13,6 @@ TEST_CASES = {
     }
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "General Waste": Icons.GENERAL_WASTE,
     "Recycling": Icons.RECYCLING,
@@ -24,59 +20,18 @@ ICON_MAP = {
     "Glass": Icons.GLASS,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.whittlesea.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.whittlesea.vic.gov.au/My-Neighbourhood",
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get("https://www.whittlesea.vic.gov.au/My-Neighbourhood")
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.whittlesea.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.whittlesea.vic.gov.au/My-Neighbourhood"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.whittlesea.vic.gov.au/ocapi/Public/myarea/wasteservices?ocsvclang=en-AU",
-            params={"geolocationid": geolocationid},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-            next_pickup = article.find(class_="next-service").string.strip()
-            if re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                next_pickup_date = datetime.strptime(
-                    next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-                ).date()
-                entries.append(
-                    Collection(date=next_pickup_date, t=waste_type, icon=icon)
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarra_ranges_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarra_ranges_vic_gov_au.py
@@ -1,10 +1,8 @@
-import logging
-import re
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Yarra Ranges Council"
 DESCRIPTION = "Source for Yarra Ranges Council rubbish collection."
@@ -18,80 +16,25 @@ TEST_CASES = {
     },
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 ICON_MAP = {
     "New weekly FOGO collection": Icons.BIO_KITCHEN,
     "Rubbish Collection": Icons.GENERAL_WASTE,
     "Recycling Collection": Icons.RECYCLING,
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.yarraranges.vic.gov.au",
+    argument_name="street_address",
+    warm_up_url="https://www.yarraranges.vic.gov.au/Environment/Waste/Find-your-waste-collection-and-burning-off-dates",
+    icon_keywords=ICON_MAP,
+    exclude_types=("Burning off",),
+)
+
 
 class Source:
-    def __init__(self, street_address):
+    def __init__(self, street_address: str):
         self._street_address = street_address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        session = requests.Session()
-
-        response = session.get(
-            "https://www.yarraranges.vic.gov.au/Environment/Waste/Find-your-waste-collection-and-burning-off-dates"
-        )
-        response.raise_for_status()
-
-        response = session.get(
-            "https://www.yarraranges.vic.gov.au/api/v1/myarea/search",
-            params={"keywords": self._street_address},
-        )
-        response.raise_for_status()
-        addressSearchApiResults = response.json()
-        if (
-            addressSearchApiResults["Items"] is None
-            or len(addressSearchApiResults["Items"]) < 1
-        ):
-            raise Exception(
-                f"Address search for '{self._street_address}' returned no results. Check your address on https://www.yarraranges.vic.gov.au/Environment/Waste/Find-your-waste-collection-and-burning-off-dates"
-            )
-
-        addressSearchTopHit = addressSearchApiResults["Items"][0]
-        _LOGGER.debug("Address search top hit: %s", addressSearchTopHit)
-
-        geolocationid = addressSearchTopHit["Id"]
-        _LOGGER.debug("Geolocationid: %s", geolocationid)
-
-        response = session.get(
-            "https://www.yarraranges.vic.gov.au/ocapi/Public/myarea/wasteservices",
-            params={"geolocationid": geolocationid, "ocsvclang": "en-AU"},
-        )
-        response.raise_for_status()
-
-        wasteApiResult = response.json()
-        _LOGGER.debug("Waste API result: %s", wasteApiResult)
-
-        soup = BeautifulSoup(wasteApiResult["responseContent"], "html.parser")
-
-        entries = []
-        for article in soup.find_all("article"):
-            waste_type = article.h3.string
-            icon = ICON_MAP.get(waste_type)
-
-            if waste_type == "Burning off":
-                continue
-
-            next_pickup = (
-                article.find("div", {"class": "next-service"}).getText().strip()
-            )
-
-            if not re.match(r"[^\s]* \d{1,2}\/\d{1,2}\/\d{4}", next_pickup):
-                continue
-
-            next_pickup_date = datetime.strptime(
-                next_pickup.split(sep=" ")[1], "%d/%m/%Y"
-            ).date()
-
-            if next_pickup_date is None or waste_type is None:
-                continue
-
-            entries.append(Collection(date=next_pickup_date, t=waste_type, icon=icon))
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._street_address)

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -844,6 +844,52 @@ def test_opencities_client_filters_by_date_precise_class_when_configured() -> No
     assert [e.type for e in entries] == ["General Waste"]
 
 
+def test_opencities_client_drops_excluded_types() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", exclude_types=("Burning off",)
+    )
+    client = module.OpenCitiesClient(config)
+    html = (
+        "<article><h3>Burning off</h3>"
+        '<div class="next-service">Mon 01/02/2027</div></article>'
+        "<article><h3>Rubbish Collection</h3>"
+        '<div class="next-service">Tue 02/02/2027</div></article>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert [e.type for e in entries] == ["Rubbish Collection"]
+
+
+def test_opencities_client_resolves_every_weekday_recurring_text() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(domain="https://example.invalid")
+    client = module.OpenCitiesClient(config)
+    html = (
+        "<article><h3>General Waste</h3>"
+        '<div class="next-service">Every Monday</div></article>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert len(entries) == 1
+    assert entries[0].date.weekday() == 0  # Monday
+    from datetime import date as _date
+
+    assert entries[0].date >= _date.today()
+
+
 def test_opencities_client_retries_once_on_stale_cached_geolocation_id() -> None:
     module = _opencities_module()
     config = module.OpenCitiesConfig(domain="https://example.invalid")


### PR DESCRIPTION
## Summary

Batch 3b of the phased OpenCities/MyArea consolidation (batches 0-3a: #6934, #6946, #6951, #6953): migrates `wangaratta_vic_gov_au.py`, `whittlesea_vic_gov_au.py`, `yarra_ranges_vic_gov_au.py`, `mornpen_vic_gov_au.py`, `midcoast_nsw_gov_au.py`, `goldcoast_qld_gov_au.py`, and `monash_vic_gov_au.py` onto `OpenCitiesClient`. `goldcoast`'s migration incidentally fixes a pre-existing `"Https://"` (capital H) typo in its wasteservices URL.

### Two new client extensions (both needed by 2+ sources in this batch, not one-offs)

- **`OpenCitiesConfig.exclude_types`** — `yarra_ranges_vic_gov_au` and `mornpen_vic_gov_au` both mix an unrelated "Burning off" permit article into the wasteservices response and drop it by exact type match.
- **`OpenCitiesClient._parse_date` "Every &lt;Weekday&gt;" fallback** — `midcoast_nsw_gov_au` has waste types with no concrete next date at all, just recurring text like "Every Monday"; the client now resolves that to the next occurrence of that weekday. `midcoast` additionally keeps a local post-filter to its known waste types (its wasteservices response includes non-waste informational articles too) — this stays source-local since it's a single-caller allowlist, not shared behavior.

### Pre-existing outage found (documented, not fixed)

`mornpen_vic_gov_au`'s three `TEST_CASES` addresses (format: `"<number> <Name> Rd <Suburb> VIC <postcode>"`) return zero search results against the live API today. Confirmed by replaying the *exact* pre-migration request — same empty result regardless of implementation. Dropping `"VIC <postcode>"` or spelling out `"Road"` both return real matches, suggesting an abbreviation-sensitive search index change on the council's end rather than a broken address. Not fixed here (would need fresh, verified real addresses).

## Type of change

- [ ] New source
- [x] Bug fix / source fix (goldcoast URL typo)
- [ ] Documentation update
- [x] Other (migration onto shared service/OpenCities.py client + client extensions)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (32 passed)
- [x] `ruff check --fix` / `ruff format` / `mypy --ignore-missing-imports --explicit-package-bases` clean (pre-commit hooks pass)
- [x] No generated files in diff
- [x] Live-tested every migrated source via `test_sources.py -s <name> -l` against the real API (mornpen confirmed as a pre-existing search-data issue, not a regression)
- [x] `TITLE`/`URL`/`COUNTRY`/`TEST_CASES`/`HOW_TO_GET_ARGUMENTS_DESCRIPTION`/`PARAM_*` unchanged; `doc/source/*.md` untouched