### PR TITLE
refactor: migrate final 2 mechanical-family OpenCities sources (batch 3c/5)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -129,6 +129,13 @@ class OpenCitiesConfig:
     response.
     """
 
+    exclude_type_prefixes: tuple[str, ...] = ()
+    """
+    Waste-type label prefixes to always drop, e.g. "Calendar" entries
+    (calendar-download links, not actual collections) some deployments mix
+    into the same wasteservices response.
+    """
+
 
 class OpenCitiesClient:
     def __init__(self, config: OpenCitiesConfig) -> None:
@@ -300,6 +307,8 @@ class OpenCitiesClient:
 
             waste_type = title.get_text(" ", strip=True)
             if waste_type in self._cfg.exclude_types:
+                continue
+            if waste_type.startswith(self._cfg.exclude_type_prefixes):
                 continue
             for suffix in self._cfg.strip_type_suffixes:
                 if waste_type.lower().endswith(suffix.lower()):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lakemac_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lakemac_nsw_gov_au.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "Lake Macquarie City Council"
 DESCRIPTION = "Source for Lake Macquarie City Council, Australia."
@@ -20,55 +19,21 @@ ICON_MAP = {
     "Bulk waste": Icons.GENERAL_WASTE,
 }
 
+HEADERS = {
+    "referer": "https://www.lakemac.com.au/For-residents/Waste-and-recycling/When-are-your-bins-collected"
+}
+
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.lakemac.com.au",
+    headers=HEADERS,
+    icon_keywords=ICON_MAP,
+)
+
 
 class Source:
-    def __init__(self, address):
+    def __init__(self, address: str):
         self._address = address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-        url = "https://www.lakemac.com.au/api/v1/myarea/search"
-
-        headers = {
-            "referer": "https://www.lakemac.com.au/For-residents/Waste-and-recycling/When-are-your-bins-collected"
-        }
-
-        params = {"keywords": self._address}
-
-        r = requests.get(url, params=params, headers=headers)
-        r.raise_for_status()
-
-        addresses = r.json()
-
-        if addresses == 0:
-            raise SourceArgumentNotFound("address", self._address)
-
-        url = "https://www.lakemac.com.au/ocapi/Public/myarea/wasteservices"
-
-        params = {"geolocationid": addresses["Items"][0]["Id"], "ocsvclang": "en-AU"}
-
-        r = requests.get(url, params=params, headers=headers)
-        r.raise_for_status()
-        waste = r.json()
-
-        soup = BeautifulSoup(waste["responseContent"], "html.parser")
-
-        waste_type = []
-
-        for tag in soup.find_all("h3"):
-            waste_type.append(tag.text)
-
-        waste_date = []
-        for tag in soup.find_all("div", {"class": "next-service"}):
-            try:
-                date_object = datetime.strptime(tag.text.strip(), "%a %d/%m/%Y").date()
-            except Exception:
-                continue
-            waste_date.append(date_object)
-
-        waste = list(zip(waste_type, waste_date, strict=False))
-
-        entries = []
-        for item in waste:
-            entries.append(Collection(item[1], item[0], icon=ICON_MAP.get(item[0])))
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/onkaparingacity_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/onkaparingacity_com.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "City of Onkaparinga Council"
 DESCRIPTION = "Source for City of Onkaparinga Council, Australia."
@@ -19,58 +18,22 @@ ICON_MAP = {
     "Green Waste": Icons.GARDEN,
 }
 
-API_URL = "https://www.onkaparingacity.com"
-HEADERS = {"referer": f"{API_URL}/Services/Waste-and-recycling/Bin-collections"}
+HEADERS = {
+    "referer": "https://www.onkaparingacity.com/Services/Waste-and-recycling/Bin-collections"
+}
+
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.onkaparingacity.com",
+    headers=HEADERS,
+    icon_keywords=ICON_MAP,
+    exclude_type_prefixes=("Calendar",),
+)
 
 
 class Source:
-    def __init__(self, address):
+    def __init__(self, address: str):
         self._address = address
+        self._client = OpenCitiesClient(_CONFIG)
 
-    def fetch(self):
-
-        params = {"keywords": self._address}
-
-        r = requests.get(
-            f"{API_URL}/api/v1/myarea/search", params=params, headers=HEADERS
-        )
-        r.raise_for_status()
-
-        addresses = r.json()
-
-        if addresses == 0:
-            raise SourceArgumentNotFound("address", self._address)
-
-        params = {"geolocationid": addresses["Items"][0]["Id"], "ocsvclang": "en-AU"}
-
-        r = requests.get(
-            f"{API_URL}/ocapi/Public/myarea/wasteservices",
-            params=params,
-            headers=HEADERS,
-        )
-        r.raise_for_status()
-
-        waste = r.json()
-
-        soup = BeautifulSoup(waste["responseContent"], "html.parser")
-
-        waste_type = []
-
-        for tag in soup.find_all("h3"):
-            if tag.text.startswith("Calendar"):
-                continue
-            waste_type.append(tag.text)
-
-        waste_date = []
-        for tag in soup.find_all("div", {"class": "next-service"}):
-            tag_text = tag.text.strip()
-            if tag_text != "":
-                date_object = datetime.strptime(tag_text, "%a %d/%m/%Y").date()
-                waste_date.append(date_object)
-
-        waste = list(zip(waste_type, waste_date, strict=False))
-
-        entries = []
-        for item in waste:
-            entries.append(Collection(item[1], item[0], icon=ICON_MAP.get(item[0])))
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._address)

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -867,6 +867,29 @@ def test_opencities_client_drops_excluded_types() -> None:
     assert [e.type for e in entries] == ["Rubbish Collection"]
 
 
+def test_opencities_client_drops_excluded_type_prefixes() -> None:
+    module = _opencities_module()
+    config = module.OpenCitiesConfig(
+        domain="https://example.invalid", exclude_type_prefixes=("Calendar",)
+    )
+    client = module.OpenCitiesClient(config)
+    html = (
+        "<article><h3>Calendar - GlassZone 8</h3>"
+        '<div class="next-service">Mon 01/02/2027</div></article>'
+        "<article><h3>General Waste</h3>"
+        '<div class="next-service">Tue 02/02/2027</div></article>'
+    )
+    client._session = _OpenCitiesSession(
+        lambda url, params: _OpenCitiesResponse(
+            json_data={"success": True, "responseContent": html}
+        )
+    )
+
+    entries = client.fetch_by_geolocation_id("abc")
+
+    assert [e.type for e in entries] == ["General Waste"]
+
+
 def test_opencities_client_resolves_every_weekday_recurring_text() -> None:
     module = _opencities_module()
     config = module.OpenCitiesConfig(domain="https://example.invalid")


### PR DESCRIPTION
## Summary

Batch 3c of the phased OpenCities/MyArea consolidation (batches 0-3b: #6934, #6946, #6951, #6953, #6955): migrates `lakemac_nsw_gov_au.py` and `onkaparingacity_com.py` onto `OpenCitiesClient`, completing the "mechanical old-style" family.

### Two latent bugs fixed as a side effect of migrating

Both sources previously paired waste-type `<h3>` tags with `.next-service` dates via **two separate `find_all()` passes zipped together positionally**. That's a correctness bug: if any block's date fails to parse and gets filtered out of one list but not the type list (or vice versa), every subsequent type/date pairing silently shifts by one. The shared client extracts type+date from the same block together, so this can't happen.

Both also had an `if addresses == 0: raise SourceArgumentNotFound(...)` guard that could never fire — `addresses` is a parsed JSON dict, never equal to the int `0` — so an empty search result would previously crash with an unhandled `IndexError` on `addresses["Items"][0]` instead of the intended error message. The client's real emptiness check fixes this.

### New client extension

**`OpenCitiesConfig.exclude_type_prefixes`** — `onkaparingacity_com` drops any waste-type starting with `"Calendar"` (calendar-download links, not real collections — these appear with a varying zone-number suffix like `"Calendar - GlassZone 8"`, so the exact-match `exclude_types` added in batch 3b wouldn't catch them all).

### Verified, not a regression

`lakemac_nsw_gov_au`'s `TestcaseI` (a deliberately vague `"te"` address) resolves to a real address (`178D Griffen Road, TERALBA NSW 2284`) with zero registered collection services — confirmed via a raw replay of the exact API calls. 0 entries for that test case matches pre-migration behavior exactly.

## Type of change

- [ ] New source
- [x] Bug fix / source fix (positional-zip misalignment, unreachable empty-result guard)
- [ ] Documentation update
- [x] Other (migration onto shared service/OpenCities.py client + client extension)

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (33 passed)
- [x] `ruff check --fix` / `ruff format` / `mypy --ignore-missing-imports --explicit-package-bases` clean (pre-commit hooks pass)
- [x] No generated files in diff
- [x] Live-tested both migrated sources via `test_sources.py -s <name> -l` against the real API
- [x] `TITLE`/`URL`/`COUNTRY`/`TEST_CASES`/`HOW_TO_GET_ARGUMENTS_DESCRIPTION`/`PARAM_*` unchanged; `doc/source/*.md` untouched