### PR TITLE
feat(6935): declare explicit WASTE_TYPES for 56 pipeline sources; shrink gate allowlist to 2

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ab_peine_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ab_peine_de.py
@@ -15,7 +15,12 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.ab-peine.de"
 
@@ -28,6 +33,7 @@ class Source(BaseSource):
     )
     URL = "https://ab-peine.de"
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Gerhart-Hauptmann-Straße (Peine-Kernstadt)": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
@@ -14,6 +14,13 @@ from waste_collection_schedule.service.AbfallIO import (
     list_choices,
 )
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 # Demonstrates: a fully declarative source over a stateful platform wizard. The
 # AbfallPlus / abfall.io acquisition (POST "init" for a token, walk the kommune
@@ -265,6 +272,13 @@ class Source(BaseSource):
     URL = "https://www.abfallplus.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Landshut": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
@@ -8,6 +8,14 @@ from waste_collection_schedule.service.AbfallnaviDe import (
     AbfallnaviRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 # Waste-type names come back as open-ended German fraktion strings that vary by
 # municipality, so this source declares NO per-source type map: the shared
@@ -193,6 +201,14 @@ class Source(BaseSource):
     )
     URL = "https://www.regioit.de"
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     # One structure (regioit.de AbfallNavi) covering many municipalities; the
     # full list is derived from the source's own provider registry at load time.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
@@ -6,6 +6,12 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 # Demonstrates: a plain ICS feed (parsers.IcsParser + ICSTransformer) whose
 # address sits in the URL *path*, not the query string. A configured
@@ -28,6 +34,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Landkreis Forchheim."
     URL = "https://www.abfalltermine-forchheim.de/"
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Dormitz": {"city": "Dormitz", "area": "Dormitz"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abki_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abki_de.py
@@ -28,7 +28,12 @@ from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _STREETS_URL = "https://abki.de/abki-services/strassennamen"
 _NUMBERS_URL = "https://abki.de/abki-services/streetnumber"
@@ -100,6 +105,7 @@ class Source(BaseSource):
     URL = "https://abki.de/"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "auguste-viktoria-straße, 14": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aha_region_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aha_region_de.py
@@ -34,6 +34,12 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _API_URL = "https://www.aha-region.de/abholtermine/abfuhrkalender"
 
@@ -53,6 +59,7 @@ class Source(BaseSource):
     URL = "https://www.aha-region.de/"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Neustadt a. Rbge., Am Rotdorn / Nöpke, 1 ": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aliaserviziambientali_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aliaserviziambientali_it.py
@@ -1,4 +1,4 @@
-from typing import final
+from typing import ClassVar, final
 
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import area_id, municipality
@@ -9,6 +9,12 @@ from waste_collection_schedule.service.junker_app import (
     JunkerRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 TITLE = "Alia Servizi Ambientali S.p.A."
 DESCRIPTION = "Source for Alia Servizi Ambientali S.p.A.."
@@ -184,6 +190,7 @@ class Source(BaseSource):
     URL = URL
     COUNTRY = COUNTRY
     HOWTO = HOWTO
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES = TEST_CASES
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/asr_chemnitz_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/asr_chemnitz_de.py
@@ -29,7 +29,13 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, PAPER, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _PROXY_URL = "https://asc.hausmuell.info/proxy.php"
 _API_URL = "https://asc.hausmuell.info/ics/ics.php"
@@ -46,6 +52,7 @@ class Source(BaseSource):
     URL = "https://www.asr-chemnitz.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Hübschmannstr. 4": {"street": "Hübschmannstr.", "house_number": "4"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aw_harburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aw_harburg_de.py
@@ -25,7 +25,13 @@ from waste_collection_schedule.config_params import cascading_select
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _LEVEL_URL = (
     "https://www.landkreis-harburg.de/bauen-umwelt/abfallwirtschaft/abfallkalender/"
@@ -92,6 +98,13 @@ class Source(BaseSource):
     URL = "https://www.landkreis-harburg.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "CityWithTwoLevels": {"level_1": "Hanstedt", "level_2": "Evendorf"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_oldenburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_oldenburg_de.py
@@ -26,7 +26,12 @@ from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import ORGANIC, PAPER, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.oldenburg.de"
 _API_URL = (
@@ -43,6 +48,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Polizeiinspektion Oldenburg": {"street": "Friedhofsweg", "house_number": 30}

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
@@ -34,7 +34,7 @@ from waste_collection_schedule.config_params import (
     text_field,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER
+from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 _API_URL = (
     "https://wastemanagement.awg.de/WasteManagementDonauwald/WasteManagementServlet"
@@ -71,6 +71,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for ZAW Donau-Wald."
     URL = "https://www.awg.de/"
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER]
 
     TEST_CASES: ClassVar[dict] = {
         "Achslach Aign 1 ": {"city": "Achslach", "street": "Aign", "hnr": "1"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/badaussee_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/badaussee_at.py
@@ -8,6 +8,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalMultiIcsRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 # Demonstrates: a RiSKommunal municipality with one fixed calendar (Gelber
 # Sack) plus three independently zoned calendars (Restmüll/Biomüll/Altpapier),
@@ -64,6 +70,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Bad Aussee, Austria."
     URL = _BASE_URL
     COUNTRY = "at"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Zone 1": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
@@ -11,6 +11,11 @@ from waste_collection_schedule.service.Pozi import (
     PoziGeoJsonRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    RECYCLABLES,
+)
 
 # Demonstrates: a Pozi GeoJSON zone lookup by direct lat/lon (no address
 # geocoding needed). The zone's properties carry a weekday plus a per-type
@@ -72,6 +77,7 @@ class Source(BaseSource):
     URL = "https://www.bendigo.vic.gov.au"
     COUNTRY = "au"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GARDEN_WASTE, GENERAL_WASTE, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Bunnings Epsom": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
@@ -8,7 +8,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.buermoos.at"
 _SELECTION_URL = "https://www.buermoos.at/Service/Aktuelles/Muellkalender"
@@ -36,6 +41,7 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Birkenstraße 76a": {"strasse": "Birkenstraße", "hausnummer": "76a"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
@@ -28,6 +28,13 @@ from waste_collection_schedule.config_params import (
 from waste_collection_schedule.exceptions import SourceArgumentRequired
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    GLASS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 DEFAULT_SUBDOMAIN = "web"
 DEFAULT_ICAL_URL_FILE = "cal"
@@ -145,6 +152,14 @@ class Source(BaseSource):
     DESCRIPTION = "Source for C-Trace.de."
     URL = "https://c-trace.de/"
     COUNTRY = "de"
+
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        GLASS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Bremen": {"ort": "Bremen", "strasse": "Abbentorstraße", "hausnummer": 5},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -19,7 +19,6 @@ from waste_collection_schedule.service.EcoHarmonogramPL import (
 )
 from waste_collection_schedule.transformers import RowTransformer
 from waste_collection_schedule.waste_types import (
-    ALL_TYPES,
     BULKY_WASTE,
     GARDEN_WASTE,
     GENERAL_WASTE,
@@ -283,10 +282,18 @@ class Source(BaseSource):
     )
 
     # The transformer resolves a per-provider, frequency-suffixed Polish label
-    # (Polish is not one of waste_types.resolve()'s alias languages), so any
-    # canonical type may appear, plus provider-specific labels preserved
+    # (Polish is not one of waste_types.resolve()'s alias languages) to one of
+    # the canonical types below, plus provider-specific labels preserved
     # verbatim when genuinely unmappable.
-    WASTE_TYPES: ClassVar[list] = list(ALL_TYPES)
+    WASTE_TYPES: ClassVar[list] = [
+        BULKY_WASTE,
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        GLASS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     retrieve = EcoharmonogramRetriever()
     parse = EcoharmonogramParser()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
@@ -8,7 +8,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.eggelsberg.at"
 VALID_ZONES = ["A", "B"]
@@ -20,6 +25,13 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Marktgemeinde Eggelsberg waste collection."
     URL = _BASE_URL
     COUNTRY = "at"
+
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Zone A": {"zone": "A"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
@@ -7,6 +7,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.gde-elsbethen.at"
 
@@ -19,6 +25,13 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
+
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Überfuhrstraße 2": {"strasse": "Überfuhrstraße", "hausnummer": "2"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
@@ -7,7 +7,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.enns.at"
 
@@ -20,6 +25,13 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
+
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Am Damm 1": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/felixdorf_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/felixdorf_gv_at.py
@@ -8,7 +8,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.felixdorf.gv.at"
 VALID_ZONES = ["Rayon 1", "Rayon 2"]
@@ -21,6 +26,13 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
+
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Rayon 1": {"zone": "Rayon 1"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankenberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankenberg_de.py
@@ -27,6 +27,7 @@ from waste_collection_schedule.transformers import ICSTransformer
 from waste_collection_schedule.waste_types import (
     GENERAL_WASTE,
     GLASS,
+    HAZARDOUS,
     ORGANIC,
     PAPER,
     RECYCLABLES,
@@ -139,6 +140,12 @@ class Source(BaseSource):
     URL = "https://www.frankenberg.de/"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+
+    WASTE_TYPES: ClassVar[list] = [
+        HAZARDOUS,
+        ORGANIC,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Viermünden": {"district": "Viermünden"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
@@ -11,6 +11,12 @@ from waste_collection_schedule.service.Pozi import (
     geocode_earth,
 )
 from waste_collection_schedule.transformers import RowTransformer
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    GLASS,
+    RECYCLABLES,
+)
 
 # Demonstrates: a Pozi GeoJSON zone lookup by address, geocoded first via
 # geocode.earth (Frankston's Pozi widget has no address lookup of its own).
@@ -82,6 +88,13 @@ class Source(BaseSource):
     URL = "https://frankston.gov.au"
     COUNTRY = "au"
     RAISE_ON_EMPTY = True
+
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        GLASS,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "45r Wedge Rd": {"address": "45r Wedge Rd, Carrum Downs Vic"},  # Monday

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
@@ -237,6 +237,13 @@ class Source(BaseSource):
     SOURCE_CODEOWNERS: ClassVar[list] = ["@markvp"]
     RAISE_ON_EMPTY = True
 
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
+
     TEST_CASES: ClassVar[dict] = {
         "Gaal": {"gemeinde": "Gaal", "strasse": "Gaal"},
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geoport_nwm_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geoport_nwm_de.py
@@ -28,6 +28,7 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district
 from waste_collection_schedule.service.ICS import ICS
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import HAZARDOUS, ORGANIC, RECYCLABLES
 
 _API_URL = "https://www.geoport-nwm.de/nwm-download/Abfuhrtermine/ICS/{year}/{arg}.ics"
 
@@ -64,6 +65,12 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Landkreis Nordwestmecklenburg."
     URL = "https://www.geoport-nwm.de"
     COUNTRY = "de"
+
+    WASTE_TYPES: ClassVar[list] = [
+        HAZARDOUS,
+        ORGANIC,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Rüting": {"district": "Rüting"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gross_gerau_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gross_gerau_de.py
@@ -15,7 +15,12 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import PAPER, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.gross-gerau.de"
 
@@ -26,6 +31,13 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Kreisstadt Groß-Gerau waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
+
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Adam-Rauch-Straße (Groß-Gerau)": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hartbeigraz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hartbeigraz_at.py
@@ -8,7 +8,14 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    BULKY_WASTE,
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.hartbeigraz.at"
 _MENUONR = "225225009"
@@ -33,6 +40,15 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
+
+    WASTE_TYPES: ClassVar[list] = [
+        BULKY_WASTE,
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Am Brühlwald 15": {"strasse": "Am Brühlwald", "hausnummer": "15"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hilchenbach_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hilchenbach_de.py
@@ -15,7 +15,14 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, HAZARDOUS
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://hilchenbach.de"
 
@@ -26,6 +33,15 @@ class Source(BaseSource):
     DESCRIPTION = "Source for 'Abfallkalender Stadt Hilchenbach'."
     URL = "https://www.hilchenbach.de"
     COUNTRY = "de"
+
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Dammstraße (Hilchenbach)": {"strasse": "Dammstr"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ilm_kreis_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ilm_kreis_de.py
@@ -15,7 +15,14 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import PAPER, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    ELECTRONICS,
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://aik.ilm-kreis.de"
 
@@ -26,6 +33,15 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Abfallwirtschaftsbetrieb Ilm-Kreis waste collection."
     URL = "https://www.ilm-kreis.de"
     COUNTRY = "de"
+
+    WASTE_TYPES: ClassVar[list] = [
+        ELECTRONICS,
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Gerhart-Hauptmann-Straße (Arnstadt)": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
@@ -8,7 +8,11 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.imst.gv.at"
 _MENUONR = "222722602"
@@ -36,6 +40,7 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Auf Arzill 154": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/infeo_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/infeo_at.py
@@ -30,6 +30,12 @@ from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,6 +160,7 @@ class Source(BaseSource):
     URL = "https://www.infeo.at/"
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     REGIONS = (
         region(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -1,4 +1,4 @@
-from typing import final
+from typing import ClassVar, final
 
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import municipality, text_field
@@ -9,6 +9,13 @@ from waste_collection_schedule.service.junker_app import (
     JunkerRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    GLASS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 TITLE = "Junker APP"
 DESCRIPTION = "Source for Junker APP."
@@ -357,6 +364,7 @@ class Source(BaseSource):
     DESCRIPTION = DESCRIPTION
     URL = URL
     COUNTRY = COUNTRY
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, GLASS, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES = TEST_CASES
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
@@ -7,7 +7,7 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import PAPER
+from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 _BASE_URL = "https://www.klosterneuburg.at"
 _SELECTION_URL = (
@@ -22,6 +22,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Stadtgemeinde Klosterneuburg waste collection."
     URL = _SELECTION_URL
     COUNTRY = "at"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER]
 
     TEST_CASES: ClassVar[dict] = {
         "Kierlinger Straße 10": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
@@ -8,6 +8,12 @@ from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSugge
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 # Demonstrates: a RiSKommunal municipality whose calendar is not exposed
 # through the platform's usual kalender.aspx table/list rendering at all.
@@ -147,6 +153,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Rathaus": {"street_name": "Hauptplatz", "street_number": 39},  # Teilgebiet 4

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kreis_ploen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kreis_ploen_de.py
@@ -15,7 +15,12 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.kreis-ploen.de"
 
@@ -26,6 +31,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Abfallwirtschaft Kreis Plön waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Hauptstraße (Köhn)": {"strasse": "Hauptstraße", "ort": "Köhn"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ks_boerde_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ks_boerde_de.py
@@ -18,7 +18,13 @@ from waste_collection_schedule.config_params import house_number, municipality, 
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import PAPER
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _DATA_URL = "https://www.ks-boerde.de/_aturis/eko/proxy.php"
 _CALENDAR_URL = "https://boerde.hausmuell.info/ics/ics.php"
@@ -69,6 +75,13 @@ class Source(BaseSource):
     URL = "https://ks-boerde.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Rathaus": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwb_goslar_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwb_goslar_de.py
@@ -24,7 +24,15 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.service.SiteparkIES import SiteparkIES
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import ELECTRONICS, HAZARDOUS
+from waste_collection_schedule.waste_types import (
+    ELECTRONICS,
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.kwb-goslar.de"
 
@@ -35,6 +43,15 @@ class Source(BaseSource):
     DESCRIPTION = "Source for kwb-goslar.de waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [
+        ELECTRONICS,
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Berliner Straße (Clausthal-Zellerfeld)": {"pois": "2523.602"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
@@ -17,6 +17,12 @@ from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _HEADERS = {"user-agent": "Mozilla/5.0 (xxxx Windows NT 10.0; Win64; x64)"}
 _BASE_URL = "https://kalender.kwu-entsorgung.de"
@@ -40,6 +46,7 @@ class Source(BaseSource):
     URL = "https://www.kwu-entsorgung.de/"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Erkner": {"city": "Erkner", "street": "Heinrich-Heine-Straße", "number": "11"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_wittmund_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_wittmund_de.py
@@ -19,7 +19,13 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIES
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.landkreis-wittmund.de"
 _API_URL = (
@@ -41,6 +47,13 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Landkreis Wittmund waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "CityWithoutStreet": {"ort": "Werdum"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lk_mecklenburgische_seenplatte_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lk_mecklenburgische_seenplatte_de.py
@@ -15,7 +15,12 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.lk-mecklenburgische-seenplatte.de"
 
@@ -26,6 +31,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Landkreis Mecklenburgische Seenplatte waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Atelierstraße (Neubrandenburg)": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
@@ -7,7 +7,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.micheldorf.at"
 
@@ -19,6 +24,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Adalbert-Stifter-Straße 1": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muehlenkreis_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muehlenkreis_de.py
@@ -17,6 +17,7 @@ from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
 from waste_collection_schedule.waste_types import (
     BULKY_WASTE,
+    ELECTRONICS,
     GENERAL_WASTE,
     HAZARDOUS,
     ORGANIC,
@@ -33,6 +34,15 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Mühlenkreis Minden-Lübbecke waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [
+        BULKY_WASTE,
+        ELECTRONICS,
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Hauptstraße (Harlinghausen)": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/neu_ulm_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/neu_ulm_de.py
@@ -15,7 +15,7 @@ from waste_collection_schedule.config_params import district
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.retrievers import TwoStepRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import ORGANIC, RECYCLABLES
+from waste_collection_schedule.waste_types import ORGANIC, PAPER, RECYCLABLES
 
 _HOST_URI = "https://nu.neu-ulm.de"
 _CALENDAR_PAGE = (
@@ -50,6 +50,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Neu-Ulm."
     URL = "https://nu.neu-ulm.de/buerger-service/leben-in-neu-ulm/abfall-sauberkeit/abfallkalender"
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Bezirk 1": {"region": "Bezirk 1"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
@@ -7,6 +7,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.oberndorf.ooe.gv.at"
 
@@ -19,6 +25,7 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Am Hang 2": {"strasse": "Am Hang", "hausnummer": "2"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ostprignitz_ruppin_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ostprignitz_ruppin_de.py
@@ -15,7 +15,14 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.ostprignitz-ruppin.de"
 
@@ -26,6 +33,14 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Ostprignitz-Ruppin waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Am alten Gymnasium (Neuruppin)": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/puchbeihallein_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/puchbeihallein_gv_at.py
@@ -7,6 +7,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.puchbeihallein.gv.at"
 
@@ -19,6 +25,7 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@nerdoc"]
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Ahornstraße 3": {"strasse": "Ahornstraße", "hausnummer": "3"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rsag_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rsag_de.py
@@ -21,7 +21,13 @@ from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _API_BASE = "https://www.rsag.de/api"
 
@@ -59,6 +65,7 @@ class Source(BaseSource):
     URL = "https://www.rsag.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Königswinter, Winzerstraße": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
@@ -7,7 +7,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.saalfelden.at"
 
@@ -19,6 +24,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Achenweg 1": {"strasse": "Achenweg", "hausnummer": 1},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
@@ -7,7 +7,12 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://www.schaerding.ooe.gv.at"
 
@@ -19,6 +24,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Adalbert-Stifter-Straße 1": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schlierbach_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schlierbach_at.py
@@ -8,7 +8,7 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
+from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 _BASE_URL = "https://www.schlierbach.at"
 VALID_ZONES = ["1", "Wohnhausanlagen"]
@@ -21,6 +21,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Gemeinde Alle (no zone)": {},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_giessen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_giessen_de.py
@@ -21,7 +21,13 @@ from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _BASE_URL = "https://stadtreinigung.giessen.de/akal/akal1.php"
 
@@ -100,6 +106,13 @@ class Source(BaseSource):
     URL = "https://stadtreinigung.giessen.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Achstattring 1": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtservice_bruehl_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtservice_bruehl_de.py
@@ -20,7 +20,13 @@ from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer, label_cleaner
-from waste_collection_schedule.waste_types import GARDEN_WASTE
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _DISTRICT_URL = "https://services.stadtservice-bruehl.de/abfallkalender/"
 _CALENDAR_URL = (
@@ -40,6 +46,13 @@ class Source(BaseSource):
     URL = "https://stadtservice-bruehl.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [
+        GARDEN_WASTE,
+        GENERAL_WASTE,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "TEST1": {"strasse": "Badorfer Straße", "hnr": "1"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/staedteservice_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/staedteservice_de.py
@@ -28,7 +28,14 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.service.ICS import ICS
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    GLASS,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _API_URL = "https://portal.staedteservice.de/api/ZeigeAbfallkalender"
 _STREETS_URL = "https://portal.staedteservice.de/api/Strassen"
@@ -43,6 +50,14 @@ class Source(BaseSource):
     URL = "https://www.staedteservice.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        GLASS,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Rüsselsheim": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stevenage_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stevenage_gov_uk.py
@@ -11,7 +11,11 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
+from waste_collection_schedule.waste_types import (
+    FOOD_WASTE,
+    GENERAL_WASTE,
+    RECYCLABLES,
+)
 
 HOSTNAME = "stevenage-self.achieveservice.com"
 BASE_URL = f"https://{HOSTNAME}"
@@ -45,6 +49,7 @@ class Source(BaseSource):
     URL = "https://www.stevenage.gov.uk/"
     COUNTRY = "uk"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [FOOD_WASTE, GENERAL_WASTE, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Chepstow Close": {"uprn": "100080879233"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
@@ -7,6 +7,7 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC
 
 _BASE_URL = "https://www.steyr.at"
 
@@ -19,6 +20,7 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC]
 
     TEST_CASES: ClassVar[dict] = {
         "Wolfernstraße 7": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
@@ -8,6 +8,7 @@ from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
 from waste_collection_schedule.service.Pozi import PoziWfsParser, PoziWfsRetriever
 from waste_collection_schedule.transformers import RowTransformer
+from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Demonstrates: a Pozi WFS spatial-query lookup by address (geocoded via the
 # shared ArcGIS World GeocodeServer). Each collection field is an HTML-ish
@@ -82,6 +83,7 @@ class Source(BaseSource):
     URL = "https://www.vincent.wa.gov.au"
     COUNTRY = "au"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "North Perth": {"address": "8 Kadina St, North Perth WA 6006"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zva_sek_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zva_sek_de.py
@@ -21,6 +21,8 @@ from waste_collection_schedule.transformers import ICSTransformer
 from waste_collection_schedule.waste_types import (
     GENERAL_WASTE,
     HAZARDOUS,
+    ORGANIC,
+    PAPER,
     RECYCLABLES,
 )
 
@@ -64,6 +66,13 @@ class Source(BaseSource):
     URL = "https://www.zva-sek.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
+    WASTE_TYPES: ClassVar[list] = [
+        GENERAL_WASTE,
+        HAZARDOUS,
+        ORGANIC,
+        PAPER,
+        RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Fritzlar": {

--- a/tests/test_declared_waste_types.py
+++ b/tests/test_declared_waste_types.py
@@ -82,73 +82,18 @@ _FIXTURES = discover_fixtures()
 
 # (a) Sources that return canonical types they never declare: the transformer
 # resolves aliases (or preserves-then-canonicalises labels) beyond its explicit
-# type_value_map, so the auto-derived WASTE_TYPES is missing those ids. Fix by
-# declaring the full produced vocabulary (or completing the map).
-_RETURNS_UNDECLARED_TYPES = {
-    "ab_peine_de",
-    "abki_de",
-    "aliaserviziambientali_it",
-    "asr_chemnitz_de",
-    "aw_harburg_de",
-    "awb_oldenburg_de",
-    "awg_de",
-    "buermoos_at",
-    "eggelsberg_at",
-    "enns_at",
-    "felixdorf_gv_at",
-    "frankenberg_de",
-    "gross_gerau_de",
-    "hartbeigraz_at",
-    "hilchenbach_de",
-    "ilm_kreis_de",
-    "imst_at",
-    "junker_app",
-    "klosterneuburg_at",
-    "kreis_ploen_de",
-    "ks_boerde_de",
-    "kwb_goslar_de",
-    "landkreis_wittmund_de",
-    "lk_mecklenburgische_seenplatte_de",
-    "micheldorf_at",
-    "muehlenkreis_de",
-    "neu_ulm_de",
-    "ostprignitz_ruppin_de",
-    "rsag_de",
-    "saalfelden_at",
-    "schaerding_ooe_gv_at",
-    "schlierbach_at",
-    "stadtreinigung_giessen_de",
-    "stadtservice_bruehl_de",
-    "staedteservice_de",
-    "stevenage_gov_uk",
-    "zva_sek_de",
-}
+# type_value_map, so the auto-derived WASTE_TYPES is missing those ids. Fixed by
+# declaring the full produced vocabulary on each source. Now cleared.
+_RETURNS_UNDECLARED_TYPES: set[str] = set()
 
 # (b) Sources whose WASTE_TYPES == the whole ALL_TYPES catalogue, via the
-# empty-map fallback. "Declaring everything" is no declaration; fix by giving
-# each a real, specific vocabulary (which also lets the fallback be removed).
+# empty-map fallback. "Declaring everything" is no declaration; fixed by giving
+# each a real, specific vocabulary. The two remaining sources emit only unmapped
+# (preserved:) labels, so they cannot declare a canonical vocabulary until their
+# labels are mapped or aliased; tracked separately, hence still allowlisted.
 _DECLARES_ALL_TYPES = {
-    "abfall_io",
-    "abfallnavi_de",
-    "abfalltermine_forchheim_de",
-    "aha_region_de",
-    "badaussee_at",
-    "bendigo_vic_gov_au",
     "bmv_at",
-    "c_trace_de",
-    "ecoharmonogram_pl",
-    "elsbethen_at",
-    "frankston_vic_gov_au",
-    "gemeinde24_at",
-    "geoport_nwm_de",
-    "infeo_at",
-    "korneuburg_stadtservice_at",
-    "kwu_de",
     "muellmax_de",
-    "oberndorf_schwanenstadt_at",
-    "puchbeihallein_gv_at",
-    "steyr_at",
-    "vincent_wa_gov_au",
 }
 
 ALLOWLIST = _RETURNS_UNDECLARED_TYPES | _DECLARES_ALL_TYPES


### PR DESCRIPTION
Phase 2 of #6935 (making `WASTE_TYPES` authoritative).

**56 pipeline sources** now declare an explicit `WASTE_TYPES` listing the exact canonical types they emit, replacing either the incomplete auto-derivation (types resolved via the shared alias vocabulary that the `type_value_map` never declared) or the `ALL_TYPES` empty-map fallback. Each declaration was derived from, and verified against, the source's recorded cassettes; no `type_value_map`, transform or classification logic changed.

The gate added in #6956 (`tests/test_declared_waste_types.py`) validates the result: with these 56 removed from the burn-down allowlist, the gate is green (536 passed, 26 skipped), i.e. every one of the 56 now returns only types it declares.

The allowlist now holds just **`bmv_at`** and **`muellmax_de`**, which emit only unmapped (`preserved:`) labels and so cannot declare a canonical vocabulary until those labels are mapped or aliased. That is tracked separately.

Remaining for #6935 after this: map or alias the two stragglers, then remove the `ALL_TYPES` fallback in `base_source.py` (Phase 3) once the allowlist reaches empty.

Part of #6935. No generated files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
