### PR TITLE
fix(abfall_io): migrate Entsorgungsbetriebe Essen to v3 GraphQL API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -28,11 +28,6 @@ SERVICE_MAP = [
         "service_id": "690a3ae4906c52b232c1322e2f88550c",
     },
     {
-        "title": "Entsorgungsbetriebe Essen",
-        "url": "https://www.ebe-essen.de/",
-        "service_id": "9b5390f095c779b9128a51db35092c9c",
-    },
-    {
         "title": "Abfallwirtschaft Landkreis Freudenstadt",
         "url": "https://www.awb-fds.de/",
         "service_id": "595f903540a36fe8610ec39aa3a06f6a",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -15,4 +15,9 @@ SERVICE_MAP = [
         "url": "https://www.kreis-reutlingen.de/",
         "service_id": "15f69fab91c4cae50d9dbb5bcfd383f0",
     },
+    {
+        "title": "Entsorgungsbetriebe Essen",
+        "url": "https://www.ebe-essen.de/",
+        "service_id": "51be67f3758f1fb57b420efe065c0663",
+    },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
@@ -137,8 +137,10 @@ class Source:
         if r.status_code == 401:
             raise ValueError(
                 f"API key '{self._key}' is no longer valid for the legacy abfall.io API. "
-                "This provider may have migrated to the new abfall.io v3 API, which is not yet supported. "
-                "See https://github.com/mampfes/hacs_waste_collection_schedule/issues/3788"
+                "This provider has likely migrated to the new abfall.io v3 API. "
+                "Please switch to the 'Abfall.IO / AbfallPlus (GraphQL)' source (abfall_io_graphql) instead, "
+                "which supports the v3 API. "
+                "See https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/source/abfall_io_graphql.md"
             )
         r.raise_for_status()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -61,6 +61,10 @@ TEST_CASES = {
         "key": "15f69fab91c4cae50d9dbb5bcfd383f0",
         "idHouseNumber": 58444,
     },
+    "Entsorgungsbetriebe Essen": {
+        "key": "51be67f3758f1fb57b420efe065c0663",
+        "idHouseNumber": 74629,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Entsorgungsbetriebe Essen (EBE) migrated to the abfall.io v3 API; the legacy `abfall_io` source's stored key for Essen now returns HTTP 401, breaking every existing configuration (#4775).
- Removes the dead Essen entry from the legacy `service/AbfallIO.py` map.
- Adds Essen to `service/AbfallIOGraphQL.py` with its new v3 service key, and adds a corresponding `abfall_io_graphql` TEST_CASES entry.
- Updates the legacy source's 401 error message, which still pointed users at issue #3788 as "not yet supported" — that PR has since merged, so the message now points at the working `abfall_io_graphql` replacement instead.

## Test plan
- [x] `ruff check --fix` / `ruff format` on all changed files
- [x] `python test_sources.py -s abfall_io_graphql -l` — all TEST_CASES pass, including the new Essen case (verified against the live API)
- [x] `python test_sources.py -s abfall_io -l` — pre-existing legacy TEST_CASES unaffected
- [x] `python -m pytest tests/test_source_components.py -q` — 33 passed

Fixes #4775

🤖 Generated with [Claude Code](https://claude.com/claude-code)