### PR TITLE
feat(source): add Abfallwirtschaft Altenburger Land to AWIDO service map

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awido_de.py
@@ -401,6 +401,11 @@ SERVICE_MAP = [
         "service_id": "ebe",
         "default_params": {"city": "Zorneding"},
     },
+    {
+        "title": "Abfallwirtschaft Altenburger Land",
+        "url": "https://www.awb-altenburg.de/",
+        "service_id": "awb-altenburg",
+    },
 ]
 
 TEST_CASES = {
@@ -408,6 +413,10 @@ TEST_CASES = {
         "customer": "gifhorn",
         "city": "Hankensbüttel",
         "street": "Allersehl",
+    },
+    "Altenburg, Langenleuba-Niederhain": {
+        "customer": "awb-altenburg",
+        "city": "Langenleuba-Niederhain",
     },
     "coburg rödental krötenleite 4": {
         "customer": "coburg",


### PR DESCRIPTION
## Summary
- Adds "Abfallwirtschaft Altenburger Land" (customer id `awb-altenburg`) to the shared AWIDO/Cubefour `SERVICE_MAP` in `awido_de.py`
- Adds a `TEST_CASES` entry for the example address from #4794 (Langenleuba-Niederhain)

Closes #4794

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python test_sources.py -s awido_de -l` — all test cases pass, including the new one (80 entries retrieved for Altenburg, Langenleuba-Niederhain)
- [x] `python -m pytest tests/test_source_components.py -q` — 29 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)