### PR TITLE
Republic Services: fix holiday schedule adjustments

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -32,15 +32,18 @@ TEST_CASES = {
         "street_address": "4420 Oasis Hill Ave, North Las Vegas, NV 89085",
         "method": 2,
     },
-}
-DELAYS = {
-    " one ": 1,
-    " two ": 2,
-    " three ": 3,
-    " four ": 4,
-    " five ": 5,
-    " six ": 6,
-    " seven ": 7,
+    # Friday pickup in a division whose Thanksgiving/Christmas are a one-day delay,
+    # so the holiday adjustment moves the Friday collection to Saturday.
+    "Friday holiday delay": {
+        "street_address": "104 Fizer Dr, Georgetown, KY 40324",
+        "method": 2,
+    },
+    # Division where Independence Day is "Not Running" rather than a delay, exercising
+    # the cancellation branch.
+    "Not Running holiday": {
+        "street_address": "700 E Warm Springs Ave, Boise, ID 83712",
+        "method": 2,
+    },
 }
 
 
@@ -132,48 +135,78 @@ class Source:
                                 }
                             )
 
-        # Compile holidays that impact collections
-        r2 = s.get(
-            "https://www.republicservices.com/api/v3/holidaySchedules/schedules",
-            params={"latitude": latitude, "longitude": longitude},
+        # Compile holidays that impact collections.
+        # The v3 GET endpoint the old code used returns an empty payload ({"data":[null]})
+        # for every address tested, so no adjustment was ever applied. The site itself
+        # uses a v2 POST that takes the lines of business as a body. Request the LOBs
+        # we actually have containers for so commercial/industrial keep working too.
+        lobs = sorted({service.lower() for service in services})
+        r2 = s.post(
+            "https://www.republicservices.com/api/v2/holidaySchedules/schedule",
+            json={"latitude": latitude, "longitude": longitude, "lobs": lobs},
         )
-        r2_data = r2.json().get("data", [])
+        r2.raise_for_status()
+        r2_data = r2.json().get("data") or []
         holidays = []
         for item in r2_data:
             if item and item["serviceImpacted"] is True and item["LOB"] in services:
-                day_offset = 0
-                for delay in DELAYS:
-                    if delay in item["description"]:
-                        day_offset = DELAYS[delay]
                 dt = datetime.strptime(item["date"].split("T")[0], "%Y-%m-%d").date()
                 holidays.append(
                     {
                         "date": dt,
                         "name": item["name"],
-                        "description": item["description"],
-                        "delay": day_offset,
-                        "incorporated": False,
+                        "service": item["LOB"],
+                        "status": (item.get("holidaySchedule") or "").lower(),
+                        "alt_date": item.get("altPickUpDate"),
                     }
                 )
+        # The site applies holidays oldest-first, so a run of holidays in one week can
+        # push a pickup forward day by day. Match that ordering.
+        holidays.sort(key=lambda holiday: holiday["date"])
 
-        # Cycle through schedule and holidays incorporating delays
-        # According to Republic Waste "Holidays typically push our residential pickup
-        # schedules back one day with regular schedules resuming the following week."
-        while True:
-            changes = 0
-            for holiday in holidays:
-                if not holiday["incorporated"]:
-                    h = holiday["date"]
-                    d = holiday["delay"]
-                    for pickup in schedule:
-                        p = pickup["date"]
-                        ns = h + timedelta(days=6 - h.weekday())
-                        if h <= p < ns:
-                            pickup["date"] = p + timedelta(days=d)
-                            holiday["incorporated"] = True
-                            changes += 1
-            if changes == 0:
-                break
+        # A holiday only affects the line of business it belongs to, so match each holiday
+        # to pickups of the same service. The API returns one holiday per line of business,
+        # so ignoring this would shift a pickup once per business line it happens to have.
+        def affects(holiday, pickup):
+            return holiday["service"] == pickup["service"]
+
+        # Reproduce the three behaviours the website applies to an impacted pickup:
+        #   "Not Running"    -> the collection is cancelled with no make-up day
+        #   "Service Moved"  -> the collection jumps to the alternate date the API supplies
+        #   "One Day Delay"  -> the collection and every later same-week collection slide
+        #                       forward one day (a Sunday-start week, on-or-after the holiday)
+        def same_week(day_a, day_b):
+            # Sunday-start week, matching the site's areDatesInSameWeek
+            return day_a - timedelta(days=(day_a.weekday() + 1) % 7) == day_b - timedelta(
+                days=(day_b.weekday() + 1) % 7
+            )
+
+        not_running = {
+            (h["date"], h["service"]) for h in holidays if h["status"] == "not running"
+        }
+        schedule = [
+            pickup
+            for pickup in schedule
+            if (pickup["date"], pickup["service"]) not in not_running
+        ]
+
+        for holiday in holidays:
+            h = holiday["date"]
+            if holiday["status"] == "service moved" and holiday["alt_date"]:
+                alt = datetime.strptime(
+                    holiday["alt_date"].split("T")[0], "%Y-%m-%d"
+                ).date()
+                for pickup in schedule:
+                    if affects(holiday, pickup) and pickup["date"] == h:
+                        pickup["date"] = alt
+            elif holiday["status"] == "one day delay":
+                for pickup in schedule:
+                    if (
+                        affects(holiday, pickup)
+                        and pickup["date"] >= h
+                        and same_week(h, pickup["date"])
+                    ):
+                        pickup["date"] = pickup["date"] + timedelta(days=1)
 
         # Build final schedule
         entries = []

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -177,9 +177,9 @@ class Source:
         #                       forward one day (a Sunday-start week, on-or-after the holiday)
         def same_week(day_a, day_b):
             # Sunday-start week, matching the site's areDatesInSameWeek
-            return day_a - timedelta(days=(day_a.weekday() + 1) % 7) == day_b - timedelta(
-                days=(day_b.weekday() + 1) % 7
-            )
+            return day_a - timedelta(
+                days=(day_a.weekday() + 1) % 7
+            ) == day_b - timedelta(days=(day_b.weekday() + 1) % 7)
 
         not_running = {
             (h["date"], h["service"]) for h in holidays if h["status"] == "not running"


### PR DESCRIPTION
Fix holiday adjustments for Republic Services

## The problem

Right now this source never adjusts collection dates for holidays. There are two separate reasons:

1. It requests holidays from `GET /api/v3/holidaySchedules/schedules`. That endpoint returns `{"data":[null]}` for every address I tested (Georgetown KY, Fremont and Elk Grove CA, Las Vegas NV, Boise ID), so the holiday list always comes back empty.
2. Even if the list were populated, the code decides how many days to shift by searching the holiday's `description` text for `" one "`, `" two "`, and so on. The actual value is `"One Day Delay"`, which contains none of those substrings, so the shift amount always stays at zero.

This is easy to overlook because it only produces a visibly wrong date when a holiday lands on or before the pickup earlier in the same week. Most weekday routes are unaffected, but a Friday route is not: Christmas 2026 falls on a Friday and the collection should move to Saturday, yet the current code leaves it on Friday.

## The fix

The change is limited to the holiday section of `fetch()`. The schedule-building code above it is untouched.

- Call the endpoint the website itself uses now: `POST /api/v2/holidaySchedules/schedule` with a body of `{latitude, longitude, lobs}`. The `lobs` list is built from the container categories the address actually has, so commercial and industrial addresses keep working the same way residential ones do.
- Instead of parsing the description text, read the `holidaySchedule` status and apply the same three behaviours the website applies:
  - **One Day Delay** — the collection, and any later collection in the same week, moves forward one day. Holidays are applied oldest first, so several holidays in one week push a collection along day by day.
  - **Not Running** — the collection is cancelled with no make-up day.
  - **Service Moved** — the collection jumps to the alternate date the API provides.
- Match each holiday to collections of its own line of business. The v2 endpoint returns a holiday once for each line of business requested, so an address that has both a residential and an industrial container would otherwise shift its Friday collection twice and land on Sunday.

## Testing

I verified the results against the live API and confirmed that calling `fetch()` a second time returns the same schedule. The existing test cases still return collections, and I added two that exercise the new code:

- `104 Fizer Dr, Georgetown, KY` is a Friday route, so its Christmas collection now moves from Friday 12/25 to Saturday 12/26.
- `700 E Warm Springs Ave, Boise, ID` is in a division where Independence Day is marked "Not Running", so it exercises the cancellation path.

`fetch()` keeps all of its state in local variables, so adjusting dates in place does not affect a second call.

## Notes

Service Moved is implemented because the website supports it, but I could not find a live address currently returning that status (`altPickUpDate` was null in every response I saw), so there is no test case for it.

On the hardcoded one-day shift: the website's front end recognises exactly five status strings, defined together in one constants object in its bundle — `Running as Normal`, `One Day Delay`, `Not Running`, `Service Moved`, and `Service By End Of Week`. Its one-day-delay handler simply adds a single day; it does not read a number out of the text. So a one-day shift matches what the site does, and a status the site doesn't recognise (a hypothetical "Two Day Delay", say) is one the site itself wouldn't act on either. In practice, across roughly 25 divisions I sampled, the only values that came back were `Running as Normal`, `One Day Delay`, and `Not Running`; I did not see `Service Moved` or `Service By End Of Week` live, and I don't have the server-side schema, so I'm describing what the front end handles rather than claiming the API can't return anything else.

`Service By End Of Week` is the one recognised status I did not implement. The website treats it as a note shown to the user rather than moving the collection to a calculated date. Any status this fix doesn't recognise leaves the collection where it is, which is the same as the current behaviour.

## Data behind the above

```
$ curl -sG .../api/v3/holidaySchedules/schedules \
    --data-urlencode latitude=38.204227 --data-urlencode longitude=-84.57942
{"statusCode":200,"data":[null]}

$ curl -s -X POST .../api/v2/holidaySchedules/schedule -H "Content-Type: application/json" \
    -d '{"latitude":38.204227,"longitude":-84.57942,"lobs":["residential"]}'
{"date":"2026-12-25T00:00:00.000Z","holidaySchedule":"One Day Delay","description":"One Day Delay",
 "LOB":"Residential","name":"Christmas Day","serviceImpacted":true,"altPickUpDate":null}
```

The description is `"One Day Delay"`, and `" one "` is not a substring of it, which is why the old code never shifted anything. Requesting both residential and industrial lines of business for the Fizer division returns Christmas Day twice, once per line of business — which is why the fix matches holidays to collections by line of business.
