### PR TITLE
feat: add Clackmannanshire Council (clackmannanshire_gov_uk) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/clackmannanshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/clackmannanshire_gov_uk.py
@@ -77,7 +77,7 @@ class Source:
         self._garden_waste = bool(garden_waste)
 
     def _find_property_url(self, session: requests.Session) -> str:
-        r = session.get(SEARCH_URL, params={"pc": self._postcode})
+        r = session.get(SEARCH_URL, params={"pc": self._postcode}, timeout=30)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 
@@ -118,7 +118,7 @@ class Source:
     def _find_ics_links(
         self, session: requests.Session, property_url: str
     ) -> list[str]:
-        r = session.get(property_url)
+        r = session.get(property_url, timeout=30)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 
@@ -155,13 +155,13 @@ class Source:
 
         entries: list[Collection] = []
 
-        r = session.get(ics_links[0])
+        r = session.get(ics_links[0], timeout=30)
         r.raise_for_status()
         for date, title in ICS().convert(r.text):
             entries.append(Collection(date=date, t=title, icon=self._get_icon(title)))
 
         if self._garden_waste and len(ics_links) > 1:
-            r = session.get(ics_links[1])
+            r = session.get(ics_links[1], timeout=30)
             r.raise_for_status()
             for date, title in ICS().convert(r.text):
                 clean_title = _YEAR_SUFFIX_RE.sub("", title).strip()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/clackmannanshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/clackmannanshire_gov_uk.py
@@ -1,0 +1,176 @@
+import re
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup, Tag
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Clackmannanshire Council"
+DESCRIPTION = "Source for Clackmannanshire Council, UK waste collection."
+URL = "https://www.clacks.gov.uk"
+COUNTRY = "uk"
+TEST_CASES = {
+    "16 Crophill, Sauchie": {
+        "postcode": "FK10 3EY",
+        "address": "16 Crophill, Sauchie",
+    },
+    "Elim Pentecostal Church, Alloa": {
+        "postcode": "FK10 1EB",
+        "address": "Elim Pentecostal Church, Alloa",
+    },
+    "With garden waste permit": {
+        "postcode": "FK10 3EY",
+        "address": "16 Crophill, Sauchie",
+        "garden_waste": True,
+    },
+}
+
+ICON_MAP = {
+    "food caddy": Icons.BIO_KITCHEN,
+    "blue bin": Icons.RECYCLING,
+    "green bin": Icons.GENERAL_WASTE,
+    "grey bin": Icons.PAPER,
+    "brown bin": Icons.GARDEN,
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "postcode": "Postcode of the property, e.g. 'FK10 3EY'.",
+        "address": (
+            "Address exactly as shown in the search results on the council "
+            "website, e.g. '16 Crophill, Sauchie'."
+        ),
+        "garden_waste": (
+            "Set to true if you hold a paid garden waste (brown bin) permit, "
+            "to include its collection dates (optional, default false)."
+        ),
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "postcode": "Postcode",
+        "address": "Address",
+        "garden_waste": "Garden waste (brown bin) permit",
+    },
+}
+
+BASE_URL = "https://www.clacks.gov.uk"
+SEARCH_URL = f"{BASE_URL}/environment/wastecollection/"
+
+_YEAR_SUFFIX_RE = re.compile(r"\s*\d{4}\s*$")
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.lower().replace(",", " ").split())
+
+
+class Source:
+    def __init__(self, postcode: str, address: str, garden_waste: bool = False) -> None:
+        self._postcode = postcode.strip()
+        self._address = address.strip()
+        self._garden_waste = bool(garden_waste)
+
+    def _find_property_url(self, session: requests.Session) -> str:
+        r = session.get(SEARCH_URL, params={"pc": self._postcode})
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        results_div = soup.find("div", {"class": "highlight"})
+        links: list[Tag] = []
+        if isinstance(results_div, Tag):
+            links = [
+                a
+                for a in results_div.find_all("a")
+                if isinstance(a, Tag)
+                and str(a.get("href", "")).startswith(
+                    "/environment/wastecollection/id/"
+                )
+            ]
+
+        if not links:
+            raise SourceArgumentNotFound(
+                "postcode",
+                self._postcode,
+                "No properties were found for this postcode on the "
+                "Clackmannanshire Council website, please check the "
+                "spelling and try again.",
+            )
+
+        target_norm = _normalize(self._address)
+
+        for a in links:
+            if _normalize(a.get_text()) == target_norm:
+                return urljoin(BASE_URL, str(a["href"]))
+
+        for a in links:
+            if target_norm in _normalize(a.get_text()):
+                return urljoin(BASE_URL, str(a["href"]))
+
+        available = [a.get_text(strip=True) for a in links]
+        raise SourceArgumentNotFoundWithSuggestions("address", self._address, available)
+
+    def _find_ics_links(
+        self, session: requests.Session, property_url: str
+    ) -> list[str]:
+        r = session.get(property_url)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        highlight = soup.find("div", {"class": "highlight"})
+        if not isinstance(highlight, Tag):
+            raise SourceArgumentNotFound(
+                "address",
+                self._address,
+                "Could not find the property details page content.",
+            )
+
+        ics_links = [
+            urljoin(BASE_URL, str(a["href"]))
+            for a in highlight.find_all("a")
+            if isinstance(a, Tag) and str(a.get("href", "")).lower().endswith(".ics")
+        ]
+        if not ics_links:
+            raise SourceArgumentNotFound(
+                "address",
+                self._address,
+                "No calendar (.ics) links were found for this property.",
+            )
+        return ics_links
+
+    def _get_icon(self, title: str) -> Icons | None:
+        return ICON_MAP.get(title.lower())
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update({"User-Agent": "Mozilla/5.0"})
+
+        property_url = self._find_property_url(session)
+        ics_links = self._find_ics_links(session, property_url)
+
+        entries: list[Collection] = []
+
+        r = session.get(ics_links[0])
+        r.raise_for_status()
+        for date, title in ICS().convert(r.text):
+            entries.append(Collection(date=date, t=title, icon=self._get_icon(title)))
+
+        if self._garden_waste and len(ics_links) > 1:
+            r = session.get(ics_links[1])
+            r.raise_for_status()
+            for date, title in ICS().convert(r.text):
+                clean_title = _YEAR_SUFFIX_RE.sub("", title).strip()
+                entries.append(
+                    Collection(
+                        date=date,
+                        t=clean_title,
+                        icon=self._get_icon(clean_title),
+                    )
+                )
+
+        return entries

--- a/doc/source/clackmannanshire_gov_uk.md
+++ b/doc/source/clackmannanshire_gov_uk.md
@@ -1,0 +1,56 @@
+# Clackmannanshire Council
+
+Support for schedules provided by [Clackmannanshire Council](https://www.clacks.gov.uk/), serving Clackmannanshire, Scotland, UK.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: clackmannanshire_gov_uk
+      args:
+        postcode: POSTCODE
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**postcode**
+*(String) (required)*
+
+Your postcode, e.g. `FK10 3EY`.
+
+**address**
+*(String) (required)*
+
+Your address, exactly as shown in the search results on the council website, e.g. `16 Crophill, Sauchie`. Commas are optional and will be ignored.
+
+**garden_waste**
+*(Boolean) (optional, default: `false`)*
+
+Set to `true` if you hold a paid garden waste (brown bin) permit, to also include its collection dates.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: clackmannanshire_gov_uk
+      args:
+        postcode: "FK10 3EY"
+        address: "16 Crophill, Sauchie"
+```
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: clackmannanshire_gov_uk
+      args:
+        postcode: "FK10 3EY"
+        address: "16 Crophill, Sauchie"
+        garden_waste: true
+```
+
+## How to get the source arguments
+
+Go to [https://www.clacks.gov.uk/environment/wastecollection/](https://www.clacks.gov.uk/environment/wastecollection/) and enter your postcode. A list of matching properties is shown; use the **exact address text** shown in that list (commas and extra spaces are fine, they'll be normalised).


### PR DESCRIPTION
## Summary
- Adds a new source for Clackmannanshire Council, Scotland, UK (https://www.clacks.gov.uk).
- Looks up the property by postcode via the council's public search page, resolves the matching address to its property-details page, then downloads and parses the property's `.ics` calendar link (weekly Food caddy, 4-weekly Blue/Green/Grey bin).
- Optional `garden_waste` parameter (default `false`) additionally includes the Brown Bin (garden waste permit) collection dates from the second `.ics` link shown on the same page.
- Includes `doc/source/clackmannanshire_gov_uk.md`.

Closes #4997.

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s clackmannanshire_gov_uk -l` — all 3 test cases pass
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed