### PR TITLE
Add Wirtschaftsbetriebe Duisburg (WBD) to abfall.io GraphQL source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -20,4 +20,9 @@ SERVICE_MAP = [
         "url": "https://www.ebe-essen.de/",
         "service_id": "51be67f3758f1fb57b420efe065c0663",
     },
+    {
+        "title": "Wirtschaftsbetriebe Duisburg (WBD)",
+        "url": "https://www.wb-duisburg.de/",
+        "service_id": "80acad6c77fe9342ebafad29a8c58bf6",
+    },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -65,6 +65,10 @@ TEST_CASES = {
         "key": "51be67f3758f1fb57b420efe065c0663",
         "idHouseNumber": 74629,
     },
+    "Wirtschaftsbetriebe Duisburg (WBD), Buchholz, Altenbrucher Damm 8": {
+        "key": "80acad6c77fe9342ebafad29a8c58bf6",
+        "idHouseNumber": 72827,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Closes #4464 — WBD Duisburg's online waste calendar (https://www.wb-duisburg.de/allgemein/online-abfallkalender) turns out to run on abfall.io's v3 widget platform (`<abfallplus-publisher key="80acad6c77fe9342ebafad29a8c58bf6">`), which is already supported by the existing `abfall_io_graphql` source.
- Adds WBD Duisburg to `AbfallIOGraphQL.SERVICE_MAP` and adds a `TEST_CASES` entry using the address from the issue (Buchholz, Altenbrucher Damm 8).

## Test plan
- [x] `ruff check --fix` / `ruff format` on both changed files
- [x] `python test_sources.py -s abfall_io_graphql -l` — all test cases pass, 62 entries returned for the new WBD Duisburg case
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)