### PR TITLE
docs(ics): add Kelkheim (Taunus) to ICS source documentation

### DIFF
--- a/doc/ics/yaml/kelkheim_de.yaml
+++ b/doc/ics/yaml/kelkheim_de.yaml
@@ -1,0 +1,19 @@
+---
+title: Kelkheim (Taunus)
+url: https://www.kelkheim.de/mod_abfallkalender/
+howto:
+  en: |
+    - Go to <https://www.kelkheim.de/mod_abfallkalender/> (Persönlicher Abfallkalender).
+    - Enter your street (`Straße`) and house number (`Hausnummer`). House numbers with a letter suffix (e.g. `9f`) are supported.
+    - Leave all `Entsorgungsarten` checkboxes checked (or uncheck the ones you don't need) and click `Erstellen`.
+    - On the results page, click `Link in Zwischenablage kopieren` next to `oder im iCal-Format abonnieren` to copy the iCal link, or right-click the `abonnieren` link and select `copy link`.
+    - Use this link (starting with `https://`, not `webcal://`) as the `url` parameter.
+  de: |
+    - Gehen Sie auf <https://www.kelkheim.de/mod_abfallkalender/> (Persönlicher Abfallkalender).
+    - Geben Sie Ihre Straße und Hausnummer ein. Hausnummern mit Buchstabenzusatz (z. B. `9f`) werden unterstützt.
+    - Lassen Sie alle Häkchen bei den Entsorgungsarten gesetzt (oder entfernen Sie nicht benötigte) und klicken Sie auf `Erstellen`.
+    - Klicken Sie auf der Ergebnisseite bei `oder im iCal-Format abonnieren` auf `Link in Zwischenablage kopieren`, oder rechtsklicken Sie auf den `abonnieren`-Link und wählen Sie `Link kopieren`.
+    - Verwenden Sie diesen Link (beginnend mit `https://`, nicht `webcal://`) als `url`-Parameter.
+test_cases:
+  Rossertstraße 9f:
+    url: https://kelkheim.de/mod_abfallkalender/index.php?action=ical&area=B-7%2C+S-7+Do&datetype=Restmuell%2CBlaue+Tonne%2CBio-Tonne%2CGelber+Sack%2CSondermuell%2CSperrmuell%2CGruenabfuhr%2CRestmuell-Container%2CGruenschnittannahmestelle%2CWertstoffhof%2CSonstige&street=Rossertstra%DFe&number=9f


### PR DESCRIPTION
## Summary
- Kelkheim (Taunus), DE runs its waste calendar on `mod_abfallkalender` (ConPresso CMS), which exposes a public, unauthenticated ICS feed via GET parameters — already fully supported by the generic [ICS](/doc/source/ics.md) source, as noted by @dt215git in #4245.
- Adds `doc/ics/yaml/kelkheim_de.yaml` documenting how to construct the feed URL (visit the personal Abfallkalender page, enter street + house number, copy the `iCal-Format abonnieren` link) and a working test-case URL for Rossertstraße 9f.
- No new source module is required.

## Test plan
- [x] Verified the test-case URL returns HTTP 200 with a valid ICS feed (140 VEVENTs across 13 waste-type categories) as of 2026-07-19.
- [x] Verified the yaml parses and generates correct markdown via `update_docu_links.py`'s doc-generation logic (not run destructively; generated files untouched).
- [x] `python -m pytest tests/test_source_components.py -q` passes (34 passed).

Closes #4245

🤖 Generated with [Claude Code](https://claude.com/claude-code)