### PR TITLE
Add Uddevalla Energi source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/uddevallaenergi_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/uddevallaenergi_se.py
@@ -1,0 +1,114 @@
+from datetime import date
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "Uddevalla Energi"
+DESCRIPTION = "Source for Uddevalla Energi waste collection schedules."
+URL = "https://www.uddevallaenergi.se/privat/sophamtning.html"
+COUNTRY = "se"
+
+TEST_CASES = {
+    "Fjällvägen 11, Ljungskile": {
+        "address": "Fjällvägen 11, Ljungskile",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Search for your address on the Uddevalla Energi waste collection "
+        "webpage and enter it exactly as shown, including the town."
+    ),
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Address",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Property address, including the town.",
+    },
+}
+
+ADDRESS_URL = "https://app.uddevallaenergi.se/wp-json/app/v2/address-flat"
+PICKUP_URL = "https://app.uddevallaenergi.se/wp-json/app/v1/next-pickup-web"
+
+HEADERS = {
+    "Accept": "application/json",
+    "X-App-Identifier": "www.uddevallaenergi.se",
+}
+
+
+def _icon_for_type(collection_type: str) -> Icons | None:
+    normalized_type = collection_type.casefold()
+
+    if "matavfall" in normalized_type:
+        return Icons.BIO_KITCHEN
+    if "restavfall" in normalized_type:
+        return Icons.GENERAL_WASTE
+    if "trädgårdsavfall" in normalized_type:
+        return Icons.GARDEN
+    if "kärl 1" in normalized_type or "kärl 2" in normalized_type:
+        return Icons.RECYCLING
+
+    return None
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address
+
+    def _get_plant_number(self) -> str:
+        response = requests.get(
+            ADDRESS_URL,
+            params={"address": self._address.split(",")[0]},
+            headers=HEADERS,
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        hits = [
+            hit
+            for hit in response.json()
+            if not hit.get("is_key") and hit.get("address") and hit.get("plant_number")
+        ]
+
+        normalized_address = self._address.strip().casefold()
+        for hit in hits:
+            if hit["address"].strip().casefold() == normalized_address:
+                return hit["plant_number"]
+
+        raise SourceArgumentNotFoundWithSuggestions(
+            "address",
+            self._address,
+            [hit["address"] for hit in hits],
+        )
+
+    def fetch(self) -> list[Collection]:
+        response = requests.get(
+            PICKUP_URL,
+            params={"plant_number": self._get_plant_number()},
+            headers=HEADERS,
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        entries = [
+            Collection(
+                date=date.fromisoformat(item["pickup_date"]),
+                t=item["type"],
+                icon=_icon_for_type(item["type"]),
+            )
+            for item in response.json()
+        ]
+
+        if not entries:
+            raise ValueError("No upcoming collections found for the selected address.")
+
+        return entries

--- a/doc/source/uddevallaenergi_se.md
+++ b/doc/source/uddevallaenergi_se.md
@@ -1,0 +1,40 @@
+# Uddevalla Energi
+
+Support for waste collection schedules provided by
+[Uddevalla Energi](https://www.uddevallaenergi.se/privat/sophamtning.html),
+serving Uddevalla municipality, Sweden.
+
+## Configuration
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: uddevallaenergi_se
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**  
+*(String) (required)*
+
+The property address, including the town, exactly as shown by the address
+search on the Uddevalla Energi website.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: uddevallaenergi_se
+      args:
+        address: Fjällvägen 11, Ljungskile
+```
+
+## How to get the source argument
+
+Visit the
+[Uddevalla Energi waste collection page](https://www.uddevallaenergi.se/privat/sophamtning.html#Hamtningsdagar),
+search for your property, and copy the complete suggested address, including
+the town.


### PR DESCRIPTION
## Summary

- add an address-based source for Uddevalla Energi
- use the public JSON API for address suggestions and upcoming pickups
- map known waste streams and four-compartment bins to canonical icons
- add source configuration documentation

## Testing

- `python test_sources.py -s uddevallaenergi_se -l`
- `python -m pytest tests/test_source_components.py -q`
- `python -m pytest tests/`

Closes #4514