### PR TITLE
fix(6959): map bmv_at and muellmax_de labels; empty the WASTE_TYPES gate allowlist

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bmv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bmv_at.py
@@ -9,6 +9,7 @@ POST) but a different step shape: each field is set one at a time behind a
 must drop the address fields (``remove=``) rather than resend them.
 """
 
+import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
@@ -16,8 +17,27 @@ from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GENERAL_WASTE,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 _SERVLET = "https://webudb.udb.at/WasteManagementUDB/WasteManagementServlet"
+
+# The udb feed labels each bin with a "-behälter" container word and a volume,
+# e.g. "Restabfallbehaelter  120 l"; strip both so the base German term resolves
+# against the shared vocabulary (Restabfall, Bioabfall, Papier, ...).
+_VOLUME_RE = re.compile(r"\s*\d+\s*l\s*$", re.IGNORECASE)
+
+
+def _clean(label: str) -> str:
+    text = _VOLUME_RE.sub("", label).strip()
+    for suffix in ("behälter", "behaelter"):
+        if text.lower().endswith(suffix):
+            return text[: -len(suffix)].strip()
+    return text
 
 
 @final
@@ -26,6 +46,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for BMV, Austria"
     URL = "https://www.bmv.at"
     COUNTRY = "at"
+    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Allersdorf": {"ort": "ALLERSDORF", "strasse": "HAUSNUMMER", "hausnummer": 9},
@@ -92,7 +113,7 @@ class Source(BaseSource):
         ],
     )
     parse = parsers.IcsParser()
-    transform = ICSTransformer()
+    transform = ICSTransformer(clean=_clean)
 
     def __init__(self, ort: str, strasse: str, hausnummer: int):
         super().__init__(ort=ort, strasse=strasse, hausnummer=hausnummer)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
@@ -11,6 +11,14 @@ from waste_collection_schedule.config_params import (
 from waste_collection_schedule.regions import Region, region
 from waste_collection_schedule.service.MuellmaxDe import MuellmaxRetriever
 from waste_collection_schedule.transformers import ICSTransformer
+from waste_collection_schedule.waste_types import (
+    GARDEN_WASTE,
+    GENERAL_WASTE,
+    HAZARDOUS,
+    ORGANIC,
+    PAPER,
+    RECYCLABLES,
+)
 
 # Demonstrates: a fully declarative source over a stateful platform wizard. The
 # Müllmax multi-step form walk lives in the service module as MuellmaxRetriever,
@@ -97,6 +105,38 @@ _PROVIDERS = [
 ]
 
 
+# Müllmax providers prefix each bin label with a provider code and often a bin
+# colour, e.g. "ASH Restmüll-Tonne" or "USB Abfuhr Grau - Restmüll", which stops
+# the shared vocabulary from matching. Reduce each label to its core German
+# waste term so the map below resolves it; unrecognised labels pass through
+# unchanged (resolved by the vocabulary or preserved verbatim).
+_TYPE_VALUE_MAP = {
+    "restmüll": GENERAL_WASTE,
+    "bioabfall": ORGANIC,
+    "altpapier": PAPER,
+    "wertstoff": RECYCLABLES,
+    "grünabfall": GARDEN_WASTE,
+    "schadstoff": HAZARDOUS,
+}
+
+
+def _clean(label: str) -> str:
+    text = label.lower()
+    if "restmüll" in text or "restabfall" in text:
+        return "restmüll"
+    if "bioabfall" in text or "biotonne" in text:
+        return "bioabfall"
+    if "altpapier" in text or "papier" in text:
+        return "altpapier"
+    if "wertstoff" in text or "gelb" in text or "verpack" in text:
+        return "wertstoff"
+    if "grünab" in text or "grüngut" in text or "grünschnitt" in text:
+        return "grünabfall"
+    if "umweltmobil" in text or "schadstoff" in text or "problemstoff" in text:
+        return "schadstoff"
+    return label
+
+
 @final
 class Source(BaseSource):
     TITLE = "Müllmax"
@@ -126,7 +166,7 @@ class Source(BaseSource):
 
     retrieve = MuellmaxRetriever()
     parse = parsers.IcsParser(min_events=1)
-    transform = ICSTransformer()
+    transform = ICSTransformer(clean=_clean, type_value_map=_TYPE_VALUE_MAP)
 
     def __init__(
         self,

--- a/tests/test_declared_waste_types.py
+++ b/tests/test_declared_waste_types.py
@@ -88,13 +88,9 @@ _RETURNS_UNDECLARED_TYPES: set[str] = set()
 
 # (b) Sources whose WASTE_TYPES == the whole ALL_TYPES catalogue, via the
 # empty-map fallback. "Declaring everything" is no declaration; fixed by giving
-# each a real, specific vocabulary. The two remaining sources emit only unmapped
-# (preserved:) labels, so they cannot declare a canonical vocabulary until their
-# labels are mapped or aliased; tracked separately, hence still allowlisted.
-_DECLARES_ALL_TYPES = {
-    "bmv_at",
-    "muellmax_de",
-}
+# each a real, specific vocabulary. Now cleared: bmv_at and muellmax_de had their
+# provider-specific labels mapped so they resolve to a declared vocabulary.
+_DECLARES_ALL_TYPES: set[str] = set()
 
 ALLOWLIST = _RETURNS_UNDECLARED_TYPES | _DECLARES_ALL_TYPES
 


### PR DESCRIPTION
Fixes #6959. Part of #6935.

`bmv_at` and `muellmax_de` were the last two entries in the `WASTE_TYPES` gate allowlist. Both emitted only unmapped (`preserved:`) labels and fell back to the whole `ALL_TYPES` catalogue, because their provider labels never resolved against the shared vocabulary.

- **bmv_at**: the udb feed labels each bin with a `-behälter` container word and a volume, e.g. `Restabfallbehaelter  120 l`. A `clean` strips both, so `Restabfall` / `Bioabfall` / `Papier` / `Leichtverpackungen` resolve; the source declares those four types.
- **muellmax_de**: a shared platform where each provider prefixes the label with a code and often a bin colour, e.g. `ASH Restmüll-Tonne`, `USB Abfuhr Grau - Restmüll`, `Umweltmobil auf Tour`. A `clean` reduces each label to its core German waste term, and a small `type_value_map` maps those terms (Restmüll, Bioabfall, Altpapier, Wertstoff, Grünabfall, Schadstoff). Unrecognised labels still pass through (resolved by the vocabulary or preserved).

Verified against every recorded cassette for both sources: each now emits only declared canonical types, with no `preserved:` labels remaining. The gate is green (541 passed, 21 skipped) with **the allowlist now empty**.

With the allowlist cleared, the `ALL_TYPES` fallback in `base_source.py` (#6935 Phase 3) can now be removed. That is a separate change and larger than it looks: a number of `ALL_TYPES`-fallback sources have no cassettes, so removing the fallback would leave them with an empty `WASTE_TYPES` and needs each of them declared first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
