### PR TITLE
Handle BOM-prefixed EcoHarmonogram responses in v3

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/EcoHarmonogramPL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/EcoHarmonogramPL.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 import re
 from collections.abc import Mapping
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 API_URL = "https://ecoharmonogram.pl/api/api.php"
+JSON_RESPONSE_ATTEMPTS = 2
 
 SUPPORTED_APPS_LITERAL = Literal[
     None,
@@ -204,9 +206,33 @@ class EcoharmonogramClient:
         params["clientId"] = self._client_id
         params["lng"] = self._language
 
-        response = self._session.post(url, headers=self._headers, data=params)
-        response.encoding = "utf-8-sig"
-        return response.json()
+        for attempt in range(1, JSON_RESPONSE_ATTEMPTS + 1):
+            response = self._session.post(url, headers=self._headers, data=params)
+            response.raise_for_status()
+
+            try:
+                # Ecoharmonogram prefixes JSON with a UTF-8 BOM and declares it
+                # as text/html. curl_cffi's Response.json() parses the raw bytes
+                # and rejects that otherwise valid payload, so decode it
+                # explicitly before handing it to the standard JSON parser.
+                return json.loads(response.content.decode("utf-8-sig"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as err:
+                if attempt < JSON_RESPONSE_ATTEMPTS:
+                    _LOGGER.warning(
+                        "Ecoharmonogram returned invalid JSON for %s; retrying once",
+                        action,
+                    )
+                    continue
+
+                content_type = response.headers.get("content-type", "unknown")
+                raise ValueError(
+                    "Ecoharmonogram returned invalid JSON for "
+                    f"{action} after {JSON_RESPONSE_ATTEMPTS} attempts "
+                    f"(status {response.status_code}, content type {content_type}, "
+                    f"{len(response.content)} bytes)"
+                ) from err
+
+        raise AssertionError("unreachable")
 
     def fetch_schedules(self, sp: SchedulePeriod, street_id: str) -> ScheduleResponse:
         return self._do_request(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test .claude .git
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py
+python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py
 markers =
     live: test fetches from a live provider endpoint; excluded from gating CI (run with `-m live` locally). Replaced by offline fixtures.

--- a/tests/test_ecoharmonogram_client.py
+++ b/tests/test_ecoharmonogram_client.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.waste_collection_schedule.waste_collection_schedule.service.EcoHarmonogramPL import (
+    EcoharmonogramClient,
+)
+
+
+class FakeResponse:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+        self.headers = {"content-type": "text/html; charset=UTF-8"}
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class FakeSession:
+    def __init__(self, *responses: FakeResponse) -> None:
+        self.responses = iter(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, _url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append(kwargs)
+        return next(self.responses)
+
+
+def test_client_decodes_utf8_bom_prefixed_json() -> None:
+    session = FakeSession(FakeResponse(b'\xef\xbb\xbf{"towns": []}'))
+    client = EcoharmonogramClient(session)
+
+    assert client.fetch_town("Test") == {"towns": []}
+    assert len(session.calls) == 1
+
+
+def test_client_retries_bom_only_response_once() -> None:
+    session = FakeSession(
+        FakeResponse(b"\xef\xbb\xbf"),
+        FakeResponse(b'\xef\xbb\xbf{"towns": []}'),
+    )
+    client = EcoharmonogramClient(session)
+
+    assert client.fetch_town("Test") == {"towns": []}
+    assert len(session.calls) == 2
+
+
+def test_client_reports_invalid_response_shape_without_exposing_body() -> None:
+    session = FakeSession(
+        FakeResponse(b"\xef\xbb\xbf"),
+        FakeResponse(b"<html>maintenance</html>"),
+    )
+    client = EcoharmonogramClient(session)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Ecoharmonogram returned invalid JSON for getTowns after 2 attempts "
+            r"\(status 200, content type text/html; charset=UTF-8, 24 bytes\)"
+        ),
+    ):
+        client.fetch_town("Test")
+
+    assert len(session.calls) == 2


### PR DESCRIPTION
## Summary

- decode EcoHarmonogram response text as UTF-8 with BOM support before parsing JSON
- retry the provider request once when a response is not valid JSON
- add focused coverage for normal JSON, BOM-prefixed JSON, and a transient invalid response

The integration-wide transient-fetch recovery previously included here has been removed at maintainer request. That work is preserved separately for a future v3.1 PR; this PR now contains only the provider-specific parser fix suitable for `release/3.0.0`.

## Validation

- 3 focused EcoHarmonogram response tests passed
- 3,070 passed, 4 skipped, and 2,139 deselected in the complete offline suite
- Ruff, Ruff format, codespell, Bandit, and mypy hooks passed

Related to #6981 and the v3 architecture in #6562.
