### PR TITLE
Add opt-in device-backed sensor controls

### DIFF
--- a/custom_components/waste_collection_schedule/__init__.py
+++ b/custom_components/waste_collection_schedule/__init__.py
@@ -2,6 +2,7 @@
 
 from .init_ui import (  # noqa: F401
     async_migrate_entry,
+    async_remove_config_entry_device,
     async_setup_entry,
     async_unload_entry,
     async_update_listener,

--- a/custom_components/waste_collection_schedule/button.py
+++ b/custom_components/waste_collection_schedule/button.py
@@ -1,0 +1,146 @@
+"""Device-page actions for Waste Collection Schedule sensors."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import (
+    CONF_DEVICE_SENSOR_CONTROLS,
+    CONF_SENSORS,
+    DOMAIN,
+    UPDATE_SENSORS_SIGNAL,
+)
+from .sensor_config_helpers import (
+    build_added_collection_type_sensor_options,
+    build_added_combined_sensor_options,
+    build_create_combined_ui_sensor_action_unique_id,
+    build_create_ui_sensor_action_unique_id,
+    has_combined_sensor,
+    missing_collection_types,
+)
+from .wcs_coordinator import WCSCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up creation action buttons for waste pickup sensors."""
+    if not entry.options.get(CONF_DEVICE_SENSOR_CONTROLS, False):
+        return
+
+    coordinator: WCSCoordinator = hass.data[DOMAIN][entry.entry_id]
+    added_action_ids: set[str] = set()
+
+    @callback
+    def add_missing_buttons() -> None:
+        """Add creation actions discovered after any successful fetch."""
+        sensors = entry.options.get(CONF_SENSORS, [])
+        entities: list[ButtonEntity] = []
+
+        combined_action_id = build_create_combined_ui_sensor_action_unique_id(
+            coordinator.shell.unique_id
+        )
+        if (
+            not has_combined_sensor(sensors)
+            and combined_action_id not in added_action_ids
+        ):
+            added_action_ids.add(combined_action_id)
+            entities.append(CreateCombinedWasteSensorButton(entry, coordinator))
+
+        for collection_type_id, display_name in missing_collection_types(
+            coordinator._aggregator.type_options,
+            sensors,
+        ):
+            action_id = build_create_ui_sensor_action_unique_id(
+                coordinator.shell.unique_id,
+                collection_type_id,
+            )
+            if action_id in added_action_ids:
+                continue
+            added_action_ids.add(action_id)
+            entities.append(
+                CreateWasteSensorButton(
+                    entry,
+                    coordinator,
+                    collection_type_id,
+                    display_name,
+                )
+            )
+
+        if entities:
+            async_add_entities(entities)
+
+    add_missing_buttons()
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, UPDATE_SENSORS_SIGNAL, add_missing_buttons)
+    )
+
+
+class CreateCombinedWasteSensorButton(ButtonEntity):
+    """Button that creates one all-types waste pickup sensor."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:trash-can"
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+    ) -> None:
+        self._entry = entry
+        self._attr_name = "Create combined next pickup sensor"
+        self._attr_unique_id = build_create_combined_ui_sensor_action_unique_id(
+            coordinator.shell.unique_id
+        )
+        self._attr_device_info = coordinator.device_info
+
+    async def async_press(self) -> None:
+        """Create the combined waste sensor and let the config entry reload."""
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            options=build_added_combined_sensor_options(self._entry),
+        )
+
+
+class CreateWasteSensorButton(ButtonEntity):
+    """Button that creates a per-type waste pickup sensor."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:plus-circle"
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        collection_type_id: str,
+        display_name: str,
+    ) -> None:
+        self._entry = entry
+        self._collection_type_id = collection_type_id
+        self._display_name = display_name
+        self._attr_name = f"Create {display_name} sensor"
+        self._attr_unique_id = build_create_ui_sensor_action_unique_id(
+            coordinator.shell.unique_id, collection_type_id
+        )
+        self._attr_device_info = coordinator.device_info
+
+    async def async_press(self) -> None:
+        """Create the waste sensor and let the config entry reload."""
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            options=build_added_collection_type_sensor_options(
+                self._entry,
+                self._collection_type_id,
+                self._display_name,
+            ),
+        )

--- a/custom_components/waste_collection_schedule/button.py
+++ b/custom_components/waste_collection_schedule/button.py
@@ -56,6 +56,7 @@ async def async_setup_entry(
         for collection_type_id, display_name in missing_collection_types(
             coordinator._aggregator.type_options,
             sensors,
+            coordinator._aggregator.type_aliases,
         ):
             action_id = build_create_ui_sensor_action_unique_id(
                 coordinator.shell.unique_id,
@@ -126,6 +127,7 @@ class CreateWasteSensorButton(ButtonEntity):
         display_name: str,
     ) -> None:
         self._entry = entry
+        self._coordinator = coordinator
         self._collection_type_id = collection_type_id
         self._display_name = display_name
         self._attr_name = f"Create {display_name} sensor"
@@ -142,5 +144,6 @@ class CreateWasteSensorButton(ButtonEntity):
                 self._entry,
                 self._collection_type_id,
                 self._display_name,
+                type_aliases=self._coordinator._aggregator.type_aliases,
             ),
         )

--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -89,6 +89,10 @@ from .const import (
 )
 from .init_ui import WCSCoordinator
 from .sensor import DetailsFormat
+from .sensor_config_helpers import (
+    preserve_device_control_options,
+    preserve_sensor_control_metadata,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -276,9 +280,11 @@ def _build_schema_from_params(
                 vol_args[key] = SelectSelector(
                     SelectSelectorConfig(
                         options=[
-                            SelectOptionDict(label=opt[0], value=opt[1])
-                            if isinstance(opt, tuple)
-                            else SelectOptionDict(label=opt, value=opt)
+                            (
+                                SelectOptionDict(label=opt[0], value=opt[1])
+                                if isinstance(opt, tuple)
+                                else SelectOptionDict(label=opt, value=opt)
+                            )
                             for opt in options
                         ],
                         mode=SelectSelectorMode.DROPDOWN,
@@ -1500,7 +1506,10 @@ class WasteCollectionOptionsFlow(OptionsFlow):
                     user_input[CONF_RANDOM_FETCH_TIME_OFFSET]["hours"] * 60
                     + user_input[CONF_RANDOM_FETCH_TIME_OFFSET]["minutes"]
                 )
-                self._options = user_input
+                self._options = preserve_device_control_options(
+                    self._entry.options,
+                    user_input,
+                )
 
                 self._customize_select = user_input.get("customize_select", [])
                 self._customize_select_idx = 0
@@ -1612,7 +1621,9 @@ class WasteCollectionOptionsFlow(OptionsFlow):
             )
 
             if len(errors) == 0:
-                self._options[CONF_SENSORS].append(args)
+                self._options[CONF_SENSORS].append(
+                    preserve_sensor_control_metadata(original_sensor, args)
+                )
                 self._sensor_select_idx += 1
                 return await self.async_step_sensor()
 

--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -90,6 +90,10 @@ from .const import (
 )
 from .init_ui import WCSCoordinator
 from .sensor import DetailsFormat
+from .sensor_config_helpers import (
+    preserve_device_control_options,
+    preserve_sensor_control_metadata,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -286,9 +290,11 @@ def _build_schema_from_params(
                 vol_args[key] = SelectSelector(
                     SelectSelectorConfig(
                         options=[
-                            SelectOptionDict(label=opt[0], value=opt[1])
-                            if isinstance(opt, tuple)
-                            else SelectOptionDict(label=opt, value=opt)
+                            (
+                                SelectOptionDict(label=opt[0], value=opt[1])
+                                if isinstance(opt, tuple)
+                                else SelectOptionDict(label=opt, value=opt)
+                            )
                             for opt in options
                         ],
                         mode=SelectSelectorMode.DROPDOWN,
@@ -1512,7 +1518,10 @@ class WasteCollectionOptionsFlow(OptionsFlow):
                     user_input[CONF_RANDOM_FETCH_TIME_OFFSET]["hours"] * 60
                     + user_input[CONF_RANDOM_FETCH_TIME_OFFSET]["minutes"]
                 )
-                self._options = user_input
+                self._options = preserve_device_control_options(
+                    self._entry.options,
+                    user_input,
+                )
 
                 self._customize_select = user_input.get("customize_select", [])
                 self._customize_select_idx = 0
@@ -1624,7 +1633,9 @@ class WasteCollectionOptionsFlow(OptionsFlow):
             )
 
             if len(errors) == 0:
-                self._options[CONF_SENSORS].append(args)
+                self._options[CONF_SENSORS].append(
+                    preserve_sensor_control_metadata(original_sensor, args)
+                )
                 self._sensor_select_idx += 1
                 return await self.async_step_sensor()
 

--- a/custom_components/waste_collection_schedule/const.py
+++ b/custom_components/waste_collection_schedule/const.py
@@ -56,6 +56,10 @@ CONF_DATE_TEMPLATE: Final = "date_template"
 CONF_COLLECTION_TYPES: Final = "types"
 CONF_ADD_DAYS_TO: Final = "add_days_to"
 CONF_EVENT_INDEX: Final = "event_index"
+CONF_DEVICE_SENSOR_CONTROLS: Final = "device_sensor_controls"
+CONF_SENSOR_ID: Final = "sensor_id"
+CONF_SENSOR_LEGACY_UNIQUE_ID: Final = "sensor_legacy_unique_id"
+CONF_PRESET_LANGUAGE: Final = "preset_language"
 
 
 CONF_SENSORS: Final = "sensors"

--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -10,7 +10,14 @@ import requests
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
+from .sensor_config_helpers import (
+    build_removed_sensor_options,
+    configured_sensor_ids,
+    ensure_sensor_ids,
+    parse_ui_sensor_device_id,
+)
 from .service import get_fetch_all_service
 from .waste_collection_schedule.service.DeviceKeyStore import (
     initialize_device_key_store,
@@ -22,7 +29,7 @@ from .waste_collection_schedule import SourceShell, Customize  # type: ignore # 
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["calendar", "sensor"]
+PLATFORMS = ["button", "calendar", "sensor", "select", "switch", "text"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -32,7 +39,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Show canonical waste-type names in the Home Assistant UI language.
     set_display_language(hass.config.language)
 
-    options = entry.options
+    options = dict(entry.options)
+    if options.get(const.CONF_DEVICE_SENSOR_CONTROLS, False):
+        sensors_with_ids, sensor_ids_changed = ensure_sensor_ids(
+            options.get(const.CONF_SENSORS, [])
+        )
+        if sensor_ids_changed:
+            options[const.CONF_SENSORS] = sensors_with_ids
+            hass.config_entries.async_update_entry(entry, options=options)
     _LOGGER.debug(
         "Setting up entry %s, with data %s and options %s",
         entry.entry_id,
@@ -123,7 +137,38 @@ async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> bool
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        coordinator = hass.data.get(const.DOMAIN, {}).pop(entry.entry_id, None)
+        if isinstance(coordinator, WCSCoordinator):
+            coordinator.cancel_scheduled_callbacks()
+    return unloaded
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Remove one configured waste sensor when its device is deleted."""
+    coordinator = hass.data.get(const.DOMAIN, {}).get(entry.entry_id)
+    if not isinstance(coordinator, WCSCoordinator):
+        return False
+
+    sensor_id = parse_ui_sensor_device_id(
+        coordinator.shell.unique_id,
+        device_entry.identifiers,
+    )
+    if sensor_id is None or sensor_id not in configured_sensor_ids(
+        entry.options.get(const.CONF_SENSORS, [])
+    ):
+        return False
+
+    hass.config_entries.async_update_entry(
+        entry,
+        options=build_removed_sensor_options(entry, sensor_id),
+    )
+    return True
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -11,7 +11,14 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers import device_registry as dr
 
+from .sensor_config_helpers import (
+    build_removed_sensor_options,
+    configured_sensor_ids,
+    ensure_sensor_ids,
+    parse_ui_sensor_device_id,
+)
 from .service import get_fetch_all_service
 from .waste_collection_schedule.service.DeviceKeyStore import (
     initialize_device_key_store,
@@ -23,7 +30,7 @@ from .waste_collection_schedule import SourceShell, Customize  # type: ignore # 
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["calendar", "sensor"]
+PLATFORMS = ["button", "calendar", "sensor", "select", "switch", "text"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -33,7 +40,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Show canonical waste-type names in the Home Assistant UI language.
     set_display_language(hass.config.language)
 
-    options = entry.options
+    options = dict(entry.options)
+    if options.get(const.CONF_DEVICE_SENSOR_CONTROLS, False):
+        sensors_with_ids, sensor_ids_changed = ensure_sensor_ids(
+            options.get(const.CONF_SENSORS, [])
+        )
+        if sensor_ids_changed:
+            options[const.CONF_SENSORS] = sensors_with_ids
+            hass.config_entries.async_update_entry(entry, options=options)
     _LOGGER.debug(
         "Setting up entry %s, with data %s and options %s",
         entry.entry_id,
@@ -133,7 +147,38 @@ async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> bool
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        coordinator = hass.data.get(const.DOMAIN, {}).pop(entry.entry_id, None)
+        if isinstance(coordinator, WCSCoordinator):
+            coordinator.cancel_scheduled_callbacks()
+    return unloaded
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Remove one configured waste sensor when its device is deleted."""
+    coordinator = hass.data.get(const.DOMAIN, {}).get(entry.entry_id)
+    if not isinstance(coordinator, WCSCoordinator):
+        return False
+
+    sensor_id = parse_ui_sensor_device_id(
+        coordinator.shell.unique_id,
+        device_entry.identifiers,
+    )
+    if sensor_id is None or sensor_id not in configured_sensor_ids(
+        entry.options.get(const.CONF_SENSORS, [])
+    ):
+        return False
+
+    hass.config_entries.async_update_entry(
+        entry,
+        options=build_removed_sensor_options(entry, sensor_id),
+    )
+    return True
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/waste_collection_schedule/select.py
+++ b/custom_components/waste_collection_schedule/select.py
@@ -1,0 +1,421 @@
+"""Device-page configuration selects for Waste Collection Schedule sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, ClassVar
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import (
+    CONF_COLLECTION_TYPES,
+    CONF_COUNT,
+    CONF_DATE_TEMPLATE,
+    CONF_DETAILS_FORMAT,
+    CONF_DEVICE_SENSOR_CONTROLS,
+    CONF_EVENT_INDEX,
+    CONF_LEADTIME,
+    CONF_PRESET_LANGUAGE,
+    CONF_SENSOR_ID,
+    CONF_SENSORS,
+    DOMAIN,
+)
+from .sensor import DetailsFormat
+from .sensor_config_helpers import (
+    build_ui_sensor_control_unique_id,
+    build_ui_sensor_device_identifier,
+    build_updated_options_by_sensor_id,
+)
+from .sensor_template_presets import (
+    CUSTOM_OPTION,
+    DATE_TEMPLATE_PRESETS,
+    DEFAULT_OPTION,
+    PRESET_LANGUAGE_OPTIONS,
+    convert_value_template_language,
+    get_preset_language_label,
+    get_preset_language_value,
+    get_preset_option,
+    get_value_template_presets,
+)
+from .wcs_coordinator import WCSCoordinator
+
+LAYOUT_LABELS = {
+    DetailsFormat.upcoming.value: "Upcoming list",
+    DetailsFormat.appointment_types.value: "By collection type",
+    DetailsFormat.generic.value: "All attributes",
+    DetailsFormat.hidden.value: "Hide details",
+}
+LAYOUT_VALUES = {label: value for value, label in LAYOUT_LABELS.items()}
+
+COUNT_LABELS = {
+    "Default": None,
+    "1 pickup": 1,
+    "2 pickups": 2,
+    "3 pickups": 3,
+    "5 pickups": 5,
+    "10 pickups": 10,
+    "20 pickups": 20,
+}
+
+LEADTIME_LABELS = {
+    "Default": None,
+    "1 day": 1,
+    "3 days": 3,
+    "7 days": 7,
+    "14 days": 14,
+    "30 days": 30,
+    "60 days": 60,
+}
+
+EVENT_INDEX_LABELS = {
+    "First matching pickup": 0,
+    "Second matching pickup": 1,
+    "Third matching pickup": 2,
+    "Fourth matching pickup": 3,
+    "Fifth matching pickup": 4,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up quick configuration selects for each configured waste sensor."""
+    if not entry.options.get(CONF_DEVICE_SENSOR_CONTROLS, False):
+        return
+
+    coordinator: WCSCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[SelectEntity] = []
+
+    for sensor_config in entry.options.get(CONF_SENSORS, []):
+        sensor_id = sensor_config.get(CONF_SENSOR_ID)
+        sensor_name = sensor_config.get(CONF_NAME, coordinator.shell.calendar_title)
+        if not sensor_id:
+            continue
+
+        entities.extend(
+            [
+                WasteSensorLayoutSelect(entry, coordinator, sensor_id, sensor_name),
+                WasteSensorLanguageSelect(entry, coordinator, sensor_id, sensor_name),
+                WasteSensorTemplatePresetSelect(
+                    entry,
+                    coordinator,
+                    sensor_id,
+                    sensor_name,
+                    key=CONF_VALUE_TEMPLATE,
+                    key_suffix="state_preset",
+                    label="State text",
+                    icon="mdi:format-text",
+                ),
+                WasteSensorTemplatePresetSelect(
+                    entry,
+                    coordinator,
+                    sensor_id,
+                    sensor_name,
+                    key=CONF_DATE_TEMPLATE,
+                    key_suffix="date_preset",
+                    label="Date format",
+                    icon="mdi:calendar-text",
+                ),
+                WasteSensorNumberPresetSelect(
+                    entry,
+                    coordinator,
+                    sensor_id,
+                    sensor_name,
+                    key=CONF_COUNT,
+                    key_suffix="count",
+                    label="Advanced: upcoming count",
+                    options=COUNT_LABELS,
+                    default_option="Default",
+                    icon="mdi:counter",
+                ),
+                WasteSensorNumberPresetSelect(
+                    entry,
+                    coordinator,
+                    sensor_id,
+                    sensor_name,
+                    key=CONF_LEADTIME,
+                    key_suffix="leadtime",
+                    label="Advanced: lead time",
+                    options=LEADTIME_LABELS,
+                    default_option="Default",
+                    icon="mdi:calendar-range",
+                ),
+                WasteSensorNumberPresetSelect(
+                    entry,
+                    coordinator,
+                    sensor_id,
+                    sensor_name,
+                    key=CONF_EVENT_INDEX,
+                    key_suffix="event_index",
+                    label="Advanced: pickup to show",
+                    options=EVENT_INDEX_LABELS,
+                    default_option="First matching pickup",
+                    icon="mdi:format-list-numbered",
+                ),
+            ]
+        )
+
+    async_add_entities(entities)
+
+
+class WasteSensorConfigEntity:
+    """Common behavior for per-sensor configuration entities."""
+
+    hass: HomeAssistant
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        sensor_id: str,
+        sensor_name: str,
+        key_suffix: str,
+        display_name: str,
+        icon: str | None = None,
+        enabled_default: bool = True,
+    ) -> None:
+        self._entry = entry
+        self._coordinator = coordinator
+        self._sensor_id = sensor_id
+        self._attr_name = display_name
+        self._attr_unique_id = build_ui_sensor_control_unique_id(
+            coordinator.shell.unique_id, sensor_id, key_suffix
+        )
+        device_identifier = build_ui_sensor_device_identifier(
+            coordinator.shell.unique_id, sensor_id
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_identifier)},
+            manufacturer=coordinator.shell.title,
+            model="Waste Pickup Sensor",
+            name=sensor_name,
+            via_device=(DOMAIN, coordinator.shell.unique_id),
+        )
+        if icon:
+            self._attr_icon = icon
+        if not enabled_default:
+            self._attr_entity_registry_enabled_default = False
+
+    @property
+    def sensor_config(self) -> Mapping[str, Any]:
+        """Return the latest stored configuration for this sensor."""
+        return next(
+            (
+                sensor
+                for sensor in self._entry.options.get(CONF_SENSORS, [])
+                if sensor.get(CONF_SENSOR_ID) == self._sensor_id
+            ),
+            {},
+        )
+
+    async def _async_save(
+        self,
+        updates: dict[str, Any] | None = None,
+        removals: tuple[str, ...] = (),
+    ) -> None:
+        """Persist the updated sensor configuration."""
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            options=build_updated_options_by_sensor_id(
+                self._entry,
+                sensor_id=self._sensor_id,
+                updates=updates,
+                removals=removals,
+            ),
+        )
+
+
+class WasteSensorLayoutSelect(WasteSensorConfigEntity, SelectEntity):
+    """Select for choosing the more-info layout of a waste sensor."""
+
+    _attr_options: ClassVar[list[str]] = list(LAYOUT_VALUES.keys())
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        sensor_id: str,
+        sensor_name: str,
+    ) -> None:
+        super().__init__(
+            entry,
+            coordinator,
+            sensor_id,
+            sensor_name,
+            key_suffix="details_format",
+            display_name="Display mode",
+            icon="mdi:view-list",
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current display mode label."""
+        current = self.sensor_config.get(
+            CONF_DETAILS_FORMAT, DetailsFormat.upcoming.value
+        )
+        if isinstance(current, DetailsFormat):
+            current = current.value
+        return LAYOUT_LABELS.get(str(current), "Upcoming list")
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist the selected display mode."""
+        await self._async_save(updates={CONF_DETAILS_FORMAT: LAYOUT_VALUES[option]})
+
+
+class WasteSensorLanguageSelect(WasteSensorConfigEntity, SelectEntity):
+    """Select for choosing the language used by display presets."""
+
+    _attr_options: ClassVar[list[str]] = list(PRESET_LANGUAGE_OPTIONS.keys())
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        sensor_id: str,
+        sensor_name: str,
+    ) -> None:
+        super().__init__(
+            entry,
+            coordinator,
+            sensor_id,
+            sensor_name,
+            key_suffix="preset_language",
+            display_name="Display language",
+            icon="mdi:translate",
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected display preset language label."""
+        return get_preset_language_label(self.sensor_config.get(CONF_PRESET_LANGUAGE))
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist the display language and translate known state presets."""
+        language = get_preset_language_value(option)
+        updates = {CONF_PRESET_LANGUAGE: language}
+        converted_template = convert_value_template_language(
+            self.sensor_config.get(CONF_VALUE_TEMPLATE), language
+        )
+        if converted_template is not None:
+            updates[CONF_VALUE_TEMPLATE] = converted_template
+
+        await self._async_save(updates=updates)
+
+
+class WasteSensorTemplatePresetSelect(WasteSensorConfigEntity, SelectEntity):
+    """Select for applying a preset template to a waste sensor field."""
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        sensor_id: str,
+        sensor_name: str,
+        key: str,
+        key_suffix: str,
+        label: str,
+        icon: str,
+        enabled_default: bool = True,
+    ) -> None:
+        super().__init__(
+            entry,
+            coordinator,
+            sensor_id,
+            sensor_name,
+            key_suffix=key_suffix,
+            display_name=label,
+            icon=icon,
+            enabled_default=enabled_default,
+        )
+        self._key = key
+
+    @property
+    def presets(self) -> dict[str, str]:
+        """Return the presets for the current sensor language and field."""
+        if self._key == CONF_VALUE_TEMPLATE:
+            collection_types = self.sensor_config.get(CONF_COLLECTION_TYPES)
+            return get_value_template_presets(
+                self.sensor_config.get(CONF_PRESET_LANGUAGE),
+                grouped=not collection_types or len(collection_types) > 1,
+            )
+        return DATE_TEMPLATE_PRESETS
+
+    @property
+    def options(self) -> list[str]:
+        """Return the available preset labels."""
+        return [DEFAULT_OPTION, *self.presets.keys(), CUSTOM_OPTION]
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current matching preset, default, or custom."""
+        return get_preset_option(self.sensor_config.get(self._key), self.presets)
+
+    async def async_select_option(self, option: str) -> None:
+        """Apply a preset to the underlying sensor option."""
+        if option == CUSTOM_OPTION:
+            return
+        if option == DEFAULT_OPTION:
+            await self._async_save(removals=(self._key,))
+            return
+        await self._async_save(updates={self._key: self.presets[option]})
+
+
+class WasteSensorNumberPresetSelect(WasteSensorConfigEntity, SelectEntity):
+    """Advanced select for numeric sensor options that can be reset to default."""
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        sensor_id: str,
+        sensor_name: str,
+        key: str,
+        key_suffix: str,
+        label: str,
+        options: Mapping[str, int | None],
+        default_option: str,
+        icon: str,
+    ) -> None:
+        super().__init__(
+            entry,
+            coordinator,
+            sensor_id,
+            sensor_name,
+            key_suffix=key_suffix,
+            display_name=label,
+            icon=icon,
+            enabled_default=False,
+        )
+        self._key = key
+        self._options = dict(options)
+        self._default_option = default_option
+        current_value = self.sensor_config.get(key)
+        if current_value is not None and current_value not in self._options.values():
+            self._options[f"Current: {current_value}"] = current_value
+        self._attr_options = list(self._options.keys())
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the label matching the stored numeric option."""
+        current = self.sensor_config.get(self._key)
+        for label, value in self._options.items():
+            if current == value:
+                return label
+        return self._default_option
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist the selected numeric option."""
+        value = self._options[option]
+        if value is None:
+            await self._async_save(removals=(self._key,))
+            return
+        await self._async_save(updates={self._key: value})

--- a/custom_components/waste_collection_schedule/sensor.py
+++ b/custom_components/waste_collection_schedule/sensor.py
@@ -1,5 +1,6 @@
 """Sensor platform support for Waste Collection Schedule."""
 
+import datetime
 import logging
 from enum import Enum
 from typing import Any
@@ -11,6 +12,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.template import Template
 
@@ -27,16 +29,24 @@ from .const import (
     CONF_DETAILS_FORMAT,
     CONF_EVENT_INDEX,
     CONF_LEADTIME,
+    CONF_PRESET_LANGUAGE,
+    CONF_SENSOR_ID,
+    CONF_SENSOR_LEGACY_UNIQUE_ID,
     CONF_SENSORS,
     CONF_SOURCE_INDEX,
     DOMAIN,
     UPDATE_SENSORS_SIGNAL,
 )
+from .sensor_config_helpers import (
+    build_ui_sensor_device_identifier,
+    build_ui_sensor_unique_id,
+)
+from .sensor_template_presets import format_default_state_text
 from .waste_collection_api import WasteCollectionApi
 
 # CollectionBase is the real Collection class; the exported `Collection` is a
 # factory instance (not valid as a type annotation).
-from .waste_collection_schedule import CollectionBase, CollectionGroup, Icons
+from .waste_collection_schedule import CollectionBase, CollectionGroup
 from .wcs_coordinator import WCSCoordinator
 
 # fmt: on
@@ -72,6 +82,115 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
+def render_sensor_preview(
+    aggregator: CollectionAggregator,
+    separator: str,
+    day_switch_time: datetime.time,
+    details_format: DetailsFormat | None,
+    count: int | None,
+    leadtime: int | None,
+    collection_types: list[str] | None,
+    value_template: Template | None,
+    date_template: Template | None,
+    add_days_to: bool,
+    event_index: int | None,
+    preset_language: str | None = None,
+) -> tuple[Any, dict[str, Any], str, str | None]:
+    """Render the current sensor state and attributes for UI preview and entities."""
+    details_format = details_format or DetailsFormat.upcoming
+    include_today = dt_util.now().time() < day_switch_time
+
+    upcoming1 = aggregator.get_upcoming_group_by_day(
+        count=1,
+        include_types=collection_types,
+        include_today=include_today,
+        start_index=event_index,
+    )
+
+    collection = upcoming1[0] if upcoming1 else None
+    value: Any = None
+    icon = "mdi:trash-can"
+    picture = None
+    if collection is not None:
+        if value_template is not None:
+            value = value_template.async_render_with_possible_json_value(
+                collection, None
+            )
+        else:
+            if preset_language is None:
+                value = (
+                    f"{separator.join(collection.types)} in {collection.daysTo} days"
+                )
+            else:
+                value = format_default_state_text(
+                    collection.types,
+                    collection.daysTo,
+                    separator,
+                    preset_language,
+                )
+        icon = collection.icon or icon
+        picture = collection.picture
+
+    def render_date(entry: CollectionBase | CollectionGroup):
+        if date_template is not None:
+            return date_template.async_render_with_possible_json_value(entry, None)
+        return entry.date.isoformat()
+
+    attributes: dict[str, Any] = {}
+    if collection_types is None:
+        available_collection_types = [
+            (display_name, display_name)
+            for display_name in sorted(aggregator.types, key=str.casefold)
+        ]
+    else:
+        available_collection_types = [
+            (type_filter, aggregator.type_options.get(type_filter, type_filter))
+            for type_filter in collection_types
+        ]
+
+    grouped_upcoming = aggregator.get_upcoming_group_by_day(
+        count=count,
+        leadtime=leadtime,
+        include_types=collection_types,
+        include_today=include_today,
+        start_index=event_index,
+    )
+
+    if details_format == DetailsFormat.upcoming:
+        for upcoming_collection in grouped_upcoming:
+            attributes[render_date(upcoming_collection)] = separator.join(
+                upcoming_collection.types
+            )
+    elif details_format == DetailsFormat.appointment_types:
+        for waste_type, display_name in available_collection_types:
+            collections = aggregator.get_upcoming(
+                count=1,
+                include_types=[waste_type],
+                include_today=include_today,
+                start_index=event_index,
+            )
+            attributes[display_name] = (
+                "" if len(collections) == 0 else render_date(collections[0])
+            )
+    elif details_format == DetailsFormat.generic:
+        attributes["types"] = [label for _, label in available_collection_types]
+        attributes["upcoming"] = aggregator.get_upcoming(
+            count=count,
+            leadtime=leadtime,
+            include_types=collection_types,
+            include_today=include_today,
+        )
+        refreshtime = ""
+        if aggregator.refreshtime is not None:
+            refreshtime = aggregator.refreshtime.isoformat(timespec="seconds")
+        attributes["last_update"] = refreshtime
+
+    if add_days_to and collection is not None:
+        attributes["daysTo"] = collection.daysTo
+
+    return value, attributes, icon, picture
+
+
 # Config flow setup
 async def async_setup_entry(hass, config: ConfigEntry, async_add_entities):
     coordinator = hass.data[DOMAIN][config.entry_id]
@@ -93,6 +212,8 @@ async def async_setup_entry(hass, config: ConfigEntry, async_add_entities):
         except vol.Invalid:  # should only happen if value_template = None, as it is already validated in the config flow if it is not None
             date_template = None
         details_format = sensor.get(CONF_DETAILS_FORMAT)
+        if details_format is None:
+            details_format = DetailsFormat.upcoming
         if isinstance(details_format, str):
             details_format = DetailsFormat(details_format)
 
@@ -102,6 +223,10 @@ async def async_setup_entry(hass, config: ConfigEntry, async_add_entities):
                 api=None,
                 coordinator=coordinator,
                 name=sensor.get(CONF_NAME, coordinator.shell.calendar_title),
+                sensor_id=sensor.get(CONF_SENSOR_ID),
+                preserve_legacy_unique_id=sensor.get(
+                    CONF_SENSOR_LEGACY_UNIQUE_ID, False
+                ),
                 aggregator=aggregator,
                 details_format=details_format,
                 count=sensor.get(CONF_COUNT),
@@ -111,6 +236,7 @@ async def async_setup_entry(hass, config: ConfigEntry, async_add_entities):
                 date_template=date_template,
                 add_days_to=sensor.get(CONF_ADD_DAYS_TO, False),
                 event_index=sensor.get(CONF_EVENT_INDEX),
+                preset_language=sensor.get(CONF_PRESET_LANGUAGE),
             )
         )
 
@@ -186,6 +312,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             api=api,
             coordinator=None,
             name=sensor_config[CONF_NAME],
+            sensor_id=sensor_config.get(CONF_SENSOR_ID),
+            preserve_legacy_unique_id=False,
             aggregator=aggregator,
             details_format=details_format,
             count=sensor_config.get(CONF_COUNT),
@@ -195,6 +323,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             date_template=date_template,
             add_days_to=sensor_config.get(CONF_ADD_DAYS_TO, False),
             event_index=sensor_config.get(CONF_EVENT_INDEX, 0),
+            preset_language=sensor_config.get(CONF_PRESET_LANGUAGE),
         )
     )
 
@@ -210,6 +339,8 @@ class ScheduleSensor(SensorEntity):
         api: WasteCollectionApi | None,
         coordinator: WCSCoordinator | None,
         name: str,
+        sensor_id: str | None,
+        preserve_legacy_unique_id: bool,
         aggregator: CollectionAggregator,
         details_format: DetailsFormat,
         count: int | None,
@@ -219,6 +350,7 @@ class ScheduleSensor(SensorEntity):
         date_template: Template | None,
         add_days_to: bool,
         event_index: int | None,
+        preset_language: str | None = None,
     ):
         """Initialize the entity."""
         self._api = api
@@ -232,6 +364,8 @@ class ScheduleSensor(SensorEntity):
         self._date_template = date_template
         self._add_days_to = add_days_to
         self._event_index = event_index
+        self._preset_language = preset_language
+        self._sensor_id = sensor_id
 
         self._value: Any = None
 
@@ -239,17 +373,38 @@ class ScheduleSensor(SensorEntity):
         self._attr_name = name
         if self._coordinator:
             shell = self._coordinator.shell
-            self._attr_unique_id = f"{shell.unique_id}_ui_sensor_{name}"
-            self._attr_device_info = self._coordinator.device_info
+            self._attr_unique_id = build_ui_sensor_unique_id(
+                shell.unique_id,
+                name,
+                sensor_id,
+                preserve_legacy_unique_id,
+            )
+            if sensor_id:
+                device_identifier = build_ui_sensor_device_identifier(
+                    shell.unique_id, sensor_id
+                )
+                self._attr_device_info = DeviceInfo(
+                    identifiers={(DOMAIN, device_identifier)},
+                    manufacturer=shell.title,
+                    model="Waste Pickup Sensor",
+                    name=name,
+                    via_device=(DOMAIN, shell.unique_id),
+                )
+            else:
+                self._attr_device_info = self._coordinator.device_info
         else:
             self._attr_unique_id = name
         self._attr_should_poll = False
 
-        async_dispatcher_connect(hass, UPDATE_SENSORS_SIGNAL, self._update_sensor)
-
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, UPDATE_SENSORS_SIGNAL, self._update_sensor
+            )
+        )
 
         if self._coordinator:
             self.async_on_remove(
@@ -284,36 +439,6 @@ class ScheduleSensor(SensorEntity):
             refreshtime = self._aggregator.refreshtime.strftime("%x %X")
         self._attr_attribution = f"Last update: {refreshtime}"
 
-    def _set_state(self, upcoming: list[CollectionGroup]):
-        """Set entity state with default format."""
-        if len(upcoming) == 0:
-            self._value = None
-            self._attr_icon = Icons.GENERAL_WASTE
-            self._attr_entity_picture = None
-            return
-
-        collection = upcoming[0]
-        # collection::=CollectionGroup{date=2020-04-01, types=['Type1', 'Type2']}
-
-        if self._value_template is not None:
-            self._value = self._value_template.async_render_with_possible_json_value(
-                collection, None
-            )
-        else:
-            self._value = (
-                f"{self._separator.join(collection.types)} in {collection.daysTo} days"
-            )
-
-        self._attr_icon = collection.icon or Icons.GENERAL_WASTE
-        self._attr_entity_picture = collection.picture
-
-    def _render_date(self, collection: CollectionBase):
-        if self._date_template is not None:
-            return self._date_template.async_render_with_possible_json_value(
-                collection, None
-            )
-        return collection.date.isoformat()
-
     @callback
     def _update_sensor(self):
         """Update the state and the device-state-attributes of the entity.
@@ -322,69 +447,29 @@ class ScheduleSensor(SensorEntity):
         """
         if self._aggregator is None:
             return
-
-        upcoming1 = self._aggregator.get_upcoming_group_by_day(
-            count=1,
-            include_types=self._collection_types,
-            include_today=self._include_today,
-            start_index=self._event_index,
+        (
+            self._value,
+            self._attr_extra_state_attributes,
+            self._attr_icon,
+            self._attr_entity_picture,
+        ) = render_sensor_preview(
+            aggregator=self._aggregator,
+            separator=self._separator,
+            day_switch_time=(
+                self._api._day_switch_time
+                if self._api
+                else self._coordinator.day_switch_time
+            ),
+            details_format=self._details_format,
+            count=self._count,
+            leadtime=self._leadtime,
+            collection_types=self._collection_types,
+            value_template=self._value_template,
+            date_template=self._date_template,
+            add_days_to=self._add_days_to,
+            event_index=self._event_index,
+            preset_language=self._preset_language,
         )
-
-        self._set_state(upcoming1)
-
-        attributes = {}
-
-        collection_types = (
-            sorted(self._aggregator.types)
-            if self._collection_types is None
-            else self._collection_types
-        )
-
-        if self._details_format == DetailsFormat.upcoming:
-            # show upcoming events list in details
-            upcoming = self._aggregator.get_upcoming_group_by_day(
-                count=self._count,
-                leadtime=self._leadtime,
-                include_types=self._collection_types,
-                include_today=self._include_today,
-                start_index=self._event_index,
-            )
-            for collection in upcoming:
-                attributes[self._render_date(collection)] = self._separator.join(
-                    collection.types
-                )
-        elif self._details_format == DetailsFormat.appointment_types:
-            # show list of collections in details
-            for t in collection_types:
-                collections = self._aggregator.get_upcoming(
-                    count=1,
-                    include_types=[t],
-                    include_today=self._include_today,
-                    start_index=self._event_index,
-                )
-                date = (
-                    "" if len(collections) == 0 else self._render_date(collections[0])
-                )
-                attributes[t] = date
-        elif self._details_format == DetailsFormat.generic:
-            # insert generic attributes into details
-            attributes["types"] = collection_types
-            attributes["upcoming"] = self._aggregator.get_upcoming(
-                count=self._count,
-                leadtime=self._leadtime,
-                include_types=self._collection_types,
-                include_today=self._include_today,
-            )
-            refreshtime = ""
-            if self._aggregator.refreshtime is not None:
-                refreshtime = self._aggregator.refreshtime.isoformat(timespec="seconds")
-            attributes["last_update"] = refreshtime
-
-        if len(upcoming1) > 0:
-            if self._add_days_to:
-                attributes["daysTo"] = upcoming1[0].daysTo
-
-        self._attr_extra_state_attributes = attributes
         self._add_refreshtime()
 
         if self.hass is not None:

--- a/custom_components/waste_collection_schedule/sensor_config_helpers.py
+++ b/custom_components/waste_collection_schedule/sensor_config_helpers.py
@@ -1,0 +1,329 @@
+"""Helpers for device-page configuration entities tied to waste sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from .const import (
+    CONF_DETAILS_FORMAT,
+    CONF_DEVICE_SENSOR_CONTROLS,
+    CONF_PRESET_LANGUAGE,
+    CONF_SENSOR_ID,
+    CONF_SENSOR_LEGACY_UNIQUE_ID,
+    CONF_SENSORS,
+    DOMAIN,
+)
+from .waste_collection_schedule.waste_types import resolve
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+
+CONF_NAME = "name"
+COMBINED_SENSOR_NAME = "Next waste pickup"
+SENSOR_CONTROL_METADATA_KEYS = (
+    CONF_SENSOR_ID,
+    CONF_SENSOR_LEGACY_UNIQUE_ID,
+    CONF_PRESET_LANGUAGE,
+)
+DEVICE_CONTROL_OPTION_KEYS = (CONF_DEVICE_SENSOR_CONTROLS,)
+
+
+def preserve_device_control_options(
+    existing_options: Mapping[str, Any], submitted_options: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Preserve device-control metadata omitted by the legacy options form."""
+    merged = deepcopy(dict(submitted_options))
+    for key in DEVICE_CONTROL_OPTION_KEYS:
+        if key in existing_options:
+            merged[key] = deepcopy(existing_options[key])
+    return merged
+
+
+def preserve_sensor_control_metadata(
+    original_sensor: Mapping[str, Any] | None,
+    submitted_sensor: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Preserve opaque identity metadata through a legacy sensor edit."""
+    merged = deepcopy(dict(submitted_sensor))
+    if original_sensor is None:
+        return merged
+    for key in SENSOR_CONTROL_METADATA_KEYS:
+        if key in original_sensor:
+            merged[key] = deepcopy(original_sensor[key])
+    return merged
+
+
+def build_legacy_ui_sensor_unique_id(shell_unique_id: str, sensor_name: str) -> str:
+    """Return the previous name-based UI sensor unique ID."""
+    return f"{shell_unique_id}_ui_sensor_{sensor_name}"
+
+
+def build_stable_ui_sensor_unique_id(shell_unique_id: str, sensor_id: str) -> str:
+    """Return the stable UI sensor unique ID."""
+    return f"{shell_unique_id}_ui_sensor_{sensor_id}"
+
+
+def build_ui_sensor_device_identifier(shell_unique_id: str, sensor_id: str) -> str:
+    """Return the stable device identifier for a configured UI sensor."""
+    return f"{shell_unique_id}_sensor_{sensor_id}"
+
+
+def parse_ui_sensor_device_identifier(
+    shell_unique_id: str, identifier: str
+) -> str | None:
+    """Extract the stable sensor ID from one of this integration's sensor devices."""
+    prefix = f"{shell_unique_id}_sensor_"
+    if not identifier.startswith(prefix):
+        return None
+    sensor_id = identifier.removeprefix(prefix)
+    return sensor_id or None
+
+
+def parse_ui_sensor_device_id(
+    shell_unique_id: str, identifiers: Iterable[tuple[str, str]]
+) -> str | None:
+    """Extract a stable sensor ID from a Home Assistant device identifier set."""
+    for domain, identifier in identifiers:
+        if domain != DOMAIN:
+            continue
+        if sensor_id := parse_ui_sensor_device_identifier(shell_unique_id, identifier):
+            return sensor_id
+    return None
+
+
+def build_ui_sensor_control_unique_id(
+    shell_unique_id: str, sensor_id: str, key_suffix: str
+) -> str:
+    """Return the stable unique ID for a per-sensor config/control entity."""
+    return f"{shell_unique_id}_ui_sensor_control_{sensor_id}_{key_suffix}"
+
+
+def build_create_combined_ui_sensor_action_unique_id(shell_unique_id: str) -> str:
+    """Return the stable unique ID for the combined-sensor creation action."""
+    return f"{shell_unique_id}_ui_sensor_action_create_combined"
+
+
+def build_create_ui_sensor_action_unique_id(
+    shell_unique_id: str, collection_type: str
+) -> str:
+    """Return the stable unique ID for a collection-type creation action."""
+    return f"{shell_unique_id}_ui_sensor_action_create_{collection_type}"
+
+
+def build_ui_sensor_unique_id(
+    shell_unique_id: str,
+    sensor_name: str,
+    sensor_id: str | None,
+    preserve_legacy_unique_id: bool = False,
+) -> str:
+    """Return a stable ID for new sensors without renaming existing entities."""
+    if sensor_id and not preserve_legacy_unique_id:
+        return build_stable_ui_sensor_unique_id(shell_unique_id, sensor_id)
+    return build_legacy_ui_sensor_unique_id(shell_unique_id, sensor_name)
+
+
+def configured_sensor_ids(sensors: list[dict[str, Any]]) -> set[str]:
+    """Return stable sensor IDs that are still configured."""
+    return {
+        sensor_id for sensor in sensors if (sensor_id := sensor.get(CONF_SENSOR_ID))
+    }
+
+
+def update_sensor_config_list_by_id(
+    sensors: list[dict[str, Any]],
+    sensor_id: str,
+    updates: dict[str, Any] | None = None,
+    removals: tuple[str, ...] = (),
+) -> list[dict[str, Any]]:
+    """Return a new sensor list with updates applied to one sensor by stable ID."""
+    updated_sensors = deepcopy(sensors)
+    for sensor in updated_sensors:
+        if sensor.get(CONF_SENSOR_ID) != sensor_id:
+            continue
+
+        for key in removals:
+            sensor.pop(key, None)
+
+        if updates:
+            sensor.update(updates)
+
+        return updated_sensors
+
+    raise KeyError(f"Sensor ID '{sensor_id}' not found")
+
+
+def remove_sensor_config_by_id(
+    sensors: list[dict[str, Any]],
+    sensor_id: str,
+) -> list[dict[str, Any]]:
+    """Return a new sensor list without the sensor matching the stable ID."""
+    return [
+        deepcopy(sensor)
+        for sensor in sensors
+        if sensor.get(CONF_SENSOR_ID) != sensor_id
+    ]
+
+
+def ensure_sensor_ids(
+    sensors: list[dict[str, Any]],
+    id_factory: Callable[[], str] | None = None,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Give existing sensors control IDs without changing their entity identity."""
+    updated_sensors = deepcopy(sensors)
+    changed = False
+    factory = id_factory or (lambda: uuid4().hex)
+
+    for sensor in updated_sensors:
+        if sensor.get(CONF_SENSOR_ID):
+            continue
+        sensor[CONF_SENSOR_ID] = factory()
+        sensor[CONF_SENSOR_LEGACY_UNIQUE_ID] = True
+        changed = True
+
+    return updated_sensors, changed
+
+
+def configured_collection_types(sensors: list[dict[str, Any]]) -> set[str]:
+    """Return collection types already covered by configured sensors."""
+    types: set[str] = set()
+    for sensor in sensors:
+        sensor_types = sensor.get("types")
+        if not sensor_types:
+            continue
+        types.update(str(sensor_type) for sensor_type in sensor_types)
+    return types
+
+
+def has_combined_sensor(sensors: list[dict[str, Any]]) -> bool:
+    """Return True when an all-types/combined waste sensor is configured."""
+    return any(not sensor.get("types") for sensor in sensors)
+
+
+def missing_collection_types(
+    available_types: Mapping[str, str],
+    sensors: list[dict[str, Any]],
+) -> list[tuple[str, str]]:
+    """Return stable type IDs and labels not already covered by a sensor.
+
+    Existing sensor filters may contain a localized/display label. New device
+    actions persist the locale-independent ID introduced by WasteType in v3.
+    """
+    configured_ids: set[str] = set()
+    normalized_labels = {
+        " ".join(label.strip().casefold().split()): type_id
+        for type_id, label in available_types.items()
+    }
+    for configured_type in configured_collection_types(sensors):
+        if configured_type in available_types:
+            configured_ids.add(configured_type)
+            continue
+        if canonical := resolve(configured_type):
+            if canonical.id in available_types:
+                configured_ids.add(canonical.id)
+                continue
+        normalized = " ".join(configured_type.strip().casefold().split())
+        if type_id := normalized_labels.get(normalized):
+            configured_ids.add(type_id)
+    return sorted(
+        (
+            (type_id, label)
+            for type_id, label in available_types.items()
+            if type_id not in configured_ids
+        ),
+        key=lambda item: item[1].casefold(),
+    )
+
+
+def build_sensor_for_collection_type(
+    collection_type_id: str,
+    display_name: str,
+    id_factory: Callable[[], str] | None = None,
+) -> dict[str, Any]:
+    """Build a default per-type waste pickup sensor configuration."""
+    factory = id_factory or (lambda: uuid4().hex)
+    return {
+        CONF_NAME: display_name,
+        CONF_SENSOR_ID: factory(),
+        CONF_DETAILS_FORMAT: "upcoming",
+        "types": [collection_type_id],
+    }
+
+
+def build_combined_waste_sensor(
+    id_factory: Callable[[], str] | None = None,
+) -> dict[str, Any]:
+    """Build a default all-types sensor that groups same-day pickups together."""
+    factory = id_factory or (lambda: uuid4().hex)
+    return {
+        CONF_NAME: COMBINED_SENSOR_NAME,
+        CONF_SENSOR_ID: factory(),
+        CONF_DETAILS_FORMAT: "upcoming",
+    }
+
+
+def build_updated_options_by_sensor_id(
+    entry: ConfigEntry,
+    sensor_id: str,
+    updates: dict[str, Any] | None = None,
+    removals: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build a new config entry options payload for one stable sensor update."""
+    options = deepcopy(dict(entry.options))
+    options[CONF_SENSORS] = update_sensor_config_list_by_id(
+        options.get(CONF_SENSORS, []),
+        sensor_id=sensor_id,
+        updates=updates,
+        removals=removals,
+    )
+    return options
+
+
+def build_removed_sensor_options(entry: ConfigEntry, sensor_id: str) -> dict[str, Any]:
+    """Build a new config entry options payload without one stable sensor."""
+    options = deepcopy(dict(entry.options))
+    options[CONF_SENSORS] = remove_sensor_config_by_id(
+        options.get(CONF_SENSORS, []), sensor_id=sensor_id
+    )
+    return options
+
+
+def build_added_collection_type_sensor_options(
+    entry: ConfigEntry,
+    collection_type_id: str,
+    display_name: str,
+    id_factory: Callable[[], str] | None = None,
+) -> dict[str, Any]:
+    """Build a new config entry options payload with one per-type sensor added."""
+    options = deepcopy(dict(entry.options))
+    sensors = deepcopy(options.get(CONF_SENSORS, []))
+    if not missing_collection_types(
+        {collection_type_id: display_name},
+        sensors,
+    ):
+        return options
+    sensors.append(
+        build_sensor_for_collection_type(
+            collection_type_id,
+            display_name,
+            id_factory,
+        )
+    )
+    options[CONF_SENSORS] = sensors
+    return options
+
+
+def build_added_combined_sensor_options(
+    entry: ConfigEntry,
+    id_factory: Callable[[], str] | None = None,
+) -> dict[str, Any]:
+    """Build a new config entry options payload with one combined sensor added."""
+    options = deepcopy(dict(entry.options))
+    sensors = deepcopy(options.get(CONF_SENSORS, []))
+    if has_combined_sensor(sensors):
+        return options
+    sensors.append(build_combined_waste_sensor(id_factory))
+    options[CONF_SENSORS] = sensors
+    return options

--- a/custom_components/waste_collection_schedule/sensor_config_helpers.py
+++ b/custom_components/waste_collection_schedule/sensor_config_helpers.py
@@ -205,6 +205,7 @@ def has_combined_sensor(sensors: list[dict[str, Any]]) -> bool:
 def missing_collection_types(
     available_types: Mapping[str, str],
     sensors: list[dict[str, Any]],
+    type_aliases: Mapping[str, set[str]] | None = None,
 ) -> list[tuple[str, str]]:
     """Return stable type IDs and labels not already covered by a sensor.
 
@@ -216,7 +217,13 @@ def missing_collection_types(
         " ".join(label.strip().casefold().split()): type_id
         for type_id, label in available_types.items()
     }
+    normalized_aliases = {
+        " ".join(label.strip().casefold().split()): ids
+        for label, ids in (type_aliases or {}).items()
+    }
     for configured_type in configured_collection_types(sensors):
+        normalized = " ".join(configured_type.strip().casefold().split())
+        configured_ids.update(normalized_aliases.get(normalized, set()))
         if configured_type in available_types:
             configured_ids.add(configured_type)
             continue
@@ -295,6 +302,8 @@ def build_added_collection_type_sensor_options(
     collection_type_id: str,
     display_name: str,
     id_factory: Callable[[], str] | None = None,
+    *,
+    type_aliases: Mapping[str, set[str]] | None = None,
 ) -> dict[str, Any]:
     """Build a new config entry options payload with one per-type sensor added."""
     options = deepcopy(dict(entry.options))
@@ -302,6 +311,7 @@ def build_added_collection_type_sensor_options(
     if not missing_collection_types(
         {collection_type_id: display_name},
         sensors,
+        type_aliases,
     ):
         return options
     sensors.append(

--- a/custom_components/waste_collection_schedule/sensor_template_presets.py
+++ b/custom_components/waste_collection_schedule/sensor_template_presets.py
@@ -1,0 +1,286 @@
+"""Shared preset definitions for waste sensor display templates."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+DEFAULT_OPTION = "Default"
+CUSTOM_OPTION = "Custom"
+DEFAULT_PRESET_LANGUAGE = "en"
+PRESET_LANGUAGE_OPTIONS: dict[str, str] = {
+    "Deutsch": "de",
+    "English": "en",
+    "Français": "fr",
+    "Italiano": "it",
+    "Nederlands": "nl",
+    "Polski": "pl",
+}
+PRESET_LANGUAGE_LABELS = {
+    value: label for label, value in PRESET_LANGUAGE_OPTIONS.items()
+}
+
+EN_RELATIVE_TEMPLATE = (
+    "{% if value.daysTo == 0 %}Today{% elif value.daysTo == 1 %}Tomorrow"
+    "{% else %}in {{value.daysTo}} days{% endif %}"
+)
+DE_RELATIVE_TEMPLATE = (
+    "{% if value.daysTo == 0 %}Heute{% elif value.daysTo == 1 %}Morgen"
+    "{% else %}in {{value.daysTo}} Tagen{% endif %}"
+)
+FR_RELATIVE_TEMPLATE = (
+    "{% if value.daysTo == 0 %}Aujourd'hui{% elif value.daysTo == 1 %}Demain"
+    "{% else %}dans {{value.daysTo}} jours{% endif %}"
+)
+IT_RELATIVE_TEMPLATE = (
+    "{% if value.daysTo == 0 %}Oggi{% elif value.daysTo == 1 %}Domani"
+    "{% else %}tra {{value.daysTo}} giorni{% endif %}"
+)
+NL_RELATIVE_TEMPLATE = (
+    "{% if value.daysTo == 0 %}Vandaag{% elif value.daysTo == 1 %}Morgen"
+    "{% else %}over {{value.daysTo}} dagen{% endif %}"
+)
+PL_RELATIVE_TEMPLATE = (
+    "{% if value.daysTo == 0 %}Dzisiaj{% elif value.daysTo == 1 %}Jutro"
+    "{% else %}za {{value.daysTo}} dni{% endif %}"
+)
+
+VALUE_TEMPLATE_PRESET_DEFINITIONS: list[dict[str, tuple[str, str]]] = [
+    {
+        "de": ("in 13 Tagen", "in {{value.daysTo}} Tagen"),
+        "en": ("in 13 days", "in {{value.daysTo}} days"),
+        "fr": ("dans 13 jours", "dans {{value.daysTo}} jours"),
+        "it": ("tra 13 giorni", "tra {{value.daysTo}} giorni"),
+        "nl": ("over 13 dagen", "over {{value.daysTo}} dagen"),
+        "pl": ("za 13 dni", "za {{value.daysTo}} dni"),
+    },
+    {
+        "de": (
+            "Bio in 13 Tagen",
+            '{{value.types|join(", ")}} in {{value.daysTo}} Tagen',
+        ),
+        "en": ("Bio in 13 days", '{{value.types|join(", ")}} in {{value.daysTo}} days'),
+        "fr": (
+            "Bio dans 13 jours",
+            '{{value.types|join(", ")}} dans {{value.daysTo}} jours',
+        ),
+        "it": (
+            "Bio tra 13 giorni",
+            '{{value.types|join(", ")}} tra {{value.daysTo}} giorni',
+        ),
+        "nl": (
+            "Bio over 13 dagen",
+            '{{value.types|join(", ")}} over {{value.daysTo}} dagen',
+        ),
+        "pl": ("Bio za 13 dni", '{{value.types|join(", ")}} za {{value.daysTo}} dni'),
+    },
+    {
+        "de": ("13", "{{value.daysTo}}"),
+        "en": ("13", "{{value.daysTo}}"),
+        "fr": ("13", "{{value.daysTo}}"),
+        "it": ("13", "{{value.daysTo}}"),
+        "nl": ("13", "{{value.daysTo}}"),
+        "pl": ("13", "{{value.daysTo}}"),
+    },
+    {
+        "de": ("Heute / Morgen / in 13 Tagen", DE_RELATIVE_TEMPLATE),
+        "en": ("Today / Tomorrow / in 13 days", EN_RELATIVE_TEMPLATE),
+        "fr": ("Aujourd'hui / Demain / dans 13 jours", FR_RELATIVE_TEMPLATE),
+        "it": ("Oggi / Domani / tra 13 giorni", IT_RELATIVE_TEMPLATE),
+        "nl": ("Vandaag / Morgen / over 13 dagen", NL_RELATIVE_TEMPLATE),
+        "pl": ("Dzisiaj / Jutro / za 13 dni", PL_RELATIVE_TEMPLATE),
+    },
+    {
+        "de": ("am 14.04.2026", 'am {{value.date.strftime("%d.%m.%Y")}}'),
+        "en": (
+            "on Tue, 14.04.2026",
+            'on {{value.date.strftime("%a")}}, {{value.date.strftime("%d.%m.%Y")}}',
+        ),
+        "fr": ("le 14/04/2026", 'le {{value.date.strftime("%d/%m/%Y")}}'),
+        "it": ("il 14/04/2026", 'il {{value.date.strftime("%d/%m/%Y")}}'),
+        "nl": ("op 14-04-2026", 'op {{value.date.strftime("%d-%m-%Y")}}'),
+        "pl": ("14.04.2026", '{{value.date.strftime("%d.%m.%Y")}}'),
+    },
+    {
+        "de": ("2026-04-14", '{{value.date.strftime("%Y-%m-%d")}}'),
+        "en": (
+            "on Tue, 2026-04-14",
+            'on {{value.date.strftime("%a")}}, {{value.date.strftime("%Y-%m-%d")}}',
+        ),
+        "fr": ("2026-04-14", '{{value.date.strftime("%Y-%m-%d")}}'),
+        "it": ("2026-04-14", '{{value.date.strftime("%Y-%m-%d")}}'),
+        "nl": ("2026-04-14", '{{value.date.strftime("%Y-%m-%d")}}'),
+        "pl": ("2026-04-14", '{{value.date.strftime("%Y-%m-%d")}}'),
+    },
+    {
+        "de": ("Bio", '{{value.types|join(", ")}}'),
+        "en": ("Bio", '{{value.types|join(", ")}}'),
+        "fr": ("Bio", '{{value.types|join(", ")}}'),
+        "it": ("Bio", '{{value.types|join(", ")}}'),
+        "nl": ("Bio", '{{value.types|join(", ")}}'),
+        "pl": ("Bio", '{{value.types|join(", ")}}'),
+    },
+]
+
+GROUPED_VALUE_TEMPLATE_LABELS: dict[int, dict[str, str]] = {
+    1: {
+        "de": "Abfallarten in 13 Tagen",
+        "en": "Waste types in 13 days",
+        "fr": "Types de déchets dans 13 jours",
+        "it": "Tipi di rifiuti tra 13 giorni",
+        "nl": "Afvalsoorten over 13 dagen",
+        "pl": "Typy odpadów za 13 dni",
+    },
+    6: {
+        "de": "Abfallarten",
+        "en": "Waste types",
+        "fr": "Types de déchets",
+        "it": "Tipi di rifiuti",
+        "nl": "Afvalsoorten",
+        "pl": "Typy odpadów",
+    },
+}
+
+
+def normalize_preset_language(language: str | None) -> str:
+    """Return a supported preset language code."""
+    if language in PRESET_LANGUAGE_LABELS:
+        return language
+    return DEFAULT_PRESET_LANGUAGE
+
+
+def get_preset_language_label(language: str | None) -> str:
+    """Return the user-facing label for a preset language code."""
+    return PRESET_LANGUAGE_LABELS[normalize_preset_language(language)]
+
+
+def get_preset_language_value(label: str) -> str:
+    """Return the preset language code for a user-facing label."""
+    return PRESET_LANGUAGE_OPTIONS.get(label, DEFAULT_PRESET_LANGUAGE)
+
+
+def get_value_template_presets(
+    language: str | None, grouped: bool = False
+) -> dict[str, str]:
+    """Return state-text presets for the selected language."""
+    language = normalize_preset_language(language)
+    presets = {}
+    for index, labels in enumerate(VALUE_TEMPLATE_PRESET_DEFINITIONS):
+        label = labels[language][0]
+        if grouped:
+            label = GROUPED_VALUE_TEMPLATE_LABELS.get(index, {}).get(language, label)
+        presets[label] = labels[language][1]
+    return presets
+
+
+def get_all_value_template_presets() -> dict[str, str]:
+    """Return every state-text preset across supported languages."""
+    presets: dict[str, str] = {}
+    for index, labels in enumerate(VALUE_TEMPLATE_PRESET_DEFINITIONS):
+        for label, template in labels.values():
+            presets[label] = template
+        for language, label in GROUPED_VALUE_TEMPLATE_LABELS.get(index, {}).items():
+            presets[label] = labels[language][1]
+    return presets
+
+
+def find_value_template_preset_index(template: str | None) -> int | None:
+    """Return the stable preset index matching a stored state template."""
+    if not template:
+        return None
+
+    for index, labels in enumerate(VALUE_TEMPLATE_PRESET_DEFINITIONS):
+        if any(template == preset_template for _, preset_template in labels.values()):
+            return index
+    return None
+
+
+def infer_preset_language_from_template(template: str | None) -> str:
+    """Infer the display language from a known state-text template."""
+    if not template:
+        return DEFAULT_PRESET_LANGUAGE
+
+    for labels in VALUE_TEMPLATE_PRESET_DEFINITIONS:
+        for language, (_, preset_template) in labels.items():
+            if template == preset_template:
+                return language
+    return DEFAULT_PRESET_LANGUAGE
+
+
+def convert_value_template_language(
+    template: str | None, language: str | None
+) -> str | None:
+    """Convert a known state-text preset template to another language."""
+    index = find_value_template_preset_index(template)
+    if index is None:
+        return None
+
+    language = normalize_preset_language(language)
+    return VALUE_TEMPLATE_PRESET_DEFINITIONS[index][language][1]
+
+
+def format_default_state_text(
+    types: Iterable[str], days_to: int, separator: str, language: str | None
+) -> str:
+    """Return the built-in sensor state text in the selected display language."""
+    type_text = separator.join(types)
+    language = normalize_preset_language(language)
+    if language == "de":
+        if days_to == 0:
+            return f"{type_text} heute"
+        if days_to == 1:
+            return f"{type_text} morgen"
+        return f"{type_text} in {days_to} Tagen"
+    if language == "fr":
+        if days_to == 0:
+            return f"{type_text} aujourd'hui"
+        if days_to == 1:
+            return f"{type_text} demain"
+        return f"{type_text} dans {days_to} jours"
+    if language == "it":
+        if days_to == 0:
+            return f"{type_text} oggi"
+        if days_to == 1:
+            return f"{type_text} domani"
+        return f"{type_text} tra {days_to} giorni"
+    if language == "nl":
+        if days_to == 0:
+            return f"{type_text} vandaag"
+        if days_to == 1:
+            return f"{type_text} morgen"
+        return f"{type_text} over {days_to} dagen"
+    if language == "pl":
+        if days_to == 0:
+            return f"{type_text} dzisiaj"
+        if days_to == 1:
+            return f"{type_text} jutro"
+        return f"{type_text} za {days_to} dni"
+
+    if days_to == 0:
+        return f"{type_text} today"
+    if days_to == 1:
+        return f"{type_text} tomorrow"
+    return f"{type_text} in {days_to} days"
+
+
+VALUE_TEMPLATE_PRESETS = get_value_template_presets(DEFAULT_PRESET_LANGUAGE)
+
+DATE_TEMPLATE_PRESETS: dict[str, str] = {
+    "14.04.2026": '{{value.date.strftime("%d.%m.%Y")}}',
+    "Tue, 14.04.2026": '{{value.date.strftime("%a, %d.%m.%Y")}}',
+    "04/14/2026": '{{value.date.strftime("%m/%d/%Y")}}',
+    "Tue, 04/14/2026": '{{value.date.strftime("%a, %m/%d/%Y")}}',
+    "2026-04-14": '{{value.date.strftime("%Y-%m-%d")}}',
+    "Tue, 2026-04-14": '{{value.date.strftime("%a, %Y-%m-%d")}}',
+}
+
+
+def get_preset_option(template: str | None, presets: Mapping[str, str]) -> str:
+    """Return the matching preset label for a stored template string."""
+    if not template:
+        return DEFAULT_OPTION
+
+    for label, preset_template in presets.items():
+        if template == preset_template:
+            return label
+
+    return CUSTOM_OPTION

--- a/custom_components/waste_collection_schedule/switch.py
+++ b/custom_components/waste_collection_schedule/switch.py
@@ -1,0 +1,172 @@
+"""Advanced device-page switches for Waste Collection Schedule sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import (
+    CONF_ADD_DAYS_TO,
+    CONF_DEVICE_SENSOR_CONTROLS,
+    CONF_SENSOR_ID,
+    CONF_SENSORS,
+    DOMAIN,
+)
+from .sensor_config_helpers import (
+    build_ui_sensor_control_unique_id,
+    build_ui_sensor_device_identifier,
+    build_updated_options_by_sensor_id,
+)
+from .wcs_coordinator import WCSCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up the opt-in switch and per-sensor advanced switches."""
+    coordinator: WCSCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[SwitchEntity] = [DeviceSensorControlsSwitch(entry, coordinator)]
+
+    if not entry.options.get(CONF_DEVICE_SENSOR_CONTROLS, False):
+        async_add_entities(entities)
+        return
+
+    for sensor_config in entry.options.get(CONF_SENSORS, []):
+        sensor_id = sensor_config.get(CONF_SENSOR_ID)
+        sensor_name = sensor_config.get(CONF_NAME, coordinator.shell.calendar_title)
+        if not sensor_id:
+            continue
+
+        entities.append(
+            WasteSensorConfigSwitch(
+                entry,
+                coordinator,
+                sensor_id,
+                sensor_name,
+                key=CONF_ADD_DAYS_TO,
+                key_suffix="days_to_attribute",
+                label="Advanced: expose days-to attribute",
+                icon="mdi:calendar-clock",
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class DeviceSensorControlsSwitch(SwitchEntity):
+    """Explicit opt-in for device-backed sensor configuration controls."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_name = "Device sensor controls"
+    _attr_icon = "mdi:tune-variant"
+
+    def __init__(self, entry: ConfigEntry, coordinator: WCSCoordinator) -> None:
+        self._entry = entry
+        self._attr_unique_id = f"{coordinator.shell.unique_id}_device_sensor_controls"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether device-backed controls are enabled."""
+        return bool(self._entry.options.get(CONF_DEVICE_SENSOR_CONTROLS, False))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable device-backed controls; the entry listener performs reload."""
+        options = deepcopy(dict(self._entry.options))
+        options[CONF_DEVICE_SENSOR_CONTROLS] = True
+        self.hass.config_entries.async_update_entry(self._entry, options=options)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Return to legacy-only editing without changing sensor identities."""
+        options = deepcopy(dict(self._entry.options))
+        options.pop(CONF_DEVICE_SENSOR_CONTROLS, None)
+        self.hass.config_entries.async_update_entry(self._entry, options=options)
+
+
+class WasteSensorConfigSwitch(SwitchEntity):
+    """Switch entity for boolean waste sensor options."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        sensor_id: str,
+        sensor_name: str,
+        key: str,
+        key_suffix: str,
+        label: str,
+        icon: str,
+    ) -> None:
+        self._entry = entry
+        self._sensor_id = sensor_id
+        self._key = key
+        self._attr_name = label
+        self._attr_unique_id = build_ui_sensor_control_unique_id(
+            coordinator.shell.unique_id, sensor_id, key_suffix
+        )
+        device_identifier = build_ui_sensor_device_identifier(
+            coordinator.shell.unique_id, sensor_id
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_identifier)},
+            manufacturer=coordinator.shell.title,
+            model="Waste Pickup Sensor",
+            name=sensor_name,
+            via_device=(DOMAIN, coordinator.shell.unique_id),
+        )
+        self._attr_icon = icon
+
+    @property
+    def sensor_config(self) -> Mapping[str, Any]:
+        """Return the latest stored configuration for this sensor."""
+        return next(
+            (
+                sensor
+                for sensor in self._entry.options.get(CONF_SENSORS, [])
+                if sensor.get(CONF_SENSOR_ID) == self._sensor_id
+            ),
+            {},
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the config option is enabled."""
+        return bool(self.sensor_config.get(self._key, False))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the config option."""
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            options=build_updated_options_by_sensor_id(
+                self._entry,
+                sensor_id=self._sensor_id,
+                updates={self._key: True},
+            ),
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the config option."""
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            options=build_updated_options_by_sensor_id(
+                self._entry,
+                sensor_id=self._sensor_id,
+                removals=(self._key,),
+            ),
+        )

--- a/custom_components/waste_collection_schedule/text.py
+++ b/custom_components/waste_collection_schedule/text.py
@@ -1,0 +1,149 @@
+"""Advanced device-page text configuration for Waste Collection Schedule sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.text import TextEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import (
+    CONF_DATE_TEMPLATE,
+    CONF_DEVICE_SENSOR_CONTROLS,
+    CONF_SENSOR_ID,
+    CONF_SENSORS,
+    DOMAIN,
+)
+from .sensor_config_helpers import (
+    build_ui_sensor_control_unique_id,
+    build_ui_sensor_device_identifier,
+    build_updated_options_by_sensor_id,
+)
+from .wcs_coordinator import WCSCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up advanced template text entities for each configured waste sensor."""
+    if not entry.options.get(CONF_DEVICE_SENSOR_CONTROLS, False):
+        return
+
+    coordinator: WCSCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[TextEntity] = []
+
+    for sensor_config in entry.options.get(CONF_SENSORS, []):
+        sensor_id = sensor_config.get(CONF_SENSOR_ID)
+        sensor_name = sensor_config.get(CONF_NAME, coordinator.shell.calendar_title)
+        if not sensor_id:
+            continue
+
+        entities.extend(
+            [
+                WasteSensorTemplateText(
+                    entry,
+                    coordinator,
+                    sensor_id,
+                    sensor_name,
+                    key=CONF_VALUE_TEMPLATE,
+                    key_suffix="state_template",
+                    label="Advanced: custom state template",
+                    icon="mdi:code-braces",
+                ),
+                WasteSensorTemplateText(
+                    entry,
+                    coordinator,
+                    sensor_id,
+                    sensor_name,
+                    key=CONF_DATE_TEMPLATE,
+                    key_suffix="date_template",
+                    label="Advanced: custom date template",
+                    icon="mdi:calendar-edit",
+                ),
+            ]
+        )
+
+    async_add_entities(entities)
+
+
+class WasteSensorTemplateText(TextEntity):
+    """Text entity for editing a waste sensor template directly from its device."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+    _attr_has_entity_name = True
+    _attr_native_min = 0
+    _attr_native_max = 500
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: WCSCoordinator,
+        sensor_id: str,
+        sensor_name: str,
+        key: str,
+        key_suffix: str,
+        label: str,
+        icon: str,
+    ) -> None:
+        self._entry = entry
+        self._sensor_id = sensor_id
+        self._key = key
+        self._attr_name = label
+        self._attr_unique_id = build_ui_sensor_control_unique_id(
+            coordinator.shell.unique_id, sensor_id, key_suffix
+        )
+        device_identifier = build_ui_sensor_device_identifier(
+            coordinator.shell.unique_id, sensor_id
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_identifier)},
+            manufacturer=coordinator.shell.title,
+            model="Waste Pickup Sensor",
+            name=sensor_name,
+            via_device=(DOMAIN, coordinator.shell.unique_id),
+        )
+        self._attr_icon = icon
+
+    @property
+    def sensor_config(self) -> Mapping[str, Any]:
+        """Return the latest stored configuration for this sensor."""
+        return next(
+            (
+                sensor
+                for sensor in self._entry.options.get(CONF_SENSORS, [])
+                if sensor.get(CONF_SENSOR_ID) == self._sensor_id
+            ),
+            {},
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return the current template string."""
+        return str(self.sensor_config.get(self._key, ""))
+
+    async def async_set_value(self, value: str) -> None:
+        """Persist the edited template string."""
+        if value.strip():
+            cv.template(value)
+            options = build_updated_options_by_sensor_id(
+                self._entry,
+                sensor_id=self._sensor_id,
+                updates={self._key: value},
+            )
+        else:
+            options = build_updated_options_by_sensor_id(
+                self._entry,
+                sensor_id=self._sensor_id,
+                removals=(self._key,),
+            )
+
+        self.hass.config_entries.async_update_entry(self._entry, options=options)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection.py
@@ -55,6 +55,7 @@ class Collection:
         self._date = date
         self._waste_type = waste_type
         self._type_override: str | None = None
+        self._source_type: str | None = None
         self._icon_override: str | None = None
         self._picture: str | None = None
         self._location: str | None = None
@@ -75,6 +76,14 @@ class Collection:
     @property
     def type(self) -> str:
         return self._type_override or display_name(self._waste_type)
+
+    @property
+    def source_type(self) -> str | None:
+        """Original provider label, retained for existing filters and aliases."""
+        return self._source_type
+
+    def set_source_type(self, value: str | None):
+        self._source_type = _clean_optional_str(value)
 
     @property
     def icon(self) -> str:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from . import CollectionGroup
 from .collection import Collection
 from .source_shell import SourceShell
+from .waste_types import resolve
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +29,31 @@ class CollectionAggregator:
     def types(self):
         """Return set() of all collection types."""
         return {e.type for e in self._entries}
+
+    @property
+    def type_options(self) -> dict[str, str]:
+        """Return stable waste-type IDs mapped to their current display labels."""
+        options: dict[str, str] = {}
+        for entry in self._entries:
+            options.setdefault(entry.waste_type.id, entry.type)
+        return options
+
+    @staticmethod
+    def _matches_type_filter(entry: Collection, value: str) -> bool:
+        """Match stable IDs, localized names, and legacy aliases."""
+        normalized = " ".join(str(value).strip().casefold().split())
+        entry_keys = {
+            entry.waste_type.id,
+            entry.type,
+            *entry.waste_type.names.values(),
+        }
+        if normalized in {
+            " ".join(key.strip().casefold().split()) for key in entry_keys
+        }:
+            return True
+
+        canonical = resolve(value)
+        return canonical is not None and canonical.id == entry.waste_type.id
 
     def get_upcoming(
         self,
@@ -98,11 +124,23 @@ class CollectionAggregator:
     ) -> list[Collection]:
         # remove unwanted waste types from include list
         if include_types is not None:
-            entries = list(filter(lambda e: e.type in set(include_types), entries))
+            included = tuple(include_types)
+            entries = [
+                entry
+                for entry in entries
+                if any(self._matches_type_filter(entry, value) for value in included)
+            ]
 
         # remove unwanted waste types from exclude list
         if exclude_types is not None:
-            entries = list(filter(lambda e: e.type not in set(exclude_types), entries))
+            excluded = tuple(exclude_types)
+            entries = [
+                entry
+                for entry in entries
+                if not any(
+                    self._matches_type_filter(entry, value) for value in excluded
+                )
+            ]
 
         # remove expired entries
         now = datetime.now().date()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/collection_aggregator.py
@@ -38,6 +38,15 @@ class CollectionAggregator:
             options.setdefault(entry.waste_type.id, entry.type)
         return options
 
+    @property
+    def type_aliases(self) -> dict[str, set[str]]:
+        """Map observed provider labels to IDs without cross-source guessing."""
+        aliases: dict[str, set[str]] = {}
+        for entry in self._entries:
+            if entry.source_type:
+                aliases.setdefault(entry.source_type, set()).add(entry.waste_type.id)
+        return aliases
+
     @staticmethod
     def _matches_type_filter(entry: Collection, value: str) -> bool:
         """Match stable IDs, localized names, and legacy aliases."""
@@ -46,6 +55,7 @@ class CollectionAggregator:
             entry.waste_type.id,
             entry.type,
             *entry.waste_type.names.values(),
+            *([entry.source_type] if entry.source_type else []),
         }
         if normalized in {
             " ".join(key.strip().casefold().split()) for key in entry_keys

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -150,7 +150,11 @@ def _customize_keys(entry: Collection) -> list[str]:
         return [entry.type]
     # id preferred; de-duplicate in case it equals the display name (e.g. an
     # English preserved label).
-    return list(dict.fromkeys([entry.waste_type.id, entry.type]))
+    return list(
+        dict.fromkeys(
+            key for key in (entry.waste_type.id, entry.type, entry.source_type) if key
+        )
+    )
 
 
 def filter_function(entry: Collection, customize: dict[str, Customize]):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/transformers.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/transformers.py
@@ -215,6 +215,8 @@ class BaseTransformer(ABC, Generic[T]):
         resolved: TypeMapValue | None,
         location: Any = None,
         description: Any = None,
+        *,
+        source_type: str | None = None,
     ) -> Collection | list[Collection] | None:
         """Build the Collection(s) for a resolved type on a given date.
 
@@ -229,6 +231,7 @@ class BaseTransformer(ABC, Generic[T]):
 
         def build(waste_type: WasteType) -> Collection:
             collection = Collection(date=date, waste_type=waste_type)
+            collection.set_source_type(source_type)
             if location is not None:
                 collection.set_location(location)
             if description is not None:
@@ -303,7 +306,9 @@ class JsonTransformer(BaseTransformer[Mapping[str, Any]]):
         raw_type = str(self._get(record, self._type_key) or "")
         resolved = self._resolve_type(raw_type)
         location, description = self._meta(record)
-        return self._collections(date, resolved, location, description)
+        return self._collections(
+            date, resolved, location, description, source_type=str(raw_type)
+        )
 
 
 class KeyValueTransformer(BaseTransformer[Iterable[Mapping[str, str]]]):
@@ -367,7 +372,11 @@ class KeyValueTransformer(BaseTransformer[Iterable[Mapping[str, str]]]):
         # Read metadata from the flattened name/value pairs, not the raw list.
         location, description = self._meta(fields)
         return self._collections(
-            self._parse_date(date_str), resolved, location, description
+            self._parse_date(date_str),
+            resolved,
+            location,
+            description,
+            source_type=raw_type,
         )
 
 
@@ -430,7 +439,9 @@ class ICSTransformer(BaseTransformer["tuple[datetime.date, str] | IcsEvent"]):
         if self._description_key is not None:
             description = self._get(record, self._description_key)
         resolved = self._resolve_type(summary)
-        return self._collections(date, resolved, location, description)
+        return self._collections(
+            date, resolved, location, description, source_type=summary
+        )
 
 
 class RowTransformer(BaseTransformer[tuple[Any, str]]):
@@ -475,7 +486,11 @@ class RowTransformer(BaseTransformer[tuple[Any, str]]):
         # A row is a tuple, so location_key/description_key must be callables.
         location, description = self._meta(record)
         return self._collections(
-            date, self._resolve_type(str(label)), location, description
+            date,
+            self._resolve_type(str(label)),
+            location,
+            description,
+            source_type=str(label),
         )
 
 
@@ -541,7 +556,9 @@ class HtmlTransformer(BaseTransformer[Tag]):
             date = self._parse_date(str(raw_date))
 
         resolved = self._resolve_type(str(raw_type))
-        return self._collections(date, resolved, location, description)
+        return self._collections(
+            date, resolved, location, description, source_type=str(raw_type)
+        )
 
 
 def label_cleaner(

--- a/custom_components/waste_collection_schedule/wcs_coordinator.py
+++ b/custom_components/waste_collection_schedule/wcs_coordinator.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from collections.abc import Callable
 from random import randrange
 from typing import Any
 
@@ -66,33 +67,42 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         super().__init__(hass, _LOGGER, name=const.DOMAIN)
 
-        self._fetch_tracker = async_track_time_change(
-            hass,
-            self._fetch_callback,
-            self._fetch_time.hour,
-            self._fetch_time.minute,
-            self._fetch_time.second,
+        self._scheduled_callbacks: list[Callable[[], None]] = []
+        self._pending_fetch_cancel: Callable[[], None] | None = None
+
+        self._scheduled_callbacks.append(
+            async_track_time_change(
+                hass,
+                self._fetch_callback,
+                self._fetch_time.hour,
+                self._fetch_time.minute,
+                self._fetch_time.second,
+            )
         )
 
         # start timer for day-switch time
         if self._day_switch_time != self._fetch_time:
-            async_track_time_change(  # TODO: cancel on unload
-                hass,
-                self._update_sensors_callback,
-                self._day_switch_time.hour,
-                self._day_switch_time.minute,
-                self._day_switch_time.second,
+            self._scheduled_callbacks.append(
+                async_track_time_change(
+                    hass,
+                    self._update_sensors_callback,
+                    self._day_switch_time.hour,
+                    self._day_switch_time.minute,
+                    self._day_switch_time.second,
+                )
             )
 
         # add a timer at midnight (if not already there) to update days-to
         midnight = datetime.time.min
         if midnight != self._fetch_time and midnight != self._day_switch_time:
-            async_track_time_change(  # TODO: cancel on unload
-                hass,
-                self._update_sensors_callback,
-                midnight.hour,
-                midnight.minute,
-                midnight.second,
+            self._scheduled_callbacks.append(
+                async_track_time_change(
+                    hass,
+                    self._update_sensors_callback,
+                    midnight.hour,
+                    midnight.minute,
+                    midnight.second,
+                )
             )
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -127,11 +137,29 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @callback
     async def _fetch_callback(self, *_):
-        async_call_later(
+        if self._pending_fetch_cancel is not None:
+            self._pending_fetch_cancel()
+        self._pending_fetch_cancel = async_call_later(
             self._hass,
             randrange(0, 60 * self._random_fetch_time_offset),
-            self._fetch_now,
+            self._run_scheduled_fetch,
         )
+
+    async def _run_scheduled_fetch(self, *_):
+        """Run a delayed fetch and release its cancellation handle."""
+        self._pending_fetch_cancel = None
+        await self._fetch_now()
+
+    @callback
+    def cancel_scheduled_callbacks(self) -> None:
+        """Cancel time trackers and delayed work owned by this coordinator."""
+        for cancel in self._scheduled_callbacks:
+            cancel()
+        self._scheduled_callbacks.clear()
+
+        if self._pending_fetch_cancel is not None:
+            self._pending_fetch_cancel()
+            self._pending_fetch_cancel = None
 
     @callback
     async def _update_sensors_callback(self, *_):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test .claude .git
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py
+python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py test_sensor_device_config_helpers.py test_sensor_structured_attributes.py test_wcs_coordinator_lifecycle.py
 markers =
     live: test fetches from a live provider endpoint; excluded from gating CI (run with `-m live` locally). Replaced by offline fixtures.

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,6 @@ filterwarnings = ignore:.*:DeprecationWarning
 # silently never runs. test_declared_waste_types, test_source_shell_customize and
 # test_source_shell_create_error_handling were in that position: 668 passing
 # tests that gated nothing.
-python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py test_loc_report.py test_declared_waste_types.py test_source_shell_customize.py test_source_shell_create_error_handling.py test_doc_examples.py test_cassette.py
+python_files = test_sensor_device_config_helpers.py test_sensor_structured_attributes.py test_wcs_coordinator_lifecycle.py test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py test_loc_report.py test_declared_waste_types.py test_source_shell_customize.py test_source_shell_create_error_handling.py test_doc_examples.py test_cassette.py
 markers =
     live: test fetches from a live provider endpoint; excluded from gating CI (run with `-m live` locally). Replaced by offline fixtures.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest bootstrap for integration platform module name collisions."""
+
+# Several architecture tests prepend the integration package directory to
+# sys.path. Load the standard-library extension first so the Home Assistant
+# select platform added by the device-controls feature cannot shadow it during
+# later asyncio/socket imports.
+import select  # noqa: F401

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,8 +18,10 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from typing import Any, cast  # isort:skip
 
-import voluptuous as vol  # isort:skip
+# Home Assistant selects its validation implementation during startup. Import it
+# before voluptuous so current HA and the minimum supported version share types.
 from homeassistant.const import CONF_NAME  # isort:skip
+import voluptuous as vol  # isort:skip
 from homeassistant.helpers.selector import (  # isort:skip
     BooleanSelector,
     SelectSelector,

--- a/tests/test_sensor_device_config_helpers.py
+++ b/tests/test_sensor_device_config_helpers.py
@@ -1,0 +1,534 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from custom_components.waste_collection_schedule import button as button_module
+from custom_components.waste_collection_schedule.sensor_config_helpers import (
+    COMBINED_SENSOR_NAME,
+    build_added_collection_type_sensor_options,
+    build_added_combined_sensor_options,
+    build_combined_waste_sensor,
+    build_create_combined_ui_sensor_action_unique_id,
+    build_create_ui_sensor_action_unique_id,
+    build_legacy_ui_sensor_unique_id,
+    build_removed_sensor_options,
+    build_sensor_for_collection_type,
+    build_ui_sensor_control_unique_id,
+    build_ui_sensor_device_identifier,
+    build_ui_sensor_unique_id,
+    configured_collection_types,
+    configured_sensor_ids,
+    ensure_sensor_ids,
+    has_combined_sensor,
+    missing_collection_types,
+    parse_ui_sensor_device_id,
+    parse_ui_sensor_device_identifier,
+    preserve_device_control_options,
+    preserve_sensor_control_metadata,
+    remove_sensor_config_by_id,
+    update_sensor_config_list_by_id,
+)
+from custom_components.waste_collection_schedule.sensor_template_presets import (
+    CUSTOM_OPTION,
+    DEFAULT_OPTION,
+    NL_RELATIVE_TEMPLATE,
+    PL_RELATIVE_TEMPLATE,
+    PRESET_LANGUAGE_OPTIONS,
+    VALUE_TEMPLATE_PRESETS,
+    convert_value_template_language,
+    format_default_state_text,
+    get_preset_option,
+    get_value_template_presets,
+)
+
+CONF_NAME = "name"
+CONF_SENSOR_ID = "sensor_id"
+CONF_SENSOR_LEGACY_UNIQUE_ID = "sensor_legacy_unique_id"
+CONF_DETAILS_FORMAT = "details_format"
+CONF_VALUE_TEMPLATE = "value_template"
+CONF_PRESET_LANGUAGE = "preset_language"
+CONF_DEVICE_SENSOR_CONTROLS = "device_sensor_controls"
+
+
+def test_get_preset_option_returns_default_for_empty_template():
+    assert get_preset_option("", VALUE_TEMPLATE_PRESETS) == DEFAULT_OPTION
+
+
+def test_get_preset_option_returns_matching_label_for_known_template():
+    assert (
+        get_preset_option("in {{value.daysTo}} days", VALUE_TEMPLATE_PRESETS)
+        == "in 13 days"
+    )
+
+
+def test_get_preset_option_returns_matching_label_for_polish_template():
+    assert (
+        get_preset_option("za {{value.daysTo}} dni", get_value_template_presets("pl"))
+        == "za 13 dni"
+    )
+
+
+def test_grouped_value_template_presets_use_group_friendly_labels():
+    presets = get_value_template_presets("en", grouped=True)
+
+    assert "Waste types in 13 days" in presets
+    assert "Bio in 13 days" not in presets
+    assert presets["Waste types in 13 days"] == (
+        '{{value.types|join(", ")}} in {{value.daysTo}} days'
+    )
+
+
+def test_display_language_options_cover_supported_sensor_presets():
+    assert set(PRESET_LANGUAGE_OPTIONS.values()) == {"de", "en", "fr", "it", "nl", "pl"}
+
+
+def test_display_language_presets_exist_for_all_supported_languages():
+    for language in PRESET_LANGUAGE_OPTIONS.values():
+        assert get_value_template_presets(language)
+
+
+def test_default_state_text_supports_all_display_languages():
+    assert format_default_state_text(["Bio"], 2, ", ", "de") == "Bio in 2 Tagen"
+    assert format_default_state_text(["Bio"], 2, ", ", "fr") == "Bio dans 2 jours"
+    assert format_default_state_text(["Bio"], 2, ", ", "it") == "Bio tra 2 giorni"
+    assert format_default_state_text(["Bio"], 2, ", ", "nl") == "Bio over 2 dagen"
+    assert format_default_state_text(["Bio"], 2, ", ", "pl") == "Bio za 2 dni"
+
+
+def test_convert_value_template_language_maps_known_preset():
+    assert (
+        convert_value_template_language(
+            "{% if value.daysTo == 0 %}Today{% elif value.daysTo == 1 %}Tomorrow"
+            "{% else %}in {{value.daysTo}} days{% endif %}",
+            "pl",
+        )
+        == PL_RELATIVE_TEMPLATE
+    )
+    assert (
+        convert_value_template_language(PL_RELATIVE_TEMPLATE, "nl")
+        == NL_RELATIVE_TEMPLATE
+    )
+
+
+def test_get_preset_option_returns_custom_for_unknown_template():
+    assert get_preset_option("{{value.date}}", VALUE_TEMPLATE_PRESETS) == CUSTOM_OPTION
+
+
+def test_update_sensor_config_list_by_id_updates_only_matching_sensor():
+    sensors = [
+        {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id"},
+        {CONF_NAME: "Paper", CONF_SENSOR_ID: "paper-id"},
+    ]
+
+    updated = update_sensor_config_list_by_id(
+        sensors,
+        sensor_id="paper-id",
+        updates={CONF_VALUE_TEMPLATE: "new"},
+    )
+
+    assert CONF_VALUE_TEMPLATE not in updated[0]
+    assert updated[1][CONF_VALUE_TEMPLATE] == "new"
+    assert CONF_VALUE_TEMPLATE not in sensors[1]
+
+
+def test_remove_sensor_config_by_id_removes_only_matching_sensor():
+    sensors = [
+        {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id"},
+        {CONF_NAME: "Paper", CONF_SENSOR_ID: "paper-id"},
+    ]
+
+    updated = remove_sensor_config_by_id(sensors, "bio-id")
+
+    assert updated == [{CONF_NAME: "Paper", CONF_SENSOR_ID: "paper-id"}]
+    assert len(sensors) == 2
+
+
+def test_ensure_sensor_ids_only_fills_missing_ids():
+    sensors = [
+        {CONF_NAME: "Bio"},
+        {CONF_NAME: "Paper", CONF_SENSOR_ID: "keep-me"},
+    ]
+
+    values = iter(["generated-id"])
+    updated, changed = ensure_sensor_ids(sensors, id_factory=lambda: next(values))
+
+    assert changed is True
+    assert updated[0][CONF_SENSOR_ID] == "generated-id"
+    assert updated[0][CONF_SENSOR_LEGACY_UNIQUE_ID] is True
+    assert updated[1][CONF_SENSOR_ID] == "keep-me"
+    assert CONF_SENSOR_LEGACY_UNIQUE_ID not in updated[1]
+    assert CONF_SENSOR_ID not in sensors[0]
+
+
+def test_missing_collection_types_ignores_types_already_covered_by_sensors():
+    sensors = [
+        {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id", "types": ["Bio"]},
+        {CONF_NAME: "All", CONF_SENSOR_ID: "all-id"},
+    ]
+
+    assert missing_collection_types(
+        {"organic": "Bio", "paper": "Paper", "glass": "Glass"}, sensors
+    ) == [
+        ("glass", "Glass"),
+        ("paper", "Paper"),
+    ]
+
+
+def test_missing_collection_types_treats_display_label_as_stable_id_coverage():
+    sensors = [
+        {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id", "types": ["Bio"]},
+    ]
+    assert missing_collection_types(
+        {
+            "organic": "Bio",
+            "paper": "Paper",
+        },
+        sensors,
+    ) == [("paper", "Paper")]
+
+
+def test_missing_collection_types_resolves_legacy_alias_across_languages():
+    sensors = [
+        {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id", "types": [" BIO "]},
+    ]
+
+    assert missing_collection_types(
+        {"organic": "Biomüll", "paper": "Altpapier"},
+        sensors,
+    ) == [("paper", "Altpapier")]
+
+
+def test_build_sensor_for_collection_type_creates_default_per_type_sensor():
+    sensor = build_sensor_for_collection_type(
+        "organic", "Bio", id_factory=lambda: "bio-id"
+    )
+
+    assert sensor == {
+        CONF_NAME: "Bio",
+        CONF_SENSOR_ID: "bio-id",
+        CONF_DETAILS_FORMAT: "upcoming",
+        "types": ["organic"],
+    }
+
+
+def test_has_combined_sensor_detects_sensor_without_type_filter():
+    assert has_combined_sensor([{CONF_NAME: "Everything"}]) is True
+    assert has_combined_sensor([{CONF_NAME: "Bio", "types": ["Bio"]}]) is False
+
+
+def test_build_combined_waste_sensor_creates_all_type_sensor():
+    sensor = build_combined_waste_sensor(id_factory=lambda: "combined-id")
+
+    assert sensor == {
+        CONF_NAME: COMBINED_SENSOR_NAME,
+        CONF_SENSOR_ID: "combined-id",
+        CONF_DETAILS_FORMAT: "upcoming",
+    }
+    assert "types" not in sensor
+
+
+def test_build_removed_sensor_options_removes_sensor_from_entry_options():
+    class Entry:
+        def __init__(self):
+            self.options = {
+                "sensors": [
+                    {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id"},
+                    {CONF_NAME: "Paper", CONF_SENSOR_ID: "paper-id"},
+                ]
+            }
+
+    options = build_removed_sensor_options(Entry(), "paper-id")
+
+    assert options["sensors"] == [{CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id"}]
+
+
+def test_build_added_collection_type_sensor_options_appends_new_sensor():
+    class Entry:
+        def __init__(self):
+            self.options = {
+                "sensors": [
+                    {
+                        CONF_NAME: "Bio",
+                        CONF_SENSOR_ID: "bio-id",
+                        "types": ["organic"],
+                    }
+                ]
+            }
+
+    options = build_added_collection_type_sensor_options(
+        Entry(), "paper", "Paper", id_factory=lambda: "paper-id"
+    )
+
+    assert options["sensors"] == [
+        {
+            CONF_NAME: "Bio",
+            CONF_SENSOR_ID: "bio-id",
+            "types": ["organic"],
+        },
+        {
+            CONF_NAME: "Paper",
+            CONF_SENSOR_ID: "paper-id",
+            CONF_DETAILS_FORMAT: "upcoming",
+            "types": ["paper"],
+        },
+    ]
+
+
+def test_build_added_collection_type_sensor_options_is_idempotent():
+    class Entry:
+        def __init__(self):
+            self.options = {
+                "sensors": [
+                    {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id", "types": ["Bio"]}
+                ]
+            }
+
+    options = build_added_collection_type_sensor_options(
+        Entry(),
+        "organic",
+        "Biomüll",
+        id_factory=lambda: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    assert options["sensors"] == [
+        {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id", "types": ["Bio"]}
+    ]
+
+
+def test_build_added_combined_sensor_options_appends_new_sensor():
+    class Entry:
+        def __init__(self):
+            self.options = {
+                "sensors": [
+                    {
+                        CONF_NAME: "Bio",
+                        CONF_SENSOR_ID: "bio-id",
+                        "types": ["organic"],
+                    }
+                ]
+            }
+
+    options = build_added_combined_sensor_options(
+        Entry(), id_factory=lambda: "combined-id"
+    )
+
+    assert options["sensors"] == [
+        {
+            CONF_NAME: "Bio",
+            CONF_SENSOR_ID: "bio-id",
+            "types": ["organic"],
+        },
+        {
+            CONF_NAME: COMBINED_SENSOR_NAME,
+            CONF_SENSOR_ID: "combined-id",
+            CONF_DETAILS_FORMAT: "upcoming",
+        },
+    ]
+
+
+def test_build_added_combined_sensor_options_is_idempotent():
+    class Entry:
+        def __init__(self):
+            self.options = {
+                "sensors": [{CONF_NAME: "Everything", CONF_SENSOR_ID: "all-id"}]
+            }
+
+    options = build_added_combined_sensor_options(
+        Entry(),
+        id_factory=lambda: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    assert options["sensors"] == [{CONF_NAME: "Everything", CONF_SENSOR_ID: "all-id"}]
+
+
+def test_configured_collection_types_returns_selected_sensor_types():
+    sensors = [
+        {CONF_NAME: "Bio", "types": ["Bio"]},
+        {CONF_NAME: "Mixed", "types": ["Paper", "Glass"]},
+        {CONF_NAME: "Everything"},
+    ]
+
+    assert configured_collection_types(sensors) == {"Bio", "Glass", "Paper"}
+
+
+def test_configured_sensor_ids_returns_stable_sensor_ids():
+    sensors = [
+        {CONF_NAME: "Bio", CONF_SENSOR_ID: "bio-id"},
+        {CONF_NAME: "Legacy"},
+    ]
+
+    assert configured_sensor_ids(sensors) == {"bio-id"}
+
+
+def test_build_ui_sensor_unique_id_uses_stable_id_when_available():
+    assert (
+        build_ui_sensor_unique_id("source-1", "Bio", "sensor-1")
+        == "source-1_ui_sensor_sensor-1"
+    )
+
+
+def test_build_ui_sensor_unique_id_falls_back_to_legacy_name():
+    assert build_ui_sensor_unique_id("source-1", "Bio", None) == (
+        "source-1_ui_sensor_Bio"
+    )
+
+
+def test_build_ui_sensor_unique_id_preserves_existing_entity_identity():
+    assert build_ui_sensor_unique_id(
+        "source-1",
+        "Bio",
+        "sensor-1",
+        preserve_legacy_unique_id=True,
+    ) == build_legacy_ui_sensor_unique_id("source-1", "Bio")
+
+
+def test_build_ui_sensor_device_identifier_uses_stable_sensor_id():
+    assert (
+        build_ui_sensor_device_identifier("source-1", "sensor-1")
+        == "source-1_sensor_sensor-1"
+    )
+
+
+def test_parse_ui_sensor_device_identifier_returns_stable_sensor_id():
+    assert (
+        parse_ui_sensor_device_identifier("source-1", "source-1_sensor_sensor-1")
+        == "sensor-1"
+    )
+
+
+def test_parse_ui_sensor_device_identifier_ignores_other_identifiers():
+    assert (
+        parse_ui_sensor_device_identifier("source-1", "other_sensor_sensor-1") is None
+    )
+    assert parse_ui_sensor_device_identifier("source-1", "source-1") is None
+
+
+def test_parse_ui_sensor_device_id_uses_domain_identifier():
+    assert (
+        parse_ui_sensor_device_id(
+            "source-1",
+            {
+                ("other_domain", "source-1_sensor_sensor-1"),
+                ("waste_collection_schedule", "source-1_sensor_sensor-2"),
+            },
+        )
+        == "sensor-2"
+    )
+
+
+def test_build_ui_sensor_control_unique_id_uses_stable_sensor_id():
+    assert build_ui_sensor_control_unique_id("source-1", "sensor-1", "mode") == (
+        "source-1_ui_sensor_control_sensor-1_mode"
+    )
+
+
+def test_build_create_ui_sensor_action_unique_ids_are_stable():
+    assert (
+        build_create_combined_ui_sensor_action_unique_id("source-1")
+        == "source-1_ui_sensor_action_create_combined"
+    )
+    assert (
+        build_create_ui_sensor_action_unique_id("source-1", "Bio")
+        == "source-1_ui_sensor_action_create_Bio"
+    )
+
+
+def test_legacy_editor_round_trip_preserves_device_control_metadata():
+    existing_options = {
+        CONF_DEVICE_SENSOR_CONTROLS: True,
+        "sensors": [
+            {
+                CONF_NAME: "Bio",
+                CONF_SENSOR_ID: "bio-id",
+                CONF_SENSOR_LEGACY_UNIQUE_ID: True,
+                CONF_PRESET_LANGUAGE: "pl",
+                "types": ["organic"],
+            }
+        ],
+    }
+    submitted_options = {"separator": " / "}
+    submitted_sensor = {CONF_NAME: "Bio renamed", "types": ["organic"]}
+
+    updated_options = preserve_device_control_options(
+        existing_options,
+        submitted_options,
+    )
+    updated_sensor = preserve_sensor_control_metadata(
+        existing_options["sensors"][0],
+        submitted_sensor,
+    )
+    updated_options["sensors"] = [updated_sensor]
+
+    assert updated_options == {
+        CONF_DEVICE_SENSOR_CONTROLS: True,
+        "separator": " / ",
+        "sensors": [
+            {
+                CONF_NAME: "Bio renamed",
+                CONF_SENSOR_ID: "bio-id",
+                CONF_SENSOR_LEGACY_UNIQUE_ID: True,
+                CONF_PRESET_LANGUAGE: "pl",
+                "types": ["organic"],
+            }
+        ],
+    }
+
+
+def test_button_platform_adds_new_type_actions_after_later_fetch(monkeypatch):
+    class Aggregator:
+        def __init__(self):
+            self.type_options = {}
+
+    class Shell:
+        unique_id = "source-1"
+
+    class Coordinator:
+        def __init__(self):
+            self.shell = Shell()
+            self.device_info = "service-device"
+            self._aggregator = Aggregator()
+
+    class Entry:
+        def __init__(self):
+            self.entry_id = "entry-1"
+            self.options = {CONF_DEVICE_SENSOR_CONTROLS: True, "sensors": []}
+            self.unload_callbacks = []
+
+        def async_on_unload(self, callback):
+            self.unload_callbacks.append(callback)
+
+    class Hass:
+        def __init__(self, coordinator):
+            self.data = {"waste_collection_schedule": {"entry-1": coordinator}}
+
+    coordinator = Coordinator()
+    entry = Entry()
+    dispatcher_callbacks = []
+    added_entities = []
+
+    def connect(_hass, _signal, callback):
+        dispatcher_callbacks.append(callback)
+        return lambda: None
+
+    monkeypatch.setattr(button_module, "async_dispatcher_connect", connect)
+
+    asyncio.run(
+        button_module.async_setup_entry(
+            Hass(coordinator),
+            entry,
+            lambda entities: added_entities.extend(entities),
+        )
+    )
+
+    assert len(added_entities) == 1
+    assert len(dispatcher_callbacks) == 1
+    assert len(entry.unload_callbacks) == 1
+
+    coordinator._aggregator.type_options = {"organic": "Organic Waste"}
+    dispatcher_callbacks[0]()
+    dispatcher_callbacks[0]()
+
+    assert len(added_entities) == 2
+    assert isinstance(added_entities[1], button_module.CreateWasteSensorButton)

--- a/tests/test_sensor_device_config_helpers.py
+++ b/tests/test_sensor_device_config_helpers.py
@@ -480,6 +480,7 @@ def test_button_platform_adds_new_type_actions_after_later_fetch(monkeypatch):
     class Aggregator:
         def __init__(self):
             self.type_options = {}
+            self.type_aliases = {}
 
     class Shell:
         unique_id = "source-1"

--- a/tests/test_sensor_structured_attributes.py
+++ b/tests/test_sensor_structured_attributes.py
@@ -1,0 +1,189 @@
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import custom_components.waste_collection_schedule.sensor as sensor_module
+from custom_components.waste_collection_schedule.sensor import (
+    DetailsFormat,
+    render_sensor_preview,
+)
+from custom_components.waste_collection_schedule.waste_collection_schedule import (
+    Collection,
+)
+from custom_components.waste_collection_schedule.waste_collection_schedule.collection_aggregator import (
+    CollectionAggregator,
+)
+from custom_components.waste_collection_schedule.waste_collection_schedule.waste_types import (
+    ORGANIC,
+    set_display_language,
+)
+
+
+class DummyShell:
+    def __init__(self, entries):
+        self._entries = entries
+        self._customize = {}
+        self.refreshtime = None
+
+
+def test_collection_aggregator_filters_by_stable_type_id_across_languages():
+    pickup_date = datetime.date.today() + datetime.timedelta(days=3)
+    aggregator = CollectionAggregator(
+        [DummyShell([Collection(pickup_date, waste_type=ORGANIC)])]
+    )
+
+    try:
+        set_display_language("de")
+        assert aggregator.type_options == {"organic": "Biomüll"}
+        assert aggregator.get_upcoming(include_types=["organic"])
+        assert aggregator.get_upcoming(include_types=["Organic Waste"])
+        assert aggregator.get_upcoming(include_types=[" BIO "])
+        assert not aggregator.get_upcoming(exclude_types=["bio"])
+    finally:
+        set_display_language("en")
+
+
+def test_collection_aggregator_keeps_direct_legacy_type_matches():
+    pickup_date = datetime.date.today() + datetime.timedelta(days=3)
+    aggregator = CollectionAggregator([DummyShell([Collection(pickup_date, "Bio")])])
+
+    assert aggregator.get_upcoming(include_types=[" bio "])
+
+
+def test_render_sensor_preview_uses_home_assistant_local_time(monkeypatch):
+    pickup_date = datetime.date.today()
+    aggregator = CollectionAggregator([DummyShell([Collection(pickup_date, "Bio")])])
+
+    class LateSystemDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls.combine(pickup_date, datetime.time(22), tz)
+
+    monkeypatch.setattr(sensor_module.datetime, "datetime", LateSystemDateTime)
+    monkeypatch.setattr(
+        sensor_module.dt_util,
+        "now",
+        lambda: datetime.datetime.combine(pickup_date, datetime.time(8)),
+    )
+
+    state, _, _, _ = render_sensor_preview(
+        aggregator=aggregator,
+        separator=", ",
+        day_switch_time=datetime.time(9),
+        details_format=DetailsFormat.upcoming,
+        count=None,
+        leadtime=None,
+        collection_types=None,
+        value_template=None,
+        date_template=None,
+        add_days_to=False,
+        event_index=0,
+    )
+
+    assert state == "Bio in 0 days"
+
+
+def test_render_sensor_preview_defaults_missing_details_format_to_upcoming():
+    pickup_date = datetime.date.today() + datetime.timedelta(days=3)
+    aggregator = CollectionAggregator(
+        [DummyShell([Collection(pickup_date, "Bio", icon="mdi:leaf")])]
+    )
+
+    _, attributes, _, _ = render_sensor_preview(
+        aggregator=aggregator,
+        separator=", ",
+        day_switch_time=datetime.time(23, 59),
+        details_format=None,
+        count=None,
+        leadtime=None,
+        collection_types=None,
+        value_template=None,
+        date_template=None,
+        add_days_to=False,
+        event_index=0,
+    )
+
+    assert attributes[pickup_date.isoformat()] == "Bio"
+
+
+def test_render_sensor_preview_respects_hidden_details():
+    pickup_date = datetime.date.today() + datetime.timedelta(days=1)
+    aggregator = CollectionAggregator(
+        [DummyShell([Collection(pickup_date, "Bio", icon="mdi:leaf")])]
+    )
+
+    _, attributes, _, _ = render_sensor_preview(
+        aggregator=aggregator,
+        separator=", ",
+        day_switch_time=datetime.time(23, 59),
+        details_format=DetailsFormat.hidden,
+        count=None,
+        leadtime=None,
+        collection_types=None,
+        value_template=None,
+        date_template=None,
+        add_days_to=False,
+        event_index=0,
+    )
+
+    assert attributes == {}
+
+
+def test_render_sensor_preview_preserves_empty_pickup_detail_contracts():
+    aggregator = CollectionAggregator([DummyShell([])])
+    common = {
+        "aggregator": aggregator,
+        "separator": ", ",
+        "day_switch_time": datetime.time(23, 59),
+        "count": None,
+        "leadtime": None,
+        "collection_types": ["Bio"],
+        "value_template": None,
+        "date_template": None,
+        "add_days_to": True,
+        "event_index": 0,
+    }
+
+    state, generic_attributes, icon, picture = render_sensor_preview(
+        **common,
+        details_format=DetailsFormat.generic,
+    )
+    _, type_attributes, _, _ = render_sensor_preview(
+        **common,
+        details_format=DetailsFormat.appointment_types,
+    )
+
+    assert state is None
+    assert icon == "mdi:trash-can"
+    assert picture is None
+    assert generic_attributes == {
+        "types": ["Bio"],
+        "upcoming": [],
+        "last_update": "",
+    }
+    assert type_attributes == {"Bio": ""}
+
+
+def test_render_sensor_preview_localizes_default_state_text():
+    pickup_date = datetime.date.today() + datetime.timedelta(days=1)
+    aggregator = CollectionAggregator(
+        [DummyShell([Collection(pickup_date, "Bio", icon="mdi:leaf")])]
+    )
+
+    state, _, _, _ = render_sensor_preview(
+        aggregator=aggregator,
+        separator=", ",
+        day_switch_time=datetime.time(23, 59),
+        details_format=DetailsFormat.upcoming,
+        count=None,
+        leadtime=None,
+        collection_types=None,
+        value_template=None,
+        date_template=None,
+        add_days_to=False,
+        event_index=0,
+        preset_language="pl",
+    )
+
+    assert state == "Bio jutro"

--- a/tests/test_sensor_structured_attributes.py
+++ b/tests/test_sensor_structured_attributes.py
@@ -187,3 +187,63 @@ def test_render_sensor_preview_localizes_default_state_text():
     )
 
     assert state == "Bio jutro"
+
+
+def test_provider_labels_survive_v3_filters_customization_and_creation_actions():
+    from custom_components.waste_collection_schedule.sensor_config_helpers import (
+        missing_collection_types,
+    )
+    from custom_components.waste_collection_schedule.waste_collection_schedule.source.ecoharmonogram_pl import (
+        Source,
+    )
+    from custom_components.waste_collection_schedule.waste_collection_schedule.source_shell import (
+        Customize,
+        customize_function,
+    )
+
+    pickup_date = datetime.date.today() + datetime.timedelta(days=3)
+    labels = [
+        "ODPADY ZMIESZANE",
+        "BIO (wrzucamy bez worków - luzem)",
+        "ODPADY SEGREGOWANE",
+        "WIELKOGABARYTY",
+    ]
+    entries = [Source.transform((pickup_date, label)) for label in labels]
+    bio = entries[1]
+    original_identity = hash(bio)
+    assert bio.source_type == labels[1]
+    assert hash(Source.transform((pickup_date, "BIO"))) == original_identity
+    customize_function(bio, {labels[1]: Customize(labels[1], alias="BIO")})
+    assert bio.type == "BIO"
+    aggregator = CollectionAggregator([DummyShell(entries)])
+    for label, entry in zip(labels, entries, strict=True):
+        assert aggregator.get_upcoming(include_types=[label]) == [entry]
+        assert entry not in aggregator.get_upcoming(exclude_types=[label])
+    sensors = [{"types": [label]} for label in labels]
+    assert (
+        missing_collection_types(
+            aggregator.type_options, sensors, aggregator.type_aliases
+        )
+        == []
+    )
+
+
+def test_combined_provider_label_matches_each_emitted_type():
+    from custom_components.waste_collection_schedule.waste_collection_schedule.transformers import (
+        JsonTransformer,
+    )
+    from custom_components.waste_collection_schedule.waste_collection_schedule.waste_types import (
+        GLASS,
+        PAPER,
+    )
+
+    pickup_date = datetime.date.today() + datetime.timedelta(days=3)
+    transform = JsonTransformer(
+        date_key="date",
+        type_key="type",
+        type_value_map={"Local combined round": [PAPER, GLASS]},
+    )
+    entries = transform({"date": pickup_date, "type": "Local combined round"})
+    aggregator = CollectionAggregator([DummyShell(entries)])
+    assert len(aggregator.get_upcoming(include_types=["Local combined round"])) == 2
+    assert aggregator.type_aliases == {"Local combined round": {"paper", "glass"}}

--- a/tests/test_sensor_structured_attributes.py
+++ b/tests/test_sensor_structured_attributes.py
@@ -208,11 +208,30 @@ def test_provider_labels_survive_v3_filters_customization_and_creation_actions()
         "ODPADY SEGREGOWANE",
         "WIELKOGABARYTY",
     ]
-    entries = [Source.transform((pickup_date, label)) for label in labels]
+
+    def transform_label(label):
+        raw = {
+            "reports": [
+                {
+                    "scheduleDescription": [{"id": 1, "name": label}],
+                    "schedules": [
+                        {
+                            "scheduleDescriptionId": 1,
+                            "year": pickup_date.year,
+                            "month": pickup_date.month,
+                            "days": str(pickup_date.day),
+                        }
+                    ],
+                }
+            ]
+        }
+        return Source.transform(Source.parse(raw)[0])
+
+    entries = [transform_label(label) for label in labels]
     bio = entries[1]
     original_identity = hash(bio)
     assert bio.source_type == labels[1]
-    assert hash(Source.transform((pickup_date, "BIO"))) == original_identity
+    assert hash(transform_label("BIO")) == original_identity
     customize_function(bio, {labels[1]: Customize(labels[1], alias="BIO")})
     assert bio.type == "BIO"
     aggregator = CollectionAggregator([DummyShell(entries)])

--- a/tests/test_wcs_coordinator_lifecycle.py
+++ b/tests/test_wcs_coordinator_lifecycle.py
@@ -1,0 +1,32 @@
+from unittest.mock import Mock
+
+from custom_components.waste_collection_schedule.wcs_coordinator import WCSCoordinator
+
+
+def test_cancel_scheduled_callbacks_cancels_trackers_and_delayed_fetch():
+    coordinator = object.__new__(WCSCoordinator)
+    first_tracker = Mock()
+    second_tracker = Mock()
+    delayed_fetch = Mock()
+    coordinator._scheduled_callbacks = [first_tracker, second_tracker]
+    coordinator._pending_fetch_cancel = delayed_fetch
+
+    coordinator.cancel_scheduled_callbacks()
+
+    first_tracker.assert_called_once_with()
+    second_tracker.assert_called_once_with()
+    delayed_fetch.assert_called_once_with()
+    assert coordinator._scheduled_callbacks == []
+    assert coordinator._pending_fetch_cancel is None
+
+
+def test_cancel_scheduled_callbacks_is_idempotent():
+    coordinator = object.__new__(WCSCoordinator)
+    coordinator._scheduled_callbacks = []
+    coordinator._pending_fetch_cancel = None
+
+    coordinator.cancel_scheduled_callbacks()
+    coordinator.cancel_scheduled_callbacks()
+
+    assert coordinator._scheduled_callbacks == []
+    assert coordinator._pending_fetch_cancel is None


### PR DESCRIPTION
Successor to #6052, built on the v3 collection model.

Adds opt-in configuration controls on the integration service device, with a child device for each configured sensor. The existing bulk options editor remains available. Create/delete actions and per-sensor configuration preserve sensor identities and history; creation actions are idempotent and appear for types discovered by later fetches.

New sensors store stable `WasteType.id` filters. Existing display-name and provider-label filters keep working without rewriting saved configuration. Pipeline collections retain their original provider label so source-specific filters and custom aliases survive canonical type mapping. Coordinator timers and delayed callbacks are cancelled on unload.

Rebased on the current `release/3.0.0` branch. This remains a draft for 3.1 and should be retargeted to `master` after the 3.0 tag, as requested. No generated documentation or translation output is included.

Validation: 7,718 offline tests passed, 8 skipped; focused migration tests cover source parsing, old filters, aliases, identity, and duplicate creation. All pre-commit checks pass in the Python 3.14 validation environment. An independent compatibility review found no actionable issues.
