### PR TITLE
Update Lichfield source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+
 import requests
 from bs4 import BeautifulSoup
 from dateutil import parser
@@ -36,7 +37,7 @@ class Source:
             headers={"User-Agent": "Mozilla"},
         )
         soup = BeautifulSoup(response.text, "html.parser")
-
+        
         entries = []
 
         boxes = soup.find_all("div", class_="boxed")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -42,8 +42,9 @@ class Source:
         boxes = soup.find_all("div", class_="boxed")
 
         for box in boxes:
-            bdate_els = box.find_all("p",
-                class_=re.compile("bin-collection-tasks__(date|frequency)"))
+            bdate_els = box.find_all(
+                "p", class_=re.compile("bin-collection-tasks__(date|frequency)")
+            )
             if bdate_els:
                 bdate_str = bdate_els[0].contents[-1].string
                 bdate = parser.parse(bdate_str).date()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -37,7 +37,7 @@ class Source:
             headers={"User-Agent": "Mozilla"},
         )
         soup = BeautifulSoup(response.text, "html.parser")
-        
+
         entries = []
 
         boxes = soup.find_all("div", class_="boxed")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -18,7 +18,7 @@ TEST_CASES = {
 ICON_MAP = {
     "Black Bin": Icons.GENERAL_WASTE,
     "Blue Bin": Icons.RECYCLING,
-    "Blue Sack": Icons.RECYCLING,
+    "Blue Bag": Icons.RECYCLING,
     "Purple Bin": Icons.RECYCLING,
     "Garden Bin": Icons.GARDEN,
     "Brown Bin": Icons.GARDEN,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -43,7 +43,7 @@ class Source:
 
         for box in boxes:
             bdate_els = box.find_all(
-                "p", class_=re.compile("bin-collection-tasks__(date|frequency)")
+                    "p", class_=re.compile("bin-collection-tasks__(date|frequency)")
             )
             if bdate_els:
                 bdate_str = bdate_els[0].contents[-1].string

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -43,7 +43,7 @@ class Source:
 
         for box in boxes:
             bdate_els = box.find_all(
-                    "p", class_=re.compile("bin-collection-tasks__(date|frequency)")
+                "p", class_=re.compile("bin-collection-tasks__(date|frequency)")
             )
             if bdate_els:
                 bdate_str = bdate_els[0].contents[-1].string

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -1,5 +1,5 @@
 import datetime
-
+import re
 import requests
 from bs4 import BeautifulSoup
 from dateutil import parser
@@ -20,7 +20,8 @@ ICON_MAP = {
     "Blue Sack": Icons.RECYCLING,
     "Purple Bin": Icons.RECYCLING,
     "Garden Bin": Icons.GARDEN,
-    "Brown Bin": Icons.BIO_KITCHEN,
+    "Brown Bin": Icons.GARDEN,
+    "Food Waste Caddy": Icons.BIO_KITCHEN,
 }
 
 
@@ -38,24 +39,29 @@ class Source:
 
         entries = []
 
-        bins = soup.find_all("h3", class_="bin-collection-tasks__heading")
-        dates = soup.find_all("p", class_="bin-collection-tasks__date")
+        boxes = soup.find_all("div",class_="boxed")
 
-        for i in range(len(dates)):
-            bint = " ".join(bins[i].text.split()[2:4])
-            date = parser.parse(dates[i].text).date()
-            if (
-                date.month == 1
-                and datetime.date.today().month == 12
-                and date.year == datetime.date.today().year
-            ):
-                date = date.replace(year=date.year + 1)
-            entries.append(
-                Collection(
-                    date=date,
-                    t=bint,
-                    icon=ICON_MAP.get(bint),
+        for box in boxes:
+            bdate_els = box.find_all("p",class_=re.compile("bin-collection-tasks__(date|frequency)"))
+            if bdate_els:
+                bdate_str = bdate_els[0].contents[-1].string
+                bdate = parser.parse(bdate_str).date()
+                bname_els = box.find_all("h3", class_="bin-collection-tasks__heading")
+                bname = bname_els[0].contents[1]
+
+                if (
+                    bdate.month == 1
+                    and datetime.date.today().month == 12
+                    and bdate.year == datetime.date.today().year
+                ):
+                    bdate = bdate.replace(year=bdate.year + 1)
+
+                entries.append(
+                    Collection(
+                        date=bdate,
+                        t=bname,
+                        icon=ICON_MAP.get(bname),
+                    )
                 )
-            )
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lichfielddc_gov_uk.py
@@ -39,10 +39,11 @@ class Source:
 
         entries = []
 
-        boxes = soup.find_all("div",class_="boxed")
+        boxes = soup.find_all("div", class_="boxed")
 
         for box in boxes:
-            bdate_els = box.find_all("p",class_=re.compile("bin-collection-tasks__(date|frequency)"))
+            bdate_els = box.find_all("p",
+                class_=re.compile("bin-collection-tasks__(date|frequency)"))
             if bdate_els:
                 bdate_str = bdate_els[0].contents[-1].string
                 bdate = parser.parse(bdate_str).date()


### PR DESCRIPTION
Updating Lichfield to accommodate new web layout and weekly food caddy collections.

## Summary

This PR updates the Lichfield source to accommodate their revised web layout and new food caddy collections.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
