### PR TITLE
Align validation with the supported Home Assistant version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: requirements.txt
       - name: Install dependencies

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "Waste Collection Schedule",
   "domains": ["sensor"],
   "iot_class": "cloud_polling",
-  "homeassistant": "2023.12.0"
+  "homeassistant": "2024.4.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@ python-dateutil>=2.8.2
 pytz>=2021.3
 PyYAML>=6.0.1
 requests>=2.31.0
-urllib3>=2.0.7
+urllib3>=1.26.18
 jinja2>=3.1.2
 lxml>=4.9.4
 pycryptodome>=3.20.0
 typing_extensions>=4.12.2
 pypdf>=5.1.0
 pdfminer.six>=20221105
-homeassistant
+homeassistant>=2024.4.0


### PR DESCRIPTION
## Summary

- raise the declared Home Assistant minimum to 2024.4.0
- run repository validation on Python 3.12
- allow urllib3 1.26.18 and newer in the development requirements

## Why

The current `master` config flow imports `ConfigFlowResult`, which is available from Home Assistant 2024.4. Keeping 2023.12 as the declared minimum therefore understates the integration's real runtime requirement.

This remains separate from #6983 so the transient-fetch recovery PR stays product-focused.

## Validation

- Python 3.12 with Home Assistant 2024.4.0 successfully imported `ConfigFlowResult` and the integration config flow
- 34 base tests passed
- dependency consistency check passed
- workflow YAML formatting and actionlint passed
