### PR TITLE
Align v3 validation with the supported Home Assistant version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: pip
           cache-dependency-path: requirements.txt
       - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ Pillow>=10.0.0
 pdfminer.six>=20221105
 Babel>=2.12.0
 holidays>=0.40
-homeassistant
+homeassistant>=2023.12.0


### PR DESCRIPTION
## Summary

- run v3 validation on Python 3.11, matching the repository's advertised Home Assistant 2023.12 compatibility floor
- prevent the unbounded development dependency from resolving to Home Assistant 2023.7.3

The existing Python 3.10 job cannot install Home Assistant 2023.12 and silently selects 2023.7.3 instead. Integration-level test collection then fails because that unsupported version does not export `DeviceInfo` from `homeassistant.helpers.device_registry`.

This is separated from #6984 and #6985 so the Ecoharmonogram and device-control PRs remain product-focused.

## Validation

- clean Python 3.11 resolution installed Home Assistant 2023.12.4
- `DeviceInfo` import succeeded
- 2,414 v3 architecture tests passed (4 skipped)
- #6984's 2,417 focused/architecture tests passed (4 skipped)
- #6985's 2,459 focused/architecture tests passed (4 skipped)
- YAML formatting, codespell, and diff checks passed