### PR TITLE
Add Peoria (IL) to RecycleCoach EXTRA_INFO

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -320,6 +320,12 @@ EXTRA_INFO = [
         "country": "us",
         "default_params": {"project_id": "3015", "district_id": "NEWRO"},
     },
+    {
+        "title": "Peoria (IL)",
+        "url": "https://www.peoriagov.org/533/Yes-Peoria-Picks-Up",
+        "country": "us",
+        "default_params": {"project_id": "PEORIA", "district_id": "PEORIA"},
+    },
 ]
 
 TEST_CASES = {
@@ -429,6 +435,11 @@ TEST_CASES = {
         "district_id": "NEWRO",
         "project_id": 3015,
         "zone_id": "zone-z19582-z19705",
+    },
+    "Peoria, IL, USA": {
+        "street": "10303 N Churchill Dr",
+        "city": "Peoria",
+        "state": "Illinois",
     },
 }
 


### PR DESCRIPTION
## Summary
- Peoria, IL (https://www.peoriagov.org/533/Yes-Peoria-Picks-Up) already embeds the Recycle Coach "My Schedule" widget for collection lookups, so it's covered by the existing `recyclecoach_com` shared source rather than needing a new source module.
- Adds an `EXTRA_INFO` entry (`project_id`/`district_id` = `PEORIA`) so it shows up in the docs/config-flow list.
- Adds a `TEST_CASES` entry using the example address from the issue.

Closes #5019

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python -m pytest tests/test_source_components.py -q` (34 passed)
- [x] `python test_sources.py -s recyclecoach_com -l` — full TEST_CASES suite passes, including the new "Peoria, IL, USA" case (726 entries fetched, correct types/icons, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)