### PR TITLE
fix(publidata_fr): add Sud Sainte Baume (Saint-Cyr-sur-Mer) to Publidata source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/publidata_fr.py
@@ -56,6 +56,11 @@ TEST_CASES = {
         "insee_code": "50129",
         "instance_id": 1011,
     },
+    "Sud Sainte Baume, Saint-Cyr-sur-Mer": {
+        "address": "20 Rue Victor Hugo",
+        "insee_code": "83112",
+        "instance_id": 1483,
+    },
     # "Saumur Val de Loire, Allones": {
     # "address": "5 rue du Bellay",
     # "insee_code": "49002",
@@ -131,6 +136,7 @@ ICON_MAP = {
     "verre": Icons.GLASS,
     "bio": Icons.ORGANIC,
     "sapin": Icons.CHRISTMAS_TREE,
+    "jrm": Icons.PAPER,
 }
 
 LABEL_MAP = {
@@ -141,6 +147,7 @@ LABEL_MAP = {
     "verre": "Verres",
     "bio": "Biodéchets",
     "sapin": "Sapin",
+    "jrm": "Papiers / Magazines",
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
@@ -301,6 +308,11 @@ EXTRA_INFO = [
         "title": "Le Cotentin",
         "url": "https://dechets.lecotentin.fr/",
         "default_params": {"instance_id": 1011},
+    },
+    {
+        "title": "Sud Sainte Baume",
+        "url": "https://www.agglo-sudsaintebaume.fr/",
+        "default_params": {"instance_id": 1483},
     },
 ]
 


### PR DESCRIPTION
## Summary
- Add Sud Sainte Baume (instance_id 1483) to `publidata_fr.py`'s `EXTRA_INFO` and `TEST_CASES`, as requested in #4581
- Add a `jrm` (papers/magazines) waste-type mapping to `ICON_MAP`/`LABEL_MAP`, since this instance surfaces that stream and it previously had no mapping
- The `"list index out of range"` crash originally reported in #4581 was already fixed by #5896 (merged after this issue was filed); verified live that the source now works correctly for this instance

Fixes #4581

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python test_sources.py -s publidata_fr -l -t` — all test cases pass, including the new "Sud Sainte Baume, Saint-Cyr-sur-Mer" case (533 entries, no errors)
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)