### PR TITLE
fix(carmarthenshire_gov_wales): handle UPRNs with no collection data

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/carmarthenshire_gov_wales.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/carmarthenshire_gov_wales.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "Carmarthenshire County Council"
 DESCRIPTION = "Source script for carmarthenshire.gov.wales"
@@ -71,7 +72,11 @@ class Source:
         entries = []
         for item in containers:
             dates = item.findAll("p", {"class": "font11 text-center"})
-            if "  " not in dates[0].text:
+            # Some containers (e.g. when the council has no record for the
+            # UPRN, or a service such as garden/nappy waste is not signed up
+            # for) don't include a date paragraph at all. Skip those instead
+            # of crashing with an IndexError.
+            if not dates or "  " not in dates[0].text:
                 continue
             entries.append(
                 Collection(
@@ -81,6 +86,15 @@ class Source:
                     t=REMAP_WASTE.get(item["class"][1].upper()),
                     icon=ICON_MAP.get(item["class"][1].upper()),
                 )
+            )
+
+        if not entries:
+            raise SourceArgumentNotFound(
+                "uprn",
+                self._uprn,
+                "the council has no collection information for this UPRN. "
+                "Please double-check the UPRN or contact Carmarthenshire "
+                "County Council directly.",
             )
 
         return entries


### PR DESCRIPTION
## Summary
- Fixes a crash (`IndexError: list index out of range`, surfaced to users as "The source returned an invalid response") reported in #5256.
- Root cause: when Carmarthenshire's site has no record for a given UPRN, it returns a container div without the expected `<p class="font11 text-center">` date paragraph. The code indexed into an empty list without checking.
- Now: containers missing the date paragraph are skipped, and if no valid entries are found at all, a `SourceArgumentNotFound` is raised with a message directing the user to double-check their UPRN or contact the council.

## Test plan
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python test_sources.py -s carmarthenshire_gov_wales -l` — all 3 existing TEST_CASES still return correct results
- [x] Manually verified against a live UPRN with no council record — previously threw IndexError, now raises a clear `SourceArgumentNotFound`
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed

Fixes #5256