### PR TITLE
feat(source): add GLØR (glor_no) waste collection for Norway

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/glor_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/glor_no.py
@@ -1,0 +1,140 @@
+import datetime
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+TITLE = "GLØR"
+DESCRIPTION = (
+    "Source for GLØR (Gudbrandsdal Lillehammer Øyer Ringebu Renovasjon), Norway."
+)
+URL = "https://glor.no"
+COUNTRY = "no"
+
+TEST_CASES = {
+    "Storgata 1, Lillehammer": {"address": "Storgata 1, Lillehammer"},
+    "Segalstadsetervegen 33, Gausdal": {"address": "Segalstadsetervegen 33, Gausdal"},
+    "Gudbrandsdalsvegen 187 (without city)": {"address": "Gudbrandsdalsvegen 187"},
+}
+
+SEARCH_URL = "https://proaktiv.glor.offcenit.no/search"
+DETAILS_URL = "https://proaktiv.glor.offcenit.no/details"
+REQUEST_TIMEOUT = 30
+
+ICON_MAP = {
+    "Restavfall": Icons.GENERAL_WASTE,
+    "Papir, papp": Icons.PAPER,
+    "Plast blandet": Icons.PLASTIC_PACKAGING,
+    "Matavfall": Icons.BIO_KITCHEN,
+    "Hermetikk- og glassemballasje": Icons.GLASS,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Search for your address at glor.no/tømmeplan. Use the address exactly "
+        "as shown in the result list, optionally followed by the municipality "
+        "name, for example 'Storgata 1, Lillehammer'."
+    )
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Address, optionally followed by the municipality, e.g. 'Storgata 1, Lillehammer'.",
+    }
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Address",
+    }
+}
+
+
+def _normalize(value: str) -> str:
+    return "".join(value.casefold().replace(".", "").replace(",", "").split())
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address
+
+    def fetch(self) -> list[Collection]:
+        candidates = self._lookup_properties()
+
+        entries: list[Collection] = []
+        seen: set[tuple[str, str]] = set()
+        for candidate in candidates:
+            r = requests.get(
+                DETAILS_URL,
+                params={"id": candidate["id"]},
+                timeout=REQUEST_TIMEOUT,
+            )
+            r.raise_for_status()
+            for item in r.json():
+                date_str = item["dato"][:10]
+                waste_type = item["fraksjon"]
+                key = (date_str, waste_type)
+                if key in seen:
+                    continue
+                seen.add(key)
+                entries.append(
+                    Collection(
+                        date=datetime.date.fromisoformat(date_str),
+                        t=waste_type,
+                        icon=ICON_MAP.get(waste_type),
+                    )
+                )
+
+        if not entries:
+            raise SourceArgumentNotFound(
+                "address",
+                self._address,
+                "no collection schedule found for this address",
+            )
+
+        return entries
+
+    def _lookup_properties(self) -> list[dict]:
+        # The municipality name may optionally be appended after a comma, e.g.
+        # "Storgata 1, Lillehammer". The search API only matches on the
+        # street + house number part, so that is what is used as the query.
+        address_part = self._address.split(",")[0].strip()
+        kommune_part = (
+            self._address.split(",", 1)[1].strip() if "," in self._address else None
+        )
+
+        r = requests.get(
+            SEARCH_URL, params={"q": address_part}, timeout=REQUEST_TIMEOUT
+        )
+        r.raise_for_status()
+        matches = r.json()
+
+        addr_norm = _normalize(address_part)
+        candidates = [m for m in matches if _normalize(m["adresse"]) == addr_norm]
+
+        if kommune_part:
+            kommune_norm = _normalize(kommune_part)
+            candidates = [
+                m for m in candidates if _normalize(m["kommune"]) == kommune_norm
+            ]
+        elif len({m["kommune"] for m in candidates}) > 1:
+            # The same street name exists in more than one municipality served
+            # by GLØR — the user needs to disambiguate by adding the
+            # municipality name after a comma.
+            suggestions = sorted(
+                {f"{m['adresse']}, {m['kommune']}" for m in candidates}
+            )
+            raise SourceArgumentNotFoundWithSuggestions(
+                "address", self._address, suggestions
+            )
+
+        if not candidates:
+            suggestions = sorted({f"{m['adresse']}, {m['kommune']}" for m in matches})
+            raise SourceArgumentNotFoundWithSuggestions(
+                "address", self._address, suggestions
+            )
+
+        return candidates

--- a/doc/source/glor_no.md
+++ b/doc/source/glor_no.md
@@ -1,0 +1,34 @@
+# GLØR
+
+Support for schedules provided by [GLØR](https://glor.no) (Gudbrandsdal Lillehammer Øyer Ringebu Renovasjon), serving the municipalities of Lillehammer, Øyer, Ringebu and Gausdal, Norway.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: glor_no
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**  
+*(String) (required)*
+
+The address, optionally followed by the municipality name after a comma, for example `Storgata 1, Lillehammer`. The municipality is only required if the same street name exists in more than one municipality served by GLØR.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: glor_no
+      args:
+        address: Storgata 1, Lillehammer
+```
+
+## How to get the source argument
+
+Visit [https://glor.no/tømmeplan](https://glor.no/t%C3%B8mmeplan), search for your address, and use the address exactly as shown in the result list, optionally followed by the municipality name.


### PR DESCRIPTION
## Summary
- Adds a new source for GLØR (Gudbrandsdal Lillehammer Øyer Ringebu Renovasjon), covering Lillehammer, Øyer, Ringebu and Gausdal municipalities in Norway.
- Uses the public `proaktiv.glor.offcenit.no` search/details JSON API (no login, no Cloudflare challenge).
- Handles multi-unit buildings (several property sub-records sharing one schedule, merged/deduped) and disambiguates addresses that are ambiguous across municipalities via `SourceArgumentNotFoundWithSuggestions`.
- Closes #4487.

## Test plan
- [x] `ruff check` / `ruff format` clean
- [x] `python -m pytest tests/test_source_components.py -q` passes (34 passed)
- [x] Live test against all 3 `TEST_CASES` via `test_sources.py -s glor_no -l` — all succeeded