### PR TITLE
Add Stadtwerke Aschaffenburg (GIPS/ICS); remove stale MyMuell listing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -135,7 +135,6 @@ SERVICE_MAP = {
         "comment": "MyMuell App",
         "url": "https://www.mymuell.de/",
         "list": [
-            "Aschaffenburg",
             "Bad Arolsen",
             "Beverungen",
             "Darmstadt",

--- a/doc/ics/yaml/gipsprojekt_de.yaml
+++ b/doc/ics/yaml/gipsprojekt_de.yaml
@@ -18,10 +18,16 @@ description: |
   | Region | URL |
   | ------ | --- |
   | Stadtwerke Speyer | <https://www.stadtwerke-speyer.de/muellkalender> |
+  | Stadtwerke Aschaffenburg | <https://www.stwab.de/Abfall-Stadtreinigung/Muellabfuhr/Abfuhrtermine-und-Bezirk/> |
 extra_info:
   - title: Stadtwerke Speyer
     url: https://www.stadtwerke-speyer.de/muellkalender
     country: de
+  - title: Stadtwerke Aschaffenburg
+    url: https://www.stwab.de/Abfall-Stadtreinigung/Muellabfuhr/Abfuhrtermine-und-Bezirk/
+    country: de
 test_cases:
   Speyer, Schnaudigelweg (Abfallgebiet Hellgrün):
     url: https://www.stadtwerke-speyer.de/speyerGips/Gips?SessionMandant=Speyer&Anwendung=Abfuhrkalender&Methode=TermineAnzeigenICS&Mandant=Speyer&Abfuhrkalender=Speyer{%Y}&Bezirk_ID=22&Jahr={%Y}
+  Aschaffenburg, Schillerstraße (bis Hs.Nrn. 108):
+    url: https://www.stwab.de/aschaffenburgGips/Gips?SessionMandant=Aschaffenburg&Anwendung=Abfuhrkalender&Methode=TermineAnzeigenICS&Mandant=Aschaffenburg&Abfuhrkalender=Aschaffenburg&Bezirk_ID=1647&Jahr={%Y}


### PR DESCRIPTION
## Summary
- Stadtwerke Aschaffenburg (stwab.de) uses the same "GIPS" (Gemeinsame Internetplattform für Stadtwerke) system as Stadtwerke Speyer, already documented as the shared `Gipsprojekt` ICS platform. Document Aschaffenburg there instead of adding a new dedicated source.
- The previously documented MyMuell/Junker listing for the *city* of Aschaffenburg (`jumomind_de.py`, `mymuell` service) has returned zero collection dates for every street since 2024 (confirmed live against the MyMuell API) — remove the stale entry. `Landkreis Aschaffenburg` (the surrounding district, a different provider/list) is unaffected.

## Test plan
- [x] Verified the stwab.de ICS feed (`Bezirk_ID=1647`) fetches correctly through the generic `ics` source for 2025 and 2026.
- [x] `python -m pytest tests/test_source_components.py -q` passes.
- [x] `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s jumomind_de` — all existing test cases still pass.

Closes #4406

🤖 Generated with [Claude Code](https://claude.com/claude-code)