### PR TITLE
Add City of Raleigh, NC to ReCollect shared-platform list

### DIFF
--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -197,6 +197,9 @@ extra_info:
   - title: City of Apopka, FL
     url: https://www.apopka.gov/319/Solid-Waste
     country: us
+  - title: City of Raleigh, NC
+    url: https://raleighnc.gov/landfill-and-reuse/services/raleigh-reuse-web-tool-and-mobile-app
+    country: us
 
 howto:
   en: |
@@ -253,6 +256,7 @@ howto:
     |Atlantic Waste Services, GA|USA|[atlanticwaste.com](https://atlanticwaste.com)|
     |Newcastle upon Tyne|UK|[new.newcastle.gov.uk](https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day)|
     |City of Apopka, FL|USA|[apopka.gov](https://www.apopka.gov/319/Solid-Waste)|
+    |City of Raleigh, NC|USA|[raleighnc.gov](https://raleighnc.gov/landfill-and-reuse/services/raleigh-reuse-web-tool-and-mobile-app)|
 
     and probably a lot more.
 


### PR DESCRIPTION
## Summary
- Raleigh, NC's "Raleigh Reuse" waste/recycling tool (raleighnc.gov) is powered by the ReCollect platform (`area: CityofRaleighNC`), already supported by this repo via the generic ICS source.
- Adds City of Raleigh, NC to the `extra_info` list and the `howto.en` table in `doc/ics/yaml/recollect.yaml` so it shows up in the generated docs/README/sources.json.

Closes #4265.

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes (34 passed)
- [ ] A Raleigh resident follows the existing ReCollect howto instructions (search address on the reuse tool, "Get a calendar" → "Add to Google Calendar", strip `client_id`) to obtain their working ICS URL and confirms it works with the generic `ics` source