### PR TITLE
fix(abfall_io_graphql): add Landkreis Göttingen to v3 GraphQL service map

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -30,4 +30,9 @@ SERVICE_MAP = [
         "url": "https://www.wb-duisburg.de/",
         "service_id": "80acad6c77fe9342ebafad29a8c58bf6",
     },
+    {
+        "title": "Landkreis Göttingen",
+        "url": "https://www.landkreisgoettingen.de/",
+        "service_id": "4b5702d771c82b611c386ebbc7629026",
+    },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -73,6 +73,10 @@ TEST_CASES = {
         "key": "80acad6c77fe9342ebafad29a8c58bf6",
         "idHouseNumber": 72827,
     },
+    "Landkreis Göttingen, Scheden": {
+        "key": "4b5702d771c82b611c386ebbc7629026",
+        "idHouseNumber": 641,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Landkreis Göttingen (`landkreisgoettingen.de`) uses the abfall.io v3 API and exposes only a flat `idhousenumber` (no kommune/bezirk/strasse hierarchy), so the legacy `abfall_io` source's multi-step form flow cannot resolve an address for it — that's what the reporter hit in #4125.
- Verified live that abfall.io key `4b5702d771c82b611c386ebbc7629026` is a valid v3 API key and that the existing `abfall_io_graphql` source's GraphQL flow returns correct collection data for it.
- Adds Landkreis Göttingen to `AbfallIOGraphQL.SERVICE_MAP` so it appears in the config wizard/EXTRA_INFO listing, plus a `TEST_CASES` entry (`idHouseNumber=641`, Scheden) for CI coverage.

Fixes #4125

## Test plan
- [x] `ruff check --fix` / `ruff format` on both changed files
- [x] `python test_sources.py -s abfall_io_graphql -l` — all 8 test cases pass, including the new Landkreis Göttingen case
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed