### PR TITLE
Fix integer config parameter coercion

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -286,8 +286,11 @@ def _build_schema_from_params(
                 )
             elif param.widget == "integer":
                 # config_params.integer(): a free-form whole-number field.
-                vol_args[key] = NumberSelector(
-                    NumberSelectorConfig(mode=NumberSelectorMode.BOX, step=1)
+                vol_args[key] = vol.All(
+                    NumberSelector(
+                        NumberSelectorConfig(mode=NumberSelectorMode.BOX, step=1)
+                    ),
+                    vol.Coerce(int),
                 )
             elif param.widget == "boolean":
                 # config_params.boolean(): a true/false toggle.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test .claude .git
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py
+python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py
 markers =
     live: test fetches from a live provider endpoint; excluded from gating CI (run with `-m live` locally). Replaced by offline fixtures.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,21 @@
-from waste_collection_schedule.config_params import integer
+import calendar  # noqa: F401 — must import stdlib calendar FIRST
+import os
+import sys
 
-from custom_components.waste_collection_schedule.config_flow import (
+# Ensure the inner library package is importable.
+# IMPORTANT: stdlib calendar must be imported ABOVE before this path is added,
+# because HA's calendar.py in this path shadows the stdlib calendar module.
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "../custom_components/waste_collection_schedule",
+    ),
+)
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from waste_collection_schedule.config_params import integer  # isort:skip
+from custom_components.waste_collection_schedule.config_flow import (  # isort:skip
     _build_schema_from_params,
 )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,19 @@
+from waste_collection_schedule.config_params import integer
+
+from custom_components.waste_collection_schedule.config_flow import (
+    _build_schema_from_params,
+)
+
+
+def test_integer_selector_coerces_submitted_value() -> None:
+    schema = _build_schema_from_params(
+        [integer("count")],
+        pre_filled={},
+        args_input=None,
+        include_title=False,
+    )
+
+    result = schema({"count": 5.0})
+
+    assert result["count"] == 5
+    assert isinstance(result["count"], int)


### PR DESCRIPTION
## Summary

Closes #6941

Integer config fields now coerce the NumberSelector's float output to `int` before source construction. A regression test covers the submitted-value type.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
