### PR TITLE
Add West Kelowna (BC) to recyclecoach_com source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -225,6 +225,15 @@ EXTRA_INFO = [
         },
     },
     {
+        "title": "West Kelowna (BC)",
+        "url": "https://www.rdco.com/",
+        "country": "ca",
+        "default_params": {
+            "project_id": "502",
+            "district_id": "WestKelowna",
+        },
+    },
+    {
         "title": "Plainville (CT)",
         "url": "https://www.plainvillect.com/",
         "country": "us",
@@ -435,6 +444,13 @@ TEST_CASES = {
         "district_id": "NEWRO",
         "project_id": 3015,
         "zone_id": "zone-z19582-z19705",
+    },
+    "West Kelowna, BC, Canada (with district_id & project_id)": {
+        "street": "2760 Cameron Rd",
+        "city": "West Kelowna",
+        "state": "British Columbia",
+        "district_id": "WestKelowna",
+        "project_id": "502",
     },
     "Peoria, IL, USA": {
         "street": "10303 N Churchill Dr",


### PR DESCRIPTION
## Summary
- West Kelowna, BC uses the same RDCO/Recycle Coach project (`project_id: 502`) as the already-supported Kelowna (BC), just with `district_id: WestKelowna` instead of `Kelowna`.
- Adds a new `EXTRA_INFO` entry for "West Kelowna (BC)" and a corresponding `TEST_CASES` entry using the reporter's public example address.

## Test plan
- [x] Verified via the live Recycle Coach city-search API that West Kelowna resolves to `project_id: 502`, `district_id: WestKelowna`, `stage: 3` (fully supported)
- [x] `ruff check --fix` / `ruff format` on the changed file
- [x] `python custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s recyclecoach_com -l` — new "West Kelowna, BC, Canada" test case returns 189 entries
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed

Closes #7002

🤖 Generated with [Claude Code](https://claude.com/claude-code)