### PR TITLE
fix(abfall_io): migrate ASG Nordsachsen to v3 GraphQL API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -148,11 +148,6 @@ SERVICE_MAP = [
         "service_id": "d287412901d68d66825e588a60c94641",
     },
     {
-        "title": "ASG Nordsachsen",
-        "url": "https://www.asg-nordsachsen.de/",
-        "service_id": "1d78841c5d7fc43ebe52b9dc01f6b962",
-    },
-    {
         "title": "AVR Kommunal, Rhein-Neckar-Kreis",
         "url": "https://www.avr-kommunal.de/",
         "service_id": "914fb9d000a9a05af4fd54cfba478860",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -35,4 +35,9 @@ SERVICE_MAP = [
         "url": "https://www.landkreisgoettingen.de/",
         "service_id": "4b5702d771c82b611c386ebbc7629026",
     },
+    {
+        "title": "ASG Nordsachsen",
+        "url": "https://www.asg-nordsachsen.de/",
+        "service_id": "2085afd95285e645e15ee9623d0c5172",
+    },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -77,6 +77,10 @@ TEST_CASES = {
         "key": "4b5702d771c82b611c386ebbc7629026",
         "idHouseNumber": 641,
     },
+    "ASG Nordsachsen, Delitzsch-Beerendorf": {
+        "key": "2085afd95285e645e15ee9623d0c5172",
+        "idHouseNumber": 360435,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- ASG Nordsachsen's legacy abfall.io v2 key (`1d78841c5d7fc43ebe52b9dc01f6b962`) now returns HTTP 401 — same root cause as #4775 (Entsorgungsbetriebe Essen, fixed in #6961). The provider has migrated to the abfall.io v3 GraphQL API.
- Removed the stale entry from the legacy `AbfallIO` service map and added it to `AbfallIOGraphQL` with the new v3 key (`2085afd95285e645e15ee9623d0c5172`), found live in the widget embed on https://www.asg-nordsachsen.de/entsorgung/abfalltermine.html.
- Added a `TEST_CASES` entry for ASG Nordsachsen (Delitzsch-Beerendorf) to `abfall_io_graphql`.

## Test plan
- [x] `ruff check --fix` / `ruff format` on changed files
- [x] `python test_sources.py -s abfall_io_graphql -l` — 27 entries found for the new ASG Nordsachsen test case, no errors
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed

Fixes #4335