### PR TITLE
fix(abfallnavi_de): don't abort fetch when a street resolves to multiple split segments

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallnaviDe.py
@@ -344,16 +344,45 @@ class AbfallnaviDe:
         street_ids = self.get_street_ids(city_id, street)
 
         dates = []
+        not_found_errors = []
         for street_id in street_ids:
             # find house_number_id (which is optional: not all house number do have an id)
-            house_number_id = self.get_house_number_id(street_id, house_number)
-
-            # return dates for specific house number of street if house number
-            # doesn't have an own id
-            if house_number_id is not None:
-                dates += self.get_dates_by_house_number_id(house_number_id)
+            try:
+                house_number_id = self.get_house_number_id(street_id, house_number)
+            except SourceArgumentNotFoundWithSuggestions as e:
+                # Some providers split a single street name into multiple
+                # entries covering different house-number ranges (e.g. by
+                # city district; see Solingen "Katternberger Straße" in
+                # issue #4701, where "Mitte" and "Burg-Höhscheid" share the
+                # same street name but cover disjoint house numbers). If the
+                # requested house number isn't part of this particular
+                # split, skip it and keep trying the other matches instead
+                # of aborting the whole fetch.
+                if len(street_ids) > 1:
+                    not_found_errors.append(e)
+                    continue
+                raise
             else:
-                dates += self.get_dates_by_street_id(street_id)
+                # return dates for specific house number of street if house
+                # number doesn't have an own id
+                if house_number_id is not None:
+                    dates += self.get_dates_by_house_number_id(house_number_id)
+                else:
+                    dates += self.get_dates_by_street_id(street_id)
+
+        if not dates and not_found_errors:
+            # none of the split street entries contained the requested
+            # house number: raise with the combined suggestions from all
+            # of them
+            suggestions: list = []
+            for err in not_found_errors:
+                for s in err.suggestions:
+                    if s not in suggestions:
+                        suggestions.append(s)
+            raise SourceArgumentNotFoundWithSuggestions(
+                "hausnummer", house_number, suggestions
+            )
+
         return dates
 
     def _find_in_inverted_dict(self, mydict, value):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
@@ -72,6 +72,12 @@ TEST_CASES = {
         "ort": "Frankenthal",
         "strasse": "Am Martinspfad",
     },
+    "Solingen, Katternberger Straße 95 (street split by district)": {
+        "service": "solingen",
+        "ort": "Solingen",
+        "strasse": "Katternberger Straße",
+        "hausnummer": "95",
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Fixes #4701: `abfallnavi_de` returned zero collection entries (empty
  calendar, all sensors "unknown") for any address on a street that the
  provider's API splits into multiple entries sharing the same name but
  covering disjoint house-number ranges (e.g. by city district). Confirmed
  live for Solingen, where 12 street names are split this way, e.g.
  "Katternberger Straße" is split into "Mitte" (house numbers 2-57) and
  "Burg-Höhscheid" (78-...) with different internal street IDs.
- Root cause: `AbfallnaviDe.get_street_ids()` correctly matches all IDs
  sharing a street name, but `get_dates()` iterated over them without
  catching per-segment lookup errors — if the user's house number wasn't
  in the *first* matched segment, `get_house_number_id()` raised
  immediately and aborted the whole fetch, even though a later segment
  would have resolved successfully.
- Fix: when more than one street ID matches, a "house number not found"
  error for one segment is now caught and that segment is skipped instead
  of aborting; the fetch only raises if none of the matched segments
  contain the house number (with combined suggestions from all of them).
  Single-match streets (the common case) are unaffected.
- Added a new TEST_CASE reproducing the Solingen scenario.

## Test plan
- [x] `ruff check --fix` / `ruff format` on both changed files
- [x] `python test_sources.py -s abfallnavi_de -l` — all test cases pass
      except a pre-existing, unrelated failure ("Pinneberg Kummerfeld no
      Street") that reproduces identically on master and is not touched
      by this change
- [x] `python -m pytest tests/test_source_components.py -q` — passes