### PR TITLE
Add Gemeinde Mils (Tyrol, Austria) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mils_tirol_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mils_tirol_at.py
@@ -1,0 +1,79 @@
+from typing import ClassVar
+
+from waste_collection_schedule import Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
+
+TITLE = "Gemeinde Mils"
+DESCRIPTION = "Source for Gemeinde Mils, Tyrol, Austria."
+URL = "https://mils-tirol.at"
+COUNTRY = "at"
+SOURCE_CODEOWNERS = ["@bbr111"]
+
+TEST_CASES: dict[str, dict] = {
+    "Fichtenweg 21": {
+        "strasse": "Fichtenweg",
+        "hausnummer": "21",
+    },
+    "Dorfplatz 1": {
+        "strasse": "Dorfplatz",
+        "hausnummer": "1",
+    },
+}
+
+ICON_MAP = {
+    "Biomüll": Icons.ORGANIC,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Altpapier&Kleinkartons": Icons.PAPER,
+    "Problemstoffsammlung": Icons.HAZARDOUS,
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+    "de": {
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Street name as listed in the Mils waste calendar dropdown.",
+        "hausnummer": "House number as listed in the Mils waste calendar dropdown.",
+    },
+    "de": {
+        "strasse": "Straßenname wie in der Abfallkalender-Auswahl von Mils aufgeführt.",
+        "hausnummer": "Hausnummer wie in der Abfallkalender-Auswahl von Mils aufgeführt.",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Open https://mils-tirol.at/Service/Dienstleistungen/Abfallkalender, pick "
+        "your street and house number from the dropdowns, and use the same values "
+        "for 'strasse' and 'hausnummer'."
+    ),
+    "de": (
+        "Öffnen Sie https://mils-tirol.at/Service/Dienstleistungen/Abfallkalender, "
+        "wählen Sie Ihre Straße und Hausnummer aus den Dropdown-Menüs, und "
+        "verwenden Sie dieselben Werte für 'strasse' und 'hausnummer'."
+    ),
+}
+
+
+class Source(RiSKommunalSource):
+    BASE_URL = "https://mils-tirol.at"
+    ICON_MAP = ICON_MAP
+    SELECTION_URL = "https://mils-tirol.at/Service/Dienstleistungen/Abfallkalender"
+    LOOKAHEAD_DAYS = 365
+    MAX_PAGES = 30
+    QUERY_PARAMS: ClassVar = {
+        "sprache": "1",
+        "menuonr": "226285523",
+    }
+
+    def __init__(self, strasse: str, hausnummer: str | int):
+        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/doc/source/mils_tirol_at.md
+++ b/doc/source/mils_tirol_at.md
@@ -1,0 +1,41 @@
+# Gemeinde Mils
+
+Support for waste collection schedules provided by [Gemeinde Mils](https://mils-tirol.at), Tyrol, Austria.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mils_tirol_at
+      args:
+        strasse: STREET
+        hausnummer: HOUSE_NUMBER
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required)*
+
+Street name as listed in the Mils waste calendar dropdown.
+
+**hausnummer**
+*(string | integer) (required)*
+
+House number as listed in the Mils waste calendar dropdown.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mils_tirol_at
+      args:
+        strasse: "Fichtenweg"
+        hausnummer: "21"
+```
+
+## How to get the source arguments
+
+Open <https://mils-tirol.at/Service/Dienstleistungen/Abfallkalender>, pick your street and house number from the dropdowns, and use the same values for `strasse` and `hausnummer`.


### PR DESCRIPTION
## Summary
- Adds waste collection schedule support for Gemeinde Mils, Tyrol, Austria (closes #7008)
- Mils publishes its Abfallkalender on the RiSKommunal ("RIS") municipal CMS, the same platform already used by `fritzens_gv_at.py`, `buermoos_at.py`, and other sources — this reuses the shared `RiSKommunalSource` base class
- Address-based lookup (street + house number), resolved via the page's embedded `strassenArr` to per-address `typids` (this determines the Biomüll zone — Mils Nord vs. Mils Süd — and whether Problemstoffsammlung/Biomüll even apply to that address)
- Waste types covered: Biomüll, Gelber Sack, Restmüll, Altpapier&Kleinkartons, Problemstoffsammlung

## Test plan
- [x] `python test_sources.py -s mils_tirol_at -l` — both test cases (Fichtenweg 21, Dorfplatz 1) return upcoming collections without errors
- [x] `ruff check --fix` / `ruff format` — clean
- [x] `python -m pytest tests/test_source_components.py -q` — all structural checks pass
- [x] `doc/source/mils_tirol_at.md` created

🤖 Generated with [Claude Code](https://claude.com/claude-code)