### PR TITLE
Add Gemeinde Rödinghausen to Abfall Export (vCal) ICS provider

### DIFF
--- a/doc/ics/yaml/abfall_export_vcal.yaml
+++ b/doc/ics/yaml/abfall_export_vcal.yaml
@@ -12,6 +12,9 @@ extra_info:
   - title: Stadt Vlotho
     url: https://www.vlotho.de
     country: de
+  - title: Gemeinde Rödinghausen
+    url: https://www.roedinghausen.de
+    country: de
 howto:
   en: |
     - Go to your municipality's waste collection calendar page.
@@ -20,11 +23,15 @@ howto:
     - Copy the full URL and use it as the `url` parameter.
 test_cases:
   Stadt Löhne:
-    url: https://www.loehne.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.4&strasse=430.197.1&vtyp=4&vMo=1&vJ=2026&bMo=12
+    url: https://www.loehne.de/output/abfall_export.php?csv_export=1&amp;mode=vcal&amp;ort=393.4&amp;strasse=430.197.1&amp;vtyp=4&amp;vMo=1&amp;vJ=2026&amp;bMo=12
     year_field: vJ
   Kirchhain Grossseelheim:
-    url: https://www.kirchhain.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=2848.6&strasse=2848.158.1&vtyp=2&vMo=01&vJ=2025&bMo=12
+    url: https://www.kirchhain.de/output/abfall_export.php?csv_export=1&amp;mode=vcal&amp;ort=2848.6&amp;strasse=2848.158.1&amp;vtyp=2&amp;vMo=01&amp;vJ=2025&amp;bMo=12
     year_field: vJ
   Stadt Vlotho Topsundernweg:
-    url: https://www.vlotho.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.8&strasse=3136.359.1&abfart%5B0%5D=3136.1&abfart%5B1%5D=3136.2&abfart%5B2%5D=3136.3&abfart%5B3%5D=3136.4&abfart%5B4%5D=3136.5&vtyp=1&vMo=01&vJ=2026&bMo=12
+    url: https://www.vlotho.de/output/abfall_export.php?csv_export=1&amp;mode=vcal&amp;ort=393.8&amp;strasse=3136.359.1&amp;abfart%5B0%5D=3136.1&amp;abfart%5B1%5D=3136.2&amp;abfart%5B2%5D=3136.3&amp;abfart%5B3%5D=3136.4&amp;abfart%5B4%5D=3136.5&amp;vtyp=1&amp;vMo=01&amp;vJ=2026&amp;bMo=12
+    year_field: vJ
+  Gemeinde Rödinghausen Studieker Weg:
+    url: https://www.roedinghausen.de/output/abfall_export.php?csv_export=1&amp;mode=vcal&amp;ort=393.1&amp;strasse=521.244.1&amp;vtyp=2&amp;vMo=01&amp;vJ=2026&amp;bMo=12
+    params: {}
     year_field: vJ


### PR DESCRIPTION
## Summary
- Adds Gemeinde Rödinghausen (Germany) to the shared "Abfall Export (vCal)" ICS
  provider list. The municipality uses the same advantic/ikiss CMS and
  `abfall_export.php?mode=vcal` export endpoint as the existing Löhne,
  Kirchhain and Vlotho entries.
- Adds a `test_cases` example for the "Studieker Weg" address requested in
  #3547, live-verified to return real collection events.

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] Manually fetched the new URL via `ics.Source` and confirmed it returns
      valid, parseable collection entries (Restmüll, Biotonne, Gelbe Tonne,
      etc.)

Closes #3547