### PR TITLE
Add Senden to MyMuell (Jumomind) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -44,6 +44,11 @@ TEST_CASES = {
         "service_id": "mymuell",
         "city": "Bad Wünnenberg-Bleiwäsche",
     },
+    "mymuell Senden, Birkenweg": {
+        "service_id": "mymuell",
+        "city": "Senden",
+        "street": "Birkenweg (Senden)",
+    },
     "neustadt": {
         "service_id": "esn",
         "city": "Neustadt",
@@ -165,6 +170,7 @@ SERVICE_MAP = {
             "Schmitten im Taunus",
             "Schöneck",
             "Seligenstadt",
+            "Senden",
             "Ulm",
             "Usingen",
             "Volkmarsen",


### PR DESCRIPTION
## Summary
- Senden (Bavaria) is served by the MyMuell App, which is already implemented via the shared `jumomind_de` source (`service_id: mymuell`), but the city was missing from the documented list.
- Verified against the live MyMuell API that "Senden" (id 57310) is present with street-level resolution, and added a test case using the "Birkenweg (Senden)" street mentioned by a user in the issue thread.

## Test plan
- [x] `python test_sources.py -s jumomind_de -l` — all test cases pass, including new "mymuell Senden, Birkenweg" case (44 entries fetched)
- [x] `ruff check --fix` / `ruff format` — clean
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed

Closes #4162