### PR TITLE
Add millvalleyrefuse source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/millvalleyrefuse_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/millvalleyrefuse_com.py
@@ -1,0 +1,144 @@
+import datetime
+
+from curl_cffi import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Mill Valley Refuse Service"
+DESCRIPTION = (
+    "Source for Mill Valley Refuse Service (MVRS), Marin County, California, USA."
+)
+URL = "https://www.millvalleyrefuse.com"
+
+TEST_CASES = {
+    "Whole service area": {},
+    "With pickup day (Wednesday)": {"pickup_day": "Wednesday"},
+    "With pickup day (Tuesday)": {"pickup_day": "Tuesday"},
+}
+
+COUNTRY = "us"
+
+# MVRS publishes one alternating-week residential recycling schedule for its
+# whole service area as three public Google Calendars, embedded on
+# https://www.millvalleyrefuse.com/residential-services . Container recycling
+# and paper recycling are collected on alternating weeks (citywide); garbage and
+# compost are weekly on each address's normal route day and are not published in
+# a machine-readable feed.
+RECYCLING_CALENDARS = {
+    "Container Recycling": (
+        "https://calendar.google.com/calendar/ical/"
+        "uokfjeogcqe0daugrn58mvkgo0%40group.calendar.google.com/public/basic.ics"
+    ),
+    "Paper Recycling": (
+        "https://calendar.google.com/calendar/ical/"
+        "d5mdlvop2qp45vmstm6gs5p1kg%40group.calendar.google.com/public/basic.ics"
+    ),
+}
+# Office-closure / holiday service notices.
+HOLIDAY_CALENDAR = (
+    "https://calendar.google.com/calendar/ical/"
+    "millvalleyrefuse%40gmail.com/public/basic.ics"
+)
+
+ICON_MAP = {
+    "Container Recycling": Icons.RECYCLING,
+    "Paper Recycling": Icons.PAPER,
+}
+
+# Number of days after the Sunday that starts each collection week.
+_WEEKDAY_OFFSETS = {
+    "Sunday": 0,
+    "Monday": 1,
+    "Tuesday": 2,
+    "Wednesday": 3,
+    "Thursday": 4,
+    "Friday": 5,
+    "Saturday": 6,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "No address lookup is required. Mill Valley Refuse Service publishes a "
+        "single alternating-week recycling schedule for its whole service area "
+        "(Mill Valley, Corte Madera, Tiburon, Belvedere, Strawberry and "
+        "unincorporated Marin). Optionally set 'pickup_day' to the weekday your "
+        "street is serviced so each collection lands on your actual pickup day "
+        "instead of the start of the week."
+    )
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "pickup_day": "Pickup Day",
+    }
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "pickup_day": (
+            "The weekday your address is serviced (e.g. 'Wednesday'). MVRS "
+            "collects Monday-Friday depending on your street. If omitted, each "
+            "recycling week is marked on the Sunday it begins."
+        ),
+    }
+}
+
+
+def _weekly_collections(
+    dates: list[datetime.date], waste_type: str, offset: int
+) -> list[Collection]:
+    """Collapse a stream's per-day ICS events into one entry per week.
+
+    MVRS marks each alternating recycling week with all-day calendar events.
+    Group every event date by the Sunday that starts its week, then emit a
+    single collection per week - shifted by ``offset`` days so it falls on the
+    resident's pickup weekday (0 = the week-start Sunday).
+    """
+    week_starts = {
+        # date.isoweekday(): Mon=1 .. Sun=7  ->  Sun%7=0, Mon%7=1, ...
+        d - datetime.timedelta(days=d.isoweekday() % 7)
+        for d in dates
+    }
+    return [
+        Collection(
+            ws + datetime.timedelta(days=offset),
+            waste_type,
+            icon=ICON_MAP.get(waste_type),
+        )
+        for ws in sorted(week_starts)
+    ]
+
+
+class Source:
+    def __init__(self, pickup_day: str | None = None):
+        if pickup_day is not None:
+            match = [
+                d for d in _WEEKDAY_OFFSETS if d.lower() == pickup_day.strip().lower()
+            ]
+            if not match:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "pickup_day", pickup_day, list(_WEEKDAY_OFFSETS)
+                )
+            pickup_day = match[0]
+        self._pickup_day = pickup_day
+        self._ics = ICS()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session(impersonate="chrome")
+        offset = _WEEKDAY_OFFSETS[self._pickup_day] if self._pickup_day else 0
+        entries: list[Collection] = []
+
+        for waste_type, url in RECYCLING_CALENDARS.items():
+            r = session.get(url)
+            r.raise_for_status()
+            dates = [d for d, _ in self._ics.convert(r.text)]
+            entries.extend(_weekly_collections(dates, waste_type, offset))
+
+        r = session.get(HOLIDAY_CALENDAR)
+        r.raise_for_status()
+        for d, title in self._ics.convert(r.text):
+            icon = Icons.EVENT if "as usual" in title.lower() else Icons.NO_COLLECTION
+            entries.append(Collection(d, title, icon=icon))
+
+        return entries

--- a/doc/source/millvalleyrefuse_com.md
+++ b/doc/source/millvalleyrefuse_com.md
@@ -1,0 +1,36 @@
+# Mill Valley Refuse Service
+
+Support for schedules provided by [Mill Valley Refuse Service (MVRS)](https://www.millvalleyrefuse.com), serving Mill Valley, Corte Madera, Tiburon, Belvedere, Strawberry and unincorporated southern Marin County, California, USA.
+
+MVRS publishes a single **alternating-week recycling schedule** for its entire service area as public Google Calendars (embedded on the [residential services page](https://www.millvalleyrefuse.com/residential-services)). One week is *Container Cart Recycling*, the next is *Paper Cart Recycling*, and so on, city-wide. This source reads those calendars live, so it stays in sync with whatever MVRS publishes. MVRS office-closure / holiday service notices are included automatically as an additional stream.
+
+Garbage and compost are collected **weekly on your normal route day** and are not published in a machine-readable feed, so they are not provided by this source. Use the optional `pickup_day` argument to align the recycling entries with your route day.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: millvalleyrefuse_com
+```
+
+### Configuration Variables
+
+**pickup_day**
+*(string) (optional)*
+
+The weekday your address is serviced (e.g. `Wednesday`). MVRS collects Monday–Friday depending on your street. When set, each alternating recycling week is reported on that weekday. When omitted, each recycling week is marked on the Sunday it begins.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: millvalleyrefuse_com
+      args:
+        pickup_day: Wednesday
+```
+
+## How it works
+
+No address lookup is required — the schedule is identical across the whole MVRS service area. The source fetches MVRS's public Google Calendar ICS feeds for container recycling, paper recycling and holiday notices, collapses each alternating recycling week into a single collection, and (if `pickup_day` is set) reports it on your route weekday.


### PR DESCRIPTION
## Summary

Adds a new source for **Mill Valley Refuse Service (MVRS)**, which serves Mill Valley, Corte Madera, Tiburon, Belvedere, Strawberry and unincorporated southern Marin County, California, USA.

MVRS publishes one alternating-week residential recycling schedule for its whole service area as three public Google Calendars (embedded on their [residential services page](https://www.millvalleyrefuse.com/residential-services)):

- **Container Recycling** and **Paper Recycling**, collected on alternating weeks city-wide
- **Office-closure / holiday** service notices

The source reads these Google Calendar ICS feeds live. Each recycling week is published as seven consecutive all-day "(Day 1/7 … 7/7)" events; the source groups events by week to emit a single clean collection per week. An optional `pickup_day` argument shifts each collection onto the resident's actual route weekday (MVRS collects Mon–Fri by address). Garbage and compost are weekly on that route day and are not published in any machine-readable feed, so they are intentionally not emitted (no hardcoded schedule).

**Why a dedicated source rather than the generic ICS config:** MVRS emits seven events per recycling week, and the generic ICS source's `regex` option can only relabel events — it never drops them — so the generic route would produce ~7 collections per week. The dedicated source collapses each week to one entry.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new source
- [x] TEST_CASES use real, publicly accessible addresses (not my own) — MVRS requires no address lookup; the schedule is identical service-area-wide, so TEST_CASES only vary the optional `pickup_day`
