### PR TITLE
fix(6943): RAISE_ON_EMPTY on address/UPRN pipeline sources

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aberdeenshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aberdeenshire_gov_uk.py
@@ -31,6 +31,10 @@ class Source(BaseSource):
     URL = "https://aberdeenshire.gov.uk"
     COUNTRY = "uk"
 
+    # UPRN/property-id lookup: a wrong id yields no collections, so surface
+    # it as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Test_001": {"uprn": "000151124612"},
         "Test_002": {"uprn": "000151004105"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
@@ -39,6 +39,10 @@ class Source(BaseSource):
     URL = "https://www.abfallwirtschaft-pforzheim.de"
     COUNTRY = "de"
 
+    # A wrong street/house number yields an empty Athos schedule; surface it
+    # as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Abnobstraße": {
             "street": "Abnobastraße",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
@@ -44,6 +44,10 @@ class Source(BaseSource):
     URL = "https://www.awb-emsland.de"
     COUNTRY = "de"
 
+    # A wrong street/house number yields an empty Athos schedule; surface it
+    # as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Andervenne Am Gallenberg": {
             "city": "Andervenne",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
@@ -39,6 +39,10 @@ class Source(BaseSource):
     URL = "https://www.awn-online.de"
     COUNTRY = "de"
 
+    # A wrong street/house number yields an empty Athos schedule; surface it
+    # as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Adelsheim": {"city": "Adelsheim", "street": "Badstr.", "house_number": 1},
         "Mosbach": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bexley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bexley_gov_uk.py
@@ -42,6 +42,10 @@ class Source(BaseSource):
     URL = "https://bexley.gov.uk"
     COUNTRY = "uk"
 
+    # UPRN/property-id lookup: a wrong id yields no collections, so surface
+    # it as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Test_001": {"uprn": "200001604426"},
         "Test_002": {"uprn": 100020194783},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
@@ -49,6 +49,10 @@ class Source(BaseSource):
     URL = "https://bielefeld.de"
     COUNTRY = "de"
 
+    # A wrong street/house number yields an empty Athos schedule; surface it
+    # as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Umweltbetrieb": {"street": "Eckendorfer Straße", "house_number": 57},
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bromley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bromley_gov_uk.py
@@ -34,6 +34,10 @@ class Source(BaseSource):
     URL = "https://bromley.gov.uk"
     COUNTRY = "uk"
 
+    # UPRN/property-id lookup: a wrong id yields no collections, so surface
+    # it as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Test_001": {"property": 6328436},
         "Test_002": {"property": "6146611"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwinana_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwinana_wa_gov_au.py
@@ -87,6 +87,10 @@ class Source(BaseSource):
     URL = "https://www.kwinana.wa.gov.au"
     COUNTRY = "au"
 
+    # An address that IntraMaps cannot resolve yields no collections; surface
+    # that as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "Kwinana Town Centre": {"address": "1 Chisham Avenue KWINANA TOWN CENTRE"},
         "Wellard": {"address": "25 Breccia Parade WELLARD"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/launceston_tas_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/launceston_tas_gov_au.py
@@ -71,6 +71,10 @@ class Source(BaseSource):
     URL = "https://www.launceston.tas.gov.au"
     COUNTRY = "au"
 
+    # An address ArcGis cannot resolve yields no collections; surface it as
+    # an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     FEATURE_URL = "https://services.arcgis.com/yeXpdyjk3azbqItW/arcgis/rest/services/Waste/FeatureServer/0"
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
@@ -25,6 +25,10 @@ class Source(BaseSource):
     URL = "https://peterborough.gov.uk"
     COUNTRY = "uk"
 
+    # UPRN/property-id lookup: a wrong id yields no collections, so surface
+    # it as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "houseUprn": {"post_code": "PE57AX", "uprn": "100090214774"},
     }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/reading_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/reading_gov_uk.py
@@ -67,6 +67,11 @@ class Source(BaseSource):
     URL = "https://reading.gov.uk"
     COUNTRY = "uk"
 
+    # The direct-UPRN path skips the postcode/house-number validation, so a
+    # well-formed but wrong UPRN returns no collections. Surface that as an
+    # error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "known_uprn": {"uprn": "310027679"},
         "known_uprn as number": {"uprn": 310027679},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
@@ -71,6 +71,10 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Stirling."
     URL = "https://www.stirling.wa.gov.au"
     COUNTRY = "au"
+
+    # A geocode failure already raises; this also surfaces an address that
+    # geocodes but has no schedule (outside the service area) (#6943).
+    RAISE_ON_EMPTY = True
     SOURCE_CODEOWNERS: ClassVar[list] = ["@markvp"]
     API_URL = "https://www.stirling.wa.gov.au/bincollectioncheck/getresult"
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
@@ -32,6 +32,10 @@ class Source(BaseSource):
     URL = "https://sutton.gov.uk"
     COUNTRY = "uk"
 
+    # UPRN/property-id lookup: a wrong id yields no collections, so surface
+    # it as an error instead of a silently empty calendar (#6943).
+    RAISE_ON_EMPTY = True
+
     TEST_CASES: ClassVar[dict] = {
         "4721996": {"id": 4721996},
         "4499298": {"id": "4499298"},


### PR DESCRIPTION
Closes #6943.

Address and UPRN/property-id lookup pipeline sources returned a silently empty calendar for a wrong argument instead of surfacing an error. This adds `RAISE_ON_EMPTY = True` across the swept sources.

**UPRN / property-id lookups** (empty = bad id):
`reading_gov_uk` (reported — direct-UPRN path), `aberdeenshire_gov_uk`, `bexley_gov_uk`, `bromley_gov_uk`, `sutton_gov_uk`, `peterborough_gov_uk`.

**Address-resolution lookups** (empty = unresolved/unserved address):
`kwinana_wa_gov_au` (reported — IntraMaps), `launceston_tas_gov_au` (ArcGis), `stirling_wa_gov_au` (geocoded; also covers a location that geocodes but has no schedule), and the Athos street/house sources `abfallwirtschaft_pforzheim_de`, `awb_emsland_de`, `awn_de`, `bielefeld_de`.

**Intentionally excluded:** `narab_se` — it already raises `SourceArgument*` explicitly on a bad address or customer number, so `RAISE_ON_EMPTY` would be redundant.

Verified: `ruff` clean, and the offline fixtures for every changed source pass (recorded data is non-empty, so the flag never misfires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)