### PR TITLE
fix(6940): render alternatives() group members with their own widgets

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -228,13 +228,14 @@ def _build_schema_from_params(
             )
         ] = str
 
-    for param in params:
+    def _add_param_fields(param: ConfigParam, force_optional: bool = False) -> None:
         # A field is optional in the form when its param is required=False, the
         # param declares mutually-exclusive groups (alternatives), or the field
         # has a default. A dependent_select child whose options aren't known yet
         # (parent not chosen) is also shown as optional so the form can submit
-        # the parent first.
-        param_optional = (not param.required) or bool(param.groups)
+        # the parent first. Members of an alternatives() group are forced
+        # optional (validate() enforces exactly one group is provided).
+        param_optional = force_optional or (not param.required) or bool(param.groups)
         for field_name in param.fields:
             description = None
             if args_input is not None and field_name in args_input:
@@ -301,6 +302,15 @@ def _build_schema_from_params(
                 vol_args[key] = ObjectSelector()
             else:
                 vol_args[key] = cv.string
+
+    for param in params:
+        if param.widget == "alternatives" and param.members:
+            # Render each member with its own widget (dropdown, boolean,
+            # postcode, coords, ...) rather than a free-text fallback (#6940).
+            for member in param.members:
+                _add_param_fields(member, force_optional=True)
+        else:
+            _add_param_fields(param)
 
     return vol.Schema(vol_args)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/config_params.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/config_params.py
@@ -82,6 +82,12 @@ class ConfigParam:
     # outside the list is still accepted.
     options: list[str] = field(default_factory=list)
 
+    # For an "alternatives" widget: the flattened member params, each keeping its
+    # own widget/options. The config-flow schema builder renders each member
+    # field with its proper selector (all forced optional) instead of falling
+    # back to free text (#6940). Empty for non-alternatives params.
+    members: tuple["ConfigParam", ...] = field(default_factory=tuple)
+
 
 def _title(field_name: str, label: str | None) -> str:
     """A field's display label: the explicit ``label`` or a Title-Cased name."""
@@ -584,9 +590,11 @@ def alternatives(*groups: list[ConfigParam]) -> ConfigParam:
     descriptions: dict[str, dict[str, str]] = {}
     defaults: dict[str, str] = {}
     group_field_names: list[tuple[str, ...]] = []
+    members: list[ConfigParam] = []
     for group in groups:
         names: list[str] = []
         for param in group:
+            members.append(param)
             fields.update(param.fields)
             names.extend(param.fields)
             for lang, mapping in param.labels.items():
@@ -603,4 +611,5 @@ def alternatives(*groups: list[ConfigParam]) -> ConfigParam:
         required=False,
         defaults=defaults,
         groups=tuple(group_field_names),
+        members=tuple(members),
     )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,10 +14,29 @@ sys.path.insert(
 )
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from waste_collection_schedule.config_params import integer  # isort:skip
+import voluptuous as vol  # isort:skip
+from homeassistant.helpers.selector import (  # isort:skip
+    BooleanSelector,
+    SelectSelector,
+)
+
+from waste_collection_schedule.config_params import (  # isort:skip
+    alternatives,
+    boolean,
+    dropdown,
+    integer,
+    uprn,
+)
 from custom_components.waste_collection_schedule.config_flow import (  # isort:skip
     _build_schema_from_params,
 )
+
+
+def _marker_and_validator(schema: vol.Schema, field_name: str):
+    for marker, validator in schema.schema.items():
+        if getattr(marker, "schema", marker) == field_name:
+            return marker, validator
+    raise KeyError(field_name)
 
 
 def test_integer_selector_coerces_submitted_value() -> None:
@@ -32,3 +51,31 @@ def test_integer_selector_coerces_submitted_value() -> None:
 
     assert result["count"] == 5
     assert isinstance(result["count"], int)
+
+
+def test_alternatives_group_members_render_their_widgets() -> None:
+    # #6940: fields inside an alternatives() group fell through to a free-text
+    # box, losing their dropdown/boolean/... selector. Each member must render
+    # with its proper selector instead.
+    schema = _build_schema_from_params(
+        [
+            alternatives(
+                [uprn()],
+                [dropdown("region", ["A", "B"]), boolean("flag")],
+            )
+        ],
+        pre_filled={},
+        args_input=None,
+        include_title=False,
+    )
+
+    region_marker, region_validator = _marker_and_validator(schema, "region")
+    flag_marker, flag_validator = _marker_and_validator(schema, "flag")
+
+    assert isinstance(region_validator, SelectSelector)
+    assert isinstance(flag_validator, BooleanSelector)
+
+    # Every member of an alternatives group is optional in the form (validate()
+    # enforces that exactly one group is fully provided).
+    assert isinstance(region_marker, vol.Optional)
+    assert isinstance(flag_marker, vol.Optional)


### PR DESCRIPTION
Closes #6940.

`_build_schema_from_params` had no branch for the `"alternatives"` widget, so every field of an `alternatives()` group fell through to `else: cv.string` — a free-text box. A dropdown/boolean/postcode/coords inside a group lost its selector. The merged `alternatives` `ConfigParam` also discarded the member params' widgets and options, so the information wasn't even available to the schema builder.

Fix:
- `config_params.alternatives()` now preserves the flattened member params on a new `ConfigParam.members` field (additive; empty for every other param).
- `_build_schema_from_params` renders each alternatives member with its own widget (via a small extracted helper), all forced optional — `validate()` still enforces that exactly one group is fully provided.

Verified: `ruff` clean, `pyright (new architecture)` clean, and a new regression test asserts a `dropdown`/`boolean` inside an `alternatives()` group render as `SelectSelector`/`BooleanSelector` (not free text) and as optional markers. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)