### PR TITLE
fix(6944): options-flow sensor type gathering + dead form call

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -1132,7 +1132,6 @@ class WasteCollectionConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call
                     CONF_SOURCE_ARGS: args_input,
                 }
                 self._options.update(options)
-                self.async_show_form(step_id="options")
                 return await self.async_step_flow_type()
         return self.async_show_form(
             step_id=f"args_{self._id}",
@@ -1524,10 +1523,12 @@ class WasteCollectionOptionsFlow(OptionsFlow):
     def get_types_of_sensors_and_customizations(self):
         fetched_types = list(self._entry.options.get(CONF_CUSTOMIZE, {}).keys())
         for c in self._entry.options.get(CONF_SENSORS, []):
-            if CONF_TYPE in c:
-                fetched_types.extend(
-                    c[CONF_TYPE] if isinstance(c[CONF_TYPE], list) else [c[CONF_TYPE]]
-                )
+            # Sensors store their waste types under CONF_COLLECTION_TYPES (see
+            # finish()); CONF_TYPE was never present here, so the edit-sensor
+            # type list was only ever populated from customisation keys (#6944).
+            if CONF_COLLECTION_TYPES in c:
+                types = c[CONF_COLLECTION_TYPES]
+                fetched_types.extend(types if isinstance(types, list) else [types])
         return list(set(fetched_types))
 
     async def async_step_customize(self, user_input: dict[str, Any] | None = None):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,7 +14,10 @@ sys.path.insert(
 )
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
+from typing import Any, cast  # isort:skip
+
 import voluptuous as vol  # isort:skip
+from homeassistant.const import CONF_NAME  # isort:skip
 from homeassistant.helpers.selector import (  # isort:skip
     BooleanSelector,
     SelectSelector,
@@ -28,7 +31,13 @@ from waste_collection_schedule.config_params import (  # isort:skip
     uprn,
 )
 from custom_components.waste_collection_schedule.config_flow import (  # isort:skip
+    WasteCollectionOptionsFlow,
     _build_schema_from_params,
+)
+from custom_components.waste_collection_schedule.const import (  # isort:skip
+    CONF_COLLECTION_TYPES,
+    CONF_CUSTOMIZE,
+    CONF_SENSORS,
 )
 
 
@@ -79,3 +88,28 @@ def test_alternatives_group_members_render_their_widgets() -> None:
     # enforces that exactly one group is fully provided).
     assert isinstance(region_marker, vol.Optional)
     assert isinstance(flag_marker, vol.Optional)
+
+
+def test_options_flow_gathers_sensor_collection_types() -> None:
+    # #6944: sensors store waste types under CONF_COLLECTION_TYPES, but the
+    # options flow read CONF_TYPE, so configured sensor types were never
+    # gathered for the edit-sensor list (only customisation keys were).
+    class _Entry:
+        def __init__(self) -> None:
+            self.options = {
+                CONF_CUSTOMIZE: {"Glass": {}},
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "s1",
+                        CONF_COLLECTION_TYPES: ["General Waste", "Recycling"],
+                    }
+                ],
+            }
+
+    flow = object.__new__(WasteCollectionOptionsFlow)
+    flow._entry = cast(Any, _Entry())
+
+    types = set(flow.get_types_of_sensors_and_customizations())
+
+    assert {"General Waste", "Recycling"} <= types  # sensor types now included
+    assert "Glass" in types  # customisation keys still included


### PR DESCRIPTION
Addresses #6944 (grouped minor config-flow / framework issues). Fixes the two clear-cut bugs:

1. **Sensor types never gathered for the edit list.** `get_types_of_sensors_and_customizations()` checked `CONF_TYPE in c`, but sensors store their waste types under `CONF_COLLECTION_TYPES` (see `finish()`), so the condition was always false and the edit-sensor type list came only from customisation keys. Now reads `CONF_COLLECTION_TYPES`.
2. **Dead code.** Removed a `self.async_show_form(step_id="options")` whose return value was computed and discarded on the args-submit path.

Verified: `ruff` clean, and a new regression test asserts configured sensor `CONF_COLLECTION_TYPES` (plus customisation keys) are gathered.

### Split out into their own issues
The other two sub-items from #6944 need a design decision rather than a mechanical fix, so they've been split out:
- **#7024** — `waste_types.preserved()` normalises the id but not the display name (case/whitespace variants collapse to one id with an arbitrary label).
- **#7025** — `waste_types._display_language` is process-global mutable state (concurrency hazard under differing concurrent languages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)