### PR TITLE
Retry v3 setup after transient source fetch failures

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_api.py
+++ b/custom_components/waste_collection_schedule/waste_collection_api.py
@@ -109,9 +109,13 @@ class WasteCollectionApi:
             self._update_sensors_callback()
             return
 
+        fetch_succeeded = True
         for shell in self._source_shells:
-            shell.fetch()
-        self._last_fetch_date = today
+            if not shell.fetch():
+                fetch_succeeded = False
+
+        if fetch_succeeded:
+            self._last_fetch_date = today
 
         self._update_sensors_callback()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -230,8 +230,8 @@ class SourceShell:
     def day_offset(self):
         return self._day_offset
 
-    def fetch(self) -> None:
-        """Fetch data from source."""
+    def fetch(self) -> bool:
+        """Fetch data from source and report whether it succeeded."""
         try:
             # fetch returns a list of Collection's
             entries: Iterable[Collection] = self._source.fetch()
@@ -239,7 +239,7 @@ class SourceShell:
             _LOGGER.error(
                 f"fetch failed for source {self._title}:\n{traceback.format_exc()}"
             )
-            return
+            return False
         self._refreshtime = datetime.datetime.now()
 
         # Strip incidental whitespace from legacy sources' raw type strings.
@@ -283,6 +283,7 @@ class SourceShell:
             result = unique
 
         self._entries = result
+        return True
 
     def get_dedicated_calendar_types(self) -> set[str]:
         """Return set of waste types with a dedicated calendar.

--- a/custom_components/waste_collection_schedule/wcs_coordinator.py
+++ b/custom_components/waste_collection_schedule/wcs_coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.event import (
     async_call_later,
     async_track_time_change,
 )
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from . import const
 from .waste_collection_schedule import CollectionAggregator, SourceShell
@@ -97,7 +97,10 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
-        await self._fetch_now()
+        if not await self._fetch_now():
+            raise UpdateFailed(
+                f"Unable to fetch waste collection data from {self.shell.title}"
+            )
         return {}
 
     @property
@@ -134,22 +137,24 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _update_sensors_callback(self, *_):
         dispatcher_send(self._hass, const.UPDATE_SENSORS_SIGNAL)
 
-    async def _fetch_now(self, *_):
+    async def _fetch_now(self, *_) -> bool:
         today = datetime.date.today()
         if (
             self._last_fetch_date is not None
             and (today - self._last_fetch_date).days < self._fetch_interval_days
         ):
             await self._update_sensors_callback()
-            return
+            return True
 
         if self.shell:
-            await self._hass.async_add_executor_job(self.shell.fetch)
-            self._last_fetch_date = today
+            fetch_succeeded = await self._hass.async_add_executor_job(self.shell.fetch)
+            if fetch_succeeded:
+                self._last_fetch_date = today
 
-            # Save device keys to storage after fetch
-            device_store = get_device_key_store()
-            if device_store:
-                await device_store.async_save()
+                # Save device keys to storage after fetch
+                device_store = get_device_key_store()
+                if device_store:
+                    await device_store.async_save()
 
         await self._update_sensors_callback()
+        return fetch_succeeded if self.shell else True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test .claude .git
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py
+python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py
 markers =
     live: test fetches from a live provider endpoint; excluded from gating CI (run with `-m live` locally). Replaced by offline fixtures.

--- a/tests/test_fetch_retry.py
+++ b/tests/test_fetch_retry.py
@@ -1,0 +1,149 @@
+import asyncio
+import os
+import sys
+from datetime import date
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.append(
+    os.path.join(
+        os.path.dirname(__file__), "../custom_components/waste_collection_schedule"
+    )
+)
+
+from waste_collection_schedule import Collection  # isort:skip
+from waste_collection_schedule.source_shell import SourceShell  # isort:skip
+
+
+def test_source_shell_fetch_reports_success_and_failure() -> None:
+    class _Source:
+        def __init__(self) -> None:
+            self.should_fail = True
+
+        def fetch(self):
+            if self.should_fail:
+                raise RuntimeError("temporary upstream failure")
+            return [Collection(date=date(2026, 7, 20), t="Test collection")]
+
+    source = _Source()
+    shell = SourceShell(
+        source=source,
+        customize={},
+        title="Test source",
+        description="Test source",
+        url=None,
+        calendar_title=None,
+        unique_id="test-source",
+        day_offset=0,
+    )
+
+    assert shell.fetch() is False
+    assert shell.refreshtime is None
+
+    source.should_fail = False
+    assert shell.fetch() is True
+    assert shell.refreshtime is not None
+
+    cached_entries = list(shell._entries)
+    cached_refreshtime = shell.refreshtime
+    source.should_fail = True
+
+    assert shell.fetch() is False
+    assert shell._entries == cached_entries
+    assert shell.refreshtime is cached_refreshtime
+
+
+def test_coordinator_allows_same_day_retry_after_failed_fetch() -> None:
+    from custom_components.waste_collection_schedule import wcs_coordinator
+
+    class _Hass:
+        @staticmethod
+        async def async_add_executor_job(target):
+            return target()
+
+    class _Shell:
+        def __init__(self) -> None:
+            self.fetch_results = iter((False, True))
+            self.fetch_count = 0
+
+        def fetch(self) -> bool:
+            self.fetch_count += 1
+            return next(self.fetch_results)
+
+    async def _run() -> tuple[int, object]:
+        coordinator = object.__new__(wcs_coordinator.WCSCoordinator)
+        coordinator._hass = _Hass()
+        coordinator._shell = cast(Any, _Shell())
+        coordinator._last_fetch_date = None
+        coordinator._fetch_interval_days = 1
+        coordinator._update_sensors_callback = lambda *_: asyncio.sleep(0)
+
+        with patch.object(wcs_coordinator, "get_device_key_store", return_value=None):
+            await coordinator._fetch_now()
+            assert coordinator._last_fetch_date is None
+
+            await coordinator._fetch_now()
+            assert coordinator._last_fetch_date is not None
+
+            await coordinator._fetch_now()
+
+        return coordinator.shell.fetch_count, coordinator._last_fetch_date
+
+    fetch_count, last_fetch_date = asyncio.run(_run())
+
+    assert fetch_count == 2
+    assert last_fetch_date is not None
+
+
+def test_coordinator_first_refresh_reports_failed_fetch() -> None:
+    from custom_components.waste_collection_schedule import wcs_coordinator
+
+    coordinator = object.__new__(wcs_coordinator.WCSCoordinator)
+    coordinator._shell = cast(Any, type("Shell", (), {"title": "Test source"})())
+
+    async def _run() -> None:
+        with (
+            patch.object(coordinator, "_fetch_now", AsyncMock(return_value=False)),
+            pytest.raises(
+                wcs_coordinator.UpdateFailed,
+                match="Unable to fetch waste collection data from Test source",
+            ),
+        ):
+            await coordinator._async_update_data()
+
+    asyncio.run(_run())
+
+
+def test_yaml_api_retries_all_sources_after_partial_failure() -> None:
+    from custom_components.waste_collection_schedule.waste_collection_api import (
+        WasteCollectionApi,
+    )
+
+    class _Shell:
+        def __init__(self, *results: bool) -> None:
+            self.fetch_results = iter(results)
+            self.fetch_count = 0
+
+        def fetch(self) -> bool:
+            self.fetch_count += 1
+            return next(self.fetch_results)
+
+    successful_shell = _Shell(True, True)
+    recovering_shell = _Shell(False, True)
+    api = object.__new__(WasteCollectionApi)
+    api._source_shells = cast(Any, [successful_shell, recovering_shell])
+    api._last_fetch_date = None
+    api._fetch_interval_days = 1
+    api._update_sensors_callback = lambda *_: None
+
+    api._fetch()
+    assert api._last_fetch_date is None
+
+    api._fetch()
+    assert api._last_fetch_date is not None
+
+    api._fetch()
+    assert successful_shell.fetch_count == 2
+    assert recovering_shell.fetch_count == 2


### PR DESCRIPTION
## Summary

- keep cached collections when a source fetch fails instead of replacing them with an apparent successful empty result
- report first-refresh failures through `UpdateFailed` so Home Assistant can retry setup
- leave the fetch interval open after a transient failure instead of marking the day as successfully fetched
- for YAML configurations, attempt every configured source and advance the interval only when all sources succeed

## Release targeting

This is the generic recovery work split out of #6984 at maintainer request. It remains a draft for 3.1 and is rebased on the current `release/3.0.0` architecture. After 3.0 is tagged, it can be rebased or retargeted to `master`, following the same holding pattern as #6985.

The EcoHarmonogram BOM/JSON parser fix remains separate in merged #6984 and is not included here. The equivalent stable-branch recovery is #6983.

## Validation

- 4 focused recovery tests passed; 7 focused recovery/provider regression tests passed together
- 3,120 passed, 4 skipped, and 2,127 deselected in the complete Python 3.12 offline suite
- Ruff, Ruff format, codespell, Bandit, mypy, and pyright passed on the preserved recovery patch before this base-only rebase
- the source-and-test patch matches the reviewed recovery contract; only the current pytest collection list was reconciled during rebase
