### PR TITLE
fix(7024): make preserved() label deterministic and verbatim

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/waste_types.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/waste_types.py
@@ -409,10 +409,19 @@ def preserved(label: str) -> WasteType:
     Used as the no-loss fallback when ``resolve`` finds nothing: the original
     text is shown in every locale (we can't translate it), the id is prefixed
     ``preserved:`` so it's distinguishable, and it borrows OTHER's icon/colour.
+
+    The id and the display name are derived from the **same** whitespace-
+    normalised text (trim + collapse internal runs), preserving the original
+    case. Previously the id was fully normalised (``_norm``: also lower-cased)
+    while the name kept the raw casing/spacing, so two variants of one label
+    collapsed to a single id but with an arbitrary surviving label (#7024).
+    Deriving both from one value makes the label deterministic: variants that
+    differ only in incidental whitespace merge to one type shown verbatim,
+    while case-distinct labels stay distinct (and are still shown as-is).
     """
-    text = str(label).strip()
+    text = " ".join(str(label).strip().split())
     return WasteType(
-        id=f"preserved:{_norm(label)}",
+        id=f"preserved:{text}",
         icon=OTHER.icon,
         color=OTHER.color,
         names=dict.fromkeys(SUPPORTED_LANGUAGES, text),

--- a/tests/test_new_architecture.py
+++ b/tests/test_new_architecture.py
@@ -122,9 +122,28 @@ class TestWasteTypeResolution:
         from waste_collection_schedule import waste_types as wt
 
         p = wt.preserved("Frobnitz-Tonne")
-        assert p.id == "preserved:frobnitz-tonne"
+        # The id preserves the original case (#7024); only incidental
+        # whitespace is normalised.
+        assert p.id == "preserved:Frobnitz-Tonne"
         assert p.names["en"] == p.names["de"] == "Frobnitz-Tonne"
         assert p.icon == wt.OTHER.icon  # borrows OTHER's icon/colour
+
+    def test_preserved_label_is_deterministic_7024(self):
+        from waste_collection_schedule import waste_types as wt
+
+        # Variants differing only in incidental whitespace collapse to one
+        # type, shown verbatim with a deterministic label (id and name derive
+        # from the same normalised text) — previously the id merged them but
+        # the surviving display label was arbitrary.
+        a = wt.preserved("Frobnitz  Tonne")
+        b = wt.preserved(" Frobnitz Tonne ")
+        assert a.id == b.id == "preserved:Frobnitz Tonne"
+        assert a.names["en"] == b.names["en"] == "Frobnitz Tonne"
+
+        # Case-distinct labels stay distinct and each shown as-is.
+        lower = wt.preserved("frobnitz tonne")
+        assert lower.id != a.id
+        assert lower.names["en"] == "frobnitz tonne"
 
     def test_other_is_not_resolvable(self):
         # OTHER is an explicit sink, not part of the recognised vocabulary.


### PR DESCRIPTION
Closes #7024 (split out from #6944).

`preserved()` built the id from `_norm(label)` (trim + collapse whitespace + **lower-case**) but the display name from the raw stripped label. So two variants of one unrecognised label (e.g. `"Foo  Bar"` and `"foo bar"`) collapsed to the same id yet carried different names, and the surviving display label was arbitrary.

Now the id and name derive from the **same** whitespace-normalised text, preserving case:
- variants differing only in incidental whitespace merge to one type, shown verbatim with a deterministic label;
- case-distinct labels stay distinct and are each shown as-is.

### Design choice (your call on review)
This keeps `preserved()`'s documented "carries the label verbatim" intent and only merges incidental whitespace. The tradeoff: labels that differ **only in case** are now distinct `preserved:` types rather than merged. The alternative — keep the lower-cased id (so case variants merge) but then show a lower-cased label — loses the verbatim casing, so I went this way. Happy to flip it if you'd rather case-insensitive merging.

Verified: `ruff` clean, `pyright` clean, and the waste-type/`preserved` tests pass (updated the existing id assertion + added a determinism test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)