### PR TITLE
Add Schwarzwald-Baar-Kreis (Königsfeld) to Abfall.IO / AbfallPlus (GraphQL)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -45,4 +45,9 @@ SERVICE_MAP = [
         "url": "https://www.asg-nordsachsen.de/",
         "service_id": "2085afd95285e645e15ee9623d0c5172",
     },
+    {
+        "title": "Amt für Abfallwirtschaft Schwarzwald-Baar-Kreis",
+        "url": "https://www.lrasbk.de/",
+        "service_id": "30628292bdd8b43db86a48f7e0d85f85",
+    },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -85,6 +85,10 @@ TEST_CASES = {
         "key": "2085afd95285e645e15ee9623d0c5172",
         "idHouseNumber": 360435,
     },
+    "Schwarzwald-Baar-Kreis, Königsfeld": {
+        "key": "30628292bdd8b43db86a48f7e0d85f85",
+        "idHouseNumber": 16437,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Adds the Schwarzwald-Baar-Kreis "Amt für Abfallwirtschaft" (district waste office, covering Königsfeld and other municipalities) to the `AbfallIOGraphQL` `SERVICE_MAP`.
- Adds a matching `TEST_CASES` entry (`idHouseNumber: 16437`, resolved via the abfall.io GraphQL city search for "Königsfeld").

Closes #3915

## Test plan
- [x] `ruff check --fix` / `ruff format` on both changed files
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python test_sources.py -s abfall_io_graphql -l` — all test cases pass, including the new one (130 entries returned for Schwarzwald-Baar-Kreis, Königsfeld)