### PR TITLE
Fix: North Kesteven, UK — use curl_cffi to avoid Cloudflare blocks

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_kesteven_org_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/north_kesteven_org_uk.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 TITLE = "North Kesteven District Council"
@@ -21,7 +21,18 @@ ICON_MAP = {
     "GREEN": Icons.RECYCLING,
     "PURPLE": Icons.NEWSPAPER,
     "BROWN": Icons.ORGANIC,
+    "ORANGE": Icons.BIO_KITCHEN,
 }
+
+
+def _icon_for(bin_type: str):
+    # The council has changed the wording of bin type names over time
+    # (e.g. "Purple (Paper/Card)" -> "Purple Lidded", "Orange Lidded Caddy"),
+    # so match on the leading colour keyword rather than the full string.
+    for keyword, icon in ICON_MAP.items():
+        if keyword in bin_type:
+            return icon
+    return None
 
 
 class Source:
@@ -29,21 +40,26 @@ class Source:
         self._uprn = str(uprn)
 
     def fetch(self):
-        s = requests.Session()
+        # North Kesteven District Council intermittently enables Cloudflare's
+        # bot-check on this endpoint, which blocks plain "requests" sessions.
+        # Impersonating a real browser via curl_cffi avoids that in most cases.
+        s = requests.Session(impersonate="chrome")
         r = s.get(f"https://www.n-kesteven.org.uk/bins/display?uprn={self._uprn}")
+        r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
         bin_type = soup.find_all("span", {"class": "font-weight-bold"})
         bin_dates = soup.find_all("strong")
 
         entries = []
         for idx in range(len(bin_type)):
+            bin_type_upper = bin_type[idx].text.upper()
             entries.append(
                 Collection(
                     date=datetime.strptime(
                         bin_dates[idx].text.split(", ")[1], "%d %B %Y"
                     ).date(),
-                    t=bin_type[idx].text.upper(),
-                    icon=ICON_MAP.get(bin_type[idx].text.upper()),
+                    t=bin_type_upper,
+                    icon=_icon_for(bin_type_upper),
                 )
             )
 


### PR DESCRIPTION
## Summary
- Fixes #4295 (recurrence of #3538): North Kesteven's bin lookup
  endpoint intermittently enables Cloudflare bot-checking, which
  blocked the plain `requests` session this source used and made
  `fetch()` silently return `[]` (surfaced by Home Assistant as
  "source returned an empty response").
- Switches to `curl_cffi` with `impersonate="chrome"`, the project's
  documented mitigation for Cloudflare-protected sites, and adds
  `raise_for_status()` so a real HTTP failure surfaces instead of an
  empty result.
- Hardens icon lookup: the council has changed some bin type label
  wording over time (e.g. "Green (Recycling)" is gone, "Purple
  Lidded" / "Orange Lidded Caddy" have appeared). `ICON_MAP` lookup
  now matches on the leading colour keyword instead of requiring an
  exact string match, and adds an `ORANGE` → food/caddy icon mapping.

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python test_sources.py -s north_kesteven_org_uk -l -i` — all 5
      TEST_CASES return entries with resolved icons
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed