### PR TITLE
fix(app_abfallplus_de): stop leaking other municipalities' Giftmobil dates for Landkreis München

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -408,7 +408,7 @@ API_BASE = "https://app.abfallplus.de/{}"
 API_ASSISTANT = API_BASE.format("assistent/{}")  # ignore: E501
 USER_AGENT = "Android / {} 8.1.1 (1915081010) / DM=unknown;DT=vbox86p;SN=Google;SV=8.1.0 (27);MF=unknown"
 USER_AGENT_ASSISTANT = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Abfallwecker"
-ABFALLARTEN_H2_SKIP = ["Sondermüll"]
+ABFALLARTEN_H2_SKIP = ["Sondermüll", "Giftmobil"]
 VERIFY_SSL = True
 
 
@@ -895,17 +895,30 @@ class AppAbfallplusDe:
                 to_skip_element.find_parent("div") if to_skip_element else None
             )
             if div_to_skip:
-                for input in to_skip_element.find_parent("div").find_all(
+                for input in div_to_skip.find_all(
                     "input", {"name": "f_id_abfallart[]"}
                 ):
-                    if compare(input.text, self._region_search, remove_space=True):
+                    # The visible label (e.g. the municipality name for a
+                    # "Sondermüll"/"Giftmobil" per-town toggle list) lives in
+                    # a sibling <ion-item>, not in the <input> itself, which
+                    # has no text content.
+                    label_item = input.find_next_sibling("ion-item")
+                    label_text = (
+                        label_item.get_text(strip=True)
+                        if label_item is not None
+                        else input.text
+                    )
+                    if compare(label_text, self._region_search, remove_space=True):
                         id = input.attrs["id"].split("_")[-1]
-                        self._f_id_abfallart.append(input.attrs["value"])
+                        self._f_id_abfallart.append(id)
                         self._needs_subtitle.append(id)
                         if id.isdigit():
                             self._needs_subtitle.append(str(int(id) - 1))
                         break
-                # remove sondermuell h2 from soup
+                # Remove this heading's whole section from the soup so that
+                # any remaining, non-matching entries (e.g. the Giftmobil
+                # toggle for every other municipality in the Landkreis) are
+                # not swept up by the generic "value == 0" fallback below.
                 div_to_skip.decompose()
 
         for input in soup.find_all("input", {"name": "f_id_abfallart[]"}):


### PR DESCRIPTION
## Summary
- `de.k4systems.lkmabfallplus` (Landkreis München) returned Giftmobil (hazardous-waste mobile collection) events for dozens of unrelated municipalities (Brunnthal, Höhenkirchen, Ottobrunn, Aying, ...) alongside the configured address.
- Root cause: the provider's "Giftmobil" section is a per-municipality toggle list, structurally identical to the "Sondermüll" section this scraper already special-cases - but `ABFALLARTEN_H2_SKIP` only listed `"Sondermüll"`, so the "Giftmobil" section was never found/removed and a generic fallback swept every municipality's toggle id into the subscribed waste types.
- Also fixed the specific-municipality match itself, which compared against the `<input>`'s text (always empty) instead of the sibling `<ion-item>` label, and appended the wrong attribute (`value`, always `"0"`) instead of the entry's real id.

## Test plan
- [x] Live-tested against the production API for `de.k4systems.lkmabfallplus` / Haar: now returns exactly one `Giftmobil Haar` entry, no other municipalities.
- [x] `cd custom_components/waste_collection_schedule/waste_collection_schedule/test && python test_sources.py -s app_abfallplus_de -l` - all TEST_CASES pass (one pre-existing, unrelated failure for `abfallappwug`/Bergen house-number ambiguity, not touched by this change).
- [x] `python -m pytest tests/test_source_components.py -q` - 34 passed.
- [x] `ruff check --fix` / `ruff format` clean.

Fixes #7026

🤖 Generated with [Claude Code](https://claude.com/claude-code)