### PR TITLE
Add San Giovanni Teatino to Junker APP source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -328,6 +328,7 @@ SERVICE_PROVIDERS = {
     "Stradella",
     "Torre de' Passeri",
     "Scalea",
+    "San Giovanni Teatino",
 }
 
 
@@ -356,6 +357,10 @@ TEST_CASES = {
         "area": "Utenze domestiche",
     },
     "Scalea": {"municipality": "Scalea"},
+    "San Giovanni Teatino, Zona A": {
+        "municipality": "San Giovanni Teatino",
+        "area": "Zona A",
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Fixes #3780
- San Giovanni Teatino (Italy) is already served by the existing generic Junker APP source (`junker_app.py` / `service/junker_app.py`) — no new integration code needed.
- Adds it to the `SERVICE_PROVIDERS` documentation list (drives the `EXTRA_INFO` README/sources.json listing).
- Adds a `TEST_CASES` entry (`municipality="San Giovanni Teatino", area="Zona A"`) so it gets live-tested; the municipality also supports `area="Zona B"` and `area="Zona industriale e commerciale"`.

## Test plan
- [x] `ruff check --fix` / `ruff format` clean
- [x] `python test_sources.py -s junker_app -l` — live fetch returns 228 real events for San Giovanni Teatino, Zona A
- [x] `python -m pytest tests/test_source_components.py -q` — 34 passed