### PR TITLE
Prevent a stale/renamed source argument from crashing the whole integration

### DIFF
--- a/custom_components/waste_collection_schedule/init_ui.py
+++ b/custom_components/waste_collection_schedule/init_ui.py
@@ -10,6 +10,7 @@ import requests
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
 
 from .service import get_fetch_all_service
 from .waste_collection_schedule.service.DeviceKeyStore import (
@@ -62,6 +63,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         options.get(const.CONF_DAY_OFFSET, const.CONF_DAY_OFFSET_DEFAULT),
         options.get(const.CONF_IGNORE_DUPLICATES, const.CONF_IGNORE_DUPLICATES_DEFAULT),
     )
+
+    if shell is None:
+        raise ConfigEntryError(
+            f"Failed to set up source '{entry.data[const.CONF_SOURCE_NAME]}'. "
+            "This is usually caused by a stale/invalid configuration, e.g. "
+            "after the source's arguments changed in an update. Please "
+            "reconfigure this integration entry. See the Home Assistant logs "
+            "for details."
+        )
 
     coordinator = WCSCoordinator(
         hass,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source_shell.py
@@ -279,7 +279,19 @@ class SourceShell:
             return None
 
         # create source
-        source: Fetchable = source_module.Source(**source_args)  # type: ignore
+        try:
+            source: Fetchable = source_module.Source(**source_args)  # type: ignore
+        except Exception as e:
+            _LOGGER.error(
+                f"error creating source {source_name} with arguments "
+                f"{source_args}: {e}\n"
+                "This is usually caused by a stale/invalid configuration, e.g. "
+                "after the source's arguments changed in an update, or a "
+                "'customize' entry that was nested under 'args' instead of "
+                "being a sibling of it. Please check the source's "
+                f"documentation and reconfigure it.\n{traceback.format_exc()}"
+            )
+            return None
 
         # create source shell
         g = SourceShell(

--- a/tests/test_source_shell_create_error_handling.py
+++ b/tests/test_source_shell_create_error_handling.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+# Make the core library importable as `waste_collection_schedule`.
+sys.path.append(
+    os.path.join(
+        os.path.dirname(__file__), "../custom_components/waste_collection_schedule"
+    )
+)
+
+from waste_collection_schedule.source_shell import SourceShell
+
+
+def test_create_returns_none_and_logs_on_unexpected_kwarg(caplog):
+    """A stale/invalid config (e.g. renamed/removed source argument, or a
+    'customize' block accidentally nested under 'args') must not raise and
+    crash the whole integration setup. It should be logged and skipped so
+    other, correctly configured sources keep working."""
+    shell = SourceShell.create(
+        source_name="ics",
+        customize={},
+        source_args={"this_is_not_a_real_argument": "value"},
+    )
+
+    assert shell is None
+    assert any(
+        "error creating source ics" in record.message for record in caplog.records
+    )
+
+
+def test_create_succeeds_with_valid_args():
+    """Sanity check: valid arguments still create a working shell."""
+    test_file = os.path.join(
+        os.path.dirname(__file__),
+        "../custom_components/waste_collection_schedule/waste_collection_schedule/test/test.ics",
+    )
+    shell = SourceShell.create(
+        source_name="ics",
+        customize={},
+        source_args={"file": test_file},
+    )
+
+    assert shell is not None


### PR DESCRIPTION
## Summary
- A single source with stale/invalid `args` (e.g. after a source's `__init__`
  parameters changed in an update, a failed config-entry migration that left
  old args in place, or a `customize:` block accidentally nested under `args:`
  in YAML) crashed `SourceShell.create()` with an uncaught `TypeError`.
- For **YAML** configs this took down the *entire* `waste_collection_schedule`
  component (`init_yaml.async_setup` aborts on any exception from
  `add_source_shell`), so one bad source definition disabled every other,
  correctly configured source too.
- For **UI** config entries, the same failure surfaced as a raw `TypeError`
  instead of a clear "setup failed" reason.
- `SourceShell.create()` now catches instantiation failures the same way it
  already handles `ImportError` (log a clear, actionable message, return
  `None`). `WasteCollectionApi.add_source_shell` already skips a `None`
  shell gracefully, so other YAML sources keep working. `init_ui.py` now
  raises `ConfigEntryError` with an actionable message when shell creation
  fails, instead of silently continuing with `source_shell=None`.

Fixes #3580

## Test plan
- [x] `python -m pytest tests/test_source_components.py -q` (34 passed)
- [x] New unit tests in `tests/test_source_shell_create_error_handling.py`
      cover both the failure path (bogus kwarg -> `None` + log message, no
      raise) and the success path (valid args still build a working shell)
- [x] `ruff check --fix` / `ruff format` on all touched files