### PR TITLE
Add support for additional waste types to lisburn_castlereagh source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
@@ -20,19 +20,23 @@ TEST_CASES = {
     "Test_001": {"postcode": "BT28 1AG", "house_number": "19A"},
     "Test_002": {"postcode": "BT26 6AB", "house_number": "31"},
     "Test_003": {"postcode": "BT26 6AB", "house_number": 15},
-    "Test_004": {"property_id": "DYYSm8Ls8XxGi3Nq"},
-    "Test_005": {"property_id": "ZJat6DWG1Lp95xp1"},
+    "Test_004": {"property_id": "RTTKBJY77wmTr5wP"},
+    "Test_005": {"property_id": "6opWbT5hi9odCQ2u"},
 }
 
 API_URL = "https://lisburn.isl-fusion.com"
 ICON_MAP = {
     "ResidualBin": Icons.GENERAL_WASTE,
     "RecycleBin": Icons.RECYCLING,
-    "BrownBin": Icons.BIO_KITCHEN,
+    "WheelieBox": Icons.RECYCLING,
+    "BrownBin": Icons.GARDEN,
+    "FoodWaste": Icons.BIO_KITCHEN,
 }
 NICE_NAMES = {
     "ResidualBin": "Refuse",
     "RecycleBin": "Recycling",
+    "WheelieBox": "Wheelie Box",
+    "FoodWaste": "Food Waste",
     "BrownBin": "Garden",
 }
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
@@ -119,11 +119,12 @@ class Source:
             collection_date = datetime.strptime(collection["date"], "%Y-%m-%d").date()
 
             for bin in collection["collections"].values():
+                bin_type = bin["name"]
                 entries.append(
                     Collection(
                         date=collection_date,
-                        t=NICE_NAMES.get(bin["name"]),
-                        icon=ICON_MAP.get(bin["name"]),
+                        t=NICE_NAMES.get(bin_type, bin_type),
+                        icon=ICON_MAP.get(bin_type),
                     )
                 )
 

--- a/doc/source/lisburn_castlereagh_gov_uk.md
+++ b/doc/source/lisburn_castlereagh_gov_uk.md
@@ -21,7 +21,7 @@ waste_collection_schedule:
     sources:
         - name: lisburn_castlereagh_gov_uk
           args:
-            post_code: "BT28 1AG"
+            postcode: "BT28 1AG"
             house_number: "19A"
 ```
 
@@ -43,7 +43,7 @@ waste_collection_schedule:
     sources:
     - name: lisburn_castlereagh_gov_uk
       args:
-        property_id: "DYYSm8Ls8XxGi3Nq"
+        property_id: "RTTKBJY77wmTr5wP"
 ```
 
 ## How to get the property_id argument

--- a/doc/source/lisburn_castlereagh_gov_uk.md
+++ b/doc/source/lisburn_castlereagh_gov_uk.md
@@ -28,9 +28,9 @@ waste_collection_schedule:
 ### Configuration Variables
 
 **property_id**  
-*(string) (required if post_code not provided)*
+*(string) (required if postcode not provided)*
 
-**post_code**  
+**postcode**  
 *(string) (required if property_id not provided)*
 
 **house_number**  
@@ -51,6 +51,6 @@ waste_collection_schedule:
 The property_id can be found in the URL when looking up your
 bin collection days at [Lisburn and Castlereagh bin collection days](https://lisburn.isl-fusion.com).
 
-## Why property_id over post_code and house_number?
+## Why property_id over postcode and house_number?
 
 The code has to do a search by post code and house number then look up the bin collection time using property ID


### PR DESCRIPTION
## Summary
Certain regions from inside the lisburn_castlereagh_gov_uk.py source have different configurations/types of waste collection.
A number of unsupported types being returned by the API resulted in the transformation logic breaking.

To fix this I have:
- Added support for `FoodWaste` & `WheelieBox` waste to the lisburn_castlereagh_gov_uk source.
- Updated the tests to target areas with both known waste configurations.


## Type of change
- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist
- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)