### PR TITLE
fix(kvatg_ch): drop URLs from PARAM_DESCRIPTIONS to avoid config-form placeholders

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kvatg_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kvatg_ch.py
@@ -27,7 +27,7 @@ _OVERVIEW_URL = "https://www.kvatg.ch/fuer-private/entsorgungsplaene-1/"
 
 # The KVA plan for Kreuzlingen contains no Kehricht dates — the city publishes
 # its own zone plan (a map PDF with a parseable zone/weekday legend) here:
-_KREUZLINGEN_ENTSORGUNG_URL = "https://www.kreuzlingen.ch/wir-fuer-sie/entsorgung"
+_KREUZLINGEN_ENTSORGUNG_URL = "kreuzlingen.ch"
 
 COMMUNITIES = [
     "Affeltrangen",
@@ -165,14 +165,14 @@ PARAM_DESCRIPTIONS = {
         "Kreuzlingen green waste district). Leave empty to get all zones; "
         "zoned collections are then suffixed with their zone name. The zone "
         "names are printed left of the date grid in your community's plan on "
-        "kvatg.ch (https://www.kvatg.ch/fuer-private/entsorgungsplaene-1/) — an invalid "
+        "kvatg.ch — an invalid "
         "value shows a list of the valid names.",
         "kehricht_zone": "Only for Kreuzlingen: household-waste (Kehricht) "
         "zone from the city's own zone plan — 'Süd & Tägerwilen', "
         "'Nord und Ost' or 'Zentrum'. Leave empty to get all three zones. "
         "Which streets belong to which zone is shown on the Kehricht, "
         "Abfuhrplan Kreuzlingen map at "
-        "https://www.kreuzlingen.ch/wir-fuer-sie/entsorgung.",
+        "kreuzlingen.ch.",
     },
     "de": {
         "community": "Gemeindename genau wie auf der Entsorgungsplan-Seite "
@@ -182,7 +182,7 @@ PARAM_DESCRIPTIONS = {
         "das Grüngut-Gebiet in Kreuzlingen). Leer lassen für alle Zonen; "
         "zonierte Sammlungen erhalten dann den Zonennamen als Zusatz. Die "
         "Zonennamen stehen links neben dem Datumsraster im Entsorgungsplan "
-        "Ihrer Gemeinde auf kvatg.ch (https://www.kvatg.ch/fuer-private/entsorgungsplaene-1/) "
+        "Ihrer Gemeinde auf kvatg.ch "
         "— bei einem ungültigen Wert wird eine Liste der gültigen Namen "
         "angezeigt.",
         "kehricht_zone": "Nur für Kreuzlingen: Kehricht-Abfuhrzone gemäss "
@@ -190,7 +190,7 @@ PARAM_DESCRIPTIONS = {
         "oder 'Zentrum'. Leer lassen für alle drei Zonen. Welche Strassen "
         "zu welcher Zone gehören, zeigt die Karte Kehricht, Abfuhrplan "
         "Kreuzlingen unter "
-        "https://www.kreuzlingen.ch/wir-fuer-sie/entsorgung.",
+        "kreuzlingen.ch.",
     },
     "it": {
         "community": "Nome del comune esattamente come indicato sulla pagina "
@@ -200,13 +200,13 @@ PARAM_DESCRIPTIONS = {
         "l'area del verde di Kreuzlingen). Lasciare vuoto per tutte le zone; "
         "le raccolte zonali riportano poi il nome della zona. I nomi delle "
         "zone si trovano a sinistra della griglia delle date nel piano del "
-        "comune su kvatg.ch (https://www.kvatg.ch/fuer-private/entsorgungsplaene-1/) — "
+        "comune su kvatg.ch — "
         "un valore non valido mostra l'elenco dei nomi validi.",
         "kehricht_zone": "Solo per Kreuzlingen: zona di raccolta dei rifiuti "
         "domestici (Kehricht) secondo il piano zonale comunale — "
         "'Süd & Tägerwilen', 'Nord und Ost' o 'Zentrum'. Lasciare vuoto per "
         "tutte e tre le zone. La mappa Kehricht, Abfuhrplan Kreuzlingen su "
-        "https://www.kreuzlingen.ch/wir-fuer-sie/entsorgung mostra quali "
+        "kreuzlingen.ch mostra quali "
         "strade appartengono a quale zona.",
     },
     "fr": {
@@ -218,13 +218,13 @@ PARAM_DESCRIPTIONS = {
         "toutes les zones ; les collectes zonées portent alors le nom de la "
         "zone. Les noms de zones figurent à gauche de la grille des dates "
         "dans le plan de votre commune sur "
-        "kvatg.ch (https://www.kvatg.ch/fuer-private/entsorgungsplaene-1/) — une valeur "
+        "kvatg.ch — une valeur "
         "invalide affiche la liste des noms valides.",
         "kehricht_zone": "Uniquement pour Kreuzlingen : zone de collecte des "
         "ordures ménagères (Kehricht) selon le plan de zones de la ville — "
         "'Süd & Tägerwilen', 'Nord und Ost' ou 'Zentrum'. Laisser vide pour "
         "les trois zones. La carte Kehricht, Abfuhrplan Kreuzlingen sur "
-        "https://www.kreuzlingen.ch/wir-fuer-sie/entsorgung montre quelles "
+        "kreuzlingen.ch montre quelles "
         "rues appartiennent à quelle zone.",
     },
 }


### PR DESCRIPTION
Follow-up to #7060.

`update_docu_links.py` turns **any** URL in a `PARAM_DESCRIPTIONS` string (bare or markdown) into a `{url_…}` translation placeholder. For config-flow `data_description`, those placeholders are never defined at runtime, so the kvatg config form would render the literal `{url_www_kvatg_ch_…}` text (plus a stray `(`). #7060 cleared the invalid-identifier hassfest error but left this cosmetic problem.

Fix: reference the sites by bare domain (`kvatg.ch`, `kreuzlingen.ch`) instead of full URLs. Bare domains have no `http(s)://` scheme, so the generator leaves them untouched. The full URLs remain in `HOW_TO_GET_ARGUMENTS_DESCRIPTION` (which the generator does not placeholder-ise).

Verified locally: `extract_urls_from_text` now yields **zero** placeholders for every language/field; ruff + format clean; `test_source_components.py` 34/34.