### PR TITLE
Fix up the UserAgent and URL/domain so Auckland Council works again

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
@@ -6,8 +6,8 @@ from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection
 
 TITLE = "Auckland Council"
-DESCRIPTION = "Source for Auckland council."
-URL = "https://new.aucklandcouncil.govt.nz"
+DESCRIPTION = "Source for Auckland Council."
+URL = "https://www.aucklandcouncil.govt.nz"
 
 TEST_CASES = {
     "429 Sea View Road": {"area_number": "12342453293"},  # Monday
@@ -47,8 +47,11 @@ def toDate(formattedDate: str, year: int | None = None) -> datetime.date:
     return datetime.date(year, month, day)
 
 
+# if this gets too old, it'll start failing
+# so grab the latest from Chrome and put it in here.
+
 HEADER = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
 }
 
 
@@ -57,8 +60,13 @@ class Source:
         self._area_number = str(area_number)
 
     def fetch(self) -> list[Collection]:
-        url = f"https://new.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days/{self._area_number}.html"
+        url = f"https://www.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days/{self._area_number}.html"
         r = requests.get(url, headers=HEADER)
+
+        # If this is failing, this is your first thing to check - they have a WAF,
+        # so if the useragent etc is "old", it'll 406' you
+        # drop into the ../tests folder and run python test_sources.py -s aucklandcouncil_govt_nz -l to try it
+        # print(r.text)
 
         soup = BeautifulSoup(r.text, "html.parser")
         entries: list[Collection] = []

--- a/doc/source/aucklandcouncil_govt_nz.md
+++ b/doc/source/aucklandcouncil_govt_nz.md
@@ -31,6 +31,6 @@ waste_collection_schedule:
 
 The source argument is the area number from Auckland Council site:
 
-- Open your collection days page by  entering your address [on the Auckland Council collection day finder](https://new.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days.html)
+- Open your collection days page by  entering your address [on the Auckland Council collection day finder](https://www.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days.html)
 - Once an address is selected, you will see a line such as: `Assessment number: 12342306525`
 - In this example the area number is `12342306525`.


### PR DESCRIPTION
## Summary

* Change the URL as "new.aucklandcouncil.govt.nz" just redirects to www anyway
* Update the UserAgent as they have a WAF and are checking for old UAs

## Type of change

- [ ] New source
- [X] Bug fix / source fix
- [X] Documentation update
- [ ] Other

## Checklist

- [X] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [X] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [X] TEST_CASES use real, publicly accessible addresses (not my own)
