### PR TITLE
fix(swale_gov_uk): update form field IDs

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -61,10 +61,10 @@ class Source:
 
         # mimic postcode search
         payload: dict = {
-            "SQ_FORM_499078_PAGE": "1",
-            "form_email_499078_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
-            "q499089:q1": self._postcode,
-            "form_email_499078_submit": "Choose Your Address &#10140;",
+            "SQ_FORM_535662_PAGE": "1",
+            "form_email_535662_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
+            "q535679:q1": self._postcode,
+            "form_email_535662_submit": "Choose Your Address &#10140;",
         }
         r = s.post(
             "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day",
@@ -75,10 +75,10 @@ class Source:
 
         # mimic address selection
         payload = {
-            "SQ_FORM_499078_PAGE": "2",
-            "form_email_499078_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
-            "q499093:q1": self._uprn,
-            "form_email_499078_submit": "Get Bin Days &#10140;",
+            "SQ_FORM_535662_PAGE": "2",
+            "form_email_535662_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
+            "q535685:q1": self._uprn,
+            "form_email_535662_submit": "Get Bin Days &#10140;",
         }
         r = s.post(
             "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day",


### PR DESCRIPTION
## Summary

Swale Borough Council has updated the form field IDs used by the "Check Your Bin Day" form.

The current source still submits the previous field names, causing configuration to fail with:

> Could not find next collection date – the page may have changed or returned an error.

This updates both POST payloads to use the current field identifiers.

## Testing

- Tested against a live Swale Borough Council property.
- Configuration now completes successfully.
- Waste collection calendar is created successfully.
- Collection data is returned correctly.

The field names were verified against the current live Swale website.