### PR TITLE
Fix Auckland Council (aucklandcouncil_govt_nz): HTTP 406 from council WAF broke all lookups

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
@@ -47,8 +47,21 @@ def toDate(formattedDate: str, year: int | None = None) -> datetime.date:
     return datetime.date(year, month, day)
 
 
+# The council WAF rejects requests with HTTP 406 unless they carry a full
+# browser-like header set, including the Sec-Fetch-* and sec-ch-ua client
+# hints. A bare User-Agent is no longer sufficient.
 HEADER = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Upgrade-Insecure-Requests": "1",
+    "sec-ch-ua": '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
 }
 
 


### PR DESCRIPTION
## Summary

Service provider: **Auckland Council** (`aucklandcouncil_govt_nz`, New Zealand)

The Auckland Council WAF now rejects requests that only send a `User-Agent` header with **HTTP 406 Not Acceptable**, so the source returned an empty response for every `area_number` (config flow fails with "The source returned an empty response"). Sending a complete browser-like header set — `Accept`, `Accept-Language`, the `Sec-Fetch-*` fetch-metadata headers and `sec-ch-ua` client hints — restores normal operation.

Only `HEADER` in the existing source file is changed; no user-facing arguments changed, so `doc/source/aucklandcouncil_govt_nz.md` needs no update. `ruff check` and `ruff format` pass.

## Test output

Before (current master):

```
Testing source aucklandcouncil_govt_nz ...
  found 0 entries for 429 Sea View Road
  found 0 entries for 8 Dickson Road
  found 0 entries for with Food Scraps
  found 0 entries for 3 Andrew Road
```

After (this PR):

```
Testing source aucklandcouncil_govt_nz ...
  found 2 entries for 429 Sea View Road
    2026-07-27 : rubbish
    2026-08-03 : recycling
  found 2 entries for 8 Dickson Road
    2026-07-30 : rubbish
    2026-08-06 : recycling
  found 3 entries for with Food Scraps
    2026-07-27 : rubbish
    2026-07-27 : food scraps
    2026-08-03 : recycling
  found 3 entries for 3 Andrew Road
    2026-07-31 : rubbish
    2026-07-31 : food scraps
    2026-08-07 : recycling
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)