### PR TITLE
Fix: Central Bedfordshire Council — rewrite for new council site (fixes #7042)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/centralbedfordshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/centralbedfordshire_gov_uk.py
@@ -1,4 +1,4 @@
-import time
+import re
 from datetime import datetime
 
 import requests
@@ -6,19 +6,23 @@ from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequiredWithSuggestions,
 )
+from waste_collection_schedule.service.ICS import ICS
 
 TITLE = "Central Bedfordshire Council"
 DESCRIPTION = (
     "Source for www.centralbedfordshire.gov.uk services for Central Bedfordshire"
 )
 URL = "https://www.centralbedfordshire.gov.uk"
+
 TEST_CASES = {
     "postcode has space": {"postcode": "SG15 6YF", "house_name": "10 Old School Walk"},
     "postcode without space": {
         "postcode": "SG180LL",
         "house_name": "1 Chestnut Avenue",
     },
+    "uprn direct": {"uprn": "10000863589"},
 }
 
 ICON_MAP = {
@@ -28,136 +32,166 @@ ICON_MAP = {
     "Food waste": Icons.BIO_KITCHEN,
 }
 
+_BASE_URL = "https://www.centralbedfordshire.gov.uk"
+_FORM_URL = f"{_BASE_URL}/waste-and-recycling/waste-collection-schedule"
+_ICAL_URL_TMPL = (
+    f"{_BASE_URL}/waste-and-recycling/waste-collection-schedule/download/{{uprn}}"
+)
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-GB,en;q=0.9",
+}
+
+# Multi-value summaries like "Refuse (black bin) and food waste collections"
+# split into individual canonical bin names via longest-match on this table.
+# Ordered longest-first so "Refuse (black bin)" matches before "Refuse".
+_BIN_ALIASES: list[tuple[str, str]] = [
+    ("refuse (black bin)", "Refuse (black bin)"),
+    ("black bin", "Refuse (black bin)"),
+    ("refuse", "Refuse (black bin)"),
+    ("recycling", "Recycling"),
+    ("garden waste", "Garden waste"),
+    ("food waste", "Food waste"),
+]
+
+
+def _split_summary(summary: str) -> list[str]:
+    """Convert one iCal SUMMARY into a list of canonical bin names.
+
+    Unknown fragments (e.g. the calendar-expiry reminder event) return [].
+
+    Examples:
+        "Refuse (black bin) and food waste collections"
+            -> ["Refuse (black bin)", "Food waste"]
+        "Recycling, garden waste and food waste collections"
+            -> ["Recycling", "Garden waste", "Food waste"]
+        "Garden Waste Collection"
+            -> ["Garden waste"]
+        "Download your bin collection calendar"
+            -> []
+    """
+    text = summary.strip().lower()
+    # remove trailing "collection"/"collections"
+    text = re.sub(r"\s+collections?\s*$", "", text)
+    # normalise separators (" and ", commas) into a single delimiter
+    parts = re.split(r"\s*,\s*|\s+and\s+", text)
+    result: list[str] = []
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        for needle, canon in _BIN_ALIASES:
+            if needle in part:
+                result.append(canon)
+                break
+        # Unknown fragments are silently dropped — the council emits non-collection
+        # reminder events (e.g. "Download your bin collection calendar") that must
+        # not become fake entries.
+    return result
+
 
 class Source:
-    def __init__(self, postcode, house_name):
+    def __init__(
+        self,
+        postcode: str | None = None,
+        house_name: str | None = None,
+        uprn: str | int | None = None,
+    ):
+        if uprn is None and not (postcode and house_name):
+            raise SourceArgumentRequiredWithSuggestions(
+                "uprn",
+                None,
+                ["Provide `uprn` OR both `postcode` and `house_name`."],
+            )
         self._postcode = postcode
         self._house_name = house_name
+        self._uprn: str | None = str(uprn) if uprn is not None else None
 
-    def fetch(self):
-        session = requests.Session()
+    def _resolve_uprn(self, session: requests.Session) -> str:
+        """Look up UPRN by scraping the council's postcode form (Drupal LocalGov)."""
+        # Step 1 — GET the form to obtain the CSRF-like form_build_id + cookies
+        r = session.get(_FORM_URL, timeout=30)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, features="html.parser")
+        postcode_form = soup.find(id="localgov-waste-collection-postcode-form")
+        if postcode_form is None:
+            raise RuntimeError(
+                "Postcode form not found on council page — layout may have changed."
+            )
+        fbid_input = postcode_form.find("input", attrs={"name": "form_build_id"})
+        if fbid_input is None:
+            raise RuntimeError("Postcode form is missing form_build_id.")
 
-        # Add realistic browser headers to avoid bot detection
-        session.headers.update(
-            {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-                "Accept-Language": "en-GB,en;q=0.9",
-                "Accept-Encoding": "gzip, deflate, br",
-                "DNT": "1",
-                "Connection": "keep-alive",
-                "Upgrade-Insecure-Requests": "1",
-                "Sec-Fetch-Dest": "document",
-                "Sec-Fetch-Mode": "navigate",
-                "Sec-Fetch-Site": "same-origin",
-                "Cache-Control": "max-age=0",
-            }
-        )
-
-        # First, visit the page to establish session
-        url = "https://www.centralbedfordshire.gov.uk/info/163/bins_and_waste_collections_-_check_bin_collection_days"
-
-        try:
-            # Initial page load to get session cookies
-            session.get(url, timeout=30)
-            time.sleep(2)  # Be polite to the server
-
-            # Lookup postcode, then use house name to get UPRN
-            data = {
+        # Step 2 — POST the postcode
+        r = session.post(
+            _FORM_URL,
+            data={
                 "postcode": self._postcode,
-            }
-
-            r = session.post(url, data=data, timeout=30)
-            r.raise_for_status()
-
-            soup = BeautifulSoup(r.text, features="html.parser")
-
-            # Check if we got blocked or redirected
-            if "403" in r.text or "forbidden" in r.text.lower():
-                raise requests.exceptions.HTTPError(
-                    "403 Forbidden - IP may be temporarily blocked"
-                )
-
-            address_select = soup.find("select", id="address")
-            if not address_select:
-                raise ValueError(
-                    "Could not find address selection dropdown - page structure may have changed"
-                )
-
-            address = address_select.find(
-                "option",
-                text=lambda value: value and value.startswith(self._house_name),
+                "form_build_id": fbid_input["value"],
+                "form_id": "localgov_waste_collection_postcode_form",
+                "op": "Find",
+            },
+            timeout=30,
+        )
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, features="html.parser")
+        addr_select = soup.find("select", attrs={"name": "uprn"})
+        if addr_select is None:
+            raise RuntimeError(
+                "Address dropdown not found — postcode may be invalid or the page structure has changed."
             )
 
-            if address is None:
-                addresses = {
-                    option.text.removeprefix(self._postcode)
-                    for option in address_select.select("option")
-                } - {""}
-                raise SourceArgumentNotFoundWithSuggestions(
-                    "house_name",
-                    self._house_name,
-                    addresses,
-                )
+        # Build {label: uprn} map, then prefix-match against house_name
+        addresses: dict[str, str] = {}
+        for opt in addr_select.find_all("option"):
+            val = (opt.get("value") or "").strip()
+            if not val:
+                continue
+            addresses[opt.get_text(strip=True)] = val
 
-            self._uprn = address["value"]
+        target = self._house_name.strip().lower()
+        for label, uprn in addresses.items():
+            if label.lower().startswith(target):
+                return uprn
 
-            # Add some delay between requests
-            time.sleep(3)
+        raise SourceArgumentNotFoundWithSuggestions(
+            "house_name", self._house_name, set(addresses.keys())
+        )
 
-            data = {
-                "address_text": address.text,
-                "address": self._uprn,
-                "postcode": self._postcode,
-            }
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update(_HEADERS)
 
-            r = session.post(url, data=data, timeout=30)
-            r.raise_for_status()
+        # Resolve UPRN once, then reuse for subsequent fetches.
+        if self._uprn is None:
+            self._uprn = self._resolve_uprn(session)
 
-            soup = BeautifulSoup(r.text, features="html.parser")
-            collections_div = soup.find("div", id="collections")
+        # Fetch the per-UPRN iCal feed — this is the stable, structured endpoint.
+        r = session.get(_ICAL_URL_TMPL.format(uprn=self._uprn), timeout=30)
+        r.raise_for_status()
 
-            if not collections_div:
-                raise ValueError(
-                    "Could not find collections data - page structure may have changed"
-                )
+        events = ICS().convert(r.text)
 
-            s = collections_div.find_all("h3")
-            entries = []
-
-            for collection in s:
-                try:
-                    date = datetime.strptime(collection.text, "%A, %d %B %Y").date()
-                    for sibling in collection.next_siblings:
-                        if (
-                            sibling.name == "h3"
-                            or sibling.name == "p"
-                            or sibling.name == "a"
-                            or sibling.name == "div"
-                        ):
-                            break
-                        if (
-                            sibling.name != "br"
-                            and hasattr(sibling, "text")
-                            and sibling.text.strip()
-                        ):
-                            entries.append(
-                                Collection(
-                                    date=date,
-                                    t=sibling.text.strip(),
-                                    icon=ICON_MAP.get(sibling.text.strip()),
-                                )
-                            )
-                except ValueError:
-                    # Skip dates that can't be parsed
+        # Dedupe (date, bin_name) — the council emits both a standalone
+        # "Garden Waste Collection" event AND a combined "Recycling, garden
+        # waste and food waste collections" event on the same day for
+        # addresses subscribed to the paid garden-waste service.
+        seen: set[tuple] = set()
+        entries: list[Collection] = []
+        for date, summary in events:
+            for bin_name in _split_summary(summary):
+                key = (date, bin_name)
+                if key in seen:
                     continue
-
-            return entries
-
-        except requests.exceptions.RequestException as e:
-            if "403" in str(e):
-                raise requests.exceptions.HTTPError(
-                    f"403 Forbidden - Central Bedfordshire Council is blocking requests. "
-                    f"Try again later or check if your IP is temporarily banned. Error: {e}"
-                ) from e
-            raise e
+                seen.add(key)
+                entries.append(
+                    Collection(
+                        date=date, t=bin_name, icon=ICON_MAP.get(bin_name)
+                    )
+                )
+        return entries

--- a/doc/source/centralbedfordshire_gov_uk.md
+++ b/doc/source/centralbedfordshire_gov_uk.md
@@ -1,6 +1,6 @@
 # Central Bedfordshire Council
 
-Support for schedules provided by [Central Bedfordshire Council](https://www.centralbedfordshire.gov.uk/info/163/bins_and_waste_collections_-_check_bin_collection_days/), serving Central Bedfordshire, UK.
+Support for schedules provided by [Central Bedfordshire Council](https://www.centralbedfordshire.gov.uk/waste-and-recycling/waste-collection-schedule), serving Central Bedfordshire, UK.
 
 ## Configuration via configuration.yaml
 
@@ -11,27 +11,43 @@ waste_collection_schedule:
       args:
         postcode: POSTCODE
         house_name: HOUSE_NAME
-        version: 1
-
+        uprn: UPRN
 ```
 
 ### Configuration Variables
 
 **POSTCODE**  
-*(string) (required)*
+*(string) (optional if `uprn` is provided)*
 
 **HOUSE_NAME**  
-*(string) (required)*
+*(string) (optional if `uprn` is provided)*
 
-This must exactly match your house name that the search on [Central Bedfordshire Council's website](https://www.centralbedfordshire.gov.uk/info/163/bins_and_waste_collections_-_check_bin_collection_days) returns for your given postcode EXCLUDING the comma and postcode
+This must be a prefix of your address as shown on [Central Bedfordshire Council's postcode lookup](https://www.centralbedfordshire.gov.uk/waste-and-recycling/waste-collection-schedule). E.g. for `"10 Old School Walk, Arlesey, SG15 6YF"` use `"10 Old School Walk"`.
+
+**UPRN**  
+*(string) (optional)*
+
+Your property's Unique Property Reference Number. If provided, `postcode` and `house_name` are not required and the postcode-form scrape is skipped, giving a more robust configuration. To find your UPRN: use the [council's lookup](https://www.centralbedfordshire.gov.uk/waste-and-recycling/waste-collection-schedule), select your address, and read the number at the end of the URL (e.g. `.../view/10000863589`).
 
 ## Example
+
+Using postcode and house name:
 
 ```yaml
 waste_collection_schedule:
     sources:
     - name: centralbedfordshire_gov_uk
       args:
-        postcode: "SG156YF"
+        postcode: "SG15 6YF"
         house_name: "10 Old School Walk"
+```
+
+Using UPRN (recommended — more robust):
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: centralbedfordshire_gov_uk
+      args:
+        uprn: "10000863589"
 ```


### PR DESCRIPTION
Closes #7042.

Central Bedfordshire Council relaunched their website on 22 July 2026 and retired the old URL, which now returns **HTTP 404**, breaking the source for all users.

This PR rewrites the scraper against the new [LocalGov Drupal](https://localgovdrupal.org/) site. Key changes:

- Primary data source is now the council's **per-UPRN iCal feed** at `/waste-and-recycling/waste-collection-schedule/download/{UPRN}`, parsed via the repo's existing `service.ICS` helper. This is a structured public endpoint and much more robust than HTML scraping.
- Added optional `uprn` config parameter. When supplied, the scraper skips the postcode form entirely and goes straight to the iCal — recommended for stability.
- Existing `postcode` + `house_name` config remains supported (backward compatible). It now resolves the UPRN via the new site's two-stage Drupal form (GET for `form_build_id`, POST for the address select, extract UPRN, then fetch iCal).
- Combined summaries like `"Recycling, garden waste and food waste collections"` are split into individual canonical bin names via a small ordered lookup table (longest-first, so `"Refuse (black bin)"` beats `"Refuse"`).
- Deduplicated on `(date, bin_name)` — the council emits both a standalone `"Garden Waste Collection"` event and a combined event on the same day for addresses subscribed to weekly garden waste, which previously produced double entries.
- Skips the council's non-collection reminder events (e.g. `"Download your bin collection calendar"`) so they don't appear as fake collections.
- Docs updated to document `uprn` and the new hub URL.

## Test results

Tested live against all three TEST_CASES (two existing postcode+house_name cases, plus a new `uprn direct` case):

| Test | Entries | Types |
|---|---|---|
| `postcode has space` (SG15 6YF, 10 Old School Walk) | 57 | Refuse 12 / Recycling 11 / Garden 11 / Food 23 |
| `postcode without space` (SG18 0LL, 1 Chestnut Avenue) | 58 | Refuse 11 / Recycling 12 / Garden 12 / Food 23 |
| `uprn direct` (10000863589) | 57 | (identical to test 1) |

All entries match the collection days shown on the council's public calendar. Dedupe verified against SG18 0LL which subscribes to weekly garden waste and would otherwise produce duplicate `"Garden waste"` entries on combined-collection days.
