### PR TITLE
Fix Esch schedule fetch with identity encoding

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/esch_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/esch_lu.py
@@ -11,7 +11,7 @@ DESCRIPTION = "Source script for administration.esch.lu, communal website of the
 URL = "https://esch.lu"
 TEST_CASES = {"Zone A": {"zone": "A"}, "Zone B": {"zone": "B"}}
 
-API_URL = "https://administration.esch.lu/dechets/?street=0&tour="
+API_URL = "https://administration.esch.lu/dechets/"
 ICON_MAP = {
     "Poubelle ménage": Icons.GENERAL_WASTE,
     "Papier": Icons.PAPER,
@@ -53,7 +53,13 @@ class Source:
             "street": 0,
             "tour": self._zone,
         }
-        r = s.get("https://administration.esch.lu/dechets", params=params)
+        # The compressed response advertises chunked transfer encoding twice, which
+        # some urllib3 versions reject. Request identity encoding to avoid it.
+        r = s.get(
+            API_URL,
+            params=params,
+            headers={"Accept-Encoding": "identity"},
+        )
         r.raise_for_status()
         soup = BeautifulSoup(r.content, "html.parser")
 

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -141,6 +141,42 @@ def test_enfield_address_match_uses_whole_house_number() -> None:
     assert not module.Source._matches_address(normalized_input, embedded_candidate)
 
 
+def test_esch_lu_requests_identity_encoding() -> None:
+    module = _get_module("esch_lu")
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _Response:
+        content = (
+            b'<table id="garbage-table"><tr><td></td><td>Organique</td>'
+            b"<td>mardi, 28 juillet 2026</td></tr></table>"
+        )
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    class _Session:
+        def get(self, url: str, **kwargs: Any) -> _Response:
+            calls.append((url, kwargs))
+            return _Response()
+
+    with patch.object(module, "get_legacy_session", return_value=_Session()):
+        entries = module.Source(zone="A").fetch()
+
+    assert [(entry.date.isoformat(), entry.type) for entry in entries] == [
+        ("2026-07-28", "Organique")
+    ]
+    assert calls == [
+        (
+            "https://administration.esch.lu/dechets/",
+            {
+                "params": {"street": 0, "tour": "1"},
+                "headers": {"Accept-Encoding": "identity"},
+            },
+        )
+    ]
+
+
 def _param_translation_check(
     source: str,
     translations: Any,


### PR DESCRIPTION
The Esch endpoint's compressed response advertises Transfer-Encoding: chunked twice. Some urllib3 versions reject it as multiple Transfer-Encoding headers, preventing schedule refreshes.

Use the canonical trailing-slash endpoint and request identity encoding. This avoids the malformed compressed response without changing user configuration. Add a regression test covering the request and parsed schedule.
