### PR TITLE
fix(aucklandcouncil_govt_nz): bypass WAF 406 and fail loudly on empty results

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
@@ -7,7 +7,7 @@ from waste_collection_schedule import Collection
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "Auckland Council"
-DESCRIPTION = "Source for Auckland council."
+DESCRIPTION = "Source for Auckland Council."
 URL = "https://www.aucklandcouncil.govt.nz"
 
 TEST_CASES = {
@@ -125,7 +125,7 @@ class Source:
         # The site's WAF answers HTTP 406 to plain requests/urllib clients, so
         # impersonate a real browser (TLS fingerprint included).
         session = requests.Session(impersonate="chrome")
-        r = session.get(API_URL.format(self._area_number))
+        r = session.get(API_URL.format(self._area_number), timeout=30)
         r.raise_for_status()
 
         entries = parse_page(r.text)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py
@@ -1,13 +1,14 @@
 import datetime
 import re
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests
 from waste_collection_schedule import Collection
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "Auckland Council"
 DESCRIPTION = "Source for Auckland council."
-URL = "https://new.aucklandcouncil.govt.nz"
+URL = "https://www.aucklandcouncil.govt.nz"
 
 TEST_CASES = {
     "429 Sea View Road": {"area_number": "12342453293"},  # Monday
@@ -15,6 +16,8 @@ TEST_CASES = {
     "with Food Scraps": {"area_number": 12341998652},
     "3 Andrew Road": {"area_number": "12345375455"},  # friday with foodscraps
 }
+
+API_URL = "https://www.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days/{}.html"
 
 MONTH = {
     "January": 1,
@@ -29,6 +32,13 @@ MONTH = {
     "October": 10,
     "November": 11,
     "December": 12,
+}
+
+# icon class used on the page -> waste type reported by this source
+COLLECTION_TYPES = {
+    "rubbish": "rubbish",
+    "recycle": "recycling",
+    "food-waste": "food scraps",
 }
 
 
@@ -47,9 +57,64 @@ def toDate(formattedDate: str, year: int | None = None) -> datetime.date:
     return datetime.date(year, month, day)
 
 
-HEADER = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
-}
+def parse_page(html: str) -> list[Collection]:
+    soup = BeautifulSoup(html, "html.parser")
+    entries: list[Collection] = []
+
+    # Find only the household collection section
+    # Look for the card with "Household collection" title
+    household_section = None
+    schedule_cards = soup.find_all("div", class_="acpl-schedule-card")
+
+    for card in schedule_cards:
+        title_element = card.find("h4", class_="card-title")
+        if title_element and "Household collection" in title_element.get_text():
+            household_section = card
+            break
+
+    if not household_section:
+        return entries
+
+    # Look for collection information only within the household section
+    collection_paragraphs = household_section.find_all("p", class_="mb-0 lead")
+
+    for p in collection_paragraphs:
+        # Look for icon elements
+        icon = p.find("i", class_=lambda x: x and "acpl-icon" in x)
+        if not icon:
+            continue
+
+        # Extract the collection type from icon classes
+        collection_type = None
+        for cls in icon.get("class") or []:
+            if cls in COLLECTION_TYPES:
+                collection_type = COLLECTION_TYPES[cls]
+                break
+
+        if not collection_type:
+            continue
+
+        # Look for date in bold text within the paragraph
+        # (absent when this address has no such collection)
+        date_bold = p.find("b")
+        if not date_bold:
+            continue
+
+        date_text = date_bold.get_text(strip=True)
+
+        # Extract date from text using regex
+        date_match = re.search(r"([A-Za-z]+,\s+\d+\s+[A-Za-z]+)", date_text)
+        if not date_match:
+            continue
+
+        try:
+            collection_date = toDate(date_match.group(1))
+        except (ValueError, KeyError):
+            continue
+
+        entries.append(Collection(collection_date, collection_type))
+
+    return entries
 
 
 class Source:
@@ -57,68 +122,22 @@ class Source:
         self._area_number = str(area_number)
 
     def fetch(self) -> list[Collection]:
-        url = f"https://new.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days/{self._area_number}.html"
-        r = requests.get(url, headers=HEADER)
+        # The site's WAF answers HTTP 406 to plain requests/urllib clients, so
+        # impersonate a real browser (TLS fingerprint included).
+        session = requests.Session(impersonate="chrome")
+        r = session.get(API_URL.format(self._area_number))
+        r.raise_for_status()
 
-        soup = BeautifulSoup(r.text, "html.parser")
-        entries: list[Collection] = []
+        entries = parse_page(r.text)
 
-        # Find only the household collection section
-        # Look for the card with "Household collection" title
-        household_section = None
-        schedule_cards = soup.find_all("div", class_="acpl-schedule-card")
-
-        for card in schedule_cards:
-            title_element = card.find("h4", class_="card-title")
-            if title_element and "Household collection" in title_element.get_text():
-                household_section = card
-                break
-
-        if not household_section:
-            return entries
-
-        # Look for collection information only within the household section
-        collection_paragraphs = household_section.find_all("p", class_="mb-0 lead")
-
-        for p in collection_paragraphs:
-            # Look for icon elements
-            icon = p.find("i", class_=lambda x: x and "acpl-icon" in x)
-            if not icon:
-                continue
-
-            # Extract the collection type from icon classes
-            classes = icon.get("class", [])
-            collection_type = None
-            for cls in classes:
-                if cls in ["rubbish", "recycle", "food-waste"]:
-                    collection_type = cls
-                    break
-
-            if not collection_type:
-                continue
-
-            # Look for date in bold text within the paragraph
-            date_bold = p.find("b")
-            if not date_bold:
-                continue
-
-            date_text = date_bold.get_text(strip=True)
-
-            # Extract date from text using regex
-            date_match = re.search(r"([A-Za-z]+,\s+\d+\s+[A-Za-z]+)", date_text)
-            if not date_match:
-                continue
-
-            try:
-                collection_date = toDate(date_match.group(1))
-                # Normalize collection type names
-                if collection_type == "food-waste":
-                    collection_type = "food scraps"
-                elif collection_type == "recycle":
-                    collection_type = "recycling"
-
-                entries.append(Collection(collection_date, collection_type))
-            except (ValueError, KeyError):
-                continue
+        if not entries:
+            # An unknown area number still returns HTTP 200, but with empty
+            # collection dates. Fail loudly instead of reporting an empty
+            # schedule as a successful fetch.
+            raise SourceArgumentNotFound(
+                "area_number",
+                self._area_number,
+                "no collection dates were found on the Auckland Council page, please check the area number.",
+            )
 
         return entries

--- a/doc/source/aucklandcouncil_govt_nz.md
+++ b/doc/source/aucklandcouncil_govt_nz.md
@@ -1,6 +1,6 @@
 # Auckland Council
 
-Support for schedules provided by [Auckland Council](https://new.aucklandcouncil.govt.nz/).
+Support for schedules provided by [Auckland Council](https://www.aucklandcouncil.govt.nz/).
 
 ## Configuration via configuration.yaml
 
@@ -31,6 +31,6 @@ waste_collection_schedule:
 
 The source argument is the area number from Auckland Council site:
 
-- Open your collection days page by  entering your address [on the Auckland Council collection day finder](https://new.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days.html)
+- Open your collection days page by entering your address [on the Auckland Council collection day finder](https://www.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days.html)
 - Once an address is selected, you will see a line such as: `Assessment number: 12342306525`
 - In this example the area number is `12342306525`.


### PR DESCRIPTION
Fixes #7070

## Service provider

[Auckland Council](https://www.aucklandcouncil.govt.nz) (`aucklandcouncil_govt_nz`), New Zealand.

## Problem
A hard-coded `Chrome/58.0.3029.110` User-Agent (2017). Auckland Council's WAF now answers **HTTP 406 Not Acceptable** to it on the per-address collection page.

`fetch()` never checked the response status, so the 293-byte 406 error page was handed to BeautifulSoup, no `acpl-schedule-card` was found, and an empty list was returned. The coordinator logged a successful fetch with no data, and nothing appeared in the log even at debug level — exactly the silent failure described in #7070.

The page markup itself has **not** changed — the existing parser works unmodified once the request is accepted.

| Request | Result |
|---|---|
| `Chrome/58` UA (as shipped), any other headers | `406` |
| no UA | `406` |
| `python-requests/2.32.3` | `406` |
| `Chrome/128` UA, no other headers | `200` |
| `curl_cffi` `impersonate="chrome"` | `200` |



## Changes

`custom_components/waste_collection_schedule/waste_collection_schedule/source/aucklandcouncil_govt_nz.py`

- Use `curl_cffi` with `impersonate="chrome"` instead of a hand-written `User-Agent`. A hardcoded UA string is what broke here, and `impersonate` also matches on TLS fingerprint. `curl_cffi` is already in `manifest.json` / `requirements.txt` and used by other sources, so this adds no dependency.
- Call `raise_for_status()` so a future block surfaces as an error rather than an empty schedule.
- Raise `SourceArgumentNotFound("area_number", ...)` when no collections parse, covering the HTTP-200-but-empty invalid-area case.
- Extract parsing into a module-level `parse_page()` and move waste-type normalisation into a `COLLECTION_TYPES` map. The `try` block now wraps only `toDate()`, the one call that can raise — previously it also enclosed `Collection(...)` and the `append`.
- `new.aucklandcouncil.govt.nz` now 301s to `www.aucklandcouncil.govt.nz`; `URL` and the fetch URL updated.

`doc/source/aucklandcouncil_govt_nz.md`

- Same `new.` → `www.` link update (2 links, both verified 200).

Partial emptiness still parses correctly and does **not** raise — `12342453293` has no food scraps collection and returns rubbish + recycling as before.

No generated files are touched, and `update_docu_links.py` was not run.

## Test output

```
$ python test_sources.py -s aucklandcouncil_govt_nz -l
Testing source aucklandcouncil_govt_nz ...
  found 2 entries for 429 Sea View Road
    2026-08-03 : rubbish
    2026-08-03 : recycling
  found 2 entries for 8 Dickson Road
    2026-07-30 : rubbish
    2026-08-06 : recycling
  found 3 entries for with Food Scraps
    2026-08-03 : rubbish
    2026-08-03 : food scraps
    2026-08-03 : recycling
  found 3 entries for 3 Andrew Road
    2026-07-31 : rubbish
    2026-07-31 : food scraps
    2026-08-07 : recycling
```

All four `TEST_CASES` return an empty list on `master` today.

Also verified:

- `python -m pytest tests/` — 38 passed
- `ruff check` / `ruff format --check` — clean
- `mypy --ignore-missing-imports --explicit-package-bases` — clean for this file (2 pre-existing errors on `master` fixed in passing, from `icon.get("class", [])` → `icon.get("class") or []`)
- An out-of-tree regression suite covering the broken/fixed behaviour: a frozen snapshot of the `master` source asserting the 406 and the silent empty list, live checks of all four test cases plus a real address, an invalid area number raising, and offline parser tests against captured HTML fixtures. 3 passed / 7 failed before the fix, 10 passed after.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
