### PR TITLE
fix(sudestavenir_fr): parse mixed green-waste schedules

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sudestavenir_fr.py
@@ -70,17 +70,25 @@ DAY_MAP = {
 
 MONTH_MAP = {
     "janv": 1,
+    "janvier": 1,
     "fev": 2,
+    "fevrier": 2,
     "mars": 3,
     "avr": 4,
+    "avril": 4,
     "mai": 5,
     "juin": 6,
     "juill": 7,
+    "juillet": 7,
     "aout": 8,
     "sept": 9,
+    "septembre": 9,
     "oct": 10,
+    "octobre": 10,
     "nov": 11,
+    "novembre": 11,
     "dec": 12,
+    "decembre": 12,
 }
 
 WEEKLY_FREQUENCIES = {"HEBDOMADAIRE", "BIHEBDOMADAIRE", "TRIHEBDOMADAIRE"}
@@ -137,24 +145,51 @@ def _normalize(s: str) -> str:
     return re.sub(r"\s+", " ", _strip_accents(s).lower().strip())
 
 
+def _french_date(day: str, month: str, year: int) -> date | None:
+    month_number = MONTH_MAP.get(_normalize(month).rstrip("."))
+    if month_number is None or not day.isdigit():
+        return None
+    try:
+        return date(year, month_number, int(day))
+    except ValueError:
+        return None
+
+
 def _parse_precisi_dates(precisi: str, year: int) -> list[date]:
     dates: list[date] = []
     for line in precisi.splitlines():
-        m = re.match(r"^([A-Za-zÀ-ÿ]+)\.\s*:\s*([\d\s\-]+)$", line.strip())
-        if not m:
+        line = line.strip()
+        month_first = re.fullmatch(r"([A-Za-zÀ-ÿ]+)\.?\s*:\s*([\d\s-]+)", line)
+        if month_first:
+            for day in month_first.group(2).split("-"):
+                parsed = _french_date(day.strip(), month_first.group(1), year)
+                if parsed is not None:
+                    dates.append(parsed)
             continue
-        month = MONTH_MAP.get(_strip_accents(m.group(1)).lower().rstrip("."))
-        if month is None:
-            continue
-        for day_str in m.group(2).split("-"):
-            day_str = day_str.strip()
-            if not day_str.isdigit():
-                continue
-            try:
-                dates.append(date(year, month, int(day_str)))
-            except ValueError:
-                continue
+
+        day_first = re.fullmatch(r"(\d{1,2})\s+([A-Za-zÀ-ÿ]+)\.?", line)
+        if day_first:
+            parsed = _french_date(day_first.group(1), day_first.group(2), year)
+            if parsed is not None:
+                dates.append(parsed)
+
     return dates
+
+
+def _parse_precisi_range(precisi: str, year: int) -> tuple[date, date] | None:
+    match = re.search(
+        r"\ba partir du\s+(\d{1,2})\s+([a-z]+)"
+        r"\s+au\s+(\d{1,2})\s+([a-z]+)\b",
+        _normalize(precisi),
+    )
+    if not match:
+        return None
+
+    start = _french_date(match.group(1), match.group(2), year)
+    end = _french_date(match.group(3), match.group(4), year)
+    if start is None or end is None or end < start:
+        return None
+    return start, end
 
 
 def _weekly_dates(jour: str, start: date, end: date) -> list[date]:
@@ -183,6 +218,35 @@ def _biweekly_dates(jour: str, pairimp: str, start: date, end: date) -> list[dat
                 dates.append(d)
             d += timedelta(weeks=1)
     return dates
+
+
+def _schedule_dates(
+    *,
+    jour: str,
+    frequen: str,
+    pairimp: str,
+    precisi: str | None,
+    start: date,
+    end: date,
+) -> list[date]:
+    if precisi:
+        dates = _parse_precisi_dates(precisi, start.year)
+        recurring_range = _parse_precisi_range(precisi, start.year)
+        if recurring_range:
+            range_start = max(start, recurring_range[0])
+            range_end = min(end, recurring_range[1])
+            if range_start <= range_end:
+                if jour and frequen in WEEKLY_FREQUENCIES:
+                    dates.extend(_weekly_dates(jour, range_start, range_end))
+                elif jour and frequen == "QUINZAINE":
+                    dates.extend(_biweekly_dates(jour, pairimp, range_start, range_end))
+        return sorted({d for d in dates if start <= d <= end})
+
+    if jour and frequen in WEEKLY_FREQUENCIES:
+        return _weekly_dates(jour, start, end)
+    if jour and frequen == "QUINZAINE":
+        return _biweekly_dates(jour, pairimp, start, end)
+    return []
 
 
 class Source:
@@ -388,19 +452,17 @@ class Source:
                 "Matin" if am_pm == "AM" else "Après-midi" if am_pm == "PM" else None
             )
 
-            if precisi:
-                # The server precomputes exact days-of-month for the current
-                # annual calendar only; day-of-week alignment shifts each
-                # year so these figures cannot be extrapolated to next year.
-                dates = [
-                    d for d in _parse_precisi_dates(precisi, today.year) if d >= today
-                ]
-            elif jour and frequen in WEEKLY_FREQUENCIES:
-                dates = _weekly_dates(jour, today, end)
-            elif jour and frequen == "QUINZAINE":
-                dates = _biweekly_dates(jour, pairimp, today, end)
-            else:
-                continue
+            # Precision text belongs to the provider's current annual calendar.
+            # It may contain exact days, a bounded recurring range, or both;
+            # never extrapolate those ranges into the following year.
+            dates = _schedule_dates(
+                jour=jour,
+                frequen=frequen,
+                pairimp=pairimp,
+                precisi=precisi,
+                start=today,
+                end=end,
+            )
 
             for d in dates:
                 entries.append(

--- a/doc/source/sudestavenir_fr.md
+++ b/doc/source/sudestavenir_fr.md
@@ -16,7 +16,7 @@ Support for waste collection schedules provided by [Grand Paris Sud Est Avenir (
 
 Collection days depend on the exact address (commune, street and house number) and are looked up live against GPSEA's interactive collection map.
 
-Depending on the waste type and address, the source returns either a recurring weekly/bi-weekly schedule (ordures ménagères, emballages) or a precomputed list of dates for the current calendar year (verre, encombrants, déchets végétaux), matching what the source website itself provides.
+Depending on the waste type and address, the source returns a recurring weekly or bi-weekly schedule (ordures ménagères, emballages), a precomputed list of dates for the current calendar year (verre, encombrants), or a mix of the two (déchets végétaux, which often lists individual winter dates plus a weekly rule bounded to the growing season). This matches what the source website itself provides. Bounded rules are never extrapolated into the following year.
 
 ## Configuration via configuration.yaml
 

--- a/tests/test_sudestavenir_fr.py
+++ b/tests/test_sudestavenir_fr.py
@@ -1,0 +1,197 @@
+"""Regression tests for the Grand Paris Sud Est Avenir source.
+
+This source-specific file is not included by pytest.ini's default discovery.
+Run it explicitly:
+
+    python -m pytest tests/test_sudestavenir_fr.py -q
+"""
+
+import os
+import sys
+from datetime import date as real_date
+from unittest.mock import MagicMock, patch
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule import Icons
+from waste_collection_schedule.source import sudestavenir_fr
+
+MIXED_PRECISI = (
+    "7 janvier\n"
+    "4 février\n"
+    "Tous les mercredis après - midi à partir du 4 mars au 9 décembre"
+)
+
+
+def test_parse_precisi_dates_preserves_month_first_format():
+    assert sudestavenir_fr._parse_precisi_dates("Janv. : 5 - 19\nFév. : 2", 2026) == [
+        real_date(2026, 1, 5),
+        real_date(2026, 1, 19),
+        real_date(2026, 2, 2),
+    ]
+
+
+def test_parse_precisi_dates_supports_day_first_full_months():
+    assert sudestavenir_fr._parse_precisi_dates(MIXED_PRECISI, 2026) == [
+        real_date(2026, 1, 7),
+        real_date(2026, 2, 4),
+    ]
+
+
+def test_parse_precisi_range_supports_accented_french_text():
+    assert sudestavenir_fr._parse_precisi_range(MIXED_PRECISI, 2026) == (
+        real_date(2026, 3, 4),
+        real_date(2026, 12, 9),
+    )
+
+
+def test_schedule_dates_limits_weekly_rule_to_precision_range():
+    dates = sudestavenir_fr._schedule_dates(
+        jour="mercredi",
+        frequen="HEBDOMADAIRE",
+        pairimp="",
+        precisi=MIXED_PRECISI,
+        start=real_date(2026, 7, 29),
+        end=real_date(2027, 7, 29),
+    )
+
+    assert len(dates) == 20
+    assert dates[0] == real_date(2026, 7, 29)
+    assert dates[-1] == real_date(2026, 12, 9)
+    assert all(d.weekday() == 2 for d in dates)
+
+
+def test_schedule_dates_merges_and_deduplicates_explicit_dates():
+    dates = sudestavenir_fr._schedule_dates(
+        jour="mercredi",
+        frequen="HEBDOMADAIRE",
+        pairimp="",
+        precisi=(
+            "4 mars\nTous les mercredis après - midi à partir du 4 mars au 18 mars"
+        ),
+        start=real_date(2026, 1, 1),
+        end=real_date(2026, 12, 31),
+    )
+
+    assert dates == [
+        real_date(2026, 3, 4),
+        real_date(2026, 3, 11),
+        real_date(2026, 3, 18),
+    ]
+
+
+def test_schedule_dates_preserves_month_first_precision_only():
+    dates = sudestavenir_fr._schedule_dates(
+        jour="mercredi",
+        frequen="HEBDOMADAIRE",
+        pairimp="",
+        precisi="Janv. : 5 - 19\nFév. : 2",
+        start=real_date(2026, 1, 1),
+        end=real_date(2026, 12, 31),
+    )
+
+    assert dates == [
+        real_date(2026, 1, 5),
+        real_date(2026, 1, 19),
+        real_date(2026, 2, 2),
+    ]
+
+
+def test_schedule_dates_limits_fortnightly_rule_to_precision_range():
+    dates = sudestavenir_fr._schedule_dates(
+        jour="mercredi",
+        frequen="QUINZAINE",
+        pairimp="PAIRE",
+        precisi="Tous les mercredis à partir du 4 mars au 9 décembre",
+        start=real_date(2026, 3, 1),
+        end=real_date(2026, 12, 31),
+    )
+
+    assert len(dates) == 21
+    assert dates[0] == real_date(2026, 3, 4)
+    assert dates[-1] == real_date(2026, 12, 9)
+    assert all(d.weekday() == 2 for d in dates)
+    assert all(d.isocalendar().week % 2 == 0 for d in dates)
+
+
+class FrozenDate(real_date):
+    @classmethod
+    def today(cls):
+        return cls(2026, 7, 29)
+
+
+class MockResponse:
+    def __init__(self, *, text="", json_data=None):
+        self.text = text
+        self._json_data = json_data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json_data
+
+
+def _candidate(label):
+    return {"label": label, "values": [label]}
+
+
+def test_fetch_emits_green_waste_for_mixed_precision_schedule():
+    session = MagicMock()
+    session.get.side_effect = [
+        MockResponse(text="const bgSessionId = 'test-session';"),
+        MockResponse(
+            json_data={
+                "properties": {
+                    "dv_am_pm": "PM",
+                    "dv_frequen": "HEBDOMADAIRE",
+                    "dv_jour": "mercredi",
+                    "dv_pairimp": "",
+                    "dv_precisi": MIXED_PRECISI,
+                }
+            }
+        ),
+    ]
+    session.post.return_value = MockResponse(
+        json_data={"features": [{"properties": {"id_auto": 3633837}}]}
+    )
+
+    with (
+        patch.object(sudestavenir_fr, "date", FrozenDate),
+        patch.object(
+            sudestavenir_fr.Source,
+            "_resolve",
+            side_effect=[
+                _candidate("Test commune"),
+                _candidate("Test street"),
+                _candidate("1"),
+            ],
+        ),
+        patch.object(
+            sudestavenir_fr.Source,
+            "_query_filter",
+            return_value=[_candidate("Test street")],
+        ),
+        patch.object(sudestavenir_fr.requests, "Session", return_value=session),
+    ):
+        entries = sudestavenir_fr.Source(
+            commune="Test commune",
+            street="Test street",
+            house_number="1",
+        ).fetch()
+
+    assert len(entries) == 20
+    assert entries[0].date == real_date(2026, 7, 29)
+    assert entries[-1].date == real_date(2026, 12, 9)
+    assert {entry.type for entry in entries} == {"Déchets végétaux"}
+    assert {entry.icon for entry in entries} == {Icons.GARDEN}
+    assert {entry.description for entry in entries} == {"Après-midi"}


### PR DESCRIPTION
## Summary

- parse GPSEA annual precision text containing explicit French dates plus a bounded weekly or fortnightly rule
- preserve existing month-first precision-only behavior while avoiding next-year extrapolation
- add deterministic parser and fetch regressions for green waste, precision-only, and fortnightly schedules

Closes #7077.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Validation

- `python -m pytest tests/test_sudestavenir_fr.py -q` — 8 passed (focused file; not selected by the default `pytest.ini`)
- `python -m pytest tests/test_source_components.py -q` — 34 passed
- `python -m pytest tests/ -q` — 38 passed (default-discovered suite; does not include the focused file above)
- `python test_sources.py -s sudestavenir_fr` — 277 entries for the committed test case
- changed-file pre-commit hooks — Ruff, codespell, Bandit, and mypy passed
- live issue configuration — 20 green-waste entries from 2026-07-29 through 2026-12-09
- live before/after differential — all 277 serialized entries for the committed test case remained byte-for-byte identical

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on both changed files
- [x] No generated files in diff
- [x] Existing source; no new `doc/source/<name>.md` file required
- [x] Tests use mocked address data; the public issue example was used only for local live verification
