### PR TITLE
Add Coteau-du-Lac ICS waste schedule

### DIFF
--- a/doc/ics/yaml/coteau-du-lac_com.yaml
+++ b/doc/ics/yaml/coteau-du-lac_com.yaml
@@ -1,0 +1,22 @@
+---
+title: Coteau-du-lac, Québec
+url: https://portail.coteau-du-lac.com/
+country: ca
+howto:
+  en: |
+    - There is no english version of this but i've listed instructions in english here.
+    - Visit https://brossard.ca/calendrier-des-collectes/ and click on "Calendrier de collectes"
+    - Enter your address and click "soummettre"
+    - Click on the outlook icon and copy the link
+    - Use this copied URL as the `url` parameter.
+  fr: |
+    - Visitez https://brossard.ca/calendrier-des-collectes/ et sélectionnez "Calendrier de collectes".
+    - Entrez votre addresse et soumettre.
+    - Clicquez sur le calendrier outlook et copier le lien.
+    - Utilisez cette URL comme paramètre `url`.
+
+test_cases:
+    English :
+    url: https://portail.coteau-du-lac.com/avis/collectes/v2/calendrier.ics?collects=4,5
+    Français :
+    url: https://portail.coteau-du-lac.com/avis/collectes/v2/calendrier.ics?collects=4,5

--- a/doc/ics/yaml/coteau-du-lac_com.yaml
+++ b/doc/ics/yaml/coteau-du-lac_com.yaml
@@ -1,22 +1,22 @@
 ---
-title: Coteau-du-lac, Québec
-url: https://portail.coteau-du-lac.com/
+title: Coteau-du-Lac, Québec
+url: https://portail.coteau-du-lac.com
 country: ca
 howto:
   en: |
-    - There is no english version of this but i've listed instructions in english here.
-    - Visit https://brossard.ca/calendrier-des-collectes/ and click on "Calendrier de collectes"
-    - Enter your address and click "soummettre"
-    - Click on the outlook icon and copy the link
-    - Use this copied URL as the `url` parameter.
+    - Visit <https://portail.coteau-du-lac.com/calendrier-de-collectes> (the portal is in French only).
+    - Enter your address under "Pour quelle adresse désirez-vous obtenir le calendrier?", pick it from the
+      suggestions and press "Soumettre".
+    - Under "Ajouter à mon calendrier", right-click the Apple calendar icon and select `Copy link address`.
+    - Use this copied URL as the `url` parameter. The `webcal://` prefix is handled automatically.
   fr: |
-    - Visitez https://brossard.ca/calendrier-des-collectes/ et sélectionnez "Calendrier de collectes".
-    - Entrez votre addresse et soumettre.
-    - Clicquez sur le calendrier outlook et copier le lien.
-    - Utilisez cette URL comme paramètre `url`.
+    - Visitez <https://portail.coteau-du-lac.com/calendrier-de-collectes>.
+    - Saisissez votre adresse sous "Pour quelle adresse désirez-vous obtenir le calendrier?", choisissez-la
+      dans les suggestions puis cliquez sur "Soumettre".
+    - Sous "Ajouter à mon calendrier", faites un clic droit sur l'icône du calendrier Apple et sélectionnez
+      `Copier l'adresse du lien`.
+    - Utilisez cette URL comme paramètre `url`. Le préfixe `webcal://` est géré automatiquement.
 
 test_cases:
-    English :
-    url: https://portail.coteau-du-lac.com/avis/collectes/v2/calendrier.ics?collects=4,5
-    Français :
+  Coteau-du-Lac:
     url: https://portail.coteau-du-lac.com/avis/collectes/v2/calendrier.ics?collects=4,5


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->
adds source for coteau-du-lac, quebec

## Type of change

- [x ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x ] `python -m pytest tests/test_source_components.py -q` passes
- [ x] `ruff check --fix` and `ruff format` run on changed source files
- [ x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x ] `doc/source/<name>.md` created for new sources
- [x ] TEST_CASES use real, publicly accessible addresses (not my own)
