### PR TITLE
fix(kvatg_ch): restore Kreuzlingen Kehricht plan URL broken by #7061

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kvatg_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kvatg_ch.py
@@ -27,7 +27,7 @@ _OVERVIEW_URL = "https://www.kvatg.ch/fuer-private/entsorgungsplaene-1/"
 
 # The KVA plan for Kreuzlingen contains no Kehricht dates — the city publishes
 # its own zone plan (a map PDF with a parseable zone/weekday legend) here:
-_KREUZLINGEN_ENTSORGUNG_URL = "kreuzlingen.ch"
+_KREUZLINGEN_ENTSORGUNG_URL = "https://www.kreuzlingen.ch/wir-fuer-sie/entsorgung"
 
 COMMUNITIES = [
     "Affeltrangen",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kvatg_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kvatg_ch.py
@@ -165,14 +165,14 @@ PARAM_DESCRIPTIONS = {
         "Kreuzlingen green waste district). Leave empty to get all zones; "
         "zoned collections are then suffixed with their zone name. The zone "
         "names are printed left of the date grid in your community's plan on "
-        "kvatg.ch — an invalid "
-        "value shows a list of the valid names.",
+        "kvatg.ch (open 'Für Private' → 'Entsorgungspläne' from the main "
+        "page) — an invalid value shows a list of the valid names.",
         "kehricht_zone": "Only for Kreuzlingen: household-waste (Kehricht) "
         "zone from the city's own zone plan — 'Süd & Tägerwilen', "
         "'Nord und Ost' or 'Zentrum'. Leave empty to get all three zones. "
         "Which streets belong to which zone is shown on the Kehricht, "
-        "Abfuhrplan Kreuzlingen map at "
-        "kreuzlingen.ch.",
+        "Abfuhrplan Kreuzlingen map at kreuzlingen.ch (open 'Wir für Sie' "
+        "→ 'Entsorgung' from the main page).",
     },
     "de": {
         "community": "Gemeindename genau wie auf der Entsorgungsplan-Seite "
@@ -182,15 +182,15 @@ PARAM_DESCRIPTIONS = {
         "das Grüngut-Gebiet in Kreuzlingen). Leer lassen für alle Zonen; "
         "zonierte Sammlungen erhalten dann den Zonennamen als Zusatz. Die "
         "Zonennamen stehen links neben dem Datumsraster im Entsorgungsplan "
-        "Ihrer Gemeinde auf kvatg.ch "
-        "— bei einem ungültigen Wert wird eine Liste der gültigen Namen "
-        "angezeigt.",
+        "Ihrer Gemeinde auf kvatg.ch (auf der Startseite unter 'Für "
+        "Private' → 'Entsorgungspläne') — bei einem ungültigen Wert wird "
+        "eine Liste der gültigen Namen angezeigt.",
         "kehricht_zone": "Nur für Kreuzlingen: Kehricht-Abfuhrzone gemäss "
         "dem städtischen Zonenplan — 'Süd & Tägerwilen', 'Nord und Ost' "
         "oder 'Zentrum'. Leer lassen für alle drei Zonen. Welche Strassen "
         "zu welcher Zone gehören, zeigt die Karte Kehricht, Abfuhrplan "
-        "Kreuzlingen unter "
-        "kreuzlingen.ch.",
+        "Kreuzlingen unter kreuzlingen.ch (auf der Startseite unter 'Wir "
+        "für Sie' → 'Entsorgung').",
     },
     "it": {
         "community": "Nome del comune esattamente come indicato sulla pagina "
@@ -200,14 +200,15 @@ PARAM_DESCRIPTIONS = {
         "l'area del verde di Kreuzlingen). Lasciare vuoto per tutte le zone; "
         "le raccolte zonali riportano poi il nome della zona. I nomi delle "
         "zone si trovano a sinistra della griglia delle date nel piano del "
-        "comune su kvatg.ch — "
-        "un valore non valido mostra l'elenco dei nomi validi.",
+        "comune su kvatg.ch (dalla pagina principale: 'Für Private' → "
+        "'Entsorgungspläne') — un valore non valido mostra l'elenco dei "
+        "nomi validi.",
         "kehricht_zone": "Solo per Kreuzlingen: zona di raccolta dei rifiuti "
         "domestici (Kehricht) secondo il piano zonale comunale — "
         "'Süd & Tägerwilen', 'Nord und Ost' o 'Zentrum'. Lasciare vuoto per "
         "tutte e tre le zone. La mappa Kehricht, Abfuhrplan Kreuzlingen su "
-        "kreuzlingen.ch mostra quali "
-        "strade appartengono a quale zona.",
+        "kreuzlingen.ch (dalla pagina principale: 'Wir für Sie' → "
+        "'Entsorgung') mostra quali strade appartengono a quale zona.",
     },
     "fr": {
         "community": "Nom de la commune exactement comme indiqué sur la page "
@@ -217,15 +218,15 @@ PARAM_DESCRIPTIONS = {
         "pour le secteur des déchets verts de Kreuzlingen). Laisser vide pour "
         "toutes les zones ; les collectes zonées portent alors le nom de la "
         "zone. Les noms de zones figurent à gauche de la grille des dates "
-        "dans le plan de votre commune sur "
-        "kvatg.ch — une valeur "
+        "dans le plan de votre commune sur kvatg.ch (depuis la page "
+        "d'accueil : 'Für Private' → 'Entsorgungspläne') — une valeur "
         "invalide affiche la liste des noms valides.",
         "kehricht_zone": "Uniquement pour Kreuzlingen : zone de collecte des "
         "ordures ménagères (Kehricht) selon le plan de zones de la ville — "
         "'Süd & Tägerwilen', 'Nord und Ost' ou 'Zentrum'. Laisser vide pour "
         "les trois zones. La carte Kehricht, Abfuhrplan Kreuzlingen sur "
-        "kreuzlingen.ch montre quelles "
-        "rues appartiennent à quelle zone.",
+        "kreuzlingen.ch (depuis la page d'accueil : 'Wir für Sie' → "
+        "'Entsorgung') montre quelles rues appartiennent à quelle zone.",
     },
 }
 


### PR DESCRIPTION
## What

Restores the functional `_KREUZLINGEN_ENTSORGUNG_URL` constant that #7061 turned into a bare domain, and adds a short navigation hint wherever that PR reduced a plan URL to a bare domain.

## Why

#7061 replaced URLs in `kvatg_ch.py` with bare domain names so `update_docu_links.py` would stop turning them into `{url_...}` config-form placeholders. Correct **for the `PARAM_DESCRIPTIONS` strings** — but the same sweep also rewrote a line that isn't a description:

```python
-_KREUZLINGEN_ENTSORGUNG_URL = "kreuzlingen.ch"
+_KREUZLINGEN_ENTSORGUNG_URL = "https://www.kreuzlingen.ch/wir-fuer-sie/entsorgung"
```

This constant goes straight into `requests.get()`, so on the released version the Kreuzlingen city-plan fetch fails:

```
Could not fetch the Kreuzlingen city Kehricht plan:
Invalid URL 'kreuzlingen.ch': No scheme supplied.
```

The failure is swallowed by the surrounding `try/except`, then surfaces misleadingly in the config flow as an *"invalid `kehricht_zone`"* error with no suggestions.

## Why only Kehricht in Kreuzlingen is affected

Kreuzlingen pulls from **two** PDFs:

| Data | Source | URL constant | Status |
|---|---|---|---|
| Grüngut, Papier, Kleinsperrgut, … | KVA Thurgau plan | `_OVERVIEW_URL` | ✅ untouched by #7061 |
| Kehricht (household waste) | City of Kreuzlingen's own zone plan | `_KREUZLINGEN_ENTSORGUNG_URL` | ❌ broken by #7061 |

The KVA plan for Kreuzlingen carries no Kehricht dates, so the city plan is fetched separately. Only that one auxiliary fetch broke — every other waste type (green waste included) and every other community flows through the untouched KVA plan.

## Impact

| Config | Result on the broken release |
|---|---|
| Kreuzlingen, **no** `kehricht_zone` | ✅ Loads (200 entries); silently missing the city Kehricht dates |
| Kreuzlingen + green-waste `zone` (e.g. `Ost`) | ✅ Loads (62 entries), no error |
| Kreuzlingen + **`kehricht_zone`** set (e.g. `Zentrum`) | ❌ Hard config error — the only truly broken case |
| Any non-Kreuzlingen community | ✅ Unaffected |

## Changes

- **`fix`**: restore only the functional constant to the full URL. The `PARAM_DESCRIPTIONS` strings stay as bare domains per #7061, so the placeholder issue that PR fixed stays fixed.
- **`docs`**: since #7061 left users with a bare `kvatg.ch` / `kreuzlingen.ch` and no path, add a short menu breadcrumb next to each (all four languages): `kvatg.ch → 'Für Private' → 'Entsorgungspläne'` and `kreuzlingen.ch → 'Wir für Sie' → 'Entsorgung'`. No full URLs re-added; menu labels kept in German (that's what the sites display).

---

An error crept in and wasn't caught by a test afterwards; I noticed it after installing the new release and fixed it here. Hopefully it only affects me — the source's original requests (#3738 Sulgen, #4918 Dettighofen) were never Kreuzlingen-specific, and only Kreuzlingen users who set a `kehricht_zone` hit a hard error. If anyone else is caught before the next release, the temporary workaround is in the Impact table above: leave `kehricht_zone` empty and the entry still loads fine; you just won't get the Kehricht dates until this ships.
