### PR TITLE
chore(devcontainer): match the CI minimum lane, and use the pinned hooks

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -127,7 +127,7 @@ These cause CI failure if violated. Check the diff for each:
    ```
    (Repeat per file. Omit this step if no edits or new files.)
 4. [format commands: `ruff check --fix <file>` and/or `ruff format <file>`]
-5. **Mandatory structural test (do not skip):** `python -m pytest tests/test_source_components.py -q` — must pass before commit.
+5. **Mandatory checks (do not skip):** `python -m pytest tests/test_source_components.py -q` and `pre-commit run --all-files` — both must pass before commit. Use the hooks, not bare `ruff`/`mypy`/`pyright`: the hooks are pinned, and a bare `pyright` resolves a different stub set, so it reports a different error set from CI.
 6. `git add <files>`
 7. `git commit -m "<exact commit message>"`
 8. `git push https://github.com/<HEAD_OWNER>/hacs_waste_collection_schedule.git HEAD:<HEAD_BRANCH>`

--- a/.claude/agents/source-implementer.md
+++ b/.claude/agents/source-implementer.md
@@ -139,6 +139,7 @@ Only a **legacy** module-level source still needs a hand-written `doc/source/<mo
 6. Run the structural tests:
    ```bash
    python -m pytest tests/test_source_components.py -q
+   pre-commit run --all-files
    ```
    This catches missing fields, invalid `COUNTRY` codes, malformed `EXTRA_INFO`, etc.
 7. Live-test against the test cases:

--- a/.codex/agents/source-implementer.toml
+++ b/.codex/agents/source-implementer.toml
@@ -19,6 +19,7 @@ Requirements:
 - Never edit generated files or run update_docu_links.py.
 - Run ruff check --fix and ruff format on every changed Python file.
 - Run python -m pytest tests/test_source_components.py -q.
+- Run pre-commit run --all-files. Use the pinned hooks rather than bare ruff, mypy or pyright: a bare pyright resolves a different type-stub set and reports a different error set from CI.
 - For a Python source, run its live test_sources.py TEST_CASES and iterate until results are non-empty or report the real upstream blocker.
 - For a pipeline source, record a cassette once it works live: python tests/record_fixtures.py <module>, and commit tests/fixtures/<module>/*.json so CI replays it offline. A shared-service source keeps one cassette per distinct response shape. Enforced by tests/test_new_architecture.py::test_pipeline_sources_ship_a_cassette.
 - Compose shared components. Never define a Retriever or Parser subclass inside a source module, and never override retrieve, parse, preprocess or transform on the Source class. If the platform lacks something the provider needs, add it to the shared component under waste_collection_schedule/service/ so every provider on that platform benefits. Enforced by test_pipeline_sources_reuse_shared_components and test_no_new_source_local_step_overrides. Adding the source to a gate allowlist is not an acceptable fix.

--- a/.devcontainer/check-current.sh
+++ b/.devcontainer/check-current.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Reproduce the CI "current" lane: latest Home Assistant on a throwaway venv.
+#
+# The devcontainer itself matches the CI "minimum" lane (Python 3.12, the
+# oldest supported Home Assistant), because that is the floor every change has
+# to clear. The "current" lane tracks the latest Home Assistant, which pulls
+# newer transitive dependencies and type stubs, so it can fail on code the
+# minimum lane accepts. Run this before pushing anything that touches the
+# shared framework, and after a long gap between contributions.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+VENV="${TMPDIR:-/tmp}/wcs-current-lane"
+
+echo "==> Building throwaway venv at ${VENV}"
+rm -rf "${VENV}"
+python3 -m venv "${VENV}"
+# shellcheck disable=SC1091
+source "${VENV}/bin/activate"
+
+python -m pip install --upgrade pip >/dev/null
+echo "==> Installing latest Home Assistant and project requirements"
+python -m pip install ruff pytest -r requirements.txt homeassistant josepy
+
+echo "==> pytest"
+pytest
+
+echo "==> pre-commit (all files, all hooks)"
+python -m pip install pre-commit >/dev/null
+pre-commit run --all-files
+
+deactivate
+echo "==> Current lane clean"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {
-			"version": "3.13",
+			"version": "3.12",
 			"installTools": true
 		},
 		// Claude Code CLI — comment out this line if you don't use Claude Code.

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -15,6 +15,13 @@ python3 -m pip install -r requirements.txt
 echo "==> Installing development tooling (pre-commit, pytest)"
 python3 -m pip install pre-commit pytest
 
+# The CI "minimum" lane pins the oldest supported Home Assistant. Install the
+# same pins here so this container reproduces that lane, and so the tests that
+# import homeassistant (test_config_flow.py, test_fetch_retry.py and friends)
+# can actually run locally instead of failing to collect.
+echo "==> Installing Home Assistant (CI minimum lane pins)"
+python3 -m pip install "homeassistant==2024.4.0" "josepy<2"
+
 # Standalone linters/formatters so they can be run directly from the terminal
 # (e.g. `ruff check .`, `bandit -c tests/bandit.yaml -r .`, `mypy ...`).
 # Versions are pinned to match the hooks in .pre-commit-config.yaml so local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,29 @@ There are several ways of contributing to this project, including:
 - Helping answer/fix any issues raised
 - Join in with the Home Assistant Community discussion
 
+## Setting Up Your Development Environment
+
+**Use the devcontainer.** Open the repository in VS Code and choose "Reopen in Container" (or use GitHub Codespaces). It provisions Python 3.12, the project requirements, Home Assistant, and the linters pinned to the exact versions CI uses.
+
+This matters more than it sounds. The checks are sensitive to the environment they run in: dependency and type-stub versions differ between operating systems and Python versions, so a local run outside the container can report different errors from CI, in both directions. The container also fixes tooling that does not work on Windows, and installs Home Assistant so the tests that import it can run at all.
+
+Before pushing, run the same checks CI runs:
+
+```bash
+pytest
+pre-commit run --all-files
+```
+
+`pre-commit run --all-files` is the important one. Running the linters directly (`ruff`, `mypy`, `pyright` and so on) uses whatever versions happen to be on your PATH, while the hooks are pinned. Use the hooks. `pyright` in particular resolves type stubs from the installed dependency set, so a bare run and the hook can disagree about which errors exist.
+
+The container reproduces the CI **minimum** lane, the oldest supported Home Assistant, which is the floor every change must clear. CI also runs a **current** lane on the latest Home Assistant, which can fail on newer transitive dependencies. Reproduce that one on demand:
+
+```bash
+.devcontainer/check-current.sh
+```
+
+If you cannot use the container, everything still works locally, but expect occasional differences from CI and lean on the PR checks.
+
 ## Adding New Service Providers
 
 ### Fork And Clone The Repository, And Checkout A New Branch


### PR DESCRIPTION
The devcontainer ran Python 3.13 and never installed Home Assistant, so it matched neither CI lane. That is how the three pyright errors in `retrievers.py` reached CI in #7089: everyone, including the review agents, ran a bare `pyright` locally, which resolves a different type-stub set and reports a different error list. Locally we saw six bs4 errors CI does not report; CI saw three requests-stub errors we did not.

## Changes

- **Python 3.12**, matching the CI minimum lane and `ruff.toml`'s `target-version`.
- **Install `homeassistant==2024.4.0` and `josepy<2`**, the same pins as that lane. Besides fixing stub resolution, this means `test_config_flow.py`, `test_ecoharmonogram_client.py` and `test_fetch_retry.py` can be collected locally; today they cannot, so nobody runs them outside CI.
- **`.devcontainer/check-current.sh`** reproduces the CI *current* lane (latest Home Assistant) in a throwaway venv on demand. That lane tracks newer transitive dependencies, so it can fail on code the minimum lane accepts, which is exactly what happened.
- **`CONTRIBUTING.md`** gains a development environment section. It previously said nothing about setup at all.
- **Agent definitions** (`source-implementer`, `pr-reviewer`, Claude and Codex) now verify with `pre-commit run --all-files` instead of bare linters.

## Caveat

This gets local equivalent to CI for the minimum lane only. The current lane tracks *latest* Home Assistant, so it can always break on a dependency release nobody here made. That stays a CI-catches-it case, which is what `check-current.sh` is for.

I have not been able to build the container from this machine, so the Python version bump and the Home Assistant pins want a real "Reopen in Container" before merge.