### PR TITLE
chore(devcontainer): install Node for the Claude Code feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 			"version": "3.12",
 			"installTools": true
 		},
-		// Claude Code CLI — comment out this line if you don't use Claude Code.
+		// Claude Code CLI — comment out these two lines if you don't use Claude Code.
+		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/anthropics/devcontainer-features/claude-code:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},


### PR DESCRIPTION
Follow-up to #7090.

The base image is `devcontainers/base:ubuntu`, which ships no Node runtime, and the `claude-code` feature does not pull one in. Without it the feature installs but the CLI will not start.

Node sits with the Claude Code feature rather than with the Python toolchain, so the comment now covers both lines: a contributor who does not use Claude Code comments out the pair and loses nothing else.

No functional change to the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SsUMyG7ziWPfoMXnRYUgD