### PR TITLE
chore: make a local pytest run match the gating CI job

### DIFF
--- a/.devcontainer/check-current.sh
+++ b/.devcontainer/check-current.sh
@@ -20,10 +20,12 @@ source "${VENV}/bin/activate"
 
 python -m pip install --upgrade pip >/dev/null
 echo "==> Installing latest Home Assistant and project requirements"
-python -m pip install ruff pytest -r requirements.txt homeassistant josepy
+python -m pip install ruff pytest freezegun -r requirements.txt homeassistant josepy
 
+# -m "not live" matches the gating CI job. Without it pytest also collects the
+# live-provider tests, which sit on real HTTP for well over ten minutes.
 echo "==> pytest"
-pytest
+pytest -m "not live"
 
 echo "==> pre-commit (all files, all hooks)"
 python -m pip install pre-commit >/dev/null

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -12,8 +12,11 @@ python3 -m pip install --upgrade pip setuptools wheel
 echo "==> Installing project requirements (requirements.txt)"
 python3 -m pip install -r requirements.txt
 
-echo "==> Installing development tooling (pre-commit, pytest)"
-python3 -m pip install pre-commit pytest
+# freezegun is a hard import in tests/cassette.py, so the offline fixture tests
+# cannot even be collected without it. CI installs it explicitly rather than via
+# requirements.txt, so install it here too.
+echo "==> Installing development tooling (pre-commit, pytest, freezegun)"
+python3 -m pip install pre-commit pytest freezegun
 
 # The CI "minimum" lane pins the oldest supported Home Assistant. Install the
 # same pins here so this container reproduces that lane, and so the tests that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,11 @@ This matters more than it sounds. The checks are sensitive to the environment th
 Before pushing, run the same checks CI runs:
 
 ```bash
-pytest
+pytest -m "not live"
 pre-commit run --all-files
 ```
+
+`-m "not live"` matters. A plain `pytest` also collects the live-provider tests, which fetch real endpoints for hundreds of sources and take well over ten minutes. The gating CI job excludes them, because the offline cassettes under `tests/fixtures/` cover the same ground in seconds. Run `pytest -m live` deliberately when you want the real thing.
 
 `pre-commit run --all-files` is the important one. Running the linters directly (`ruff`, `mypy`, `pyright` and so on) uses whatever versions happen to be on your PATH, while the hooks are pinned. Use the hooks. `pyright` in particular resolves type stubs from the installed dependency set, so a bare run and the hook can disagree about which errors exist.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = -m "not live"
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test .claude .git
 filterwarnings = ignore:.*:DeprecationWarning
 python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py


### PR DESCRIPTION
Follow-up to #7090 and #7091. Two gaps survived, both found by agents working the v3 cleanup campaign in a fresh container.

### `freezegun` is missing

It is a hard import in `tests/cassette.py`, so without it `tests/test_offline_fixtures.py` cannot be collected at all. CI installs it explicitly rather than through `requirements.txt`, and neither `setup.sh` nor `check-current.sh` did. The container could not run the cassette suite it exists to run.

### A bare `pytest` runs the live lane

`pytest.ini` registers the `live` marker but does not deselect it, so a plain `pytest` also collects the live-provider tests. Those fetch real endpoints for hundreds of sources and take well over ten minutes. The gating CI job excludes them with `-m "not live"` because the offline cassettes cover the same ground in seconds.

`check-current.sh` and `CONTRIBUTING.md` both said plain `pytest`, so the script advertised as reproducing the CI current lane did not, and one agent sat on it for thirteen minutes before giving up.

### Changes

- `setup.sh` and `check-current.sh` install `freezegun`.
- `check-current.sh` runs `pytest -m "not live"`.
- `pytest.ini` sets `addopts = -m "not live"`, so the default run is the CI lane everywhere, not only where someone remembered the flag.
- `CONTRIBUTING.md` documents the flag and why it is there.

### On the `pytest.ini` default

This is the only change with repo-wide effect, so worth a deliberate look. Verified both directions:

- default run: 3183 collected, 2178 deselected
- `pytest -m live`: 2178 collected

A command-line `-m` overrides `addopts`, so `pytest -m live` still selects exactly the live tests. CI is unaffected either way, since it already passes the flag explicitly.

No functional change to the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SsUMyG7ziWPfoMXnRYUgD