### PR TITLE
fix(abfall_io): migrate ASO Abfall-Service Osterholz to v3 GraphQL API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -13,11 +13,6 @@ SERVICE_MAP = [
         "service_id": "9583a2fa1df97ed95363382c73b41b1b",
     },
     {
-        "title": "ASO Abfall-Service Osterholz",
-        "url": "https://www.aso-ohz.de/",
-        "service_id": "040b38fe83f026f161f30f282b2748c0",
-    },
-    {
         "title": "Landkreis Bayreuth",
         "url": "https://www.landkreis-bayreuth.de/",
         "service_id": "951da001077dc651a3bf437bc829964e",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -50,4 +50,9 @@ SERVICE_MAP = [
         "url": "https://www.lrasbk.de/",
         "service_id": "30628292bdd8b43db86a48f7e0d85f85",
     },
+    {
+        "title": "ASO Abfall-Service Osterholz",
+        "url": "https://www.aso-ohz.de/",
+        "service_id": "8b016df0116d1d5094fa339bebea0c65",
+    },
 ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -89,6 +89,10 @@ TEST_CASES = {
         "key": "30628292bdd8b43db86a48f7e0d85f85",
         "idHouseNumber": 16437,
     },
+    "ASO Abfall-Service Osterholz, Osterholz-Scharmbeck, Ahrensfelder Damm 4": {
+        "key": "8b016df0116d1d5094fa339bebea0c65",
+        "idHouseNumber": 6644,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- ASO Abfall-Service Osterholz (aso-ohz.de) migrated its backend to the abfall.io v3 GraphQL API; the legacy `abfall_io` source's key now returns HTTP 401.
- Removes the stale entry from the legacy `AbfallIO.py` service map and adds it to `AbfallIOGraphQL.py` with the new v3 key (`8b016df0116d1d5094fa339bebea0c65`), reported in the issue and confirmed working by multiple users.
- Adds a live TEST_CASES entry for ASO Osterholz to `abfall_io_graphql.py`.

Follows the same pattern as #7005, #6998, #6961.

## Test plan
- [x] `ruff check --fix` / `ruff format` on all changed files
- [x] `python test_sources.py -s abfall_io_graphql -l` — all test cases pass, including the new ASO Osterholz case (55 entries, including provider-specific "Sammlung Tannenbäume" waste type)
- [x] `python -m pytest tests/test_source_components.py -q` — 35 passed

Fixes #7044