### PR TITLE
refactor(v3): drop __init__ overrides that only repeat BaseSource, and gate against new ones

### DIFF
--- a/.claude/agents/source-implementer.md
+++ b/.claude/agents/source-implementer.md
@@ -31,7 +31,7 @@ For **adding a location to a shared config**:
 
 ## The pipeline platform
 
-A `BaseSource` runs four typed, swappable steps: `retrieve` (fetch raw data), `parse` (turn it into structured data), `preprocess` (normalise into one record per collection), `transform` (map each record's date and label onto a canonical `WasteType`). `BaseSource` provides the orchestration; you assign the steps from reusable components. For most providers the only source-specific code is `__init__`, which calls `super().__init__(**kwargs)` and sets `self._params` / `self._headers`.
+A `BaseSource` runs four typed, swappable steps: `retrieve` (fetch raw data), `parse` (turn it into structured data), `preprocess` (normalise into one record per collection), `transform` (map each record's date and label onto a canonical `WasteType`). `BaseSource` provides the orchestration; you assign the steps from reusable components. For most providers there is no source-specific code at all: the whole source is class attributes, with no `__init__`.
 
 Before writing any retriever or parser, check whether the provider runs on a platform that already ships reusable components in `waste_collection_schedule.service`: ArcGIS, RiSKommunal AT, AchieveForms / FirmstepSelfService (UK), IntraMaps, Abfallnavi / regio iT DE, Sitepark IES DE, Pozi (AU), WhatBinDay (AU), Sepan (PL), Junker app (IT), A Region (CH), Ecoharmonogram (PL), Cloud9 apps (UK). Also check the shared YAML and EXTRA_INFO platforms (Recollect, Recycle Coach, ICS YAML, Publidata, c-trace). If your provider is covered, add it there instead. See `doc/contributing_source.md`'s "Reusable service platforms" table for the full, current list and the components each one exposes.
 
@@ -60,6 +60,7 @@ A flat JSON API, typed by a label-to-waste-type map:
 from waste_collection_schedule import parsers
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
+from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import JsonTransformer
 from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
@@ -69,7 +70,6 @@ class Source(BaseSource):
     DESCRIPTION = "Source for <Provider Name>, <Country>."
     URL = "<provider website>"
     COUNTRY = "<lowercase code from COUNTRYCODES>"
-    API_URL = "https://api.example.com/collections"
 
     TEST_CASES = {
         "<descriptive name 1>": {"uprn": "<known-good value>"},
@@ -87,24 +87,26 @@ class Source(BaseSource):
     # are notified and assigned on bug reports for this source.
     # SOURCE_CODEOWNERS = ["@contributor-github-handle"]
 
+    retrieve = HttpGetRetriever(
+        url="https://api.example.com/collections",
+        params=lambda uprn, **_: {"uprn": uprn},
+    )
     parse = parsers.JsonParser("collections")
     transform = JsonTransformer(
         date_key="date",
         type_key="binType",
         type_value_map={"refuse": GENERAL_WASTE, "recycling": RECYCLABLES},
     )
-
-    def __init__(self, uprn: str):
-        super().__init__(uprn=uprn)
-        self._params = {"uprn": uprn}
 ```
 
-No `retrieve` is declared, so the zero-config GET is used. Set `self._params` / `self._headers` in `__init__` to shape the request. For a service-platform source, assign the platform's retriever and parser instead (see `koppl_at.py`). For alternative-input sources (UPRN or postcode plus house), declare a single `alternatives([uprn()], [postcode(), text_field("house")])` param: validation then requires exactly one group, so no hand-rolled cross-field check is needed (see `reading_gov_uk.py`). A two-call source (lookup then schedule) can use `retrievers.TwoStepRetriever` rather than overriding `retrieve` by hand.
+Note there is no `__init__`: `BaseSource.__init__` already accepts the `PARAMS` fields as keyword arguments, applies their declared defaults, validates them, and stores the result on `self.params`. Shape the request on the retriever, as above; declaring no `retrieve` at all gives the zero-config GET against `API_URL`. For a service-platform source, assign the platform's retriever and parser instead (see `koppl_at.py`). For alternative-input sources (UPRN or postcode plus house), declare a single `alternatives([uprn()], [postcode(), text_field("house")])` param: validation then requires exactly one group, so no hand-rolled cross-field check is needed (see `reading_gov_uk.py`). A two-call source (lookup then schedule) can use `retrievers.TwoStepRetriever` rather than overriding `retrieve` by hand.
 
 ### Rules
 
 - Subclass `BaseSource`. No module-level `fetch()`, no `ICON_MAP`, no `WASTE_TYPES` (unless you use `classify()`, in which case list the types it can produce).
-- `__init__` must call `super().__init__(**kwargs)`. That validates the arguments against `PARAMS` and stores them on `self.params`.
+- **Do not write an `__init__`.** `BaseSource.__init__` accepts the `PARAMS` fields as keyword arguments, applies their declared defaults, validates them, and stores the result on `self.params`. `test_pipeline_sources_dont_redeclare_init` fails any source whose `__init__` only forwards its arguments to `super()`. Add one only to do real work, and if you do, it must still call `super().__init__(**kwargs)`.
+- Declare defaults in `PARAMS` (`text_field(..., default=...)`), never in an `__init__` signature. `ConfigParam.defaults` is independent of `required`, so a merely `optional=True` field is absent from `self.params` when omitted rather than present as `None`: read it with `self.params.get("x")`, or give it an explicit `default=None` if the key must exist.
+- Put argument coercion (`str(uprn)`, `address.strip()`) on the `ConfigParam`, not in an `__init__`, so every source on the platform gets it.
 - Use the canonical `WasteType` values, never raw icons or `"mdi:..."` strings. Do not declare a per-source icon map; the icon comes from the type.
 - **Do not add a new `WasteType` yourself.** The catalogue is deliberately small. If the provider returns a genuinely new category that fits none of the eleven and is general enough that other sources would use it, pick the nearest sensible type and flag the gap in the **Open questions for the contributor** section of your report. The contributor then opens an issue proposing the addition (name, MDI icon, two or three example providers); only after maintainer agreement does the catalogue gain it.
 - If the contributor (or a user) "just prefers" a different MDI icon for a waste type, they should use the per-user icon override in their YAML configuration (the `customise`-style override), not change the canonical default. Don't pick a non-canonical type to satisfy a stated preference.
@@ -116,7 +118,7 @@ No `retrieve` is declared, so the zero-config GET is used. Set `self._params` / 
 - No `if __name__ == "__main__":` blocks. No standalone-script boilerplate.
 - No hardcoded dates or schedules. Fetch live from the provider.
 - No dummy parameters (e.g. `_`) just to satisfy the config GUI.
-- Type hints on the `__init__` signature are expected by the test suite's static checks (pyright covers pipeline sources).
+- Type-hint any function or method you do write; pyright covers pipeline sources.
 - **Do not reintroduce old-style habits inside the pipeline** (full list in `doc/contributing_source.md` "Anti-patterns"). No `datetime.strptime` (use `date_parsers.for_format(...)` / `from_epoch(...)` or `self.parse_date`); no `requests.get` / `curl_cffi.Session` in a source (use the default `http_get`, a configured retriever, or a named `Legacy*` one, all via `source.session`); no hand-built `BeautifulSoup` (use `HtmlParser`); no `self._x = x` stash that is read back unchanged (read `self.params["x"]`); prefer `REGIONS` over `EXTRA_INFO`; prefer a configured retriever over a `retrieve` method that only injects params; when migrating a source built on a shared service, split the service into a retriever + parser rather than overriding `retrieve` to reissue its request (migration is a re-implementation, not a wrapper); for ArcGIS use the declarative `ArcGis*` retrievers/parsers, not a hand-rolled geocode+query.
 
 ## Documentation page
@@ -129,7 +131,7 @@ Only a **legacy** module-level source still needs a hand-written `doc/source/<mo
 
 1. Confirm the recommendation is complete (module name, country code, parameters, data feed details, at least one test case). If anything's missing, ask the user.
 2. Check for a reusable service platform or shared YAML / EXTRA_INFO platform that already covers the provider before writing new retrieval code.
-3. Write the source `.py` file as a `BaseSource` subclass using the pipeline template. Declare the retrieve / parse / preprocess / transform steps from reusable components, set `self._params` / `self._headers` in `__init__`, and use a transformer (or `classify()`) rather than a hand-written `fetch()`.
+3. Write the source `.py` file as a `BaseSource` subclass using the pipeline template. Declare the retrieve / parse / preprocess / transform steps from reusable components, shape the request on the retriever rather than in an `__init__`, and use a transformer (or `classify()`) rather than a hand-written `fetch()`.
 4. Encourage the contributor to add their GitHub handle to `SOURCE_CODEOWNERS` (a class attribute on a pipeline source, a module-level variable on a legacy source). Explain that this means they will be automatically notified and assigned on bug reports for their source. If they decline or are not present, leave the commented-out placeholder.
 5. Lint/format:
    ```bash

--- a/.claude/commands/new-source.md
+++ b/.claude/commands/new-source.md
@@ -41,7 +41,7 @@ A **PDF-only** provider is otherwise a normal new source, not a blocker: the pip
 
 If the recommendation is **a new source**: confirm with the user that the approach (ICS YAML / Python source / etc.) matches their understanding. Then continue to Step 2.
 
-New Python sources are written on the `BaseSource` pipeline platform (declare retrieve, parse, preprocess and transform from reusable components; the only source-specific code is usually `__init__`). The authoritative guide is `doc/contributing_source.md`, and `doc/new_source_template.py` is an annotated skeleton to copy from. The legacy module-level `fetch()` style is reserved for editing the roughly 600 existing legacy sources, not for new work.
+New Python sources are written on the `BaseSource` pipeline platform (declare retrieve, parse, preprocess and transform from reusable components; usually there is no source-specific code at all, and no `__init__`). The authoritative guide is `doc/contributing_source.md`, and `doc/new_source_template.py` is an annotated skeleton to copy from. The legacy module-level `fetch()` style is reserved for editing the roughly 600 existing legacy sources, not for new work.
 
 ## Step 2: implement
 
@@ -58,7 +58,7 @@ prompt: |
 
   Write a BaseSource pipeline source (see doc/contributing_source.md): declare
   the retrieve / parse / preprocess / transform steps from reusable components,
-  set self._params and self._headers in __init__, no ICON_MAP, no fetch().
+  shape the request on the retriever, no __init__, no ICON_MAP, no fetch().
   Follow your standard step-by-step: write the source, lint, run
   tests/test_source_components.py, run test_sources.py live. Iterate until the
   test cases return non-empty collections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ ruff format <file>
 
 There are two source styles. The full guide is `doc/contributing_source.md`.
 
-1. **`BaseSource` pipeline (preferred for new sources).** The source declares which reusable steps to use: `retrieve` (raw fetch) then `parse` (structure) then `preprocess` (records) then `transform` (one `Collection` per record). Metadata, `PARAMS` and the steps are class attributes; usually the only source-specific code is `__init__` (which calls `super().__init__(**kwargs)`). No `fetch()`, no per-source `ICON_MAP`, no manual date parsing. Use `classify()` instead of a transformer for irregular providers. See the converted examples (`kwinana_wa_gov_au.py`, `koppl_at.py`, `reading_gov_uk.py`).
+1. **`BaseSource` pipeline (preferred for new sources).** The source declares which reusable steps to use: `retrieve` (raw fetch) then `parse` (structure) then `preprocess` (records) then `transform` (one `Collection` per record). Metadata, `PARAMS` and the steps are class attributes; usually there is no source-specific code at all. No `__init__` (`BaseSource.__init__` takes the `PARAMS` fields as kwargs, applies their defaults, validates, and stores them on `self.params`), no `fetch()`, no per-source `ICON_MAP`, no manual date parsing. Use `classify()` instead of a transformer for irregular providers. See the converted examples (`kwinana_wa_gov_au.py`, `koppl_at.py`, `reading_gov_uk.py`).
 2. **Legacy module-level contract (still fully supported).** Module-level `TITLE`/`URL`/... plus a `Source` class with a hand-written `fetch() -> list[Collection]` returning `Collection(date, t, icon=...)`. Around 600 sources use this. A bug fix to one does not need converting.
 
 Both styles need this metadata (on the class for pipeline sources, at module level for legacy):
@@ -108,7 +108,7 @@ Both styles need this metadata (on the class for pipeline sources, at module lev
 | `COUNTRY` | `str` | **Lowercase code** from `update_docu_links.py`'s `COUNTRYCODES` list. UK = `"uk"` (NOT `"gb"`); Canada = `"ca"` (lowercase). An invalid value silently orphans the source out of README/info/sources.json. |
 | `TEST_CASES` | `dict` | Maps test-case name to constructor kwargs. Must not be empty. |
 
-Pipeline sources also declare `PARAMS` (typed `config_params` descriptors), the step attributes, and a `transformer` (or `classify()`). Legacy sources provide the `Source` class with `__init__(**kwargs)` and `fetch()`.
+Pipeline sources also declare `PARAMS` (typed `config_params` descriptors), the step attributes, and a `transformer` (or `classify()`), but no `__init__`. Legacy sources provide the `Source` class with `__init__(**kwargs)` and `fetch()`.
 
 **Cassette rule (enforced).** Every pipeline source ships a recorded cassette under `tests/fixtures/<module>/`, so CI replays it offline instead of calling live providers. Record with `python tests/record_fixtures.py <module>` and commit the JSON. `tests/test_new_architecture.py::test_pipeline_sources_ship_a_cassette` enforces it. A shared-service source keeps one cassette per distinct response shape.
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/base_source.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/base_source.py
@@ -12,9 +12,11 @@ A source is a composition of typed, callable pipeline steps:
 BaseSource is generic over the parser output type and the transformer input
 type. Wiring an incompatible parser + transformer is a static (mypy) error.
 
-Sources declare which standard steps to use. For most sources, the only
-source-specific code is ``__init__`` (validating and storing constructor args
-via ``super().__init__(**kwargs)``). Everything else is declarative::
+Sources declare which standard steps to use. For most sources there is no
+source-specific code at all, and in particular no ``__init__``: this class's
+``__init__`` already accepts the declared ``PARAMS`` as keyword arguments,
+applies their defaults, validates them, and stores the result on ``self.params``.
+Everything is declarative::
 
     class Source(BaseSource):
         TITLE = "Example Council"
@@ -183,8 +185,16 @@ class BaseSource(ABC, Generic[ParserType, TransformerType]):
         """Validate constructor args against PARAMS and store them.
 
         Validation happens up front so that retrievers and transformers can
-        assume clean params. Sources may override __init__ for custom
-        validation but should call ``super().__init__(**kwargs)``.
+        assume clean params.
+
+        This accepts the fields declared in PARAMS as keyword arguments, so a
+        source does not need its own __init__ and should not write one that only
+        forwards its arguments here (``test_pipeline_sources_dont_redeclare_init``
+        enforces that). Override it only to do real work, and still call
+        ``super().__init__(**kwargs)``. Declare defaults on the ConfigParam
+        rather than in an override's signature: ``defaults`` is independent of
+        ``required``, so a field that is only ``optional=True`` is absent from
+        ``self.params`` when omitted rather than present as None.
         """
         prepared = apply_defaults(self.PARAMS, dict(kwargs))
         validate(self.PARAMS, prepared)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/1coast_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/1coast_com_au.py
@@ -174,6 +174,3 @@ class Source(BaseSource):
             "240L Green Lid Garden Vegetation Bin": GARDEN_WASTE,
         }
     )
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
@@ -61,6 +61,3 @@ class Source(BaseSource):
             "gelbe tonne": RECYCLABLES,
         },
     )
-
-    def __init__(self, ort: str, strasse: str):
-        super().__init__(ort=ort, strasse=strasse)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallkalender_prezero_network.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallkalender_prezero_network.py
@@ -163,6 +163,3 @@ class Source(BaseSource):
             "Schadstoffsammlung": HAZARDOUS,
         }
     )
-
-    def __init__(self, street: str, house_number: str, city: str = "bad-oeynhausen"):
-        super().__init__(street=street, house_number=house_number, city=city)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
@@ -53,6 +53,3 @@ class Source(BaseSource):
     # ResponseShapeError rather than silently returning nothing.
     parse = parsers.IcsParser(min_events=1)
     transform = ICSTransformer()
-
-    def __init__(self, city: str, area: str):
-        super().__init__(city=city, area=area)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_fuerth_eu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_fuerth_eu.py
@@ -59,6 +59,3 @@ class Source(BaseSource):
             "Altpapier": PAPER,
         }
     )
-
-    def __init__(self, id: int):
-        super().__init__(id=id)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
@@ -109,8 +109,3 @@ class Source(BaseSource):
             "Grossmuellbehaelter": GENERAL_WASTE,
         },
     )
-
-    def __init__(self, street: str, house_number: int, address_suffix: str = ""):
-        super().__init__(
-            street=street, house_number=house_number, address_suffix=address_suffix
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_vechta_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_vechta_de.py
@@ -157,6 +157,3 @@ class Source(BaseSource):
             "Mobile Schadstoff.": HAZARDOUS,
         }
     )
-
-    def __init__(self, stadt: str, strasse: str):
-        super().__init__(stadt=stadt, strasse=strasse)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
@@ -95,6 +95,3 @@ class Source(BaseSource):
             PACKAGING_LABEL: RECYCLABLES,
         }
     )
-
-    def __init__(self, calendar_url: str):
-        super().__init__(calendar_url=calendar_url)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
@@ -110,17 +110,3 @@ class Source(BaseSource):
             "Bioabfallbehaelter": ORGANIC,
         }
     )
-
-    def __init__(
-        self,
-        city: str,
-        street: str,
-        house_number: int | str,
-        address_suffix: str = "",
-    ):
-        super().__init__(
-            city=city,
-            street=street,
-            house_number=house_number,
-            address_suffix=address_suffix,
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awbkoeln_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awbkoeln_de.py
@@ -62,6 +62,3 @@ class Source(BaseSource):
         type_key="type",
         type_value_map=_TYPE_VALUE_MAP,
     )
-
-    def __init__(self, street_code, building_number):
-        super().__init__(street_code=street_code, building_number=building_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_wuppertal_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_wuppertal_de.py
@@ -64,6 +64,3 @@ class Source(BaseSource):
             "Sperrmüll": BULKY_WASTE,
         },
     )
-
-    def __init__(self, street: str):
-        super().__init__(street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
@@ -182,6 +182,3 @@ class Source(BaseSource):
             "Gelbe Tonne/Gelben Sack": RECYCLABLES,
         }
     )
-
-    def __init__(self, ort: str, strasse: str, hnr: "str | int"):
-        super().__init__(ort=ort, strasse=strasse, hnr=hnr)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awn_de.py
@@ -95,17 +95,3 @@ class Source(BaseSource):
     )
     parse = parsers.IcsParser()
     transform = ICSTransformer()
-
-    def __init__(
-        self,
-        city: str,
-        street: str,
-        house_number: int,
-        address_suffix: str = "",
-    ):
-        super().__init__(
-            city=city,
-            street=street,
-            house_number=house_number,
-            address_suffix=address_suffix,
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awr_de.py
@@ -50,6 +50,3 @@ class Source(BaseSource):
     retrieve = CollectionDatesRetriever(base_url=BASE_URL)
     parse = IcsParser()
     transform = ICSTransformer(clean=clean_waste_type)
-
-    def __init__(self, city: str, street: str):
-        super().__init__(city=city, street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awsh_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awsh_de.py
@@ -40,6 +40,3 @@ class Source(BaseSource):
     retrieve = CollectionDatesRetriever(base_url=BASE_URL)
     parse = IcsParser()
     transform = ICSTransformer(clean=clean_waste_type)
-
-    def __init__(self, city: str, street: str):
-        super().__init__(city=city, street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awv_ot_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awv_ot_de.py
@@ -115,6 +115,3 @@ class Source(BaseSource):
     parse = IcsFeedsParser(parsers.IcsParser(regex=_SUMMARY_RE))
 
     transform = ICSTransformer(type_value_map=_TYPE_VALUE_MAP)
-
-    def __init__(self, city: str, street: str, hnr: str):
-        super().__init__(city=city, street=street, hnr=hnr)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bassendean_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bassendean_wa_gov_au.py
@@ -103,6 +103,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bathurst_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bathurst_nsw_gov_au.py
@@ -107,6 +107,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str, suburb: str):
-        super().__init__(address=address, suburb=suburb)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayside_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayside_vic_gov_au.py
@@ -101,6 +101,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, street_address: str):
-        super().__init__(street_address=street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayswater_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayswater_wa_gov_au.py
@@ -95,6 +95,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
@@ -79,6 +79,3 @@ class Source(BaseSource):
             _SDK: HAZARDOUS,
         }
     )
-
-    def __init__(self) -> None:
-        super().__init__()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bexley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bexley_gov_uk.py
@@ -70,6 +70,3 @@ class Source(BaseSource):
         },
         clean=_clean_bin_label,
     )
-
-    def __init__(self, uprn: str):
-        super().__init__(uprn=uprn)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
@@ -106,8 +106,3 @@ class Source(BaseSource):
     def preprocess(self, records, source=None):
         """Drop the calendar's own "Die neue ICal..." announcement VEVENT."""
         return (r for r in records if "Die neue ICal" not in r[1])
-
-    def __init__(self, street: str, house_number: int, address_suffix: str = ""):
-        super().__init__(
-            street=street, house_number=house_number, address_suffix=address_suffix
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bmv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bmv_at.py
@@ -114,6 +114,3 @@ class Source(BaseSource):
     )
     parse = parsers.IcsParser()
     transform = ICSTransformer(clean=_clean)
-
-    def __init__(self, ort: str, strasse: str, hausnummer: int):
-        super().__init__(ort=ort, strasse=strasse, hausnummer=hausnummer)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bromley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bromley_gov_uk.py
@@ -62,6 +62,3 @@ class Source(BaseSource):
         },
         clean=label_cleaner(strip_suffixes=[" collection"]),
     )
-
-    def __init__(self, property: str):
-        super().__init__(property=property)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bsr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bsr_de.py
@@ -83,9 +83,6 @@ class Source(BaseSource):
     # date in ``serviceDate_actual``, so dropping the grouping key loses nothing.
     preprocess = FlattenGroups()
 
-    def __init__(self, schedule_id: str) -> None:
-        super().__init__(schedule_id=schedule_id)
-
     def classify(self, record: dict[str, Any]) -> Collection | None:
         date = datetime.datetime.strptime(
             record["serviceDate_actual"], "%d.%m.%Y"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
@@ -99,6 +99,3 @@ class Source(BaseSource):
     parse = parsers.JsonParser(shape=list[ScheduleRecord])
     preprocess = preprocessors.RecurrenceExpander(_describe)
     transform = ICSTransformer(type_value_map=TYPE_MAP)
-
-    def __init__(self, street_address: str):
-        super().__init__(street_address=street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ceb_coburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ceb_coburg_de.py
@@ -91,6 +91,3 @@ class Source(BaseSource):
 
     # The two feeds overlap around the year boundary, repeating collections.
     parse = IcsFeedsParser(parsers.IcsParser(), dedupe=True)
-
-    def __init__(self, street: str):
-        super().__init__(street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesapeake_va_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesapeake_va_us.py
@@ -67,6 +67,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
@@ -112,6 +112,3 @@ class Source(BaseSource):
     parse = ArcGis.ArcGisFeatureParser()
     preprocess = RecurrenceExpander(_describe)
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, property_location: str):
-        super().__init__(property_location=property_location)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/derbyshiredales_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/derbyshiredales_gov_uk.py
@@ -68,6 +68,3 @@ class Source(BaseSource):
             "garden waste": GARDEN_WASTE,
         },
     )
-
-    def __init__(self, address_id: str):
-        super().__init__(address_id=address_id)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eko_tom_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eko_tom_pl.py
@@ -78,6 +78,3 @@ class Source(BaseSource):
         parse_date=date_parsers.for_format("%d.%m.%Y"),
     )
     transform = ICSTransformer(type_value_map=TYPE_MAP)
-
-    def __init__(self, street: str, city: str, nr: str):
-        super().__init__(city=city, street=street, nr=nr)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
@@ -72,6 +72,3 @@ class Source(BaseSource):
             "Restabfall 4-wöchentlich": GENERAL_WASTE,
         },
     )
-
-    def __init__(self, strasse: str, hausnummer: str):
-        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/erlangen_hoechstadt_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/erlangen_hoechstadt_de.py
@@ -58,6 +58,3 @@ class Source(BaseSource):
         return entries
 
     transform = ICSTransformer()
-
-    def __init__(self, city: str, street: str):
-        super().__init__(city=city, street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
@@ -122,6 +122,3 @@ class Source(BaseSource):
     parse = PoziGeoJsonParser()
     preprocess = RecurrenceExpander(_describe)
     transform = RowTransformer()
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frasercoast_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frasercoast_qld_gov_au.py
@@ -93,6 +93,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geoport_nwm_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geoport_nwm_de.py
@@ -114,6 +114,3 @@ class Source(BaseSource):
     parse = IcsFeedsParser(parsers.IcsParser())
 
     transform = ICSTransformer()
-
-    def __init__(self, district: str):
-        super().__init__(district=district)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gfa_lueneburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gfa_lueneburg_de.py
@@ -120,6 +120,3 @@ class Source(BaseSource):
             "Sperrmuell Altmetall": BULKY_WASTE,
         }
     )
-
-    def __init__(self, city: str, street: str, house_number: int | str):
-        super().__init__(city=city, street=street, house_number=house_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/greaterdandenong_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/greaterdandenong_vic_gov_au.py
@@ -112,6 +112,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hohokus_nj_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hohokus_nj_us.py
@@ -159,6 +159,3 @@ class Source(BaseSource):
     transform = ICSTransformer(
         type_value_map={GENERAL: GENERAL_WASTE, YARD: GARDEN_WASTE},
     )
-
-    def __init__(self, district: str):
-        super().__init__(district=district)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hoover_al_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hoover_al_us.py
@@ -68,6 +68,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ichisystem_eu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ichisystem_eu.py
@@ -84,6 +84,3 @@ class Source(BaseSource):
     )
     parse = SepanReportParser()
     transform = RowTransformer(type_value_map=TYPE_VALUE_MAP)
-
-    def __init__(self, city: str, street: str, house_number: str):
-        super().__init__(city=city, street=street, house_number=house_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaev_niederlausitz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaev_niederlausitz.py
@@ -113,6 +113,3 @@ class Source(BaseSource):
     parse = IcsFeedsParser(parsers.IcsParser())
 
     transform = ICSTransformer(clean=lambda title: title.removesuffix(", "))
-
-    def __init__(self, abf_suche: str):
-        super().__init__(abf_suche=abf_suche)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
@@ -59,6 +59,3 @@ class Source(BaseSource):
             "Papiermüll": PAPER,
         },
     )
-
-    def __init__(self, street: str, house_number: str):
-        super().__init__(street=street, house_number=house_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ks_boerde_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ks_boerde_de.py
@@ -113,6 +113,3 @@ class Source(BaseSource):
     )
     parse = IcsParser()
     transform = ICSTransformer(type_value_map={"Papier, Pappe, Karton": PAPER})
-
-    def __init__(self, village: str, street: str, house_number: "str | int"):
-        super().__init__(village=village, street=street, house_number=house_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kumberg_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kumberg_gv_at.py
@@ -58,6 +58,3 @@ class Source(BaseSource):
             "Sperrmüll": BULKY_WASTE,
         },
     )
-
-    def __init__(self):
-        super().__init__()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwinana_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwinana_wa_gov_au.py
@@ -110,6 +110,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
@@ -138,6 +138,3 @@ class Source(BaseSource):
     )
     parse = IcsParser()
     transform = ICSTransformer()
-
-    def __init__(self, city: str, street: str, number: "str | int"):
-        super().__init__(city=city, street=street, number=number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_helmstedt_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_helmstedt_de.py
@@ -145,19 +145,3 @@ class Source(BaseSource):
         hint="check the PDF calendar for valid collection areas",
     )
     transform = ICSTransformer()
-
-    def __init__(
-        self,
-        municipal: str,
-        restabfall: int,
-        altpapier: int,
-        gelber_sack: int,
-        bioabfall: int,
-    ):
-        super().__init__(
-            municipal=municipal,
-            restabfall=restabfall,
-            altpapier=altpapier,
-            gelber_sack=gelber_sack,
-            bioabfall=bioabfall,
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_kusel_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_kusel_de.py
@@ -120,6 +120,3 @@ class Source(BaseSource):
         # own ``d[1].split(" ")[0]``).
         clean=lambda label: label.split(" ")[0],
     )
-
-    def __init__(self, ortsgemeinde: str):
-        super().__init__(ortsgemeinde=ortsgemeinde)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_verden_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_verden_de.py
@@ -151,17 +151,3 @@ class Source(BaseSource):
             "Weihnachtsbaum": GARDEN_WASTE,
         },
     )
-
-    def __init__(
-        self,
-        city: str,
-        street: str,
-        house_number: int | str,
-        house_number_addition: str = "",
-    ) -> None:
-        super().__init__(
-            city=city,
-            street=street,
-            house_number=house_number,
-            house_number_addition=house_number_addition,
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/launceston_tas_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/launceston_tas_gov_au.py
@@ -100,6 +100,3 @@ class Source(BaseSource):
             field: waste_type for field, (waste_type, _) in _SERVICES.items()
         }
     )
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lawrence_ma_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lawrence_ma_us.py
@@ -106,6 +106,3 @@ class Source(BaseSource):
     transform = ICSTransformer(
         type_value_map={"trash": GENERAL_WASTE, "recycling": RECYCLABLES},
     )
-
-    def __init__(self, street: str):
-        super().__init__(street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lobbe_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lobbe_app.py
@@ -234,6 +234,3 @@ class Source(BaseSource):
             "Elektroschrott": ELECTRONICS,
         }
     )
-
-    def __init__(self, state: str, city: str, street: str):
-        super().__init__(state=state, city=city, street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/magdeburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/magdeburg_de.py
@@ -105,6 +105,3 @@ class Source(BaseSource):
             else label.removeprefix(_PREFIX)
         ),
     )
-
-    def __init__(self, street: str):
-        super().__init__(street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mandurah_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mandurah_wa_gov_au.py
@@ -160,6 +160,3 @@ class Source(BaseSource):
     )
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
@@ -111,6 +111,3 @@ class Source(BaseSource):
     preprocess = Compose(PanelFieldSet(), RecurrenceExpander(_describe))
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
@@ -67,6 +67,3 @@ class Source(BaseSource):
             "Restabfall 6-wöchentlich": GENERAL_WASTE,
         },
     )
-
-    def __init__(self, strasse: str, hausnummer: str):
-        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/moonee_valley_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/moonee_valley_vic_gov_au.py
@@ -94,6 +94,3 @@ class Source(BaseSource):
     parse = ArcGisFeatureParser()
     preprocess = RecurrenceExpander(_describe)
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, property_location: str):
-        super().__init__(property_location=property_location)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mpgk_com_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mpgk_com_pl.py
@@ -66,6 +66,3 @@ class Source(BaseSource):
             "Odpady B I O zbierane w pojemnikach": ORGANIC,
         }
     )
-
-    def __init__(self, street: str, number: str | int):
-        super().__init__(street=street, number=number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/neu_ulm_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/neu_ulm_de.py
@@ -74,6 +74,3 @@ class Source(BaseSource):
         },
         clean=lambda label: label.replace("Abfuhr ", "").strip(),
     )
-
-    def __init__(self, region: str):
-        super().__init__(region=region)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_nsw_gov_au.py
@@ -100,6 +100,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/northville_township_mi_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/northville_township_mi_us.py
@@ -75,6 +75,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsr_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsr_se.py
@@ -141,6 +141,3 @@ class Source(BaseSource):
             "Miljöfarligt avfall": HAZARDOUS,
         }
     )
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nuernberger_land_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nuernberger_land_de.py
@@ -54,6 +54,3 @@ class Source(BaseSource):
             "Giftmobil": HAZARDOUS,
         }
     )
-
-    def __init__(self, id: int):
-        super().__init__(id=id)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
@@ -49,6 +49,3 @@ class Source(BaseSource):
             "Empty Bin 240L Brown": ORGANIC,
         }
     )
-
-    def __init__(self, post_code: str, uprn: str):
-        super().__init__(post_code=post_code, uprn=uprn)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
@@ -106,6 +106,3 @@ class Source(BaseSource):
     transform = ICSTransformer(
         type_value_map={"general": GENERAL_WASTE, "recycling": RECYCLABLES}
     )
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pointe_claire_qc_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pointe_claire_qc_ca.py
@@ -87,6 +87,3 @@ class Source(BaseSource):
             "Leaf Collection": GARDEN_WASTE,
         }
     )
-
-    def __init__(self, sector: str):
-        super().__init__(sector=sector)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rapperswil_be_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rapperswil_be_ch.py
@@ -68,6 +68,3 @@ class Source(BaseSource):
             "Papier und Karton": PAPER,
         }
     )
-
-    def __init__(self):
-        super().__init__()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/reso_gmbh_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/reso_gmbh_de.py
@@ -93,6 +93,3 @@ class Source(BaseSource):
             "gelber-sack": RECYCLABLES,
         }
     )
-
-    def __init__(self, ort: str, ortsteil: str):
-        super().__init__(ort=ort, ortsteil=ortsteil)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rsag_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rsag_de.py
@@ -155,6 +155,3 @@ class Source(BaseSource):
         clean=_clean_type,
         type_value_map={"Wertstoff": RECYCLABLES, "Weihnachtsbaum": GARDEN_WASTE},
     )
-
-    def __init__(self, city: str, street: str):
-        super().__init__(city=city, street=street)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rugby_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rugby_gov_uk.py
@@ -48,6 +48,3 @@ class Source(BaseSource):
             "Green garden waste bin": GARDEN_WASTE,
         },
     )
-
-    def __init__(self, uprn):
-        super().__init__(uprn=uprn)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
@@ -60,6 +60,3 @@ class Source(BaseSource):
             "glass": GLASS,
         },
     )
-
-    def __init__(self, postcode: str, address: str):
-        super().__init__(postcode=postcode, address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rv_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rv_de.py
@@ -100,8 +100,3 @@ class Source(BaseSource):
             "gelbe tonne": RECYCLABLES,
         }
     )
-
-    def __init__(
-        self, ort: str, strasse: str, hnr: "str | int", hnr_zusatz: "str | int" = ""
-    ):
-        super().__init__(ort=ort, strasse=strasse, hnr=hnr, hnr_zusatz=hnr_zusatz)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
@@ -69,6 +69,3 @@ class Source(BaseSource):
             "Restabfall 6-wöchentlich": GENERAL_WASTE,
         },
     )
-
-    def __init__(self, strasse: str, hausnummer: str | int):
-        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/seab_biella_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/seab_biella_it.py
@@ -76,6 +76,3 @@ class Source(BaseSource):
     )
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, url: str) -> None:
-        super().__init__(url=url)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sepan_remondis_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sepan_remondis_pl.py
@@ -88,8 +88,3 @@ class Source(BaseSource):
     )
     parse = SepanPositionalReportParser(name_map=NAME_MAP)
     transform = RowTransformer(type_value_map=TYPE_VALUE_MAP)
-
-    def __init__(self, city: str, street_name: str, street_number: str):
-        super().__init__(
-            city=city, street_name=street_name, street_number=street_number
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sjshire_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sjshire_wa_gov_au.py
@@ -112,6 +112,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southkesteven_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southkesteven_gov_uk.py
@@ -71,6 +71,3 @@ class Source(BaseSource):
             "purple": PAPER,
         },
     )
-
-    def __init__(self, address_id: str):
-        super().__init__(address_id=address_id)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southperth_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southperth_wa_gov_au.py
@@ -93,6 +93,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadt_bamberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadt_bamberg_de.py
@@ -107,8 +107,3 @@ class Source(BaseSource):
             "gelber": RECYCLABLES,
         },
     )
-
-    def __init__(self, street: str, house_number: int, address_suffix: str = ""):
-        super().__init__(
-            street=street, house_number=house_number, address_suffix=address_suffix
-        )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_dresden_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_dresden_de.py
@@ -90,6 +90,3 @@ class Source(BaseSource):
             "restabfall": GENERAL_WASTE,
         }
     )
-
-    def __init__(self, standort: int):
-        super().__init__(standort=standort)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_leipzig_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_leipzig_de.py
@@ -106,6 +106,3 @@ class Source(BaseSource):
     )
     parse = parsers.IcsParser()
     transform = ICSTransformer(clean=_clean, type_value_map=_TYPE_VALUE_MAP)
-
-    def __init__(self, street: str, house_number: int):
-        super().__init__(street=street, house_number=house_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtservice_bruehl_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtservice_bruehl_de.py
@@ -114,6 +114,3 @@ class Source(BaseSource):
         clean=_clean_type,
         type_value_map={"Straßenlaub": GARDEN_WASTE},
     )
-
-    def __init__(self, strasse: str, hnr: str):
-        super().__init__(strasse=strasse, hnr=hnr)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
@@ -56,6 +56,3 @@ class Source(BaseSource):
     # Sperrmüll, Altglas, Problemstoff) resolves against the shared vocabulary
     # unmapped; no type_value_map needed.
     transform = ICSTransformer()
-
-    def __init__(self, strasse: str, hausnummer: str):
-        super().__init__(strasse=strasse, hausnummer=hausnummer)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stkh_hu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stkh_hu.py
@@ -70,6 +70,3 @@ class Source(BaseSource):
     )
 
     transform = ICSTransformer(type_value_map=_TYPE_VALUE_MAP)
-
-    def __init__(self, url: str):
-        super().__init__(url=url)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stuttgart_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stuttgart_de.py
@@ -44,6 +44,3 @@ class Source(BaseSource):
     retrieve = StuttgartRetriever()
     parse = StuttgartParser()
     transform = RowTransformer()
-
-    def __init__(self, street, streetnr):
-        super().__init__(street=street, streetnr=streetnr)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
@@ -56,6 +56,3 @@ class Source(BaseSource):
         },
         clean=label_cleaner(strip_suffixes=[" collection"]),
     )
-
-    def __init__(self, id: str | int):
-        super().__init__(id=id)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swan_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swan_wa_gov_au.py
@@ -90,6 +90,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tibi_be.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tibi_be.py
@@ -89,6 +89,3 @@ class Source(BaseSource):
         parse_date=date_parsers.for_format("%Y-%m-%d"),
         type_value_map=_TYPE_MAP,
     )
-
-    def __init__(self, commune: str):
-        super().__init__(commune=commune)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ubzzw_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ubzzw_de.py
@@ -92,6 +92,3 @@ class Source(BaseSource):
             "problemstoff-sammlung": HAZARDOUS,
         },
     )
-
-    def __init__(self, street: str, house_number: str):
-        super().__init__(street=street, house_number=house_number)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
@@ -106,6 +106,3 @@ class Source(BaseSource):
     parse = PoziWfsParser()
     preprocess = RecurrenceExpander(_describe)
     transform = RowTransformer()
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/waipa_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/waipa_nz.py
@@ -85,6 +85,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wanneroo_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wanneroo_wa_gov_au.py
@@ -160,6 +160,3 @@ class Source(BaseSource):
     preprocess = RecurrenceExpander(_describe)
 
     transform = ICSTransformer(type_value_map=_TYPE_MAP)
-
-    def __init__(self, address: str):
-        super().__init__(address=address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarra_ranges_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarra_ranges_vic_gov_au.py
@@ -111,6 +111,3 @@ class Source(BaseSource):
         type_value_map=_TYPE_MAP,
         parse_date=parse_date,
     )
-
-    def __init__(self, street_address: str):
-        super().__init__(street_address=street_address)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zaw_sr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zaw_sr_de.py
@@ -132,6 +132,3 @@ class Source(BaseSource):
             "wertstofftonne": RECYCLABLES,
         },
     )
-
-    def __init__(self, city: str, street: str, hnr: str, addition: str = ""):
-        super().__init__(city=city, street=street, hnr=hnr, addition=addition)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zke_sb_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zke_sb_de.py
@@ -99,6 +99,3 @@ class Source(BaseSource):
             "gelbe tonne": RECYCLABLES,
         },
     )
-
-    def __init__(self, street: str, house_number: "str | int"):
-        super().__init__(street=street, house_number=house_number)

--- a/doc/contributing_source.md
+++ b/doc/contributing_source.md
@@ -4,7 +4,7 @@
 
 There are two ways to write a source:
 
-1. **The `BaseSource` pipeline (recommended for new sources).** You declare which standard, reusable steps to use (retrieve, parse, preprocess, transform). For most providers the only source-specific code is `__init__`. This is the platform described in this guide.
+1. **The `BaseSource` pipeline (recommended for new sources).** You declare which standard, reusable steps to use (retrieve, parse, preprocess, transform). For most providers there is no source-specific code at all: the whole source is class attributes. This is the platform described in this guide.
 2. **The legacy module-level contract.** A module that defines `TITLE`, `URL`, `TEST_CASES` and a `Source` class with a hand-written `fetch()`. Around 600 existing sources use this style and it remains fully supported. See [Legacy module-level sources](#legacy-module-level-sources) at the end.
 
 Both styles produce the same `Collection` data and live in the same folder. New contributions should prefer the pipeline because it removes most of the boilerplate (no `fetch()`, no per-source icon map, no manual date parsing) and reuses tested components.
@@ -49,6 +49,7 @@ from typing import final
 from waste_collection_schedule import parsers
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
+from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import JsonTransformer
 from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
@@ -59,7 +60,6 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Example Council."
     URL = "https://example.com"
     COUNTRY = "uk"
-    API_URL = "https://api.example.com/collections"
 
     TEST_CASES = {
         "Test 1": {"uprn": "100012345678"},
@@ -67,24 +67,24 @@ class Source(BaseSource):
 
     PARAMS = [uprn()]
 
+    retrieve = HttpGetRetriever(
+        url="https://api.example.com/collections",
+        params=lambda uprn, **_: {"uprn": uprn},
+    )
     parse = parsers.JsonParser("collections")
     transform = JsonTransformer(
         date_key="date",
         type_key="binType",
         type_value_map={"refuse": GENERAL_WASTE, "recycling": RECYCLABLES},
     )
-
-    def __init__(self, uprn: str):
-        super().__init__(uprn=uprn)
-        self._params = {"uprn": uprn}
 ```
 
 Notes:
 
 - Decorate the class with `@typing.final`. A `Source` is only ever instantiated by the framework, never subclassed, so marking it final lets the type checker (pyright) verify it fully and correctly implements the `BaseSource` contract; without it, override and signature mismatches in the source can go unreported.
-- No `retrieve` is declared, so the default zero-config GET is used. It reads `API_URL`, `self._params`, `self._headers` and `TIMEOUT` from the source. Set `self._params` / `self._headers` in `__init__` to shape the request.
+- **There is no `__init__`.** `BaseSource.__init__` takes the declared `PARAMS` as keyword arguments, applies their defaults, validates them, and stores the result on `self.params`. Restating that in the source adds a second place for the argument list to drift from `PARAMS`, so `test_pipeline_sources_dont_redeclare_init` rejects an `__init__` that only forwards its arguments to `super()`. Write one only when it does real work.
+- The request is shaped on the retriever. `HttpGetRetriever(params=...)` takes a callable receiving the params by name (end it with `**_` so it ignores the ones it does not use). Declaring no `retrieve` at all gives the zero-config GET, which reads `API_URL`, `self._params`, `self._headers` and `TIMEOUT` from the source; prefer the configured retriever, since setting `self._params` needs an `__init__`.
 - No icons. The icon comes from the canonical `WasteType`, not from a per-source map.
-- `__init__` must call `super().__init__(**kwargs)`. That validates the arguments against `PARAMS` and stores them on `self.params`.
 
 ## Building blocks
 
@@ -223,6 +223,8 @@ A param is required by default. Three ways to relax that:
 - **Optional with a default.** `text_field(..., default=...)` (and the `api_key(...)` wrapper for provider keys) makes a field optional and pre-fills it, e.g. an embedded public API key. The default is applied before validation, so the user need not supply one but can override it.
 - **Optional, no default.** `text_field(..., optional=True)` / `dropdown(..., optional=True)` makes a field optional with no pre-filled value, for a refinement the source can do without (e.g. an extra street or route filter alongside a required city). Prefer this over `dataclasses.replace(..., required=False)`.
 - **Alternative input.** `alternatives([uprn()], [postcode(), text_field("house")])` declares mutually-exclusive input groups: validation requires exactly one group to be fully provided. Use this instead of a hand-rolled cross-field check in `__init__` (see `reading_gov_uk.py`).
+
+Declare every default here rather than in an `__init__` signature, because the two are not equivalent. `ConfigParam.defaults` is independent of `required`: `apply_defaults` fills only the fields that declare a default, so a field that is merely `optional=True` is **absent** from `self.params` when the user omits it, where an `__init__` default of `None` would have made it present and `None`. Read an optional field with `self.params.get("x")`, and if the pipeline needs the key to exist, give it an explicit `default=None`.
 
 `dependent_select(parent, child)` is a cascading two-level dropdown. The source MUST implement `get_choices(parent_value) -> list[str]` (child options for a chosen parent) and MAY implement `get_parent_choices() -> list[str]` (parent options; absent means the parent is free text). Both run at config-flow time and may fetch live. See `gemeinde24_at.py`.
 
@@ -396,7 +398,10 @@ These are the old-style habits the pipeline exists to remove. A new or converted
 | `requests.get(...)` / `curl_cffi.Session(...)` in a source | the default `http_get`, a configured `HttpGetRetriever`, or a named `Legacy*` retriever; all use `source.session` |
 | `BeautifulSoup(...)` built by hand | `parse = parsers.HtmlParser(selector, ...)` |
 | `ICON_MAP` / `mdi:*` strings | the icon comes from the canonical `WasteType`; declare none |
-| `self._x = x` in `__init__` that is read back unchanged | read `self.params["x"]` at point of use (keep the `__init__` signature) |
+| `self._x = x` in `__init__` that is read back unchanged | read `self.params["x"]` at point of use, then delete the `__init__` |
+| an `__init__` that only forwards its arguments to `super()` | delete it; `BaseSource.__init__` applies the `PARAMS` defaults, validates, and stores them |
+| `str(uprn)` / `address.strip()` in `__init__` | declare the coercion on the `ConfigParam` so every source on the platform gets it |
+| a default in the `__init__` signature (`ort: str \| None = None`) | `text_field(..., default=None)` / `optional=True`, so `PARAMS` is the single source of truth |
 | a `retrieve` / `parse` method that only injects params or calls `.json()` | a configured retriever + a declared `parse =` parser |
 | a `retrieve()` override that reissues a shared service's request by hand | split the service into a `Retriever` + `Parser` and declare them (see [Migrating a source built on a shared service](#migrating-a-source-built-on-a-shared-service)) |
 | a pass-through `classify()` over already-resolved records | yield `(date, key)` and use a transformer |

--- a/doc/new_source_template.py
+++ b/doc/new_source_template.py
@@ -8,8 +8,8 @@ that do not apply. The full reference is ``doc/contributing_source.md``; the
 ``source-implementer`` agent (or ``/new-source``) can generate this for you.
 
 The pipeline is four swappable steps: retrieve, parse, preprocess, transform.
-For most sources the only source-specific code is ``__init__``; everything else
-is declarative class attributes.
+For most sources there is no source-specific code at all: the whole source is
+declarative class attributes, and there is no ``__init__``.
 """
 
 from typing import ClassVar, TypedDict, final
@@ -17,6 +17,7 @@ from typing import ClassVar, TypedDict, final
 from waste_collection_schedule import date_parsers, parsers
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn  # >>> pick your params
+from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import JsonTransformer
 from waste_collection_schedule.waste_types import (  # >>> map only what you emit
     GENERAL_WASTE,
@@ -64,6 +65,14 @@ class Source(BaseSource):
         "en": "Find your UPRN at https://www.findmyaddress.co.uk/",
     }
 
+    # >>> Shape the request here, not in an __init__. params= takes a callable
+    # receiving the PARAMS fields by name; end it with **_ to ignore the rest.
+    # Declare no `retrieve` at all for a zero-config GET against API_URL.
+    retrieve = HttpGetRetriever(
+        url="https://api.example.com/collections",
+        params=lambda uprn, **_: {"uprn": uprn},
+    )
+
     # >>> Parse the response. JsonParser("key", "subkey") drills into nested
     # data; HtmlParser/IcsParser/PdfTextParser/XmlParser/CsvParser also exist.
     # shape= validates the response and raises ResponseShapeError on a mismatch.
@@ -82,12 +91,12 @@ class Source(BaseSource):
         },
     )
 
-    def __init__(self, uprn: str | None = None):
-        # super().__init__ validates kwargs against PARAMS and stores them.
-        super().__init__(uprn=uprn)
-        # >>> If the request needs params/headers built from the inputs, set
-        # self._params / self._headers here (read by the default retriever).
-        self._params = {"uprn": uprn}
+    # >>> No __init__. BaseSource.__init__ accepts the PARAMS fields as keyword
+    # arguments, applies their declared defaults, validates them, and stores the
+    # result on self.params, which every step can read. An __init__ that only
+    # forwards its arguments to super() is rejected by
+    # test_pipeline_sources_dont_redeclare_init. Add one only to do real work,
+    # and declare defaults in PARAMS rather than in its signature.
 
     # >>> Most sources need none of the below. Add only what applies:
     #

--- a/tests/test_new_architecture.py
+++ b/tests/test_new_architecture.py
@@ -4477,6 +4477,151 @@ def test_pipeline_sources_ship_a_cassette(stem: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Redundant __init__ gate
+#
+# A pipeline source that declares PARAMS needs no __init__. BaseSource.__init__
+# already applies the declared defaults, validates against PARAMS, and stores the
+# result on self.params. An override that only forwards its arguments to super()
+# under the same names restates that contract in a second place, where it can
+# drift from PARAMS, and it is the reason the three consumers of the constructor
+# signature (test_source_has_necessary_parameters, test_params_fields_match_init
+# and update_docu_links) each carry a PARAMS fallback.
+#
+# This gate is deliberately narrow: it fires only when the override provably does
+# nothing. An __init__ that coerces a value, supplies a default PARAMS does not
+# declare, or does any other work is left alone, because deleting it would change
+# behaviour. Both of those are better fixed at the source (declare the coercion
+# on the ConfigParam, declare the default in PARAMS) and then the __init__ goes
+# too, but that is a behavioural change and not this gate's business.
+# --------------------------------------------------------------------------- #
+
+
+def _redundant_init_reason(stem: str, cls: type) -> str | None:
+    """Return a reason if this source's __init__ is a pure passthrough.
+
+    None means the override earns its place (or there is no override).
+    """
+    import ast
+    from pathlib import Path
+
+    from waste_collection_schedule.base_source import BaseSource
+
+    # getattr rather than cls.__init__, which mypy rejects as unsound on a type.
+    if getattr(cls, "__init__", None) is BaseSource.__init__:
+        return None  # already inherits: nothing to answer for
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components/waste_collection_schedule/waste_collection_schedule/source"
+        / f"{stem}.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    node = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.ClassDef) and n.name == "Source"
+        ),
+        None,
+    )
+    if node is None:
+        return None
+    init = next(
+        (
+            b
+            for b in node.body
+            if isinstance(b, ast.FunctionDef) and b.name == "__init__"
+        ),
+        None,
+    )
+    if init is None:
+        return None
+
+    args = init.args
+    if args.posonlyargs or args.vararg or args.kwonlyargs:
+        return None  # an unusual signature is doing something on purpose
+
+    body = [
+        statement
+        for statement in init.body
+        if not (
+            isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Constant)
+            and isinstance(statement.value.value, str)
+        )
+    ]
+    if len(body) != 1:
+        return None  # real work beyond the super() call
+    statement = body[0]
+    if not (
+        isinstance(statement, ast.Expr)
+        and isinstance(statement.value, ast.Call)
+        and isinstance(statement.value.func, ast.Attribute)
+        and statement.value.func.attr == "__init__"
+        and isinstance(statement.value.func.value, ast.Call)
+    ):
+        return None
+    call = statement.value
+    if call.args:
+        return None  # positional forwarding is not the shape this gate matches
+
+    named = [a.arg for a in args.args if a.arg != "self"]
+    passed = {
+        kw.arg: ast.unparse(kw.value) for kw in call.keywords if kw.arg is not None
+    }
+    starred = [kw for kw in call.keywords if kw.arg is None]
+
+    if args.kwarg and starred and not named:
+        if ast.unparse(starred[0].value) == args.kwarg:
+            return "it forwards **kwargs to super() unchanged"
+        return None
+    if starred or set(passed) != set(named) or not all(passed[k] == k for k in named):
+        return None  # renames or coerces something on the way through
+
+    fields: set[str] = set()
+    declared_defaults: dict[str, object] = {}
+    for param in getattr(cls, "PARAMS", ()) or ():
+        fields.update(param.fields.keys())
+        declared_defaults.update(param.defaults)
+    if set(named) != fields:
+        return None  # signature and PARAMS disagree; not a safe deletion
+
+    # A default the PARAMS does not declare is load-bearing: ConfigParam.defaults
+    # is independent of `required`, so without it an omitted optional field is
+    # absent from self.params rather than present as None.
+    signature_defaults = dict(
+        zip(named[len(named) - len(args.defaults) :], args.defaults, strict=True)
+    )
+    for field_name, default_node in signature_defaults.items():
+        if field_name not in declared_defaults:
+            return None
+        if repr(declared_defaults[field_name]) != ast.unparse(default_node):
+            return None
+
+    return "it forwards every argument to super() under the same name"
+
+
+@pytest.mark.skipif(
+    len(_NEW_STYLE_SOURCES) == 0,
+    reason="No new-style sources discoverable (likely missing dependencies)",
+)
+@pytest.mark.parametrize(
+    "stem,cls", _NEW_STYLE_SOURCES, ids=[s[0] for s in _NEW_STYLE_SOURCES]
+)
+def test_pipeline_sources_dont_redeclare_init(stem: str, cls: type) -> None:
+    """A pipeline source must not restate what BaseSource.__init__ already does."""
+    reason = _redundant_init_reason(stem, cls)
+    assert reason is None, (
+        f"{stem} declares an __init__ that can be deleted outright, because "
+        f"{reason}. BaseSource.__init__ already applies the PARAMS defaults, "
+        "validates, and stores the values on self.params, so delete the override "
+        "and let it be inherited. Keep an __init__ only when it does real work; "
+        "put argument coercion on the ConfigParam and declare defaults in PARAMS "
+        "rather than in the signature."
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Step-override ratchet
 #
 # Overriding retrieve/parse/preprocess/transform on a source puts provider


### PR DESCRIPTION
A pipeline source that declares `PARAMS` does not need an `__init__`. `BaseSource.__init__` already accepts those fields as keyword arguments, applies their declared defaults, validates them, and stores the result on `self.params`. 97 sources restated that by hand and then forwarded each argument to `super()` under its own name, so this deletes them: 347 lines, no insertions, and no change to `BaseSource`.

Nothing needed adapting, because the three places that introspect the constructor were already written for this case. `test_source_has_necessary_parameters` asks `_uses_base_source_init()` and takes the names from `PARAMS`; `test_params_fields_match_init` returns early on a `**kwargs` signature; and `update_docu_links` falls back to `PARAMS` when introspection yields `["kwargs"]`, so the generated listings and translations are unaffected.

Only overrides that contribute nothing are removed. Three groups are left alone: 56 coerce their arguments (`str(uprn)`, `address.strip()`), 45 supply a default `PARAMS` does not declare, and 28 do real work. The middle group matters more than it looks. `ConfigParam.defaults` is independent of `required`, so an omitted `optional=True` field with no declared default is *absent* from `self.params` rather than present as `None`. Deleting those would change what the pipeline sees, so they need their defaults declared first, which is a behavioural change and a separate PR.

Equivalence was checked per source rather than assumed. For every `TEST_CASE` of every touched source, the `params` dict now built matches `apply_defaults` + `validate` over the same kwargs; omitted defaulted fields still resolve to their `PARAMS` default; and a missing required field still raises `SourceArgumentRequired`.

These overrides existed because the documentation asked for them. Six places described `__init__` as the normal home for source-specific work, and `doc/contributing_source.md`'s anti-pattern table went further and said to keep the signature while moving the body out. The second commit corrects all six and adds a gate so the correction does not have to hold on its own.

`test_pipeline_sources_dont_redeclare_init` joins the reuse and cassette gates over every discovered pipeline source. It is deliberately narrow and fires only when the override provably does nothing, which keeps it at zero exceptions today, unlike the two it sits beside. Checked both ways: it passes on all 245 pipeline sources, and reintroducing the override in `abfall_havelland_de` fails with the reason and the fix.

The docs now say a pipeline source has no `__init__`, and shape the request on the retriever instead, since `self._params` was the main thing pulling people into writing one. The minimal example and `doc/new_source_template.py` both lose their `__init__` and gain an `HttpGetRetriever(params=lambda ...)`, so the skeleton people copy no longer models what the gate rejects. Two rules that were written down nowhere now are: the `defaults`-versus-`required` distinction above, and coercion belonging on the `ConfigParam`.

Measured with `tools/loc_report.py --migrated master`, the migrated sources move from -4,497 to -4,737 code lines, mean 91.6 to 90.7 per source, and 161 now shrink against 90 that grew.

Full suite passes, 4,195 tests, up 245 from the new gate. `pre-commit` clean across ruff, ruff format, codespell, bandit, mypy and pyright.

Refs #7113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKQNey3jsRaVpHrnFjahR2
