### PR TITLE
refactor(v3): import the waste_types module rather than each type by name

### DIFF
--- a/.claude/agents/source-implementer.md
+++ b/.claude/agents/source-implementer.md
@@ -58,11 +58,11 @@ A flat JSON API, typed by a label-to-waste-type map:
 
 ```python
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 
 class Source(BaseSource):
@@ -95,7 +95,7 @@ class Source(BaseSource):
     transform = JsonTransformer(
         date_key="date",
         type_key="binType",
-        type_value_map={"refuse": GENERAL_WASTE, "recycling": RECYCLABLES},
+        type_value_map={"refuse": wt.GENERAL_WASTE, "recycling": wt.RECYCLABLES},
     )
 ```
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/1coast_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/1coast_com_au.py
@@ -25,6 +25,7 @@ candidate match.
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import (
@@ -44,14 +45,6 @@ from waste_collection_schedule.retrievers import (
     reuse_prepared,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SEARCH_URL = "https://1coast.com.au/ajax.php"
 _COLLECTION_URL = (
@@ -164,13 +157,13 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Trash": GENERAL_WASTE,
-            "Glass": GLASS,
-            "Bio": ORGANIC,
-            "Paper": PAPER,
-            "Recycle": RECYCLABLES,
-            "240L Yellow Lid Recycle Bin": RECYCLABLES,
-            "140L Red Lid General Waste Bin": GENERAL_WASTE,
-            "240L Green Lid Garden Vegetation Bin": GARDEN_WASTE,
+            "Trash": wt.GENERAL_WASTE,
+            "Glass": wt.GLASS,
+            "Bio": wt.ORGANIC,
+            "Paper": wt.PAPER,
+            "Recycle": wt.RECYCLABLES,
+            "240L Yellow Lid Recycle Bin": wt.RECYCLABLES,
+            "140L Red Lid General Waste Bin": wt.GENERAL_WASTE,
+            "240L Green Lid Garden Vegetation Bin": wt.GARDEN_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ab_peine_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ab_peine_de.py
@@ -11,16 +11,11 @@ and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.ab-peine.de"
 
@@ -33,7 +28,12 @@ class Source(BaseSource):
     )
     URL = "https://ab-peine.de"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Gerhart-Hauptmann-Straße (Peine-Kernstadt)": {
@@ -56,6 +56,6 @@ class Source(BaseSource):
     # since the shared aliases only cover "gelber sack" (singular).
     transform = ICSTransformer(
         type_value_map={
-            "Gelbe Säcke": RECYCLABLES,
+            "Gelbe Säcke": wt.RECYCLABLES,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aberdeencity_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aberdeencity_gov_uk.py
@@ -3,6 +3,7 @@ import re
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.exceptions import SourceArgumentException
@@ -13,13 +14,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # The Firmstep "AchieveForms" platform exposes the bin lookup as a two-step
 # apibroker/runLookup flow. Each step is keyed by a hardcoded lookup id that
@@ -123,11 +117,11 @@ class Source(BaseSource):
     transform = RowTransformer(
         parse_date=date_parsers.for_format("%A %d %B %Y"),
         type_value_map={
-            "general": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
-            "mixed recycling": RECYCLABLES,
-            "garden": GARDEN_WASTE,
-            "food": FOOD_WASTE,
-            "food and garden": ORGANIC,
+            "general": wt.GENERAL_WASTE,
+            "recycling": wt.RECYCLABLES,
+            "mixed recycling": wt.RECYCLABLES,
+            "garden": wt.GARDEN_WASTE,
+            "food": wt.FOOD_WASTE,
+            "food and garden": wt.ORGANIC,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aberdeenshire_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aberdeenshire_gov_uk.py
@@ -2,10 +2,10 @@ from typing import ClassVar, final
 
 from bs4 import Tag
 from waste_collection_schedule import date_parsers, parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.transformers import HtmlTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, OTHER, RECYCLABLES
 
 # Demonstrates: HtmlTransformer + parsers.HtmlParser(selector) + legacy SSL GET.
 # No custom methods needed — retrieve and parse are declarative class attributes.
@@ -55,14 +55,14 @@ class Source(BaseSource):
     parse = parsers.HtmlParser("tr", skip=1, require=["tr td"])
 
     # Explicit WASTE_TYPES: OTHER covers any bin types not in the map below.
-    WASTE_TYPES: ClassVar[list] = [RECYCLABLES, GENERAL_WASTE, OTHER]
+    WASTE_TYPES: ClassVar[list] = [wt.RECYCLABLES, wt.GENERAL_WASTE, wt.OTHER]
 
     transform = HtmlTransformer(
         date_getter=lambda el: _cell_text(el, "td:nth-child(1)").split(" ")[0],
         type_getter=lambda el: _cell_text(el, "td:nth-child(2)"),
         parse_date=date_parsers.for_format("%d/%m/%Y"),
         type_value_map={
-            "Mixed recycling and food waste": RECYCLABLES,
-            "Refuse and food waste": GENERAL_WASTE,
+            "Mixed recycling and food waste": wt.RECYCLABLES,
+            "Refuse and food waste": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_havelland_de.py
@@ -11,16 +11,11 @@ the waste-type map.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.abfall-havelland.de/ics.php"
 
@@ -55,9 +50,9 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=label_cleaner(strip_suffixes=[" - Abholtermin"]),
         type_value_map={
-            "mülltonne": GENERAL_WASTE,
-            "bio-tonne": ORGANIC,
-            "papier u. pappe": PAPER,
-            "gelbe tonne": RECYCLABLES,
+            "mülltonne": wt.GENERAL_WASTE,
+            "bio-tonne": wt.ORGANIC,
+            "papier u. pappe": wt.PAPER,
+            "gelbe tonne": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import field_terms
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     api_key,
@@ -14,13 +15,6 @@ from waste_collection_schedule.service.AbfallIO import (
     list_choices,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Demonstrates: a fully declarative source over a stateful platform wizard. The
 # AbfallPlus / abfall.io acquisition (POST "init" for a token, walk the kommune
@@ -263,11 +257,11 @@ class Source(BaseSource):
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_io_graphql.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import api_key, text_field, waste_types
 from waste_collection_schedule.regions import Region, region
@@ -8,13 +9,6 @@ from waste_collection_schedule.service.AbfallIOGraphQL import (
     AbfallIoGraphQLRetriever,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Declarative source on the abfall.io v3 GraphQL components (AbfallIoGraphQL-
 # Retriever + AbfallIoGraphQLParser). The transformer turns each appointment into a
@@ -86,11 +80,11 @@ class Source(BaseSource):
     # Canonical types observed across the registered providers; the transformer
     # resolves each provider's German labels through the shared vocabulary.
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_lro_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_lro_de.py
@@ -22,17 +22,12 @@ from urllib.parse import urlencode
 from bs4 import BeautifulSoup, Tag
 from bs4.element import NavigableString
 from waste_collection_schedule import retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import municipality, street, text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 API_URL = "https://www.abfall-lro.de/de/abfuhrtermine/"
 GUESTROW_URL = "https://www.abfall-lro.de/de/abfuhrtermine/guestrow.php"
@@ -42,10 +37,10 @@ ICAL_URL = "https://www.abfall-lro.de/default-wGlobal/wGlobal/abfuhrtermine/ical
 # (2W)"); the legacy source classified by the first word only
 # (``d[1].split()[0]``), which is the bin colour, not the waste stream name.
 _TYPE_VALUE_MAP = {
-    "Schwarze": GENERAL_WASTE,
-    "Grüne": ORGANIC,
-    "Blaue": PAPER,
-    "Gelbe": RECYCLABLES,
+    "Schwarze": wt.GENERAL_WASTE,
+    "Grüne": wt.ORGANIC,
+    "Blaue": wt.PAPER,
+    "Gelbe": wt.RECYCLABLES,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
@@ -11,18 +11,11 @@ manual request params and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.neunkirchen-siegerland.de"
 
@@ -73,13 +66,13 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Biotonne": ORGANIC,
-            "Papiertonne / Papiercontainer": PAPER,
-            "Restmülltonne": GENERAL_WASTE,
-            "Spartonne Restmüll": GENERAL_WASTE,
-            "Container Restmüll": GENERAL_WASTE,
-            "Gelbe Tonne": RECYCLABLES,
-            "Astschnittsammlung": GARDEN_WASTE,
-            "Schadstoffsammlung": HAZARDOUS,
+            "Biotonne": wt.ORGANIC,
+            "Papiertonne / Papiercontainer": wt.PAPER,
+            "Restmülltonne": wt.GENERAL_WASTE,
+            "Spartonne Restmüll": wt.GENERAL_WASTE,
+            "Container Restmüll": wt.GENERAL_WASTE,
+            "Gelbe Tonne": wt.RECYCLABLES,
+            "Astschnittsammlung": wt.GARDEN_WASTE,
+            "Schadstoffsammlung": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallkalender_prezero_network.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallkalender_prezero_network.py
@@ -16,19 +16,13 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.field_terms import CITY
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://abfallkalender.prezero.network"
 _REDIRECT_STATUSES = (301, 302, 303, 307, 308)
@@ -152,11 +146,11 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Biotonne": ORGANIC,
-            "Gelbe Tonne": RECYCLABLES,
-            "Restmülltonne": GENERAL_WASTE,
-            "Restmülltonne 4-wl.": GENERAL_WASTE,
-            "Papiertonne": PAPER,
-            "Schadstoffsammlung": HAZARDOUS,
+            "Biotonne": wt.ORGANIC,
+            "Gelbe Tonne": wt.RECYCLABLES,
+            "Restmülltonne": wt.GENERAL_WASTE,
+            "Restmülltonne 4-wl.": wt.GENERAL_WASTE,
+            "Papiertonne": wt.PAPER,
+            "Schadstoffsammlung": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallnavi_de.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     text_field,
@@ -10,14 +11,6 @@ from waste_collection_schedule.service.AbfallnaviDe import (
     AbfallnaviRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Waste-type names come back as open-ended German fraktion strings that vary by
 # municipality, so this source declares NO per-source type map: the shared
@@ -204,12 +197,12 @@ class Source(BaseSource):
     URL = "https://www.regioit.de"
     COUNTRY = "de"
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     # One structure (regioit.de AbfallNavi) covering many municipalities; the

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfalltermine_forchheim_de.py
@@ -2,6 +2,7 @@ import urllib.parse
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -9,12 +10,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Demonstrates: a plain ICS feed (parsers.IcsParser + ICSTransformer) whose
 # address sits in the URL *path*, not the query string. A configured
@@ -37,7 +32,12 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Landkreis Forchheim."
     URL = "https://www.abfalltermine-forchheim.de/"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Dormitz": {"city": "Dormitz", "area": "Dormitz"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_fuerth_eu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_fuerth_eu.py
@@ -13,16 +13,11 @@ rather than this one alone.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import location_id
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://abfallwirtschaft.fuerth.eu/termine.php"
 
@@ -53,9 +48,9 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall": GENERAL_WASTE,
-            "Biotonne": ORGANIC,
-            "Gelber Sack": RECYCLABLES,
-            "Altpapier": PAPER,
+            "Restabfall": wt.GENERAL_WASTE,
+            "Biotonne": wt.ORGANIC,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Altpapier": wt.PAPER,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_germersheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_germersheim_de.py
@@ -12,21 +12,13 @@ import re
 from typing import ClassVar, NamedTuple, final
 
 from bs4 import BeautifulSoup, Tag
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.abfallwirtschaft-germersheim.de/online-service/abfall-termine/abfalltermine-ics-export-bis-240-liter.html"
 
@@ -125,13 +117,13 @@ class Source(BaseSource):
     parse = IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Bioabfall": ORGANIC,
-            "Gelber Sack": RECYCLABLES,
-            "Glasbox": GLASS,
-            "Heckenschnitt": GARDEN_WASTE,
-            "Papier": PAPER,
-            "Problemmüll": HAZARDOUS,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Bioabfall": wt.ORGANIC,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Glasbox": wt.GLASS,
+            "Heckenschnitt": wt.GARDEN_WASTE,
+            "Papier": wt.PAPER,
+            "Problemmüll": wt.HAZARDOUS,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_pforzheim_de.py
@@ -18,16 +18,11 @@ Jahresübersicht.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://onlineservices.abfallwirtschaft-pforzheim.de/WasteManagementPforzheim/WasteManagementServlet"
 
@@ -102,10 +97,10 @@ class Source(BaseSource):
         # every variant still resolves to its canonical type.
         clean=lambda label: label.split()[0] if label.split() else label,
         type_value_map={
-            "Restmuell": GENERAL_WASTE,
-            "Biobehaelter": ORGANIC,
-            "Papierbehaelter": PAPER,
-            "Gelbe": RECYCLABLES,
-            "Grossmuellbehaelter": GENERAL_WASTE,
+            "Restmuell": wt.GENERAL_WASTE,
+            "Biobehaelter": wt.ORGANIC,
+            "Papierbehaelter": wt.PAPER,
+            "Gelbe": wt.RECYCLABLES,
+            "Grossmuellbehaelter": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_vechta_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfallwirtschaft_vechta_de.py
@@ -18,18 +18,11 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsSessionRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.abfallwirtschaft-vechta.de"
 _STADT_SUCHE_URL = f"{_BASE_URL}/CALENDER/inc.suche_stadt.php"
@@ -144,16 +137,16 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall": GENERAL_WASTE,
-            "Glass": GLASS,
-            "Glas": GLASS,
-            "Bioabfall": ORGANIC,
-            "Altpapier": PAPER,
-            "Altpapier Siemer": PAPER,
-            "Altpapier Pamo": PAPER,
-            "Gelbe Tonne": RECYCLABLES,
-            "Altkleider": RECYCLABLES,
-            "Altkleider (Außer Langförden)": RECYCLABLES,
-            "Mobile Schadstoff.": HAZARDOUS,
+            "Restabfall": wt.GENERAL_WASTE,
+            "Glass": wt.GLASS,
+            "Glas": wt.GLASS,
+            "Bioabfall": wt.ORGANIC,
+            "Altpapier": wt.PAPER,
+            "Altpapier Siemer": wt.PAPER,
+            "Altpapier Pamo": wt.PAPER,
+            "Gelbe Tonne": wt.RECYCLABLES,
+            "Altkleider": wt.RECYCLABLES,
+            "Altkleider (Außer Langförden)": wt.RECYCLABLES,
+            "Mobile Schadstoff.": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfuhrplan_landkreis_neumarkt_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfuhrplan_landkreis_neumarkt_de.py
@@ -7,6 +7,7 @@ the ``/getical`` form POST -- is the shared ``AbfuhrplanRetriever``.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.parsers import IcsParser
@@ -15,12 +16,6 @@ from waste_collection_schedule.service.AbfuhrplanDe import (
     prepare_arg,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.abfuhrplan-landkreis-neumarkt.de"
 
@@ -47,10 +42,10 @@ class Source(BaseSource):
     parse = IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Papiertonne": PAPER,
-            "Gelber Sack": RECYCLABLES,
-            "Biotonne": ORGANIC,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Papiertonne": wt.PAPER,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Biotonne": wt.ORGANIC,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfuhrplan_schwabach_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfuhrplan_schwabach_de.py
@@ -9,6 +9,7 @@ deployment also strips commas out of a street name, which the platform's
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street
 from waste_collection_schedule.parsers import IcsParser
@@ -17,12 +18,6 @@ from waste_collection_schedule.service.AbfuhrplanDe import (
     prepare_arg,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Trailing slash is part of the provider's own URL structure; the getical
 # endpoint below is requested with a doubled slash to match, matching the
@@ -55,12 +50,12 @@ class Source(BaseSource):
     parse = IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Restmüllcontainer": GENERAL_WASTE,
-            "Papiertonne": PAPER,
-            "Gelber Sack": RECYCLABLES,
-            "Biotonne": ORGANIC,
-            "Biocontainer": ORGANIC,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Restmüllcontainer": wt.GENERAL_WASTE,
+            "Papiertonne": wt.PAPER,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Biotonne": wt.ORGANIC,
+            "Biocontainer": wt.ORGANIC,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abilene_tx_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abilene_tx_us.py
@@ -3,6 +3,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisMultiFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, GENERAL_WASTE
 
 # Abilene publishes trash and yard-waste collection as two separate ArcGIS
 # layers. A point-in-polygon query against each layer returns:
@@ -39,8 +39,8 @@ LAYERS = [
 ]
 
 _TYPE_MAP = {
-    "Trash": GENERAL_WASTE,
-    "Yard Waste": GARDEN_WASTE,
+    "Trash": wt.GENERAL_WASTE,
+    "Yard Waste": wt.GARDEN_WASTE,
 }
 
 # Number of weekly trash collections to project (matches the legacy WEEKS_AHEAD).

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abki_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abki_de.py
@@ -23,16 +23,11 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _STREETS_URL = "https://abki.de/abki-services/strassennamen"
 _NUMBERS_URL = "https://abki.de/abki-services/streetnumber"
@@ -115,7 +110,12 @@ class Source(BaseSource):
     URL = "https://abki.de/"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "auguste-viktoria-straße, 14": {
@@ -142,5 +142,5 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         clean=_strip_size,
-        type_value_map={"gelbe tonne / gelber sack": RECYCLABLES},
+        type_value_map={"gelbe tonne / gelber sack": wt.RECYCLABLES},
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aha_region_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aha_region_de.py
@@ -19,6 +19,7 @@ source's ``d[1].replace("Abfuhr", "").strip().replace(" *", "")``.
 from typing import ClassVar, final
 
 from bs4 import BeautifulSoup, Tag
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     house_number,
@@ -33,12 +34,6 @@ from waste_collection_schedule.exceptions import (
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.aha-region.de/abholtermine/abfuhrkalender"
 
@@ -153,7 +148,12 @@ class Source(BaseSource):
     URL = "https://www.aha-region.de/"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Neustadt a. Rbge., Am Rotdorn / Nöpke, 1 ": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/alba_com_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/alba_com_pl.py
@@ -1,31 +1,23 @@
 import datetime
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.service.Sepan import SepanReportParser, SepanRetriever
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Labels as rendered by this SEPAN/ICHI System deployment's report table. Not
 # in Polish shared-vocabulary aliases (Polish isn't a resolve() language), so
 # every label is mapped explicitly rather than relying on auto-resolution.
 TYPE_VALUE_MAP = {
-    "Zmieszane odpady komunalne": GENERAL_WASTE,
-    "Metale i tworzywa sztuczne": RECYCLABLES,
-    "Papier": PAPER,
-    "Szkło": GLASS,
-    "Bioodpady": ORGANIC,
-    "Bioodpady - Drzewka świąteczne": GARDEN_WASTE,
-    "Odpady wystawkowe": BULKY_WASTE,
+    "Zmieszane odpady komunalne": wt.GENERAL_WASTE,
+    "Metale i tworzywa sztuczne": wt.RECYCLABLES,
+    "Papier": wt.PAPER,
+    "Szkło": wt.GLASS,
+    "Bioodpady": wt.ORGANIC,
+    "Bioodpady - Drzewka świąteczne": wt.GARDEN_WASTE,
+    "Odpady wystawkowe": wt.BULKY_WASTE,
 }
 
 # The ALBA deployment's harmonogram path is year-suffixed; try the current

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/albany_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/albany_wa_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,7 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisMultiFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # Albany publishes its collection zones as four separate ArcGIS layers
 # (General/Recycling x Zone A/B). The point-in-polygon query against each layer
@@ -22,8 +22,8 @@ from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 # fortnightly dates without the source hand-rolling retrieve()/parse().
 
 _TYPE_MAP = {
-    "General Waste & FOGO": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
+    "General Waste & FOGO": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
 }
 
 # Each layer: the FeatureServer URL plus a (waste_type, anchor) label. The label

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/alexandria_va_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/alexandria_va_us.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,11 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     epoch_ms_to_date,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # City of Alexandria alx311Info MapServer, three independent zone layers:
 # layer 3 = Refuse Day Zone (DAYSERVED, weekly; every serviced address has
@@ -42,9 +38,9 @@ _FIELDS = {
 }
 
 _TYPE_MAP = {
-    "Trash": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "Leaf Collection": GARDEN_WASTE,
+    "Trash": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Leaf Collection": wt.GARDEN_WASTE,
 }
 
 # Number of weekly collections to project (matches the legacy WEEKS_AHEAD).

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aliaserviziambientali_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aliaserviziambientali_it.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import area_id, municipality
 from waste_collection_schedule.regions import region
@@ -9,12 +10,6 @@ from waste_collection_schedule.service.junker_app import (
     JunkerRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 TITLE = "Alia Servizi Ambientali S.p.A."
 DESCRIPTION = "Source for Alia Servizi Ambientali S.p.A.."
@@ -190,7 +185,12 @@ class Source(BaseSource):
     URL = URL
     COUNTRY = COUNTRY
     HOWTO = HOWTO
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES = TEST_CASES
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/allerdale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/allerdale_gov_uk.py
@@ -2,6 +2,7 @@ import logging
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.field_terms import POSTCODE
@@ -10,11 +11,6 @@ from waste_collection_schedule.service.WhitespaceWRP import (
     WhitespaceRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Declarative source on the shared Whitespace WRP components (WhitespaceRetriever
 # + WhitespaceParser). A RowTransformer maps the council's open-ended type labels
@@ -23,9 +19,9 @@ from waste_collection_schedule.waste_types import (
 _LOGGER = logging.getLogger(__name__)
 
 _TYPE_MAP = {
-    "Domestic Waste": GENERAL_WASTE,
-    "Glass Cans and Plastic Recycling": RECYCLABLES,
-    "Garden Waste": GARDEN_WASTE,
+    "Domestic Waste": wt.GENERAL_WASTE,
+    "Glass Cans and Plastic Recycling": wt.RECYCLABLES,
+    "Garden Waste": wt.GARDEN_WASTE,
 }
 
 
@@ -38,7 +34,7 @@ class Source(BaseSource):
     URL = "https://www.allerdale.gov.uk"
     COUNTRY = "uk"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, GARDEN_WASTE]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.RECYCLABLES, wt.GARDEN_WASTE]
     API_URL = "https://abc-wrp.whitespacews.com/"
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/amarsul_pt.py
@@ -16,6 +16,7 @@ hardcoded.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.service.PdfImageCalendar import (
@@ -24,7 +25,6 @@ from waste_collection_schedule.service.PdfImageCalendar import (
     PdfImageRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import PAPER, RECYCLABLES
 
 # Cell labels (mapped to canonical waste types by the transformer below).
 PAPER_LABEL = "Papel/Cartao"
@@ -91,7 +91,7 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            PAPER_LABEL: PAPER,
-            PACKAGING_LABEL: RECYCLABLES,
+            PAPER_LABEL: wt.PAPER,
+            PACKAGING_LABEL: wt.RECYCLABLES,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/angern_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/angern_gv_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, GENERAL_WASTE, PAPER
 
 _BASE_URL = "https://www.angern.at"
 
@@ -40,13 +40,13 @@ class Source(BaseSource):
     # explicit entries because the suffix breaks the exact-match resolution.
     transform = ICSTransformer(
         type_value_map={
-            "Grünschnitt Ollersdorf": GARDEN_WASTE,
-            "Grünschnitt Angern, Mannersdorf": GARDEN_WASTE,
-            "Restmülltonne Angern": GENERAL_WASTE,
-            "Restmülltonne Mannersdorf, Stillfried": GENERAL_WASTE,
-            "Restmülltonne Grub, Ollersdorf": GENERAL_WASTE,
-            "Altpapiertonne Angern": PAPER,
-            "Altpapiertonne Mannersdorf, Stillfried": PAPER,
-            "Altpapiertonne Grub, Ollersdorf": PAPER,
+            "Grünschnitt Ollersdorf": wt.GARDEN_WASTE,
+            "Grünschnitt Angern, Mannersdorf": wt.GARDEN_WASTE,
+            "Restmülltonne Angern": wt.GENERAL_WASTE,
+            "Restmülltonne Mannersdorf, Stillfried": wt.GENERAL_WASTE,
+            "Restmülltonne Grub, Ollersdorf": wt.GENERAL_WASTE,
+            "Altpapiertonne Angern": wt.PAPER,
+            "Altpapiertonne Mannersdorf, Stillfried": wt.PAPER,
+            "Altpapiertonne Grub, Ollersdorf": wt.PAPER,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/api_hubert_schmid_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/api_hubert_schmid_de.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -8,7 +9,6 @@ from waste_collection_schedule.config_params import (
     street,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
 
 # Demonstrates: http_post retriever + DateListParser for a single-stream feed.
 # Notable: the API returns a flat date array with no bin type field, so
@@ -47,7 +47,7 @@ class Source(BaseSource):
 
     retrieve = retrievers.http_post
     parse = parsers.DateListParser("cal", label=BLAUE_TONNE, drop_values=(SENTINEL,))
-    transform = RowTransformer(type_value_map={BLAUE_TONNE: RECYCLABLES})
+    transform = RowTransformer(type_value_map={BLAUE_TONNE: wt.RECYCLABLES})
 
     def __init__(
         self,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_abfallplus_de.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import field_terms
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import cascading_select, text_field
 from waste_collection_schedule.regions import Region, region
@@ -11,14 +12,6 @@ from waste_collection_schedule.service.AppAbfallplusDe import (
     discover_choices,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Declarative source over the "Apps by Abfall+" platform. The whole live wizard
 # (token, Bundesland -> Landkreis -> Kommune -> Bezirk -> Straße -> Hausnummer
@@ -48,12 +41,12 @@ class Source(BaseSource):
     # The platform's provider labels are open-ended; these are the canonical
     # types the shared vocabulary resolves. Anything else is preserved verbatim.
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
-        GARDEN_WASTE,
-        HAZARDOUS,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.HAZARDOUS,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_my_local_services_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/app_my_local_services_au.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timedelta
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import coords
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -12,12 +13,6 @@ from waste_collection_schedule.service.ArcGis import (
     coords_point,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # My Local Services (used by ~45 South Australian councils) takes a lat/lon
 # straight from the map picker: there is no address to geocode, so the shared
@@ -80,10 +75,10 @@ def _describe(record: tuple, source):
 
 
 _TYPE_MAP = {
-    "General Waste": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "Green Waste": GARDEN_WASTE,
-    "FOGO (Organics)": ORGANIC,
+    "General Waste": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Green Waste": wt.GARDEN_WASTE,
+    "FOGO (Organics)": wt.ORGANIC,
 }
 
 # List from https://www.localcouncils.sa.gov.au/my-local-services-app#accordion__target-1426969-2

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/art_trier_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/art_trier_de.py
@@ -13,11 +13,11 @@ from typing import ClassVar, final
 from urllib.parse import quote
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, postcode
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER, RECYCLABLES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,9 +79,9 @@ class Source(BaseSource):
     )
     transform = ICSTransformer(
         type_value_map={
-            "Altpapier": PAPER,
-            "Restmüll": GENERAL_WASTE,
-            "Gelber Sack": RECYCLABLES,
+            "Altpapier": wt.PAPER,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Gelber Sack": wt.RECYCLABLES,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/arun_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/arun_gov_uk.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -12,12 +13,6 @@ from waste_collection_schedule.service.uk_cloud9_apps import (
     Cloud9Retriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 
 @final
@@ -60,9 +55,9 @@ class Source(BaseSource):
     parse = Cloud9Parser()
     transform = RowTransformer(
         type_value_map={
-            "General Waste Bins": GENERAL_WASTE,
-            "Recycling Bins": RECYCLABLES,
-            "Food Waste Bins": FOOD_WASTE,
-            "Garden Waste Bins": GARDEN_WASTE,
+            "General Waste Bins": wt.GENERAL_WASTE,
+            "Recycling Bins": wt.RECYCLABLES,
+            "Food Waste Bins": wt.FOOD_WASTE,
+            "Garden Waste Bins": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/asr_chemnitz_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/asr_chemnitz_de.py
@@ -16,6 +16,7 @@ TEST_CASES) is mapped for parity with the legacy ``ICON_MAP``.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.parsers import IcsParser
@@ -25,13 +26,6 @@ from waste_collection_schedule.service.HausmuellInfo import (
     Lookup,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://asc.hausmuell.info/"
 
@@ -84,7 +78,12 @@ class Source(BaseSource):
     URL = "https://www.asr-chemnitz.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Hübschmannstr. 4": {"street": "Hübschmannstr.", "house_number": "4"},
@@ -132,9 +131,9 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean_label,
         type_value_map={
-            "pappe, papier & kart.": PAPER,
-            "leichtstoffverpackungen": RECYCLABLES,
-            "weihnachtsbaum": GARDEN_WASTE,
+            "pappe, papier & kart.": wt.PAPER,
+            "leichtstoffverpackungen": wt.RECYCLABLES,
+            "weihnachtsbaum": wt.GARDEN_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/aw_harburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/aw_harburg_de.py
@@ -20,19 +20,13 @@ from typing import ClassVar, final
 
 from bs4 import BeautifulSoup, Tag
 from waste_collection_schedule import field_terms
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import cascading_select
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import EachResponse, IcsParser
 from waste_collection_schedule.retrievers import FanOutRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _LEVEL_URL = (
     "https://www.landkreis-harburg.de/bauen-umwelt/abfallwirtschaft/abfallkalender/"
@@ -146,11 +140,11 @@ class Source(BaseSource):
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -172,9 +166,9 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "altpapier": PAPER,
-            "hausmüll 14-täglich": GENERAL_WASTE,
-            "hausmüll 4-wöchentlich": GENERAL_WASTE,
+            "altpapier": wt.PAPER,
+            "hausmüll 14-täglich": wt.GENERAL_WASTE,
+            "hausmüll 4-wöchentlich": wt.GENERAL_WASTE,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_emsland_de.py
@@ -18,6 +18,7 @@ carries (the same fallback the legacy source used when it found no
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -27,12 +28,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://portal.awb-emsland.de/WasteManagementEmsland/WasteManagementServlet"
 
@@ -104,9 +99,9 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restabfallbehaelter": GENERAL_WASTE,
-            "Papierbehaelter": PAPER,
-            "Wertstoffbehaelter": RECYCLABLES,
-            "Bioabfallbehaelter": ORGANIC,
+            "Restabfallbehaelter": wt.GENERAL_WASTE,
+            "Papierbehaelter": wt.PAPER,
+            "Wertstoffbehaelter": wt.RECYCLABLES,
+            "Bioabfallbehaelter": wt.ORGANIC,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_es_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_es_de.py
@@ -33,17 +33,12 @@ from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, dropdown, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.preprocessors import RowFilter
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SEARCH_URL = "https://www.awb-es.de/statics/abfallplus/search.json.php"
 _CALENDAR_URL = "https://www.awb-es.de/abfuhr/abfuhrtermine/__Abfuhrtermine.html"
@@ -164,10 +159,10 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "biotonne": ORGANIC,
-            "gelbe/r sack/tonne": RECYCLABLES,
-            "papiersammlung (vereine)": PAPER,
-            "restmüll 2-wöchentlich": GENERAL_WASTE,
-            "restmüll 4-wöchentlich": GENERAL_WASTE,
+            "biotonne": wt.ORGANIC,
+            "gelbe/r sack/tonne": wt.RECYCLABLES,
+            "papiersammlung (vereine)": wt.PAPER,
+            "restmüll 2-wöchentlich": wt.GENERAL_WASTE,
+            "restmüll 4-wöchentlich": wt.GENERAL_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_oldenburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awb_oldenburg_de.py
@@ -20,18 +20,13 @@ from datetime import date
 from typing import ClassVar, NamedTuple, final
 
 from bs4 import BeautifulSoup, Tag
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.oldenburg.de"
 _API_URL = (
@@ -112,7 +107,12 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Polizeiinspektion Oldenburg": {"street": "Friedhofsweg", "house_number": 30}
@@ -131,8 +131,8 @@ class Source(BaseSource):
     parse = IcsParser(regex=r"(.*)\:\s*\!")
     transform = ICSTransformer(
         type_value_map={
-            "altpapier": PAPER,
-            "gelber sack/tonne": RECYCLABLES,
-            "sommerbiotonne": ORGANIC,
+            "altpapier": wt.PAPER,
+            "gelber sack/tonne": wt.RECYCLABLES,
+            "sommerbiotonne": wt.ORGANIC,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awbkoeln_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awbkoeln_de.py
@@ -2,19 +2,19 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.parsers import JsonParser
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER, RECYCLABLES
 
 # The API labels each record with a bin colour-code ("grey", "blue") or
 # "wertstoff" rather than a German bin name, which the shared vocabulary does not
 # resolve, so map the codes explicitly.
 _TYPE_VALUE_MAP = {
-    "grey": GENERAL_WASTE,
-    "blue": PAPER,
-    "wertstoff": RECYCLABLES,
+    "grey": wt.GENERAL_WASTE,
+    "blue": wt.PAPER,
+    "wertstoff": wt.RECYCLABLES,
 }
 
 # Standalone JSON-API source. The calendar endpoint takes the street_code +
@@ -44,7 +44,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Abfallwirtschaftsbetriebe Köln waste collection."
     URL = "https://www.awbkoeln.de"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.PAPER, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {"Koeln": {"street_code": 2, "building_number": 50}}
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_de.py
@@ -28,6 +28,7 @@ the live servlet and all three recorded cassettes:
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -37,7 +38,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 _API_URL = (
     "https://wastemanagement.awg.de/WasteManagementDonauwald/WasteManagementServlet"
@@ -59,7 +59,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for ZAW Donau-Wald."
     URL = "https://www.awg.de/"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.PAPER]
 
     TEST_CASES: ClassVar[dict] = {
         "Achslach Aign 1 ": {"city": "Achslach", "street": "Aign", "hnr": "1"},
@@ -104,9 +104,9 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restmuelltonne": GENERAL_WASTE,
-            "Restmüllcontainer": GENERAL_WASTE,
-            "Papiercontainer": PAPER,
+            "Restmuelltonne": wt.GENERAL_WASTE,
+            "Restmüllcontainer": wt.GENERAL_WASTE,
+            "Papiercontainer": wt.PAPER,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_wuppertal_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awg_wuppertal_de.py
@@ -16,17 +16,11 @@ transformer's ``clean`` the second.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street
 from waste_collection_schedule.service.BwWasteCalendar import WasteCalendarRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://awg-wuppertal.de"
 _API_URL = f"{_BASE_URL}/privatkunden/abfallkalender.html"
@@ -57,10 +51,10 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_leading_type,
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Gelb": RECYCLABLES,
-            "Bio": ORGANIC,
-            "Papier": PAPER,
-            "Sperrmüll": BULKY_WASTE,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Gelb": wt.RECYCLABLES,
+            "Bio": wt.ORGANIC,
+            "Papier": wt.PAPER,
+            "Sperrmüll": wt.BULKY_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awigo_de.py
@@ -17,6 +17,7 @@ import re
 from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, municipality, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -24,13 +25,6 @@ from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.preprocessors import RowRelabel
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.awigo.de/index.php"
 _WASTE_TYPE_KEYS = ("rest", "paper", "yellow", "brown", "mobile")
@@ -175,10 +169,10 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Restmülltonne": GENERAL_WASTE,
-            "Glass": GLASS,
-            "Bio-Tonne": ORGANIC,
-            "Papiermülltonne": PAPER,
-            "Gelbe Tonne/Gelben Sack": RECYCLABLES,
+            "Restmülltonne": wt.GENERAL_WASTE,
+            "Glass": wt.GLASS,
+            "Bio-Tonne": wt.ORGANIC,
+            "Papiermülltonne": wt.PAPER,
+            "Gelbe Tonne/Gelben Sack": wt.RECYCLABLES,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awista_kommunal_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awista_kommunal_de.py
@@ -12,6 +12,7 @@ and where the calendar lives.
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -21,12 +22,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 DOMAIN = "https://www.awista-kommunal.de"
 BASE_URL = f"{DOMAIN}/abfallkalender"
@@ -101,9 +96,9 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean_label,
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Bioabfall": ORGANIC,
-            "Papier": PAPER,
-            "Wertstofftonne": RECYCLABLES,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Bioabfall": wt.ORGANIC,
+            "Papier": wt.PAPER,
+            "Wertstofftonne": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awm_muenchen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awm_muenchen_de.py
@@ -15,6 +15,7 @@ so this source is a declarative composition of it with ``EachResponse``.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.service.AwmMuenchen import (
@@ -22,12 +23,6 @@ from waste_collection_schedule.service.AwmMuenchen import (
     CollectionCalendarRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 
 def _clean_label(label: str) -> str:
@@ -114,10 +109,10 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean_label,
         type_value_map={
-            "Restmülltonne": GENERAL_WASTE,
-            "Biotonne": ORGANIC,
-            "Papiertonne": PAPER,
-            "Wertstofftonne": RECYCLABLES,
+            "Restmülltonne": wt.GENERAL_WASTE,
+            "Biotonne": wt.ORGANIC,
+            "Papiertonne": wt.PAPER,
+            "Wertstofftonne": wt.RECYCLABLES,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awr_de.py
@@ -7,6 +7,7 @@ address and downloads the calendar.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.parsers import IcsParser
@@ -15,12 +16,6 @@ from waste_collection_schedule.service.AwrCollectionDates import (
     clean_waste_type,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 BASE_URL = "https://www.awr.de"
 
@@ -34,10 +29,10 @@ class Source(BaseSource):
     # Canonical types observed in the calendar feed; the cleaned German labels
     # resolve through the shared multilingual vocabulary.
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awsh_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awsh_de.py
@@ -7,6 +7,7 @@ address and downloads the calendar.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.parsers import IcsParser
@@ -15,7 +16,6 @@ from waste_collection_schedule.service.AwrCollectionDates import (
     clean_waste_type,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 BASE_URL = "https://www.awsh.de"
 
@@ -28,7 +28,7 @@ class Source(BaseSource):
     COUNTRY = "de"
     # Canonical types observed in the calendar feed; the cleaned German labels
     # resolve through the shared multilingual vocabulary.
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.PAPER]
 
     TEST_CASES: ClassVar[dict] = {
         "Reinbek": {"city": "Reinbek", "street": "Ahornweg"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/awv_ot_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/awv_ot_de.py
@@ -20,22 +20,17 @@ from typing import ClassVar, final
 from urllib.parse import urlencode
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsSessionRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.awv-ot.de/tourenauskunft/auskunftbatix.php"
 _ICS_URL = "https://www.awv-ot.de/tourenauskunft/ics/ics.php"
 
 _TYPE_VALUE_MAP = {
-    "hausmuelltonne": GENERAL_WASTE,
+    "hausmuelltonne": wt.GENERAL_WASTE,
 }
 
 # Every summary reads "Leerung <bin>"; the group is the bin, trimmed.
@@ -73,7 +68,12 @@ class Source(BaseSource):
     # ("Biotonne", "Papiertonne", "Gelbe Tonne") resolve through the shared
     # vocabulary, so the auto-derived set would miss them. Declare the full
     # emittable vocabulary explicitly.
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Bethenhausen Caasen 15A": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/badaussee_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/badaussee_at.py
@@ -1,6 +1,7 @@
 import re
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -8,12 +9,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalMultiIcsRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Demonstrates: a RiSKommunal municipality with one fixed calendar (Gelber
 # Sack) plus three independently zoned calendars (Restmüll/Biomüll/Altpapier),
@@ -70,7 +65,12 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Bad Aussee, Austria."
     URL = _BASE_URL
     COUNTRY = "at"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Zone 1": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bassendean_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bassendean_wa_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,11 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # ArcGis single spatial query -> one feature carrying a ServiceDay, from which
 # three recurring schedules are projected: FOGO weekly, and General Waste and
@@ -25,9 +21,9 @@ from waste_collection_schedule.waste_types import (
 FEATURE_URL = "https://services-ap1.arcgis.com/551UnqKK1GZeDKxQ/arcgis/rest/services/address_lookup_for_bin_days_dissolved/FeatureServer/0"
 
 _TYPE_MAP = {
-    "FOGO": ORGANIC,
-    "General Waste": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
+    "FOGO": wt.ORGANIC,
+    "General Waste": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
 }
 
 # Base dates for fortnightly schedules, extracted from the ArcGIS Arcade

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bathurst_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bathurst_nsw_gov_au.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     street_address,
@@ -14,7 +15,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Address + suburb lookup (IntraMapsRetriever's optional suburb disambiguates
 # multiple search matches). Two columns are weekly (a bare weekday name);
@@ -31,9 +31,9 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 
 # IntraMaps column name -> canonical waste type.
 _TYPE_MAP = {
-    "Garbage": GENERAL_WASTE,
-    "Organic": ORGANIC,
-    "Recycling": RECYCLABLES,
+    "Garbage": wt.GENERAL_WASTE,
+    "Organic": wt.ORGANIC,
+    "Recycling": wt.RECYCLABLES,
 }
 
 # Columns whose value is a bare weekday name (weekly); every other mapped

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/baton_rouge_la_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/baton_rouge_la_us.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -9,7 +10,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisMultiFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # Baton Rouge publishes three ArcGIS feature layers (garbage, trash, recycling).
 # A spatial point query against each layer returns one feature whose day-of-week
@@ -35,9 +35,9 @@ _LAYERS = [
 ]
 
 _TYPE_MAP = {
-    "Garbage": GENERAL_WASTE,
-    "Trash": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
+    "Garbage": wt.GENERAL_WASTE,
+    "Trash": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
 }
 
 DAY_FIELDS = [

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/baumkirchen_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/baumkirchen_gv_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
 
 _BASE_URL = "https://www.baumkirchen.gv.at"
 
@@ -42,6 +42,6 @@ class Source(BaseSource):
     # type (matching the legacy Icons.PLASTIC_PACKAGING classification).
     transform = ICSTransformer(
         type_value_map={
-            "Plastikmüll": RECYCLABLES,
+            "Plastikmüll": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayside_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayside_vic_gov_au.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Three collection columns share one value shape family: either
 # "Fortnightly/Weekly on Thursday, Next: 23 Jul 2026" (an explicit next
@@ -35,9 +35,9 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 # "Street Sweeping" are also present in the response but are not collection
 # fields, so they are left out of this map (and therefore ignored).
 _TYPE_MAP = {
-    "Recycling": RECYCLABLES,
-    "Domestic Waste": GENERAL_WASTE,
-    "Garden Waste": ORGANIC,  # displayed to residents as "Food & Green Waste"
+    "Recycling": wt.RECYCLABLES,
+    "Domestic Waste": wt.GENERAL_WASTE,
+    "Garden Waste": wt.ORGANIC,  # displayed to residents as "Food & Green Waste"
 }
 
 _NEXT_DATE_RE = re.compile(r"Next:\s*(\d{1,2}\s+\w+\s+\d{4})")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayswater_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bayswater_wa_gov_au.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Two value-text cadences on one council: FOGO is a bare "Every Friday"
 # (weekly); General Waste and Recycling are "Friday - 24 July 2026"
@@ -30,9 +30,9 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 # IntraMaps column name -> canonical waste type. One map: selects the
 # collection fields (others ignored) and types them.
 _TYPE_MAP = {
-    "FOGO_Green_Lid": ORGANIC,
-    "General_Waste_Red_Lid": GENERAL_WASTE,
-    "Recycling_Yellow_Lid": RECYCLABLES,
+    "FOGO_Green_Lid": wt.ORGANIC,
+    "General_Waste_Red_Lid": wt.GENERAL_WASTE,
+    "Recycling_Yellow_Lid": wt.RECYCLABLES,
 }
 
 # Values are free text such as "Friday - 24 July 2026"; pull out just the

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bendigo_vic_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import coords
 from waste_collection_schedule.exceptions import SourceArgumentException
@@ -11,11 +12,6 @@ from waste_collection_schedule.service.Pozi import (
     PoziGeoJsonRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Demonstrates: a Pozi GeoJSON zone lookup by direct lat/lon (no address
 # geocoding needed). The zone's properties carry a weekday plus a per-type
@@ -77,7 +73,7 @@ class Source(BaseSource):
     URL = "https://www.bendigo.vic.gov.au"
     COUNTRY = "au"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GARDEN_WASTE, GENERAL_WASTE, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.GARDEN_WASTE, wt.GENERAL_WASTE, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Bunnings Epsom": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berdorf_lu.py
@@ -17,6 +17,7 @@ can hide in the grid.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.retrievers import PdfLinkRetriever
 from waste_collection_schedule.service.PdfTextCalendar import (
@@ -26,7 +27,6 @@ from waste_collection_schedule.service.PdfTextCalendar import (
     LabelRule,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import HAZARDOUS, RECYCLABLES
 
 _DATA_URL = "https://www.berdorf.lu/service-citoyens/dechets"
 
@@ -75,7 +75,7 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "PMC": RECYCLABLES,
-            _SDK: HAZARDOUS,
+            "PMC": wt.RECYCLABLES,
+            _SDK: wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/berndorf_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/berndorf_gv_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 _BASE_URL = "https://www.berndorf.gv.at"
 
@@ -60,7 +60,7 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean,
         type_value_map={
-            "Gelbe Säcke": RECYCLABLES,
-            "Aschetonne": GENERAL_WASTE,
+            "Gelbe Säcke": wt.RECYCLABLES,
+            "Aschetonne": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bexley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bexley_gov_uk.py
@@ -12,18 +12,11 @@ waste-type map, and a small label cleaner: the raw summary is
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.retrievers import PollingIcsRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 
 def _clean_bin_label(label: str) -> str:
@@ -61,12 +54,12 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Green Wheelie": GENERAL_WASTE,
-            "Brown Caddy": FOOD_WASTE,
-            "Brown Wheelie": ORGANIC,
-            "Blue Lidded Wheelie": PAPER,
-            "White Lidded Wheelie": GLASS,
-            "Recycling Box": RECYCLABLES,
+            "Green Wheelie": wt.GENERAL_WASTE,
+            "Brown Caddy": wt.FOOD_WASTE,
+            "Brown Wheelie": wt.ORGANIC,
+            "Blue Lidded Wheelie": wt.PAPER,
+            "White Lidded Wheelie": wt.GLASS,
+            "Recycling Box": wt.RECYCLABLES,
         },
         clean=_clean_bin_label,
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bielefeld_de.py
@@ -20,16 +20,11 @@ need it.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://anwendungen.bielefeld.de/WasteManagementBielefeldTest/WasteManagementServlet"
 # Actual production URL; the servlet above returned 404 for it at conversion
@@ -96,10 +91,10 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restabfallbehaelter": GENERAL_WASTE,
-            "Bioabfallbehaelter": ORGANIC,
-            "Papierbehaelter": PAPER,
-            "Wertstofftonne": RECYCLABLES,
+            "Restabfallbehaelter": wt.GENERAL_WASTE,
+            "Bioabfallbehaelter": wt.ORGANIC,
+            "Papierbehaelter": wt.PAPER,
+            "Wertstofftonne": wt.RECYCLABLES,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bmv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bmv_at.py
@@ -13,16 +13,11 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://webudb.udb.at/WasteManagementUDB/WasteManagementServlet"
 
@@ -46,7 +41,12 @@ class Source(BaseSource):
     DESCRIPTION = "Source for BMV, Austria"
     URL = "https://www.bmv.at"
     COUNTRY = "at"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Allersdorf": {"ort": "ALLERSDORF", "strasse": "HAUSNUMMER", "hausnummer": 9},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/boroondara_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/boroondara_vic_gov_au.py
@@ -4,13 +4,13 @@ from datetime import date, timedelta
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import recurrence, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
 from waste_collection_schedule.service.ArcGis import ArcGisZoneParser
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Boroondara has no FeatureServer to query: the collection zones ship as a
 # GeoJSON bundle embedded in the council's own JS (main-v2.min.js), so the
@@ -40,9 +40,9 @@ FOGO = "FOGO"
 GENERAL = "General Waste"
 
 _TYPE_MAP = {
-    RECYCLING: RECYCLABLES,
-    FOGO: ORGANIC,
-    GENERAL: GENERAL_WASTE,
+    RECYCLING: wt.RECYCLABLES,
+    FOGO: wt.ORGANIC,
+    GENERAL: wt.GENERAL_WASTE,
 }
 
 # Number of collections to project for each stream (matches the legacy default).

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bromley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bromley_gov_uk.py
@@ -12,17 +12,11 @@ template, a " collection" suffix strip (every summary ends with it, e.g.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.retrievers import PollingIcsRetriever
 from waste_collection_schedule.transformers import ICSTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    PAPER,
-)
 
 
 @final
@@ -54,11 +48,11 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Non-Recyclable Refuse": GENERAL_WASTE,
-            "Food Waste": FOOD_WASTE,
-            "Garden Waste": GARDEN_WASTE,
-            "Paper & Cardboard": PAPER,
-            "Mixed Recycling (Cans, Plastics & Glass)": GLASS,
+            "Non-Recyclable Refuse": wt.GENERAL_WASTE,
+            "Food Waste": wt.FOOD_WASTE,
+            "Garden Waste": wt.GARDEN_WASTE,
+            "Paper & Cardboard": wt.PAPER,
+            "Mixed Recycling (Cans, Plastics & Glass)": wt.GLASS,
         },
         clean=label_cleaner(strip_suffixes=[" collection"]),
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bsr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bsr_de.py
@@ -1,20 +1,13 @@
 import datetime
 from typing import Any, ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.collection import Collection
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.parsers import JsonParser
 from waste_collection_schedule.preprocessors import FlattenGroups
 from waste_collection_schedule.retrievers import HttpGetRetriever
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-    WasteType,
-    preserved,
-)
 
 # Berliner Stadtreinigungsbetriebe (BSR) publishes a per-address collection
 # schedule behind an OData endpoint keyed by a "schedule_id" (AddrKey). The
@@ -34,12 +27,12 @@ FILTERTEMPLATE_PICKUPS = (
 # the verbatim text BSR uses; it is shown unchanged when another company runs
 # the round, so the codes map straight to a type here rather than going through
 # the shared resolver.
-_CATEGORIES: dict[str, tuple[WasteType, str]] = {
-    "BI": (ORGANIC, "Biogut"),
-    "HM": (GENERAL_WASTE, "Hausmüll"),
-    "LT": (GARDEN_WASTE, "Laubtonne"),
-    "WS": (RECYCLABLES, "Wertstoffe"),
-    "WB": (GARDEN_WASTE, "Weihnachtsbaum"),
+_CATEGORIES: dict[str, tuple[wt.WasteType, str]] = {
+    "BI": (wt.ORGANIC, "Biogut"),
+    "HM": (wt.GENERAL_WASTE, "Hausmüll"),
+    "LT": (wt.GARDEN_WASTE, "Laubtonne"),
+    "WS": (wt.RECYCLABLES, "Wertstoffe"),
+    "WB": (wt.GARDEN_WASTE, "Weihnachtsbaum"),
 }
 
 
@@ -67,7 +60,12 @@ class Source(BaseSource):
     RAISE_ON_EMPTY = True
     # classify() may preserve an unknown company-suffixed label, so the produced
     # set is open-ended beyond the four canonical types the codes resolve to.
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, ORGANIC, GARDEN_WASTE]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.RECYCLABLES,
+        wt.ORGANIC,
+        wt.GARDEN_WASTE,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Hufeland_45a": {"schedule_id": "04901100010300413840045A"},
@@ -95,5 +93,7 @@ class Source(BaseSource):
         if company and company != "BSR":
             # Another company runs this round: keep the verbatim, company-tagged
             # label rather than collapsing it onto the canonical type.
-            return Collection(date=date, waste_type=preserved(f"{label} ({company})"))
-        return Collection(date=date, waste_type=waste_type or preserved(label))
+            return Collection(
+                date=date, waste_type=wt.preserved(f"{label} ({company})")
+            )
+        return Collection(date=date, waste_type=waste_type or wt.preserved(label))

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/buermoos_at.py
@@ -1,6 +1,7 @@
 import re
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -8,12 +9,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.buermoos.at"
 _SELECTION_URL = "https://www.buermoos.at/Service/Aktuelles/Muellkalender"
@@ -41,7 +36,12 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Birkenstraße 76a": {"strasse": "Birkenstraße", "hausnummer": "76a"},
@@ -88,11 +88,11 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean,
         type_value_map={
-            "GELB": RECYCLABLES,
-            "ROT": GENERAL_WASTE,
-            "WEIß": GENERAL_WASTE,
-            "LVP-Behälter Wohnanlagen und Betriebe": RECYCLABLES,
-            "LVP-Behälter Betriebe - Wohnanlagen & Betriebe": RECYCLABLES,
-            "Biomüllabfuhr": ORGANIC,
+            "GELB": wt.RECYCLABLES,
+            "ROT": wt.GENERAL_WASTE,
+            "WEIß": wt.GENERAL_WASTE,
+            "LVP-Behälter Wohnanlagen und Betriebe": wt.RECYCLABLES,
+            "LVP-Behälter Betriebe - Wohnanlagen & Betriebe": wt.RECYCLABLES,
+            "Biomüllabfuhr": wt.ORGANIC,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/burnley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/burnley_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,11 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "your.burnley.gov.uk"
 INITIAL_URL = (
@@ -67,9 +63,9 @@ class Source(BaseSource):
         type_key=lambda r: r["display"].split(" - ")[0],
         parse_date=date_parsers.next_weekday("%A %d %B"),
         type_value_map={
-            "refuse": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
-            "garden": GARDEN_WASTE,
+            "refuse": wt.GENERAL_WASTE,
+            "recycling": wt.RECYCLABLES,
+            "garden": wt.GARDEN_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/c_trace_de.py
@@ -15,6 +15,7 @@ this source covers are dropped by the conversion.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     district,
@@ -30,13 +31,6 @@ from waste_collection_schedule.service.CTrace import (
     resolve_service,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # All waste-type ids: the provider returns every collection when none are
 # filtered out, matching the legacy default of "0|1|2|...|299".
@@ -51,11 +45,11 @@ class Source(BaseSource):
     COUNTRY = "de"
 
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        GLASS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.GLASS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/calgary_ca.py
@@ -3,12 +3,12 @@ from collections.abc import Iterable, Mapping
 from typing import ClassVar, Literal, TypedDict, final
 
 from waste_collection_schedule import date_parsers, parsers, preprocessors, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import Schedule
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Demonstrates: a recurring schedule published as rules rather than dates, where
 # the cadence is "collect on ISO-even / ISO-odd numbered weeks". A describe()
@@ -22,7 +22,7 @@ from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCL
 
 API_URL = "https://data.calgary.ca/resource/jq4t-b745.json"
 
-TYPE_MAP = {"Green": ORGANIC, "Black": GENERAL_WASTE, "Blue": RECYCLABLES}
+TYPE_MAP = {"Green": wt.ORGANIC, "Black": wt.GENERAL_WASTE, "Blue": wt.RECYCLABLES}
 
 _parse_window = date_parsers.auto
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cannock_chase_dc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cannock_chase_dc_gov_uk.py
@@ -1,16 +1,10 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import postcode, uprn
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-    WasteType,
-)
 
 # Demonstrates: parsers.XmlParser on a real, namespaced SOAP-style XML feed,
 # transformed declaratively with JsonTransformer callable keys.
@@ -27,11 +21,11 @@ from waste_collection_schedule.waste_types import (
 
 _NS = "{http://webservices.whitespacews.com/}"
 
-_SERVICE_MAP: dict[str, WasteType] = {
-    "Refuse Collection Service": GENERAL_WASTE,
-    "Recycle Collection Service": RECYCLABLES,
-    "Garden Collection Service": GARDEN_WASTE,
-    "Food Waste Collection Service": FOOD_WASTE,
+_SERVICE_MAP: dict[str, wt.WasteType] = {
+    "Refuse Collection Service": wt.GENERAL_WASTE,
+    "Recycle Collection Service": wt.RECYCLABLES,
+    "Garden Collection Service": wt.GARDEN_WASTE,
+    "Food Waste Collection Service": wt.FOOD_WASTE,
 }
 
 
@@ -78,7 +72,12 @@ class Source(BaseSource):
         parse_date=date_parsers.for_format("%d/%m/%Y %H:%M:%S"),
     )
 
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, GARDEN_WASTE, FOOD_WASTE]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.FOOD_WASTE,
+    ]
 
     def __init__(self, uprn: str | int, postcode: str):
         super().__init__(uprn=str(uprn).zfill(12), postcode=postcode)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ceb_coburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ceb_coburg_de.py
@@ -16,12 +16,12 @@ from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsLookupRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER, RECYCLABLES
 
 API_URL = "https://abfuhrkalender.ceb-coburg.de/"
 
@@ -29,9 +29,9 @@ API_URL = "https://abfuhrkalender.ceb-coburg.de/"
 # reading "Restmüll (Schwarze Tonne)" matches "schwarz"); the confusingly
 # named bin colour is preserved exactly as before: the green bin -> paper.
 _TYPE_VALUE_MAP = {
-    "schwarz": GENERAL_WASTE,
-    "grün": PAPER,
-    "gelb": RECYCLABLES,
+    "schwarz": wt.GENERAL_WASTE,
+    "grün": wt.PAPER,
+    "gelb": wt.RECYCLABLES,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesapeake_va_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/chesapeake_va_us.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -9,7 +10,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 # ArcGis single spatial query -> one feature with PICKUP_DAY, from which a single
 # weekly trash schedule is projected. Acquisition + parse are the shared ArcGis
@@ -18,7 +18,7 @@ from waste_collection_schedule.waste_types import GENERAL_WASTE
 FEATURE_URL = "https://gis.cityofchesapeake.net/mapping/rest/services/WasteManagement/Trash_Collection_Areas/MapServer/0"
 
 _TYPE_MAP = {
-    "Trash": GENERAL_WASTE,
+    "Trash": wt.GENERAL_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cheshire_west_and_chester_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cheshire_west_and_chester_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -11,12 +12,6 @@ from waste_collection_schedule.service.AchieveForms import (
     lookup_context,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "my.cheshirewestandchester.gov.uk"
 INITIAL_URL = (
@@ -34,10 +29,10 @@ SCHEDULE_LOOKUP_ID = "6101d23110243"
 # the provider's serviceTypes lookup maps each UPRN's own labels back onto
 # these generic categories; only a recognised generic category is kept.
 GENERIC_SERVICE_TYPES = {
-    "Domestic": GENERAL_WASTE,
-    "Food": FOOD_WASTE,
-    "Recycling": RECYCLABLES,
-    "Garden": GARDEN_WASTE,
+    "Domestic": wt.GENERAL_WASTE,
+    "Food": wt.FOOD_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Garden": wt.GARDEN_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cm_lisboa_pt.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cm_lisboa_pt.py
@@ -1,6 +1,7 @@
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,7 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER, RECYCLABLES
 
 # Lisboa's Amb_Reciclagem FeatureServer keys each collection area by name
 # (NOME) and carries three fields of Portuguese weekday abbreviations, one
@@ -44,9 +44,9 @@ _FIELDS = {
 }
 
 _TYPE_MAP = {
-    "Indiferenciado": GENERAL_WASTE,
-    "Papel e Cartão": PAPER,
-    "Embalagens": RECYCLABLES,
+    "Indiferenciado": wt.GENERAL_WASTE,
+    "Papel e Cartão": wt.PAPER,
+    "Embalagens": wt.RECYCLABLES,
 }
 
 # Number of weekly collections to project (matches the legacy default).

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cmcitymedia_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cmcitymedia_de.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, text_field
 from waste_collection_schedule.regions import Region, region
@@ -9,13 +10,6 @@ from waste_collection_schedule.service.CMCityMedia import (
     CMCityMediaRetriever,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Declarative source on the CM City Media components (CMCityMediaRetriever +
 # CMCityMediaParser). The provider registry lives here, in the source that owns
@@ -80,11 +74,11 @@ class Source(BaseSource):
     # vocabulary; the canonical types the enabled providers actually emit
     # (verified by cassette replay) are declared here.
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     # Both cases exercise the enabled Blankenheim provider (district-based and

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/communitywastedisposal_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/communitywastedisposal_com.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, final
 
 from dateutil.rrule import FR, MO, SA, SU, TH, TU, WE, WEEKLY, rrule
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import (
@@ -12,14 +13,6 @@ from waste_collection_schedule.preprocessors import (
 )
 from waste_collection_schedule.service import ArcGis, NewEdgeServices
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # CWD (North Texas) publishes pickup days/frequency per service across SIX ArcGIS
 # FeatureServer layers, queried with a single spatial point each. The geocode
@@ -51,12 +44,12 @@ LAYERS = [
 ]
 
 _TYPE_MAP = {
-    "HHW": HAZARDOUS,
-    "Recycling": RECYCLABLES,
-    "Trash": GENERAL_WASTE,
-    "Bulk Waste": BULKY_WASTE,
-    "Yard Waste": GARDEN_WASTE,
-    "Compost": ORGANIC,
+    "HHW": wt.HAZARDOUS,
+    "Recycling": wt.RECYCLABLES,
+    "Trash": wt.GENERAL_WASTE,
+    "Bulk Waste": wt.BULKY_WASTE,
+    "Yard Waste": wt.GARDEN_WASTE,
+    "Compost": wt.ORGANIC,
 }
 
 WEEKDAY_MAP = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/crawley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/crawley_gov_uk.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 from typing import Any, ClassVar, final
 
 from dateutil.parser import parse as _parse_dayfirst_date
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field, uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -15,11 +16,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 BASE_URL = "https://my.crawley.gov.uk"
 INITIAL_URL = f"{BASE_URL}/en/service/check_my_bin_collection"
@@ -108,9 +104,9 @@ class Source(BaseSource):
     transform = RowTransformer(
         parse_date=_parse_dayfirst,
         type_value_map={
-            "rubbish": GENERAL_WASTE,
-            "recycle": RECYCLABLES,
-            "green": GARDEN_WASTE,
+            "rubbish": wt.GENERAL_WASTE,
+            "recycle": wt.RECYCLABLES,
+            "green": wt.GARDEN_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
@@ -2,17 +2,12 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
 from waste_collection_schedule.service import ArcGis
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    OTHER,
-    RECYCLABLES,
-)
 
 # Attribute query in two steps (address LIKE -> OBJECTID -> full record), then a
 # mix of recurring schedules: weekly rubbish, fortnightly green/recycling from
@@ -26,10 +21,10 @@ _SIX_WEEKLY = datetime.timedelta(weeks=6)
 _from_ms = date_parsers.from_epoch(unit="ms")
 
 _TYPE_MAP = {
-    "Rubbish": GENERAL_WASTE,
-    "Green Waste": GARDEN_WASTE,
-    "Recycling": RECYCLABLES,
-    "Street Sweeping": OTHER,
+    "Rubbish": wt.GENERAL_WASTE,
+    "Green Waste": wt.GARDEN_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Street Sweeping": wt.OTHER,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/derbyshiredales_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/derbyshiredales_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.service.FirmstepSelfService import (
@@ -8,12 +9,6 @@ from waste_collection_schedule.service.FirmstepSelfService import (
     FirmstepAddressFormRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 FORM_URL = (
     "https://selfserve.derbyshiredales.gov.uk/"
@@ -62,9 +57,9 @@ class Source(BaseSource):
     preprocess = DerbyshireDalesRowClassifier()
     transform = RowTransformer(
         type_value_map={
-            "domestic waste": GENERAL_WASTE,
-            "recycling waste": RECYCLABLES,
-            "food waste": FOOD_WASTE,
-            "garden waste": GARDEN_WASTE,
+            "domestic waste": wt.GENERAL_WASTE,
+            "recycling waste": wt.RECYCLABLES,
+            "food waste": wt.FOOD_WASTE,
+            "garden waste": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/dienten_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/dienten_gv_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import PAPER
 
 _BASE_URL = "https://www.dienten.gv.at"
 
@@ -43,7 +43,7 @@ class Source(BaseSource):
     # is classified by the shared vocabulary.
     transform = ICSTransformer(
         type_value_map={
-            "Papier Gewerbe": PAPER,
-            "Karton Gewerbe": PAPER,
+            "Papier Gewerbe": wt.PAPER,
+            "Karton Gewerbe": wt.PAPER,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/durban_gov_za.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/durban_gov_za.py
@@ -12,6 +12,7 @@ ICSTransformer.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -20,7 +21,6 @@ from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.preprocessors import Compose, RowFilter, RowRelabel
 from waste_collection_schedule.retrievers import TwoStepRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 _ICS_BASE = (
     "https://raw.githubusercontent.com/robtesch/hacs_waste_collection_schedule/"
@@ -153,7 +153,7 @@ class Source(BaseSource):
     )
 
     transform = ICSTransformer(
-        type_value_map={"General Waste": GENERAL_WASTE, "Recycling": RECYCLABLES}
+        type_value_map={"General Waste": wt.GENERAL_WASTE, "Recycling": wt.RECYCLABLES}
     )
 
     def __init__(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastcambs_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastcambs_gov_uk.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.exceptions import SourceArgumentException
@@ -13,12 +14,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Live-verified (2026-07): the standard AchieveForms handshake
 # (init_session -> authapi/isauthenticated) authenticates East Cambridgeshire's
@@ -118,17 +113,17 @@ class Source(BaseSource):
         parse_date=date_parsers.for_format("%d/%m/%Y"),
         clean=_clean_bin_type,
         type_value_map={
-            "recycling bin": RECYCLABLES,
-            "outdoor food caddy": FOOD_WASTE,
-            "indoor food caddy": FOOD_WASTE,
-            "rubbish bin": GENERAL_WASTE,
-            "garden waste bin": GARDEN_WASTE,
-            "brown bags": GENERAL_WASTE,
-            "purple bags": RECYCLABLES,
-            "clear bags": RECYCLABLES,
-            "black bag": GENERAL_WASTE,
+            "recycling bin": wt.RECYCLABLES,
+            "outdoor food caddy": wt.FOOD_WASTE,
+            "indoor food caddy": wt.FOOD_WASTE,
+            "rubbish bin": wt.GENERAL_WASTE,
+            "garden waste bin": wt.GARDEN_WASTE,
+            "brown bags": wt.GENERAL_WASTE,
+            "purple bags": wt.RECYCLABLES,
+            "clear bags": wt.RECYCLABLES,
+            "black bag": wt.GENERAL_WASTE,
             # East Cambridgeshire's blue bin is general recycling, not the
             # paper-only round the shared "blue bin" alias resolves to.
-            "blue bin": RECYCLABLES,
+            "blue bin": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ecoharmonogram_pl.py
@@ -1,6 +1,7 @@
 import re
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -18,15 +19,6 @@ from waste_collection_schedule.service.EcoHarmonogramPL import (
     EcoharmonogramRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Ecoharmonogram.pl serves ~16 Polish municipalities/operators (see REGIONS
 # below), each free to phrase its bin categories differently, so the label
@@ -59,42 +51,42 @@ def _strip_frequency_suffix(label: str) -> str:
 
 
 TYPE_VALUE_MAP = {
-    "zmieszane": GENERAL_WASTE,
-    "odpady zmieszane": GENERAL_WASTE,
-    "odpady komunalne zmieszane": GENERAL_WASTE,
-    "zmieszane odpady komunalne": GENERAL_WASTE,
-    "tylko odpady zmieszane": GENERAL_WASTE,
-    "niesegregowane (zmieszane) odpady komunalne": GENERAL_WASTE,
-    "odpady resztkowe": GENERAL_WASTE,
-    "resztkowe": GENERAL_WASTE,
-    "popiół": GENERAL_WASTE,
-    "bio": ORGANIC,
-    "bioodpady": ORGANIC,
-    "odpady bio": ORGANIC,
-    "odpady biodegradowalne": ORGANIC,
-    "biodegradowalne": ORGANIC,
-    "odpady ulegające biodegradacji - bio": ORGANIC,
-    "papier": PAPER,
-    "makulatura": PAPER,
-    "szkło": GLASS,
-    "szkło opakowaniowe": GLASS,
-    "metale i tworzywa": RECYCLABLES,
-    "metale i tworzywa sztuczne": RECYCLABLES,
-    "tworzywa sztuczne i metale": RECYCLABLES,
-    "plastik": RECYCLABLES,
-    "plastik, metal": RECYCLABLES,
-    "odpady segregowane": RECYCLABLES,
-    "szkło, papier, tworzywa sztuczne, opakowania wielomateriałowe, metal": RECYCLABLES,
-    "odpady wielkogabarytowe": BULKY_WASTE,
+    "zmieszane": wt.GENERAL_WASTE,
+    "odpady zmieszane": wt.GENERAL_WASTE,
+    "odpady komunalne zmieszane": wt.GENERAL_WASTE,
+    "zmieszane odpady komunalne": wt.GENERAL_WASTE,
+    "tylko odpady zmieszane": wt.GENERAL_WASTE,
+    "niesegregowane (zmieszane) odpady komunalne": wt.GENERAL_WASTE,
+    "odpady resztkowe": wt.GENERAL_WASTE,
+    "resztkowe": wt.GENERAL_WASTE,
+    "popiół": wt.GENERAL_WASTE,
+    "bio": wt.ORGANIC,
+    "bioodpady": wt.ORGANIC,
+    "odpady bio": wt.ORGANIC,
+    "odpady biodegradowalne": wt.ORGANIC,
+    "biodegradowalne": wt.ORGANIC,
+    "odpady ulegające biodegradacji - bio": wt.ORGANIC,
+    "papier": wt.PAPER,
+    "makulatura": wt.PAPER,
+    "szkło": wt.GLASS,
+    "szkło opakowaniowe": wt.GLASS,
+    "metale i tworzywa": wt.RECYCLABLES,
+    "metale i tworzywa sztuczne": wt.RECYCLABLES,
+    "tworzywa sztuczne i metale": wt.RECYCLABLES,
+    "plastik": wt.RECYCLABLES,
+    "plastik, metal": wt.RECYCLABLES,
+    "odpady segregowane": wt.RECYCLABLES,
+    "szkło, papier, tworzywa sztuczne, opakowania wielomateriałowe, metal": wt.RECYCLABLES,
+    "odpady wielkogabarytowe": wt.BULKY_WASTE,
     # The provider's own spelling (missing an "a"); mapped verbatim since the
     # key must match the label it actually sends.
-    "odpady wielkogabrytowe": BULKY_WASTE,
-    "wielkogabaryty": BULKY_WASTE,
-    "gabaryty": BULKY_WASTE,
-    "choinki": GARDEN_WASTE,
-    "drzewka świąteczne": GARDEN_WASTE,
-    "odpady zielone": GARDEN_WASTE,
-    "zielone": GARDEN_WASTE,
+    "odpady wielkogabrytowe": wt.BULKY_WASTE,
+    "wielkogabaryty": wt.BULKY_WASTE,
+    "gabaryty": wt.BULKY_WASTE,
+    "choinki": wt.GARDEN_WASTE,
+    "drzewka świąteczne": wt.GARDEN_WASTE,
+    "odpady zielone": wt.GARDEN_WASTE,
+    "zielone": wt.GARDEN_WASTE,
 }
 
 # Apps/deployments Ecoharmonogram.pl runs under a `customApp` value (the
@@ -286,13 +278,13 @@ class Source(BaseSource):
     # the canonical types below, plus provider-specific labels preserved
     # verbatim when genuinely unmappable.
     WASTE_TYPES: ClassVar[list] = [
-        BULKY_WASTE,
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        GLASS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.BULKY_WASTE,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.GLASS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     retrieve = EcoharmonogramRetriever()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/edlitz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/edlitz_at.py
@@ -1,17 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.edlitz.at"
 
@@ -43,9 +38,9 @@ class Source(BaseSource):
     # tested; kept for parity in case they appear on other dates.
     transform = ICSTransformer(
         type_value_map={
-            "Biomüllabfuhr": ORGANIC,
-            "Papier Tonne": PAPER,
-            "Grüne Tonne": RECYCLABLES,
-            "Restmüll mit Panoramastraße": GENERAL_WASTE,
+            "Biomüllabfuhr": wt.ORGANIC,
+            "Papier Tonne": wt.PAPER,
+            "Grüne Tonne": wt.RECYCLABLES,
+            "Restmüll mit Panoramastraße": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eggelsberg_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -8,12 +9,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.eggelsberg.at"
 VALID_ZONES = ["A", "B"]
@@ -27,10 +22,10 @@ class Source(BaseSource):
     COUNTRY = "at"
 
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -72,9 +67,9 @@ class Source(BaseSource):
     # Altpapier and Gelber Sack resolve unmapped.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
-            "Restabfall 6-wöchentlich": GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 6-wöchentlich": wt.GENERAL_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eigenbetrieb_abfallwirtschaft_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eigenbetrieb_abfallwirtschaft_de.py
@@ -17,24 +17,19 @@ using the same map.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city_id, location_id
 from waste_collection_schedule.preprocessors import RowRelabel
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.eigenbetrieb-abfallwirtschaft.de"
 
 _TYPE_VALUE_MAP = {
-    "Restmüll": GENERAL_WASTE,
-    "Biotonne": ORGANIC,
-    "Papiercontainer": PAPER,
-    "Gelbe(r) Sack/Tonne": RECYCLABLES,
+    "Restmüll": wt.GENERAL_WASTE,
+    "Biotonne": wt.ORGANIC,
+    "Papiercontainer": wt.PAPER,
+    "Gelbe(r) Sack/Tonne": wt.RECYCLABLES,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eilenburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eilenburg_de.py
@@ -11,20 +11,20 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsIndexRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, PAPER, RECYCLABLES
 
 # The feed labels each pickup "<service> - EB <zone>", e.g.
 # "Restabfallentsorgung - EB Berg" or "Entsorgung gelber Sack - EB 1", which the
 # shared vocabulary does not match. Reduce the label to its core waste term for
 # the type_value_map.
 _TYPE_VALUE_MAP = {
-    "restabfall": GENERAL_WASTE,
-    "gelber sack": RECYCLABLES,
-    "papier": PAPER,
+    "restabfall": wt.GENERAL_WASTE,
+    "gelber sack": wt.RECYCLABLES,
+    "papier": wt.PAPER,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eko_tom_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eko_tom_pl.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -10,14 +11,6 @@ from waste_collection_schedule.config_params import (
 from waste_collection_schedule.preprocessors import HtmlGroupedDates
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Demonstrates: HTML scraping where the waste type is encoded in the *container's*
 # CSS class, not in each dated <li>. parsers.HtmlParser selects the per-type
@@ -35,12 +28,12 @@ _BASE_URL = (
 
 # The discriminating c-trace CSS class on each container -> canonical waste type.
 TYPE_MAP = {
-    "rest": GENERAL_WASTE,
-    "glas": GLASS,
-    "plastik": RECYCLABLES,
-    "bio": ORGANIC,
-    "papier": PAPER,
-    "sperr": BULKY_WASTE,
+    "rest": wt.GENERAL_WASTE,
+    "glas": wt.GLASS,
+    "plastik": wt.RECYCLABLES,
+    "bio": wt.ORGANIC,
+    "papier": wt.PAPER,
+    "sperr": wt.BULKY_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/elmbridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/elmbridge_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,12 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    ELECTRONICS,
-    FOOD_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "elmbridge-self.achieveservice.com"
 INITIAL_URL = f"https://{HOSTNAME}/service/Your_bin_collection_days"
@@ -69,9 +64,9 @@ class Source(BaseSource):
         parse_date=date_parsers.for_format("%d/%m/%Y"),
         clean=label_cleaner(strip_suffixes=[" Collection Service"]),
         type_value_map={
-            "Domestic Waste": GENERAL_WASTE,
-            "Domestic Recycling": RECYCLABLES,
-            "Food Waste": FOOD_WASTE,
-            "Textiles and Small WEEE": ELECTRONICS,
+            "Domestic Waste": wt.GENERAL_WASTE,
+            "Domestic Recycling": wt.RECYCLABLES,
+            "Food Waste": wt.FOOD_WASTE,
+            "Textiles and Small WEEE": wt.ELECTRONICS,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/elsbethen_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.gde-elsbethen.at"
 
@@ -27,10 +22,10 @@ class Source(BaseSource):
     RAISE_ON_EMPTY = True
 
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/enns_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.enns.at"
 
@@ -27,10 +22,10 @@ class Source(BaseSource):
     RAISE_ON_EMPTY = True
 
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -68,7 +63,7 @@ class Source(BaseSource):
     # Altpapier, Gelber Sack, Sperrmüll and Altglas all resolve unmapped.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eppingforestdc_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eppingforestdc_gov_uk.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,13 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 HOSTNAME = "eppingforestdc-self.achieveservice.com"
 LOOKUP_COLLECTIONS = "6651dfb99a74d"
@@ -76,10 +70,10 @@ class Source(BaseSource):
     )
     transform = RowTransformer(
         type_value_map={
-            "food waste service": FOOD_WASTE,
-            "food and garden service": ORGANIC,
-            "garden waste service": GARDEN_WASTE,
-            "recycling service": RECYCLABLES,
-            "refuse service": GENERAL_WASTE,
+            "food waste service": wt.FOOD_WASTE,
+            "food and garden service": wt.ORGANIC,
+            "garden waste service": wt.GARDEN_WASTE,
+            "recycling service": wt.RECYCLABLES,
+            "refuse service": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/felixdorf_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/felixdorf_gv_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -8,12 +9,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.felixdorf.gv.at"
 VALID_ZONES = ["Rayon 1", "Rayon 2"]
@@ -28,10 +23,10 @@ class Source(BaseSource):
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
 
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -73,11 +68,11 @@ class Source(BaseSource):
     # Gelber Sack are classified by the shared vocabulary.
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll 1.100-Liter-Container": GENERAL_WASTE,
-            "Restmüll 120 Liter und 240 Liter": GENERAL_WASTE,
-            "Papier 1.100-Liter-Container": PAPER,
-            "Papier 120 Liter und 240 Liter": PAPER,
-            "Windeltonne": GENERAL_WASTE,
+            "Restmüll 1.100-Liter-Container": wt.GENERAL_WASTE,
+            "Restmüll 120 Liter und 240 Liter": wt.GENERAL_WASTE,
+            "Papier 1.100-Liter-Container": wt.PAPER,
+            "Papier 120 Liter und 240 Liter": wt.PAPER,
+            "Windeltonne": wt.GENERAL_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankenberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankenberg_de.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.exceptions import (
@@ -28,14 +29,6 @@ from waste_collection_schedule.exceptions import (
     SourceArgumentRequiredWithSuggestions,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _ORTSTEILE_URL = "https://abfall.frankenberg.de/module/abfallkalender/get_ortsteile.php"
 _STRASSEN_URL = "https://abfall.frankenberg.de/module/abfallkalender/get_strassen.php"
@@ -150,9 +143,9 @@ class Source(BaseSource):
     RAISE_ON_EMPTY = True
 
     WASTE_TYPES: ClassVar[list] = [
-        HAZARDOUS,
-        ORGANIC,
-        RECYCLABLES,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -179,10 +172,10 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Trash": GENERAL_WASTE,
-            "Glass": GLASS,
-            "Bio": ORGANIC,
-            "Paper": PAPER,
-            "Recycle": RECYCLABLES,
+            "Trash": wt.GENERAL_WASTE,
+            "Glass": wt.GLASS,
+            "Bio": wt.ORGANIC,
+            "Paper": wt.PAPER,
+            "Recycle": wt.RECYCLABLES,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frankston_vic_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,12 +12,6 @@ from waste_collection_schedule.service.Pozi import (
     geocode_earth,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    RECYCLABLES,
-)
 
 # Demonstrates: a Pozi GeoJSON zone lookup by address, geocoded first via
 # geocode.earth (Frankston's Pozi widget has no address lookup of its own).
@@ -90,10 +85,10 @@ class Source(BaseSource):
     RAISE_ON_EMPTY = True
 
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        GLASS,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.GLASS,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/frasercoast_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/frasercoast_qld_gov_au.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # "Bin Day" is a bare weekday name (weekly general waste); "Recycling Day" is
 # fortnightly with an explicit "Next: <date>" marker. The only source-specific
@@ -30,8 +30,8 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 
 # IntraMaps column name -> canonical waste type.
 _TYPE_MAP = {
-    "Bin Day": GENERAL_WASTE,
-    "Recycling Day": RECYCLABLES,
+    "Bin Day": wt.GENERAL_WASTE,
+    "Recycling Day": wt.RECYCLABLES,
 }
 
 # The recycling value is free text such as "Thursday Week A; Next: 23 Jul

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fredrikstad_no.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fredrikstad_no.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
@@ -10,12 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     feature_query,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    RECYCLABLES,
-)
 
 # Fredrikstad kommune's MinRenovasjon MapServer splits the flow across two
 # unrelated layers: layer 0 resolves a street address to an "AvtLnr" (renovation
@@ -46,11 +41,11 @@ WASTE_TYPE_FALLBACK: dict[int, str] = {
 # shared vocabulary's supported languages, so without this an unrecognised label
 # is preserved verbatim (still correct, just without a canonical icon/colour).
 _TYPE_MAP = {
-    "Restavfall": GENERAL_WASTE,
-    "Papir og plast": RECYCLABLES,
-    "Glass og metall": RECYCLABLES,
-    "Farlig avfall": HAZARDOUS,
-    "Matavfall": FOOD_WASTE,
+    "Restavfall": wt.GENERAL_WASTE,
+    "Papir og plast": wt.RECYCLABLES,
+    "Glass og metall": wt.RECYCLABLES,
+    "Farlig avfall": wt.HAZARDOUS,
+    "Matavfall": wt.FOOD_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fritzens_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fritzens_gv_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
 
 _BASE_URL = "https://www.fritzens.gv.at"
 
@@ -42,6 +42,6 @@ class Source(BaseSource):
     # classification).
     transform = ICSTransformer(
         type_value_map={
-            "Kunststoffmüll": RECYCLABLES,
+            "Kunststoffmüll": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fuquay_varina_nc_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fuquay_varina_nc_us.py
@@ -2,6 +2,7 @@ import re
 from datetime import date, datetime
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.service.ArcGis import (
@@ -9,7 +10,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # Fuquay-Varina's Solid_Waste_Information FeatureServer keys one feature per
 # address and reports each stream's *next* pickup date as free text (e.g. "The
@@ -27,8 +27,8 @@ _FIELDS = {
 }
 
 _TYPE_MAP = {
-    "Garbage": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
+    "Garbage": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
 }
 
 _MONTHS = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemeinde24_at.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any, ClassVar, TypedDict, final
 
 from waste_collection_schedule import date_parsers, parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     dependent_select,
@@ -13,17 +14,6 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    ELECTRONICS,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Demonstrates: the config_params.dependent_select(parent, child) PARAM and the
 # get_choices() contract it relies on, on the BaseSource pipeline.
@@ -50,16 +40,16 @@ SEARCH_LONGITUDE = "14.5000"
 # also resolved against the shared German vocabulary; the code map is the
 # authoritative override (titles are free text and occasionally custom).
 _CODE_MAP = {
-    "rm": GENERAL_WASTE,
-    "bm": ORGANIC,
-    "lf": RECYCLABLES,
-    "ap": PAPER,
-    "ag": GLASS,
-    "am": ELECTRONICS,
-    "sp": BULKY_WASTE,
-    "gs": GARDEN_WASTE,
-    "ps": HAZARDOUS,
-    "el": ELECTRONICS,
+    "rm": wt.GENERAL_WASTE,
+    "bm": wt.ORGANIC,
+    "lf": wt.RECYCLABLES,
+    "ap": wt.PAPER,
+    "ag": wt.GLASS,
+    "am": wt.ELECTRONICS,
+    "sp": wt.BULKY_WASTE,
+    "gs": wt.GARDEN_WASTE,
+    "ps": wt.HAZARDOUS,
+    "el": wt.ELECTRONICS,
 }
 
 
@@ -253,10 +243,10 @@ class Source(BaseSource):
     RAISE_ON_EMPTY = True
 
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemuenden_wohra_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gemuenden_wohra_de.py
@@ -14,6 +14,7 @@ import re
 from collections.abc import Iterable
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import integer
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -21,13 +22,6 @@ from waste_collection_schedule.parsers import PdfTableParser
 from waste_collection_schedule.preprocessors import PdfMonthColumns
 from waste_collection_schedule.retrievers import PdfLinkRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SCHEDULE_URL = (
     "https://www.gemuenden-wohra.de/seite/461536/abfallentsorgung-abfuhrtermine.html"
@@ -102,11 +96,11 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Bioabfall": ORGANIC,
-            "Restmüll": GENERAL_WASTE,
-            "Altpapier": PAPER,
-            "Gelbe Tonne": RECYCLABLES,
-            "Sonderabfall": HAZARDOUS,
+            "Bioabfall": wt.ORGANIC,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Altpapier": wt.PAPER,
+            "Gelbe Tonne": wt.RECYCLABLES,
+            "Sonderabfall": wt.HAZARDOUS,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geoport_nwm_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geoport_nwm_de.py
@@ -25,11 +25,11 @@ import urllib.parse
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsYearRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import HAZARDOUS, ORGANIC, RECYCLABLES
 
 _API_URL = "https://www.geoport-nwm.de/nwm-download/Abfuhrtermine/ICS/{year}/{arg}.ics"
 
@@ -87,9 +87,9 @@ class Source(BaseSource):
     COUNTRY = "de"
 
     WASTE_TYPES: ClassVar[list] = [
-        HAZARDOUS,
-        ORGANIC,
-        RECYCLABLES,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gfa_lueneburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gfa_lueneburg_de.py
@@ -11,18 +11,11 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://portal.gfa-lueneburg.de:8443/WasteManagementLueneburg/WasteManagementServlet"
 
@@ -111,12 +104,12 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restabfallbehaelter": GENERAL_WASTE,
-            "Restmuell": GENERAL_WASTE,
-            "Papiertonne": PAPER,
-            "Gelber Sack": RECYCLABLES,
-            "Gruenabfall": GARDEN_WASTE,
-            "Biotonne": ORGANIC,
-            "Sperrmuell Altmetall": BULKY_WASTE,
+            "Restabfallbehaelter": wt.GENERAL_WASTE,
+            "Restmuell": wt.GENERAL_WASTE,
+            "Papiertonne": wt.PAPER,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Gruenabfall": wt.GARDEN_WASTE,
+            "Biotonne": wt.ORGANIC,
+            "Sperrmuell Altmetall": wt.BULKY_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/goessendorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/goessendorf_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import BULKY_WASTE, GENERAL_WASTE, PAPER
 
 _BASE_URL = "https://www.goessendorf.com"
 
@@ -33,11 +33,11 @@ class Source(BaseSource):
     # aliases, so each needs an explicit entry.
     transform = ICSTransformer(
         type_value_map={
-            "Altpapier P1": PAPER,
-            "Altpapier P2": PAPER,
-            "Sperrmüll S1": BULKY_WASTE,
-            "Sperrmüll S2": BULKY_WASTE,
-            "Restmüll R1": GENERAL_WASTE,
-            "Restmüll R2": GENERAL_WASTE,
+            "Altpapier P1": wt.PAPER,
+            "Altpapier P2": wt.PAPER,
+            "Sperrmüll S1": wt.BULKY_WASTE,
+            "Sperrmüll S2": wt.BULKY_WASTE,
+            "Restmüll R1": wt.GENERAL_WASTE,
+            "Restmüll R2": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/greaterdandenong_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/greaterdandenong_vic_gov_au.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,11 +11,6 @@ from waste_collection_schedule.service.IntraMaps import (
     IntegrationPanelParser,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Two-step Integration API flow (apikey search -> mapkey/dbkey -> details
 # form). Waste day is a bare weekday name (weekly); Garden/Recycling carry an
@@ -39,9 +35,9 @@ _FORTNIGHTLY_COLUMNS = {"garden_day", "recycle_day"}
 _SINGLE_COLUMN = "street_sweep"
 
 _TYPE_MAP = {
-    _WEEKLY_COLUMN: GENERAL_WASTE,
-    "garden_day": GARDEN_WASTE,
-    "recycle_day": RECYCLABLES,
+    _WEEKLY_COLUMN: wt.GENERAL_WASTE,
+    "garden_day": wt.GARDEN_WASTE,
+    "recycle_day": wt.RECYCLABLES,
 }
 
 _SWEEP_DATE_FORMAT = date_parsers.for_format("%d %B %Y")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gross_gerau_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gross_gerau_de.py
@@ -11,16 +11,11 @@ override, no manual request params and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.gross-gerau.de"
 
@@ -33,10 +28,10 @@ class Source(BaseSource):
     COUNTRY = "de"
 
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -60,7 +55,7 @@ class Source(BaseSource):
     # match an alias exactly, so they need an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Gelbe Tonne - Gelber Sack": RECYCLABLES,
-            "Papiertonne 1100 Liter": PAPER,
+            "Gelbe Tonne - Gelber Sack": wt.RECYCLABLES,
+            "Papiertonne 1100 Liter": wt.PAPER,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gruppoveritas_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gruppoveritas_it.py
@@ -18,6 +18,7 @@ import re
 from collections.abc import Iterable
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import integer, text_field
 from waste_collection_schedule.parsers import PdfTableParser
@@ -33,13 +34,6 @@ from waste_collection_schedule.preprocessors import (
 )
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-)
 
 DEFAULT_PDF_URL = (
     "https://www.gruppoveritas.it/sites/default/files/documenti/calendari/"
@@ -207,11 +201,11 @@ class Source(BaseSource):
     # covers plastic and metal packaging.
     transform = ICSTransformer(
         type_value_map={
-            "S": GENERAL_WASTE,
-            "UO": ORGANIC,
-            "VR": GARDEN_WASTE,
-            "C": PAPER,
-            "VPL": GLASS,
+            "S": wt.GENERAL_WASTE,
+            "UO": wt.ORGANIC,
+            "VR": wt.GARDEN_WASTE,
+            "C": wt.PAPER,
+            "VPL": wt.GLASS,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hartbeigraz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hartbeigraz_at.py
@@ -1,6 +1,7 @@
 import re
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -8,14 +9,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.hartbeigraz.at"
 _MENUONR = "225225009"
@@ -42,12 +35,12 @@ class Source(BaseSource):
     RAISE_ON_EMPTY = True
 
     WASTE_TYPES: ClassVar[list] = [
-        BULKY_WASTE,
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.BULKY_WASTE,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -101,8 +94,8 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean,
         type_value_map={
-            "Grün- und Strauchschnittsammlung": GARDEN_WASTE,
-            "Strauchschnittabholung": GARDEN_WASTE,
-            "Leichtverpackung": RECYCLABLES,
+            "Grün- und Strauchschnittsammlung": wt.GARDEN_WASTE,
+            "Strauchschnittabholung": wt.GARDEN_WASTE,
+            "Leichtverpackung": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hausmuell_info.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hausmuell_info.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     district,
@@ -29,15 +30,6 @@ from waste_collection_schedule.service.HausmuellInfo import (
     Lookup,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 API_URL = "https://{}.hausmuell.info/"
 
@@ -263,28 +255,28 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean_label,
         type_value_map={
-            "hausmüll": GENERAL_WASTE,
-            "restabfall": GENERAL_WASTE,
-            "restmüll": GENERAL_WASTE,
-            "glass": GLASS,
-            "biomüll": ORGANIC,
-            "biomüll mit reinigung": ORGANIC,
-            "bioabfall mit reinigung": ORGANIC,
-            "bioabfall": ORGANIC,
-            "papier": PAPER,
-            "papier, pappe, karton": PAPER,
-            "papier, pappe & kart.": PAPER,
-            "pappe, papier & kart.": PAPER,
-            "altpapier": PAPER,
-            "gelbe tonne": RECYCLABLES,
-            "gelber sack": RECYCLABLES,
-            "gelber sack / gelbe tonne": RECYCLABLES,
-            "leichtverpackungen": RECYCLABLES,
-            "leichtstoffverpackungen": RECYCLABLES,
-            "grünschnitt": GARDEN_WASTE,
-            "schadstoffe": HAZARDOUS,
-            "schadstoffmobil": HAZARDOUS,
-            "problemmüll": HAZARDOUS,
+            "hausmüll": wt.GENERAL_WASTE,
+            "restabfall": wt.GENERAL_WASTE,
+            "restmüll": wt.GENERAL_WASTE,
+            "glass": wt.GLASS,
+            "biomüll": wt.ORGANIC,
+            "biomüll mit reinigung": wt.ORGANIC,
+            "bioabfall mit reinigung": wt.ORGANIC,
+            "bioabfall": wt.ORGANIC,
+            "papier": wt.PAPER,
+            "papier, pappe, karton": wt.PAPER,
+            "papier, pappe & kart.": wt.PAPER,
+            "pappe, papier & kart.": wt.PAPER,
+            "altpapier": wt.PAPER,
+            "gelbe tonne": wt.RECYCLABLES,
+            "gelber sack": wt.RECYCLABLES,
+            "gelber sack / gelbe tonne": wt.RECYCLABLES,
+            "leichtverpackungen": wt.RECYCLABLES,
+            "leichtstoffverpackungen": wt.RECYCLABLES,
+            "grünschnitt": wt.GARDEN_WASTE,
+            "schadstoffe": wt.HAZARDOUS,
+            "schadstoffmobil": wt.HAZARDOUS,
+            "problemmüll": wt.HAZARDOUS,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/herzogsdorf_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/herzogsdorf_ooe_gv_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 _BASE_URL = "https://www.herzogsdorf.ooe.gv.at"
 
@@ -40,9 +40,9 @@ class Source(BaseSource):
     # classified by the shared vocabulary.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall wöchentlich": GENERAL_WASTE,
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
-            "Restabfall 6-wöchentlich": GENERAL_WASTE,
+            "Restabfall wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 6-wöchentlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/highland_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/highland_gov_uk.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field, uprn
 from waste_collection_schedule.preprocessors import (
@@ -18,13 +19,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    PAPER,
-    RECYCLABLES,
-)
 
 HOSTNAME = "highland-self.achieveservice.com"
 INITIAL_URL = f"https://{HOSTNAME}/en/service/Check_your_household_bin_collection_days"
@@ -127,12 +121,12 @@ class Source(BaseSource):
     transform = RowTransformer(
         parse_date=date_parsers.for_format("%Y-%m-%d"),
         type_value_map={
-            "refuse": GENERAL_WASTE,
-            "recycle": RECYCLABLES,
-            "garden": GARDEN_WASTE,
-            "food": FOOD_WASTE,
-            "containers": RECYCLABLES,
-            "fibres": PAPER,
+            "refuse": wt.GENERAL_WASTE,
+            "recycle": wt.RECYCLABLES,
+            "garden": wt.GARDEN_WASTE,
+            "food": wt.FOOD_WASTE,
+            "containers": wt.RECYCLABLES,
+            "fibres": wt.PAPER,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hilchenbach_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hilchenbach_de.py
@@ -11,18 +11,11 @@ manual request params and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://hilchenbach.de"
 
@@ -35,12 +28,12 @@ class Source(BaseSource):
     COUNTRY = "de"
 
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -78,7 +71,7 @@ class Source(BaseSource):
     # so they need an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Astschnitt": GARDEN_WASTE,
-            "Schadstoffsammlung": HAZARDOUS,
+            "Astschnitt": wt.GARDEN_WASTE,
+            "Schadstoffsammlung": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hohokus_nj_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hohokus_nj_us.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import parsers, recurrence, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     dropdown,
@@ -15,7 +16,6 @@ from waste_collection_schedule.preprocessors import (
     Schedule,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, GENERAL_WASTE
 
 # Demonstrates: seasonal/windowed recurrence (Schedule.not_before/until).
 #
@@ -159,5 +159,5 @@ class Source(BaseSource):
     )
 
     transform = ICSTransformer(
-        type_value_map={GENERAL: GENERAL_WASTE, YARD: GARDEN_WASTE},
+        type_value_map={GENERAL: wt.GENERAL_WASTE, YARD: wt.GARDEN_WASTE},
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hoover_al_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hoover_al_us.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -9,7 +10,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 # ArcGis single spatial query -> one feature with a "Trashday" string such as
 # "Monday / Thursday". Each named day projects a weekly garbage schedule.
@@ -19,7 +19,7 @@ from waste_collection_schedule.waste_types import GENERAL_WASTE
 FEATURE_URL = "https://services8.arcgis.com/LmhR4UJYxC4YhccG/arcgis/rest/services/Hoover_Garbage_Pickup_WFL1/FeatureServer/2"
 
 _TYPE_MAP = {
-    "Garbage": GENERAL_WASTE,
+    "Garbage": wt.GENERAL_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hounslow_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hounslow_gov_uk.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 from typing import Any, ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.exceptions import SourceArgumentException
@@ -11,12 +12,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "my.hounslow.gov.uk"
 TOKEN_LOOKUP_ID = "655f4290810cf"
@@ -92,9 +87,9 @@ class Source(BaseSource):
         date_key="jobDate",
         type_key=lambda r: r.get("jobType") or r.get("jobName") or "Unknown",
         type_value_map={
-            "residual": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
-            "food": FOOD_WASTE,
-            "garden": GARDEN_WASTE,
+            "residual": wt.GENERAL_WASTE,
+            "recycling": wt.RECYCLABLES,
+            "food": wt.FOOD_WASTE,
+            "garden": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ichisystem_eu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ichisystem_eu.py
@@ -2,33 +2,25 @@
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.service.Sepan import SepanReportParser, SepanRetriever
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Waste-type names as rendered by this deployment's report table (matches the
 # wording used by the alba_com_pl deployment of the same underlying
 # "SEPAN"/ICHI System platform). Not in Polish shared-vocabulary aliases
 # (Polish isn't a resolve() language), so every label is mapped explicitly.
 TYPE_VALUE_MAP = {
-    "Zmieszane odpady komunalne": GENERAL_WASTE,
-    "Metale i tworzywa sztuczne": RECYCLABLES,
-    "Papier": PAPER,
-    "Szkło": GLASS,
-    "Bioodpady": ORGANIC,
-    "Bioodpady - Drzewka świąteczne": GARDEN_WASTE,
-    "Odpady wystawkowe": BULKY_WASTE,
+    "Zmieszane odpady komunalne": wt.GENERAL_WASTE,
+    "Metale i tworzywa sztuczne": wt.RECYCLABLES,
+    "Papier": wt.PAPER,
+    "Szkło": wt.GLASS,
+    "Bioodpady": wt.ORGANIC,
+    "Bioodpady - Drzewka świąteczne": wt.GARDEN_WASTE,
+    "Odpady wystawkowe": wt.BULKY_WASTE,
 }
 
 API_BASE = "https://harmonogram.ichisystem.eu/hemar"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ilm_kreis_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ilm_kreis_de.py
@@ -11,18 +11,11 @@ the public ``URL``) and the German-to-canonical waste-type map, so there is no
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    ELECTRONICS,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://aik.ilm-kreis.de"
 
@@ -35,12 +28,12 @@ class Source(BaseSource):
     COUNTRY = "de"
 
     WASTE_TYPES: ClassVar[list] = [
-        ELECTRONICS,
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.ELECTRONICS,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -66,7 +59,7 @@ class Source(BaseSource):
     # explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Leichtverpackung": RECYCLABLES,
-            "Papier/Pappe": PAPER,
+            "Leichtverpackung": wt.RECYCLABLES,
+            "Papier/Pappe": wt.PAPER,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/imst_at.py
@@ -1,6 +1,7 @@
 import re
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -8,11 +9,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.imst.gv.at"
 _MENUONR = "222722602"
@@ -40,7 +36,7 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Auf Arzill 154": {
@@ -90,6 +86,6 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean,
         type_value_map={
-            "Gelbe Säcke": RECYCLABLES,
+            "Gelbe Säcke": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/infeo_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/infeo_at.py
@@ -17,6 +17,7 @@ legacy code's crash (a bare ``None in ...`` TypeError) when neither was.
 import logging
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -31,12 +32,6 @@ from waste_collection_schedule.parsers import EachResponse, IcsParser
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.retrievers import FanOutRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -206,7 +201,12 @@ class Source(BaseSource):
     URL = "https://www.infeo.at/"
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     REGIONS = (
         region(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/insert_it_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/insert_it_de.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -16,12 +17,6 @@ from waste_collection_schedule.service.InsertITDe import (
     InsertItRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-)
 
 # Declarative source on the Insert IT components. The per-region configuration
 # travels with each provider entry (the app path, the ICS regex, and an optional
@@ -96,10 +91,10 @@ class Source(BaseSource):
     # vocabulary; the canonical types the providers actually emit (verified by
     # cassette replay) are declared here. Unrecognised labels stay preserved.
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/isaac_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/isaac_qld_gov_au.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     dropdown,
@@ -15,7 +16,6 @@ from waste_collection_schedule.preprocessors import (
 )
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 # Demonstrates: scraping a town-wide collection weekday out of static HTML,
 # resolving the chosen town with ArgumentLookup, then projecting the result into
@@ -163,7 +163,7 @@ class Source(BaseSource):
         ArgumentLookup(_town_weekdays, argument="town"),
         RecurrenceExpander(_describe),
     )
-    transform = ICSTransformer(type_value_map={"general waste": GENERAL_WASTE})
+    transform = ICSTransformer(type_value_map={"general waste": wt.GENERAL_WASTE})
 
     def __init__(self, town: str, collection_day: str | None = None):
         super().__init__(town=town, collection_day=collection_day)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jacksonville_fl_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jacksonville_fl_us.py
@@ -2,18 +2,13 @@ from datetime import date, datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
 from waste_collection_schedule.service.ArcGis import geocoded_params
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Jacksonville has no FeatureServer to query: the ArcGIS World GeocodeServer
 # resolves the address to a point and a bespoke custhelp.com XML endpoint is
@@ -44,12 +39,12 @@ COLLECTIONS = (
 )
 
 _TYPE_MAP = {
-    "Garbage": GENERAL_WASTE,
-    "Yard Waste": GARDEN_WASTE,
-    "Recycling": RECYCLABLES,
-    "Bulk Waste": BULKY_WASTE,
-    "Tires": BULKY_WASTE,
-    "Appliances": BULKY_WASTE,
+    "Garbage": wt.GENERAL_WASTE,
+    "Yard Waste": wt.GARDEN_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Bulk Waste": wt.BULKY_WASTE,
+    "Tires": wt.BULKY_WASTE,
+    "Appliances": wt.BULKY_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/jumomind_de.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -16,15 +17,6 @@ from waste_collection_schedule.service.Jumomind import (
     JumomindRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Waste-type names come back as open-ended German labels that vary by provider,
 # so this source declares NO per-source type map: the transformer resolves the
@@ -201,13 +193,13 @@ class Source(BaseSource):
     # vocabulary; the canonical types the providers actually emit (verified by
     # cassette replay) are declared here. Unrecognised labels stay preserved.
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        GLASS,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.GLASS,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     # One structure (the Jumomind mmapp API) covering many municipalities; the

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import municipality, text_field
 from waste_collection_schedule.regions import region
@@ -9,13 +10,6 @@ from waste_collection_schedule.service.junker_app import (
     JunkerRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 TITLE = "Junker APP"
 DESCRIPTION = "Source for Junker APP."
@@ -369,7 +363,13 @@ class Source(BaseSource):
     DESCRIPTION = DESCRIPTION
     URL = URL
     COUNTRY = COUNTRY
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, GLASS, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.GLASS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES = TEST_CASES
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaev_niederlausitz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kaev_niederlausitz.py
@@ -24,6 +24,7 @@ import json
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.exceptions import (
@@ -32,7 +33,6 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsSessionRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 HOME_URL = "https://www.kaev.de/"
 LOOKUP_URL = (
@@ -82,7 +82,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Kommunaler Abfallverband Niederlausitz waste collection."
     URL = "https://www.kaev.de/"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.PAPER]
 
     TEST_CASES: ClassVar[dict] = {
         "Luckau / OT Zieckau": {"abf_suche": "Luckau / OT Zieckau"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kalamunda_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kalamunda_wa_gov_au.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence, response_shape
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown, text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -13,7 +14,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Kalamunda's IntraMaps response keys each collection column TWICE: once as a
 # "header" field whose name and value both just repeat the column's own label
@@ -57,9 +57,9 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 # field for a given collection share the same column, so this alone can't
 # tell them apart; that's what _describe's name/value check is for.
 _TYPE_MAP = {
-    "General_Next_Date": GENERAL_WASTE,
-    "Recycle_Next_Date": RECYCLABLES,
-    "Next FOGO Collection": ORGANIC,
+    "General_Next_Date": wt.GENERAL_WASTE,
+    "Recycle_Next_Date": wt.RECYCLABLES,
+    "Next FOGO Collection": wt.ORGANIC,
 }
 
 # Values are free text such as "22 July 2026, Wednesday" or "Every Wednesday";

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kanzian_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kanzian_at.py
@@ -1,13 +1,13 @@
 import re
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import RECYCLABLES
 
 _BASE_URL = "https://www.kanzian.at"
 
@@ -60,6 +60,6 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean,
         type_value_map={
-            "Leicht- und Metallverpackungen": RECYCLABLES,
+            "Leicht- und Metallverpackungen": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/karlsruhe_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/karlsruhe_de.py
@@ -21,16 +21,10 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://web{i}.karlsruhe.de/service/abfall/akal/akal_{year}.php"
 
@@ -108,11 +102,11 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Bioabfall": ORGANIC,
-            "Papier": PAPER,
-            "Wertstoff": RECYCLABLES,
-            "Sperrmüllabholung": BULKY_WASTE,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Bioabfall": wt.ORGANIC,
+            "Papier": wt.PAPER,
+            "Wertstoff": wt.RECYCLABLES,
+            "Sperrmüllabholung": wt.BULKY_WASTE,
         },
         clean=_clean_first_segment,
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kirklees_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kirklees_gov_uk.py
@@ -14,6 +14,7 @@ from datetime import date, timedelta
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import postcode, text_field, uprn
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -29,11 +30,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Live-verified (2026-07): the standard AchieveForms handshake
 # (init_session -> authapi/isauthenticated, using the un-prefixed service path
@@ -245,10 +241,10 @@ class Source(BaseSource):
     )
     transform = RowTransformer(
         type_value_map={
-            "grey wheelie bin": GENERAL_WASTE,
-            "green wheelie bin": RECYCLABLES,
-            "brown wheelie bin": GARDEN_WASTE,
-            "blue wheelie bin": RECYCLABLES,
+            "grey wheelie bin": wt.GENERAL_WASTE,
+            "green wheelie bin": wt.RECYCLABLES,
+            "brown wheelie bin": wt.GARDEN_WASTE,
+            "blue wheelie bin": wt.RECYCLABLES,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/klosterneuburg_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,7 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 _BASE_URL = "https://www.klosterneuburg.at"
 _SELECTION_URL = (
@@ -22,7 +22,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Stadtgemeinde Klosterneuburg waste collection."
     URL = _SELECTION_URL
     COUNTRY = "at"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.PAPER]
 
     TEST_CASES: ClassVar[dict] = {
         "Kierlinger Straße 10": {
@@ -56,6 +56,6 @@ class Source(BaseSource):
     # are); Restmüll, Biomüll, Gelber Sack and Sperrmüll all resolve unmapped.
     transform = ICSTransformer(
         type_value_map={
-            "Papiermüll": PAPER,
+            "Papiermüll": wt.PAPER,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/koppl_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/koppl_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 # Demonstrates: the RiSKommunal platform contributing TWO independent pipeline
 # stages — RiSKommunalRetriever (raw HTML calendar pages, fetched lazily) and
@@ -49,7 +49,7 @@ class Source(BaseSource):
     # Sperrmüll, Problemstoff, ...) is classified by the shared vocabulary.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall 14-tägig": GENERAL_WASTE,
-            "Restabfall monatlich": GENERAL_WASTE,
+            "Restabfall 14-tägig": wt.GENERAL_WASTE,
+            "Restabfall monatlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/korneuburg_stadtservice_at.py
@@ -2,6 +2,7 @@ from typing import ClassVar, final
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup, Tag
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -9,12 +10,6 @@ from waste_collection_schedule.parsers import EachResponse, IcsParser
 from waste_collection_schedule.retrievers import FanOutRetriever
 from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # A RiSKommunal municipality whose calendar is not exposed through the
 # platform's usual kalender.aspx table/list rendering at all. Korneuburg
@@ -172,7 +167,12 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Rathaus": {"street_name": "Hauptplatz", "street_number": 39},  # Teilgebiet 4

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kreis_ploen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kreis_ploen_de.py
@@ -11,16 +11,11 @@ and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.kreis-ploen.de"
 
@@ -31,7 +26,12 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Abfallwirtschaft Kreis Plön waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Hauptstraße (Köhn)": {"strasse": "Hauptstraße", "ort": "Köhn"},
@@ -52,11 +52,11 @@ class Source(BaseSource):
     # match an alias exactly, so each needs an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Bioabfall 2-wöchentlich": ORGANIC,
-            "Papier 4-wöchentlich": PAPER,
-            "Papiercontainer 4-wöchentlich": PAPER,
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
-            "Restabfallcontainer 2-wöchentlich": GENERAL_WASTE,
+            "Bioabfall 2-wöchentlich": wt.ORGANIC,
+            "Papier 4-wöchentlich": wt.PAPER,
+            "Papiercontainer 4-wöchentlich": wt.PAPER,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfallcontainer 2-wöchentlich": wt.GENERAL_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kronstorf_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 _BASE_URL = "https://www.kronstorf.at"
 
@@ -41,9 +41,9 @@ class Source(BaseSource):
     # by the shared vocabulary.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall wöchentlich": GENERAL_WASTE,
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
-            "Restabfall 6-wöchentlich": GENERAL_WASTE,
+            "Restabfall wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 6-wöchentlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ks_boerde_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ks_boerde_de.py
@@ -9,6 +9,7 @@ the platform.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, municipality, street
 from waste_collection_schedule.parsers import IcsParser
@@ -18,13 +19,6 @@ from waste_collection_schedule.service.HausmuellInfo import (
     Lookup,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://boerde.hausmuell.info/"
 _PROXY_URL = "https://www.ks-boerde.de/_aturis/eko/proxy.php"
@@ -61,11 +55,11 @@ class Source(BaseSource):
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -112,4 +106,4 @@ class Source(BaseSource):
         check_calendar_status=False,
     )
     parse = IcsParser()
-    transform = ICSTransformer(type_value_map={"Papier, Pappe, Karton": PAPER})
+    transform = ICSTransformer(type_value_map={"Papier, Pappe, Karton": wt.PAPER})

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kumberg_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kumberg_gv_at.py
@@ -15,16 +15,10 @@ bin name so the shared vocabulary can resolve it.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsIndexRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 API_URL = "https://www.kumberg.gv.at/kalender/"
 
@@ -51,10 +45,10 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Bio": ORGANIC,
-            "Papier": PAPER,
-            "Gelber Sack": RECYCLABLES,
-            "Sperrmüll": BULKY_WASTE,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Bio": wt.ORGANIC,
+            "Papier": wt.PAPER,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Sperrmüll": wt.BULKY_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwb_goslar_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwb_goslar_de.py
@@ -11,6 +11,7 @@ shared steps.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -20,15 +21,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    ELECTRONICS,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.kwb-goslar.de"
 
@@ -40,13 +32,13 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "de"
     WASTE_TYPES: ClassVar[list] = [
-        ELECTRONICS,
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.ELECTRONICS,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -85,7 +77,7 @@ class Source(BaseSource):
     # -sammlung" wording), so each needs an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Mobile Elektroaltgerätesammlung": ELECTRONICS,
-            "Mobile Schadstoffsammlung": HAZARDOUS,
+            "Mobile Elektroaltgerätesammlung": wt.ELECTRONICS,
+            "Mobile Schadstoffsammlung": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwinana_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwinana_wa_gov_au.py
@@ -3,6 +3,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -12,11 +13,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Demonstrates: a stateful-session service (IntraMapsRetriever + IntraMapsPanelParser)
 # plus the reusable RecurrenceExpander preprocessor. The only source-specific code
@@ -38,9 +34,9 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 # IntraMaps column name -> canonical waste type. One map: selects the collection
 # fields (others ignored) and types them.
 _TYPE_MAP = {
-    "Rubbish_Collection_Day": GENERAL_WASTE,
-    "Recycle_Collection": RECYCLABLES,
-    "Garden Organics Collection": GARDEN_WASTE,
+    "Rubbish_Collection_Day": wt.GENERAL_WASTE,
+    "Recycle_Collection": wt.RECYCLABLES,
+    "Garden Organics Collection": wt.GARDEN_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/kwu_de.py
@@ -12,18 +12,13 @@ from datetime import date
 from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _HEADERS = {"user-agent": "Mozilla/5.0 (xxxx Windows NT 10.0; Win64; x64)"}
 _BASE_URL = "https://kalender.kwu-entsorgung.de"
@@ -112,7 +107,12 @@ class Source(BaseSource):
     URL = "https://www.kwu-entsorgung.de/"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Erkner": {"city": "Erkner", "street": "Heinrich-Heine-Straße", "number": "11"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lancaster_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lancaster_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     house_number,
@@ -11,12 +12,6 @@ from waste_collection_schedule.service.WhitespaceWRP import (
     WhitespaceRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Demonstrates: a fully declarative service-backed source. The Whitespace WRP
 # platform's 4-step scrape lives in its service module as WhitespaceRetriever +
@@ -24,12 +19,12 @@ from waste_collection_schedule.waste_types import (
 # council's open-ended type labels onto canonical WasteTypes via a RowTransformer.
 
 _TYPE_MAP = {
-    "Domestic Waste": GENERAL_WASTE,
-    "Garden Waste": GARDEN_WASTE,
-    "Recycling Red": RECYCLABLES,
-    "Recycling Yellow": RECYCLABLES,
-    "Recycling": RECYCLABLES,
-    "Food Waste": FOOD_WASTE,
+    "Domestic Waste": wt.GENERAL_WASTE,
+    "Garden Waste": wt.GARDEN_WASTE,
+    "Recycling Red": wt.RECYCLABLES,
+    "Recycling Yellow": wt.RECYCLABLES,
+    "Recycling": wt.RECYCLABLES,
+    "Food Waste": wt.FOOD_WASTE,
 }
 _SUFFIXES = (
     " Collection Service",
@@ -57,7 +52,12 @@ class Source(BaseSource):
     URL = "https://lancaster.gov.uk"
     COUNTRY = "uk"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, GARDEN_WASTE, FOOD_WASTE]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.FOOD_WASTE,
+    ]
     API_URL = "https://lcc-wrp.whitespacews.com"
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_helmstedt_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_helmstedt_de.py
@@ -13,18 +13,13 @@ from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
 from waste_collection_schedule import retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.preprocessors import RoundAreaSelector
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 API_URL = "https://www.landkreis-helmstedt.de/portal/seiten/abfuhrkalender-900000002-34150.html"
 HEADERS = {"user-agent": "Mozilla"}
@@ -67,7 +62,12 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Landkreis Helmstedt."
     URL = "landkreis-helmstedt.de"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Grasleben": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_kusel_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_kusel_de.py
@@ -15,19 +15,12 @@ from typing import ClassVar, final
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import municipality
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsLookupRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://abfallwirtschaft.landkreis-kusel.de"
 
@@ -108,12 +101,12 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "LVP-Abfälle": RECYCLABLES,
-            "Glas": GLASS,
-            "Bioabfall": ORGANIC,
-            "Papier": PAPER,
-            "Umweltmobil": BULKY_WASTE,
+            "Restmüll": wt.GENERAL_WASTE,
+            "LVP-Abfälle": wt.RECYCLABLES,
+            "Glas": wt.GLASS,
+            "Bioabfall": wt.ORGANIC,
+            "Papier": wt.PAPER,
+            "Umweltmobil": wt.BULKY_WASTE,
         },
         # The feed's SUMMARY is e.g. "LVP-Abfälle (Gelbe Säcke) ()"; only the
         # first word identifies the waste type (matches the legacy source's

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_verden_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_verden_de.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -31,13 +32,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = (
     "https://lkv.landkreis-verden.de/WasteManagementVerden/WasteManagementServlet"
@@ -144,10 +138,10 @@ class Source(BaseSource):
         # reason. Mirror that here so every variant still resolves.
         clean=lambda label: label.split()[0] if label.split() else label,
         type_value_map={
-            "Gelber": RECYCLABLES,
-            "Restabfallbehaelter": GENERAL_WASTE,
-            "Papierbehaelter": PAPER,
-            "Kompostbehaelter": ORGANIC,
-            "Weihnachtsbaum": GARDEN_WASTE,
+            "Gelber": wt.RECYCLABLES,
+            "Restabfallbehaelter": wt.GENERAL_WASTE,
+            "Papierbehaelter": wt.PAPER,
+            "Kompostbehaelter": wt.ORGANIC,
+            "Weihnachtsbaum": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_wittmund_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/landkreis_wittmund_de.py
@@ -11,17 +11,11 @@ with ``refid_page_url``, so this source is a plain composition of shared steps.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.landkreis-wittmund.de"
 _API_URL = (
@@ -44,11 +38,11 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "de"
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -75,6 +69,6 @@ class Source(BaseSource):
     # "restabfall" form), so it needs an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfalltonne": GENERAL_WASTE,
+            "Restabfalltonne": wt.GENERAL_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/launceston_tas_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/launceston_tas_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,13 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-    WasteType,
-)
 
 # Demonstrates: the ArcGis service contributing two independent pipeline stages —
 # ArcGisFeatureRetriever (raw /query Response) and ArcGisFeatureParser (Response
@@ -28,11 +22,11 @@ from waste_collection_schedule.waste_types import (
 
 # feature field -> (canonical waste type, cadence). Single source of truth: the
 # transformer map is derived from it, and _describe reads the cadence from it.
-_SERVICES: dict[str, tuple[WasteType, str]] = {
-    "Garbagedate": (GENERAL_WASTE, "weekly"),
-    "Recycledate": (RECYCLABLES, "fortnightly"),
-    "Fogodate": (ORGANIC, "fortnightly"),
-    "Hardwastedate": (BULKY_WASTE, "once"),
+_SERVICES: dict[str, tuple[wt.WasteType, str]] = {
+    "Garbagedate": (wt.GENERAL_WASTE, "weekly"),
+    "Recycledate": (wt.RECYCLABLES, "fortnightly"),
+    "Fogodate": (wt.ORGANIC, "fortnightly"),
+    "Hardwastedate": (wt.BULKY_WASTE, "once"),
 }
 
 # cadence -> (step, count) for the recurring projection.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lawrence_ma_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lawrence_ma_us.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from typing import ClassVar, final
 
 from waste_collection_schedule import lookups, parsers, recurrence, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street
 from waste_collection_schedule.preprocessors import (
@@ -12,7 +13,6 @@ from waste_collection_schedule.preprocessors import (
     Schedule,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # Demonstrates: a weekday-list scrape resolved by preprocessors.ArgumentLookup
 # and projected into a recurring weekly schedule.
@@ -104,5 +104,5 @@ class Source(BaseSource):
     )
 
     transform = ICSTransformer(
-        type_value_map={"trash": GENERAL_WASTE, "recycling": RECYCLABLES},
+        type_value_map={"trash": wt.GENERAL_WASTE, "recycling": wt.RECYCLABLES},
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/leeds_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/leeds_gov_uk.py
@@ -2,14 +2,10 @@ import datetime
 from typing import ClassVar, TypedDict, final
 
 from waste_collection_schedule import date_parsers, parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import api_key, uprn
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Demonstrates: the config_params.api_key() PARAM on the BaseSource pipeline.
 #
@@ -83,9 +79,9 @@ class Source(BaseSource):
     }
 
     _TYPE_MAP: ClassVar[dict] = {
-        "Black": GENERAL_WASTE,
-        "Green": RECYCLABLES,
-        "Brown": GARDEN_WASTE,
+        "Black": wt.GENERAL_WASTE,
+        "Green": wt.RECYCLABLES,
+        "Brown": wt.GARDEN_WASTE,
     }
 
     retrieve = retrievers.HttpGetRetriever(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lincoln_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lincoln_gov_uk.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import postcode, uprn
 from waste_collection_schedule.preprocessors import (
@@ -17,11 +18,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "contact.lincoln.gov.uk"
 INITIAL_URL = (
@@ -109,9 +105,9 @@ class Source(BaseSource):
     )
     transform = RowTransformer(
         type_value_map={
-            "refuse": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
-            "garden": GARDEN_WASTE,
+            "refuse": wt.GENERAL_WASTE,
+            "recycling": wt.RECYCLABLES,
+            "garden": wt.GARDEN_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lk_mecklenburgische_seenplatte_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lk_mecklenburgische_seenplatte_de.py
@@ -11,16 +11,11 @@ and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.lk-mecklenburgische-seenplatte.de"
 
@@ -31,7 +26,12 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Landkreis Mecklenburgische Seenplatte waste collection."
     URL = _BASE_URL
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Atelierstraße (Neubrandenburg)": {
@@ -56,7 +56,7 @@ class Source(BaseSource):
     # observed variant needs an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Restmülltonne 14-täglichen Rhythmus": GENERAL_WASTE,
-            "Restmülltonne 28-täglichen Rhythmus": GENERAL_WASTE,
+            "Restmülltonne 14-täglichen Rhythmus": wt.GENERAL_WASTE,
+            "Restmülltonne 28-täglichen Rhythmus": wt.GENERAL_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lobbe_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lobbe_app.py
@@ -12,6 +12,7 @@ best-effort, and it re-resolves the ids rather than reusing this year's.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -23,13 +24,6 @@ from waste_collection_schedule.field_terms import STATE
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsSessionRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    ELECTRONICS,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://lobbe.app/wp-admin/admin-ajax.php"
 _TYPES = {"gelber", "biobfall", "restabfall", "altpapier", "additional_types"}
@@ -232,10 +226,10 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall": GENERAL_WASTE,
-            "Bioabfall": ORGANIC,
-            "Altpapier": PAPER,
-            "Gelber Sack / Wertstofftonne": RECYCLABLES,
-            "Elektroschrott": ELECTRONICS,
+            "Restabfall": wt.GENERAL_WASTE,
+            "Bioabfall": wt.ORGANIC,
+            "Altpapier": wt.PAPER,
+            "Gelber Sack / Wertstofftonne": wt.RECYCLABLES,
+            "Elektroschrott": wt.ELECTRONICS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/magdeburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/magdeburg_de.py
@@ -12,18 +12,13 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.service.ICS import IcsFeedsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _ICS_URL = "https://st-magdeburg.server.smart-village.app/waste_calendar/export"
 _STREET_LIST_URL = "https://sab.ssl.metageneric.de/app/sab_i_tp/index.php"
@@ -94,10 +89,10 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall": GENERAL_WASTE,
-            "Altpapier": PAPER,
-            "Gelbe Tonne": RECYCLABLES,
-            "Bioabfall": ORGANIC,
+            "Restabfall": wt.GENERAL_WASTE,
+            "Altpapier": wt.PAPER,
+            "Gelbe Tonne": wt.RECYCLABLES,
+            "Bioabfall": wt.ORGANIC,
         },
         clean=lambda label: (
             "Gelbe Tonne"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mags_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mags_de.py
@@ -13,19 +13,12 @@ rounds). ``ICSTransformer`` does the rest.
 import datetime
 from typing import TYPE_CHECKING, ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.service.ICS import ICS
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    ELECTRONICS,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 if TYPE_CHECKING:
     from waste_collection_schedule.retrievers import Response
@@ -90,13 +83,13 @@ class Source(BaseSource):
     parse = _CleanedIcsParser(split_at="/")
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll (Grau)": GENERAL_WASTE,
-            "Bioabfall (Braun)": ORGANIC,
-            "Verpackungen (Gelb)": RECYCLABLES,
-            "Altpapier (Blau)": PAPER,
-            "Papiermobil": PAPER,
-            "Grünschnitt": GARDEN_WASTE,
-            "Elektrokleingeräte-Sammlung": ELECTRONICS,
+            "Restmüll (Grau)": wt.GENERAL_WASTE,
+            "Bioabfall (Braun)": wt.ORGANIC,
+            "Verpackungen (Gelb)": wt.RECYCLABLES,
+            "Altpapier (Blau)": wt.PAPER,
+            "Papiermobil": wt.PAPER,
+            "Grünschnitt": wt.GARDEN_WASTE,
+            "Elektrokleingeräte-Sammlung": wt.ELECTRONICS,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mandurah_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mandurah_wa_gov_au.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import (
@@ -17,7 +18,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # Weekly general waste (a bare weekday name) plus fortnightly recycling (an
 # explicit "next date"), with a Christmas Day collection shifted to Boxing Day.
@@ -36,8 +36,8 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 
 # IntraMaps column name -> canonical waste type.
 _TYPE_MAP = {
-    "Refuse Day": GENERAL_WASTE,
-    "Next Recycle Day is ": RECYCLABLES,
+    "Refuse Day": wt.GENERAL_WASTE,
+    "Next Recycle Day is ": wt.RECYCLABLES,
 }
 
 # The recycling value is free text such as "next Friday - 17 Jul 2026" or

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melvillecity_com_au.py
@@ -2,6 +2,7 @@ from typing import ClassVar, final
 
 from dateutil.parser import parse as _dateutil_parse
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import (
@@ -17,7 +18,6 @@ from waste_collection_schedule.service.IntraMaps import (
     nominatim_reproject,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # The only Integration API council of the three that needs a geocode step
 # first: its single search form takes reprojected map coordinates rather than
@@ -39,9 +39,9 @@ INTRAMAPS_CONFIG = IntegrationClientConfig(
 WASTE_FORM_ID = "0e72c05c-0181-428a-b4e0-e2be69cf69dc"
 
 _TYPE_MAP = {
-    "FOGO": ORGANIC,
-    "General Waste": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
+    "FOGO": wt.ORGANIC,
+    "General Waste": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
 }
 
 # Column carrying an explicit next-collection date -> the round it belongs to.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/merri_bek_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/merri_bek_vic_gov_au.py
@@ -2,18 +2,13 @@ from typing import Any, ClassVar, final
 from urllib.parse import urlencode
 
 from waste_collection_schedule import parsers, preprocessors
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.date_parsers import for_format
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.retrievers import TwoStepRetriever
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # Merri-bek's own schedule API is not an ArcGIS endpoint: an ArcGIS FeatureServer
 # lookup resolves the address to a point plus a handful of rate/zone codes,
@@ -33,10 +28,10 @@ ALL_FOGO_DAYS = "allFogoDays"
 ALL_GLASS_DAYS = "allGlassDays"
 
 _TYPE_MAP = {
-    ALL_BIN_DAYS: GENERAL_WASTE,
-    ALL_RECYCLE_DAYS: RECYCLABLES,
-    ALL_FOGO_DAYS: ORGANIC,
-    ALL_GLASS_DAYS: GLASS,
+    ALL_BIN_DAYS: wt.GENERAL_WASTE,
+    ALL_RECYCLE_DAYS: wt.RECYCLABLES,
+    ALL_FOGO_DAYS: wt.ORGANIC,
+    ALL_GLASS_DAYS: wt.GLASS,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/micheldorf_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.micheldorf.at"
 
@@ -24,7 +19,12 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Adalbert-Stifter-Straße 1": {
@@ -62,8 +62,8 @@ class Source(BaseSource):
     # Altpapier, Gelber Sack, Sperrmüll and Altglas all resolve unmapped.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
-            "Restabfall 6-wöchentlich": GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 6-wöchentlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mid_devon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mid_devon_gov_uk.py
@@ -13,6 +13,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -22,13 +23,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-    WasteType,
-)
 
 # Live-verified (2026-07): the standard AchieveForms handshake
 # (init_session -> authapi/isauthenticated, using the landing page's resolved
@@ -60,11 +54,11 @@ class Source(BaseSource):
     COUNTRY = "uk"
     RAISE_ON_EMPTY = True
 
-    WASTE_TYPES: ClassVar[list[WasteType]] = [
-        FOOD_WASTE,
-        RECYCLABLES,
-        GENERAL_WASTE,
-        GARDEN_WASTE,
+    WASTE_TYPES: ClassVar[list[wt.WasteType]] = [
+        wt.FOOD_WASTE,
+        wt.RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.GARDEN_WASTE,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -105,14 +99,14 @@ class Source(BaseSource):
     )
     transform = RowTransformer(
         type_value_map={
-            "blue food caddy": FOOD_WASTE,
-            "black & green recycling boxes": RECYCLABLES,
-            "black and green recycling boxes": RECYCLABLES,
-            "green recycling box": RECYCLABLES,
-            "black recycling box": RECYCLABLES,
-            "garden waste": GARDEN_WASTE,
-            "domestic refuse": GENERAL_WASTE,
-            "black bin": GENERAL_WASTE,
-            "rubbish": GENERAL_WASTE,
+            "blue food caddy": wt.FOOD_WASTE,
+            "black & green recycling boxes": wt.RECYCLABLES,
+            "black and green recycling boxes": wt.RECYCLABLES,
+            "green recycling box": wt.RECYCLABLES,
+            "black recycling box": wt.RECYCLABLES,
+            "garden waste": wt.GARDEN_WASTE,
+            "domestic refuse": wt.GENERAL_WASTE,
+            "black bin": wt.GENERAL_WASTE,
+            "rubbish": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/moonee_valley_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/moonee_valley_vic_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,7 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Attribute query (address LIKE) -> one feature with a collection weekday and two
 # epoch-ms start dates. General waste is weekly; recycling and FOGO are
@@ -20,9 +20,9 @@ from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCL
 FEATURE_URL = "https://services8.arcgis.com/Qhxu8dzT7BHYuJZL/arcgis/rest/services/BinCollection_add/FeatureServer/0"
 
 _TYPE_MAP = {
-    "General Waste": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "FOGO": ORGANIC,
+    "General Waste": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "FOGO": wt.ORGANIC,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mpgk_com_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mpgk_com_pl.py
@@ -17,18 +17,11 @@ data either way.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.retrievers import HttpPostRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.mpgk.com.pl/mod/harmonogram/ics"
 
@@ -57,12 +50,12 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Odpady komunalne": GENERAL_WASTE,
-            "Odpady papier, makulatura zbierane w pojemnikach 120 l do 1100 l": PAPER,
-            "Odpady szklane zbierane w pojemnikach 120 l do 1100 l": GLASS,
-            "Odpady wielkogabarytowe dla zabudowy wielorodzinnej": BULKY_WASTE,
+            "Odpady komunalne": wt.GENERAL_WASTE,
+            "Odpady papier, makulatura zbierane w pojemnikach 120 l do 1100 l": wt.PAPER,
+            "Odpady szklane zbierane w pojemnikach 120 l do 1100 l": wt.GLASS,
+            "Odpady wielkogabarytowe dla zabudowy wielorodzinnej": wt.BULKY_WASTE,
             "Odpady z tworzyw sztucznych i metalu zbierane w pojemnikach"
-            " 120 l do 1100 l": RECYCLABLES,
-            "Odpady B I O zbierane w pojemnikach": ORGANIC,
+            " 120 l do 1100 l": wt.RECYCLABLES,
+            "Odpady B I O zbierane w pojemnikach": wt.ORGANIC,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mpo_krakow_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mpo_krakow_pl.py
@@ -11,19 +11,12 @@ diary: a weekday, the date, then the rounds collected that day, one per line).
 from typing import ClassVar, final
 
 from waste_collection_schedule import config_params
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.parsers import PdfTextParser
 from waste_collection_schedule.preprocessors import TextDatedBlocks
 from waste_collection_schedule.service.KiedyWywoz import SchedulePdfRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _TOKEN = "OkkxhC6b9etJBAq7WTHJ0LhIglO18sip"
 
@@ -71,13 +64,13 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Zmieszane": GENERAL_WASTE,
-            "Szkło": GLASS,
-            "Papier": PAPER,
-            "Tworzywa sztuczne": RECYCLABLES,
-            "Bio": ORGANIC,
-            "Zielone": GARDEN_WASTE,
-            "Choinki": GARDEN_WASTE,
+            "Zmieszane": wt.GENERAL_WASTE,
+            "Szkło": wt.GLASS,
+            "Papier": wt.PAPER,
+            "Tworzywa sztuczne": wt.RECYCLABLES,
+            "Bio": wt.ORGANIC,
+            "Zielone": wt.GARDEN_WASTE,
+            "Choinki": wt.GARDEN_WASTE,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mrcjoliette_qc_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mrcjoliette_qc_ca.py
@@ -2,17 +2,11 @@ from datetime import datetime, timezone
 from typing import ClassVar, TypedDict, final
 
 from waste_collection_schedule import date_parsers, parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # Demonstrates: date_parsers.from_epoch for a JSON API that returns collection
 # dates as Unix milliseconds, plus a dropdown whose human-readable options the
@@ -43,11 +37,11 @@ CITIES = {
 _NAME_TO_ID = {name: city_id for city_id, name in CITIES.items()}
 
 _TYPE_MAP = {
-    "bac_bleu": RECYCLABLES,
-    "bac_brun": ORGANIC,
-    "bac_noir": GENERAL_WASTE,
-    "encombrants": BULKY_WASTE,
-    "residus_verts": GARDEN_WASTE,
+    "bac_bleu": wt.RECYCLABLES,
+    "bac_brun": wt.ORGANIC,
+    "bac_noir": wt.GENERAL_WASTE,
+    "encombrants": wt.BULKY_WASTE,
+    "residus_verts": wt.GARDEN_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muehlenkreis_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muehlenkreis_de.py
@@ -11,19 +11,11 @@ and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    ELECTRONICS,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.muehlenkreis.de"
 
@@ -35,13 +27,13 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "de"
     WASTE_TYPES: ClassVar[list] = [
-        BULKY_WASTE,
-        ELECTRONICS,
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.BULKY_WASTE,
+        wt.ELECTRONICS,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -72,11 +64,11 @@ class Source(BaseSource):
     # so each needs an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Biotonne 2-wöchentlich": ORGANIC,
-            "Gelbe Tonne 4-wöchentlich": RECYCLABLES,
-            "Papiertonne 4-wöchentlich": PAPER,
-            "Restmüll 4-wöchentlich": GENERAL_WASTE,
-            "Schadstoffsammlung": HAZARDOUS,
-            "Sperrmüllabfuhr": BULKY_WASTE,
+            "Biotonne 2-wöchentlich": wt.ORGANIC,
+            "Gelbe Tonne 4-wöchentlich": wt.RECYCLABLES,
+            "Papiertonne 4-wöchentlich": wt.PAPER,
+            "Restmüll 4-wöchentlich": wt.GENERAL_WASTE,
+            "Schadstoffsammlung": wt.HAZARDOUS,
+            "Sperrmüllabfuhr": wt.BULKY_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muellmax_de.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -11,14 +12,6 @@ from waste_collection_schedule.config_params import (
 from waste_collection_schedule.regions import Region, region
 from waste_collection_schedule.service.MuellmaxDe import MuellmaxRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Demonstrates: a fully declarative source over a stateful platform wizard. The
 # Müllmax multi-step form walk lives in the service module as MuellmaxRetriever,
@@ -111,12 +104,12 @@ _PROVIDERS = [
 # waste term so the map below resolves it; unrecognised labels pass through
 # unchanged (resolved by the vocabulary or preserved verbatim).
 _TYPE_VALUE_MAP = {
-    "restmüll": GENERAL_WASTE,
-    "bioabfall": ORGANIC,
-    "altpapier": PAPER,
-    "wertstoff": RECYCLABLES,
-    "grünabfall": GARDEN_WASTE,
-    "schadstoff": HAZARDOUS,
+    "restmüll": wt.GENERAL_WASTE,
+    "bioabfall": wt.ORGANIC,
+    "altpapier": wt.PAPER,
+    "wertstoff": wt.RECYCLABLES,
+    "grünabfall": wt.GARDEN_WASTE,
+    "schadstoff": wt.HAZARDOUS,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mulhouse_alsace_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mulhouse_alsace_fr.py
@@ -4,6 +4,7 @@ from typing import Any, ClassVar, Literal, final
 
 import holidays
 from waste_collection_schedule import date_parsers, parsers, recurrence, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     district,
@@ -19,12 +20,6 @@ from waste_collection_schedule.preprocessors import (
 )
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Demonstrates: a recurrence source whose holiday calendar comes from the
 # holidays library (France, Alsace-Moselle subdivision "6AE") instead of
@@ -41,10 +36,10 @@ API_URL = (
 
 # (frequency field, day field, label, waste type)
 WASTE_FIELDS = (
-    ("freq_omr", "jour_omr", "Ordures ménagères", GENERAL_WASTE),
-    ("freq_recyc", "jour_recyc", "Tri sélectif", RECYCLABLES),
-    ("freq_bio_d", "jour_bio", "Bio-déchets", FOOD_WASTE),
-    ("freq_vert", "jour_vert", "Déchets verts", GARDEN_WASTE),
+    ("freq_omr", "jour_omr", "Ordures ménagères", wt.GENERAL_WASTE),
+    ("freq_recyc", "jour_recyc", "Tri sélectif", wt.RECYCLABLES),
+    ("freq_bio_d", "jour_bio", "Bio-déchets", wt.FOOD_WASTE),
+    ("freq_vert", "jour_vert", "Déchets verts", wt.GARDEN_WASTE),
 )
 _TYPE_MAP = {label: waste_type for _f, _d, label, waste_type in WASTE_FIELDS}
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/muttenz_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/muttenz_ch.py
@@ -2,15 +2,9 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.collection import Collection
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    HAZARDOUS,
-    PAPER,
-    RECYCLABLES,
-    WasteType,
-)
 
 # Demonstrates: parsers.AttributeJsonParser, for a JSON payload embedded inside
 # an HTML data-attribute.
@@ -29,15 +23,15 @@ from waste_collection_schedule.waste_types import (
 # ``require_keys`` selects between. Dates are dd.mm.yyyy (Swiss German), which
 # dateutil parses, so no custom locale handling is needed.
 
-_TYPE_MAP: dict[str, WasteType] = {
-    "Papiersammlung": PAPER,
-    "Kunststoffsammlung": RECYCLABLES,
+_TYPE_MAP: dict[str, wt.WasteType] = {
+    "Papiersammlung": wt.PAPER,
+    "Kunststoffsammlung": wt.RECYCLABLES,
     # "Altmetallabuhr" is the provider's own spelling (a missing "f"); match it
     # verbatim so scrap-metal collections are not silently dropped.
-    "Altmetallabuhr": RECYCLABLES,
-    "Grünabfuhr": GARDEN_WASTE,
-    "Häckseltag": GARDEN_WASTE,
-    "Sonderabfallsammlung": HAZARDOUS,
+    "Altmetallabuhr": wt.RECYCLABLES,
+    "Grünabfuhr": wt.GARDEN_WASTE,
+    "Häckseltag": wt.GARDEN_WASTE,
+    "Sonderabfallsammlung": wt.HAZARDOUS,
 }
 
 
@@ -73,7 +67,12 @@ class Source(BaseSource):
     # "Papiersammlung" would resolve on its own; the map is kept explicit so the
     # produced WASTE_TYPES are pinned and a renamed label is mapped, not silently
     # preserved verbatim.
-    WASTE_TYPES: ClassVar[list] = [PAPER, RECYCLABLES, GARDEN_WASTE, HAZARDOUS]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.PAPER,
+        wt.RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.HAZARDOUS,
+    ]
 
     parse = parsers.AttributeJsonParser(
         "[data-entities]",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzv_rotenburg_bebra_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mzv_rotenburg_bebra_de.py
@@ -3,21 +3,12 @@ from typing import ClassVar, final
 import requests
 from bs4 import BeautifulSoup, Tag
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.collection import Collection
 from waste_collection_schedule.config_params import (
     city,
     text_field,
-)
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    ELECTRONICS,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-    preserved,
-    resolve,
 )
 
 WEBAPP_URL = "https://www.mzv-rotenburg-bebra.de//webapp.html"
@@ -92,12 +83,12 @@ class Source(BaseSource):
 
     # classify() produces these — declared explicitly (no transformer to derive from).
     WASTE_TYPES: ClassVar[list] = [
-        RECYCLABLES,
-        ORGANIC,
-        GENERAL_WASTE,
-        PAPER,
-        BULKY_WASTE,
-        ELECTRONICS,
+        wt.RECYCLABLES,
+        wt.ORGANIC,
+        wt.GENERAL_WASTE,
+        wt.PAPER,
+        wt.BULKY_WASTE,
+        wt.ELECTRONICS,
     ]
 
     # min_events=1: a valid feed has at least one event; an HTML error page (no
@@ -144,5 +135,5 @@ class Source(BaseSource):
             bin_type = "papier"
 
         return Collection(
-            date=record.date, waste_type=resolve(bin_type) or preserved(bin_type)
+            date=record.date, waste_type=wt.resolve(bin_type) or wt.preserved(bin_type)
         )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/narab_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/narab_se.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import Any, ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.collection import Collection
 from waste_collection_schedule.config_params import (
@@ -13,17 +14,6 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.parsers import HtmlCalendarGrid
 from waste_collection_schedule.retrievers import LookupChainRetriever
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-    preserved,
-    resolve,
-)
 
 # Composes: LookupChainRetriever (NÅRAB's calendar lives on a separate service,
 # narabtomningskalender.se, reached in two GET steps: an address autocomplete
@@ -78,26 +68,26 @@ _COLLECTION_LABELS = {
 # through to preserved(), keeping their descriptive label rather than collapsing
 # to one canonical type. A Swedish speaker should sanity-check these.
 _CODE_TYPES = {
-    "KK": GENERAL_WASTE,
-    "HAS": GENERAL_WASTE,
-    "HAO": GENERAL_WASTE,
-    "HAX": GENERAL_WASTE,
-    "MAT": ORGANIC,
-    "ORG": ORGANIC,
-    "WELL": PAPER,
-    "TIDN": PAPER,
-    "PAPP": PAPER,
-    "B1": RECYCLABLES,
-    "PLF": RECYCLABLES,
-    "MET": RECYCLABLES,
-    "MPL": RECYCLABLES,
-    "HPL": RECYCLABLES,
-    "FG": GLASS,
-    "OFG": GLASS,
-    "TRG": GARDEN_WASTE,
-    "BATT": HAZARDOUS,
-    "OLJA": HAZARDOUS,
-    "FA": HAZARDOUS,
+    "KK": wt.GENERAL_WASTE,
+    "HAS": wt.GENERAL_WASTE,
+    "HAO": wt.GENERAL_WASTE,
+    "HAX": wt.GENERAL_WASTE,
+    "MAT": wt.ORGANIC,
+    "ORG": wt.ORGANIC,
+    "WELL": wt.PAPER,
+    "TIDN": wt.PAPER,
+    "PAPP": wt.PAPER,
+    "B1": wt.RECYCLABLES,
+    "PLF": wt.RECYCLABLES,
+    "MET": wt.RECYCLABLES,
+    "MPL": wt.RECYCLABLES,
+    "HPL": wt.RECYCLABLES,
+    "FG": wt.GLASS,
+    "OFG": wt.GLASS,
+    "TRG": wt.GARDEN_WASTE,
+    "BATT": wt.HAZARDOUS,
+    "OLJA": wt.HAZARDOUS,
+    "FA": wt.HAZARDOUS,
 }
 
 
@@ -171,13 +161,13 @@ class Source(BaseSource):
     # classify() maps each collection code to a canonical type via _CODE_TYPES;
     # mixed/ambiguous codes stay as preserved: labels (see the map's note).
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
-        GLASS,
-        GARDEN_WASTE,
-        HAZARDOUS,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+        wt.GLASS,
+        wt.GARDEN_WASTE,
+        wt.HAZARDOUS,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -224,5 +214,7 @@ class Source(BaseSource):
         if label is None:
             return None
 
-        waste_type = _CODE_TYPES.get(base_code) or resolve(label) or preserved(label)
+        waste_type = (
+            _CODE_TYPES.get(base_code) or wt.resolve(label) or wt.preserved(label)
+        )
         return Collection(date=collection_date, waste_type=waste_type)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nemaffaldsservice_kk_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nemaffaldsservice_kk_dk.py
@@ -20,22 +20,12 @@ from typing import ClassVar, final
 from urllib.parse import parse_qs, urlparse
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    ELECTRONICS,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://nemaffaldsservice.kk.dk"
 _ADDRESS_LOOKUP_URL = f"{_BASE_URL}/WasteHome/AddressByTerm/"
@@ -137,18 +127,18 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Restaffald": GENERAL_WASTE,
-            "Madaffald": ORGANIC,
-            "Bioposer": ORGANIC,
-            "Papir": PAPER,
-            "Pap": PAPER,
-            "Glas": GLASS,
-            "Metal": RECYCLABLES,
-            "Plast": RECYCLABLES,
-            "Elektronik": ELECTRONICS,
-            "Farligt affald": HAZARDOUS,
-            "Tekstil": RECYCLABLES,
-            "Storskrald": BULKY_WASTE,
-            "Haveaffald": GARDEN_WASTE,
+            "Restaffald": wt.GENERAL_WASTE,
+            "Madaffald": wt.ORGANIC,
+            "Bioposer": wt.ORGANIC,
+            "Papir": wt.PAPER,
+            "Pap": wt.PAPER,
+            "Glas": wt.GLASS,
+            "Metal": wt.RECYCLABLES,
+            "Plast": wt.RECYCLABLES,
+            "Elektronik": wt.ELECTRONICS,
+            "Farligt affald": wt.HAZARDOUS,
+            "Tekstil": wt.RECYCLABLES,
+            "Storskrald": wt.BULKY_WASTE,
+            "Haveaffald": wt.GARDEN_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/neu_ulm_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/neu_ulm_de.py
@@ -10,12 +10,12 @@ from typing import ClassVar, final
 
 from bs4 import BeautifulSoup, Tag
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.retrievers import TwoStepRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import ORGANIC, PAPER, RECYCLABLES
 
 _HOST_URI = "https://nu.neu-ulm.de"
 _CALENDAR_PAGE = (
@@ -50,7 +50,7 @@ class Source(BaseSource):
     DESCRIPTION = "Source for Neu-Ulm."
     URL = "https://nu.neu-ulm.de/buerger-service/leben-in-neu-ulm/abfall-sauberkeit/abfallkalender"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.ORGANIC, wt.PAPER, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Bezirk 1": {"region": "Bezirk 1"},
@@ -69,8 +69,8 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Gelber Sack": RECYCLABLES,
-            "Grüngut": ORGANIC,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Grüngut": wt.ORGANIC,
         },
         clean=lambda label: label.replace("Abfuhr ", "").strip(),
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newcastle_nsw_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -10,11 +11,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # ArcGis single spatial query -> one feature with Day + WeekNo, from which three
 # recurring schedules are projected (general weekly; recycling/green fortnightly
@@ -24,9 +20,9 @@ from waste_collection_schedule.waste_types import (
 FEATURE_URL = "https://services-ap1.arcgis.com/CNeUPE1voVc22gNk/arcgis/rest/services/WasteCollectionDay/FeatureServer/0"
 
 _TYPE_MAP = {
-    "General Waste": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "Green Waste": GARDEN_WASTE,
+    "General Waste": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Green Waste": wt.GARDEN_WASTE,
 }
 
 # Reference date for the fortnightly cycle (from the ArcGIS Arcade expression).

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/northherts_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/northherts_gov_uk.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -12,13 +13,6 @@ from waste_collection_schedule.service.uk_cloud9_apps import (
     Cloud9Retriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    PAPER,
-    RECYCLABLES,
-)
 
 
 @final
@@ -72,11 +66,11 @@ class Source(BaseSource):
     parse = Cloud9Parser()
     transform = RowTransformer(
         type_value_map={
-            "Non-recyclable refuse bin": GENERAL_WASTE,
-            "Mixed recycling bin": RECYCLABLES,
-            "Cardboard & paper bin": PAPER,
-            "Food Caddy": FOOD_WASTE,
-            "Garden waste bin": GARDEN_WASTE,
+            "Non-recyclable refuse bin": wt.GENERAL_WASTE,
+            "Mixed recycling bin": wt.RECYCLABLES,
+            "Cardboard & paper bin": wt.PAPER,
+            "Food Caddy": wt.FOOD_WASTE,
+            "Garden waste bin": wt.GARDEN_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/northville_township_mi_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/northville_township_mi_us.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -9,11 +10,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # ArcGis attribute query (a LIKE clause on the street address — no geocode) ->
 # one feature carrying the service weekday (New_Day). Three weekly schedules
@@ -24,9 +20,9 @@ from waste_collection_schedule.waste_types import (
 FEATURE_URL = "https://services.arcgis.com/eKu0BIfy09ymzWZF/arcgis/rest/services/Day_change_TrashCollection/FeatureServer/0"
 
 _TYPE_MAP = {
-    "Garbage": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "Compostables": ORGANIC,
+    "Garbage": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Compostables": wt.ORGANIC,
 }
 
 _WEEKDAYS = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsr_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nsr_se.py
@@ -9,6 +9,7 @@ from typing import ClassVar, final
 from urllib.parse import urlencode
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import (
@@ -19,15 +20,6 @@ from waste_collection_schedule.regions import region
 from waste_collection_schedule.retrievers import TwoStepRetriever
 from waste_collection_schedule.service.ICS import IcsFeedsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://nsr.se/api/wastecalendar"
 
@@ -127,17 +119,17 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "KÄRL 1": GENERAL_WASTE,
-            "KÄRL 2": RECYCLABLES,
-            "Trädgårdsavfall": GARDEN_WASTE,
-            "Restavfall": GENERAL_WASTE,
-            "Matavfall": FOOD_WASTE,
-            "Pappersförpackningar": PAPER,
-            "Tidningar": PAPER,
-            "Ofärgat glas": GLASS,
-            "Färgat glas": GLASS,
-            "Plastförpackningar": RECYCLABLES,
-            "Metallförpackningar": RECYCLABLES,
-            "Miljöfarligt avfall": HAZARDOUS,
+            "KÄRL 1": wt.GENERAL_WASTE,
+            "KÄRL 2": wt.RECYCLABLES,
+            "Trädgårdsavfall": wt.GARDEN_WASTE,
+            "Restavfall": wt.GENERAL_WASTE,
+            "Matavfall": wt.FOOD_WASTE,
+            "Pappersförpackningar": wt.PAPER,
+            "Tidningar": wt.PAPER,
+            "Ofärgat glas": wt.GLASS,
+            "Färgat glas": wt.GLASS,
+            "Plastförpackningar": wt.RECYCLABLES,
+            "Metallförpackningar": wt.RECYCLABLES,
+            "Miljöfarligt avfall": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/nuernberger_land_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/nuernberger_land_de.py
@@ -10,17 +10,11 @@ work; this module only supplies the URL template and the waste-type map.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import location_id
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://abfuhrkalender.nuernberger-land.de/waste_calendar"
 _FILTER = "rm:bio:p:dsd:poison"
@@ -47,10 +41,10 @@ class Source(BaseSource):
     parse = parsers.IcsParser(split_at="/")
     transform = ICSTransformer(
         type_value_map={
-            "Restmüll": GENERAL_WASTE,
-            "Biotonne": ORGANIC,
-            "Gelber Sack": RECYCLABLES,
-            "Papier": PAPER,
-            "Giftmobil": HAZARDOUS,
+            "Restmüll": wt.GENERAL_WASTE,
+            "Biotonne": wt.ORGANIC,
+            "Gelber Sack": wt.RECYCLABLES,
+            "Papier": wt.PAPER,
+            "Giftmobil": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/obdach_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/obdach_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 _BASE_URL = "https://www.obdach.gv.at"
 
@@ -38,8 +38,8 @@ class Source(BaseSource):
     # RECYCLABLES/PAPER meanings either).
     transform = ICSTransformer(
         type_value_map={
-            "Gelber Sack/Tonne": RECYCLABLES,
-            "Restmüll Abfuhrbereich 1": GENERAL_WASTE,
-            "Restmüll Abfuhrbereich 2": GENERAL_WASTE,
+            "Gelber Sack/Tonne": wt.RECYCLABLES,
+            "Restmüll Abfuhrbereich 1": wt.GENERAL_WASTE,
+            "Restmüll Abfuhrbereich 2": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/oberndorf_schwanenstadt_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.oberndorf.ooe.gv.at"
 
@@ -25,7 +20,12 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Am Hang 2": {"strasse": "Am Hang", "hausnummer": "2"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/offenbach_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/offenbach_de.py
@@ -1,9 +1,9 @@
 import logging
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.source.insert_it_de import Source as InsertItSource
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class Source(InsertItSource):
     DESCRIPTION = "Source für Abfallkalender Offenbach (deprecated)"
     URL = "https://www.offenbach.de"
     COUNTRY = "de"
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.PAPER]
 
     TEST_CASES: ClassVar[dict] = {
         "offenbach": {"f_id_location": 7036},  # Kaiserstraße 1

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/okc_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/okc_gov.py
@@ -3,6 +3,7 @@ import re
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
@@ -18,11 +19,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisMultiFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # City of Oklahoma City. Two independent feeds cover the same three waste types
 # (trash / recycling / bulky):
@@ -58,9 +54,9 @@ WASTE_LAYERS = {
 }
 
 _TYPE_MAP = {
-    "TRASH": GENERAL_WASTE,
-    "RECYCLE": RECYCLABLES,
-    "BULKY": BULKY_WASTE,
+    "TRASH": wt.GENERAL_WASTE,
+    "RECYCLE": wt.RECYCLABLES,
+    "BULKY": wt.BULKY_WASTE,
 }
 
 # The unofficial feed answers with one object per round, keyed by field name.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ort_im_innkreis_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ort_im_innkreis_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 _BASE_URL = "https://www.ort-im-innkreis.at"
 
@@ -33,7 +33,7 @@ class Source(BaseSource):
     # Sperrmüll, Problemstoff) is classified by the shared vocabulary.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ostprignitz_ruppin_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ostprignitz_ruppin_de.py
@@ -11,18 +11,11 @@ manual request params and no ICON_MAP.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street
 from waste_collection_schedule.service.SiteparkIES import SiteparkIESRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.ostprignitz-ruppin.de"
 
@@ -34,12 +27,12 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "de"
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -78,6 +71,6 @@ class Source(BaseSource):
     # aliases use the bare "grünabfall" form), so it needs an explicit map.
     transform = ICSTransformer(
         type_value_map={
-            "Grünabfallsammlung": GARDEN_WASTE,
+            "Grünabfallsammlung": wt.GARDEN_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/peterborough_gov_uk.py
@@ -9,11 +9,11 @@ module only supplies the URL template and the waste-type map.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import postcode, uprn
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 _ICS_URL = "https://report.peterborough.gov.uk/waste/{post_code}:{uprn}/calendar.ics"
 
@@ -44,8 +44,8 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Empty Bin 240L Black": GENERAL_WASTE,
-            "Empty Bin 240L Green": RECYCLABLES,
-            "Empty Bin 240L Brown": ORGANIC,
+            "Empty Bin 240L Black": wt.GENERAL_WASTE,
+            "Empty Bin 240L Green": wt.RECYCLABLES,
+            "Empty Bin 240L Brown": wt.ORGANIC,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/phila_gov.py
@@ -13,6 +13,7 @@ from datetime import date
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import recurrence, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import (
@@ -28,7 +29,6 @@ from waste_collection_schedule.service.PhilaGov import (
     HolidayCascadeShift,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 DAYS = {"MON": 0, "TUE": 1, "WED": 2, "THU": 3, "FRI": 4, "SAT": 5, "SUN": 6}
 
@@ -104,5 +104,5 @@ class Source(BaseSource):
     )
 
     transform = ICSTransformer(
-        type_value_map={"general": GENERAL_WASTE, "recycling": RECYCLABLES}
+        type_value_map={"general": wt.GENERAL_WASTE, "recycling": wt.RECYCLABLES}
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/piberbach_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/piberbach_ooe_gv_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 _BASE_URL = "https://www.piberbach.ooe.gv.at"
 
@@ -38,8 +38,8 @@ class Source(BaseSource):
     # the shared vocabulary.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
-            "Restabfall 6-wöchentlich": GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 6-wöchentlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/plano_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/plano_gov.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.preprocessors import (
@@ -15,11 +16,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # City of Plano ArcGIS "ServicedAddresses" layer, one feature per address
 # (looked up by its OBJECTID). Trash is a recurring weekday (DAY_2017),
@@ -36,9 +32,9 @@ FEATURE_URL = (
 OUT_FIELDS = "DAY_2017,BLKY_CURR,BLKY_NEXT1,BLKY_NEXT2,REC_CURR,REC_NEXT1,REC_NEXT2"
 
 _TYPE_MAP = {
-    "TRASH": GENERAL_WASTE,
-    "RECYCLE": RECYCLABLES,
-    "BULKY": BULKY_WASTE,
+    "TRASH": wt.GENERAL_WASTE,
+    "RECYCLE": wt.RECYCLABLES,
+    "BULKY": wt.BULKY_WASTE,
 }
 
 # Default number of weekly trash collections to project when daysToGenerate

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/plymouth_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/plymouth_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,7 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 HOSTNAME = "plymouth-self.achieveservice.com"
 INITIAL_URL = (
@@ -64,7 +64,7 @@ class Source(BaseSource):
         type_key="Round_Type",
         parse_date=date_parsers.for_format("%Y-%m-%dT%H:%M:%S"),
         type_value_map={
-            "DO": GENERAL_WASTE,
-            "RE": RECYCLABLES,
+            "DO": wt.GENERAL_WASTE,
+            "RE": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pointe_claire_qc_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pointe_claire_qc_ca.py
@@ -18,18 +18,12 @@ is mapped to a canonical type.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 _SECTOR_URL_MAP: dict[str, str] = {
     "A": "https://raw.githubusercontent.com/jordanconway/pointe-claire-waste-calendars/refs/heads/main/pointe-claire-a.ics",
@@ -78,12 +72,12 @@ class Source(BaseSource):
     parse = parsers.IcsParser(regex=r"^(.*?)\s*-\s*Sector [AB]$")
     transform = ICSTransformer(
         type_value_map={
-            "Household Waste": GENERAL_WASTE,
-            "Recyclables": RECYCLABLES,
-            "Organic Waste": ORGANIC,
-            "Bulky Items": BULKY_WASTE,
-            "Mattress/Box-Spring Collection": BULKY_WASTE,
-            "Christmas Tree Collection": GARDEN_WASTE,
-            "Leaf Collection": GARDEN_WASTE,
+            "Household Waste": wt.GENERAL_WASTE,
+            "Recyclables": wt.RECYCLABLES,
+            "Organic Waste": wt.ORGANIC,
+            "Bulky Items": wt.BULKY_WASTE,
+            "Mattress/Box-Spring Collection": wt.BULKY_WASTE,
+            "Christmas Tree Collection": wt.GARDEN_WASTE,
+            "Leaf Collection": wt.GARDEN_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/portsmouth_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/portsmouth_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 HOSTNAME = "my.portsmouth.gov.uk"
 INITIAL_URL = (
@@ -71,7 +71,7 @@ class Source(BaseSource):
     )
     transform = RowTransformer(
         type_value_map={
-            "refuse bin": GENERAL_WASTE,
-            "recycling bin": RECYCLABLES,
+            "refuse bin": wt.GENERAL_WASTE,
+            "recycling bin": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/puchbeihallein_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/puchbeihallein_gv_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.puchbeihallein.gv.at"
 
@@ -25,7 +20,12 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@nerdoc"]
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Ahornstraße 3": {"strasse": "Ahornstraße", "hausnummer": "3"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rapperswil_be_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rapperswil_be_ch.py
@@ -14,10 +14,10 @@ from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.retrievers import TwoStepRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, PAPER
 
 _BASE_URL = "https://www.rapperswil-be.ch"
 _API_URL = f"{_BASE_URL}/de/abfallwirtschaft/abfallkalender/"
@@ -63,8 +63,8 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Hauskehricht": GENERAL_WASTE,
-            "Grüngut": ORGANIC,
-            "Papier und Karton": PAPER,
+            "Hauskehricht": wt.GENERAL_WASTE,
+            "Grüngut": wt.ORGANIC,
+            "Papier und Karton": wt.PAPER,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/reading_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/reading_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, TypedDict, final
 
 from waste_collection_schedule import date_parsers, parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -13,12 +14,6 @@ from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Demonstrates: alternative-input PARAMS via config_params.alternatives() —
 # the user provides a UPRN, OR a postcode + house name/number. validate()
@@ -97,10 +92,10 @@ class Source(BaseSource):
     }
 
     _TYPE_MAP: ClassVar[dict] = {
-        "Domestic Waste Collection Service": GENERAL_WASTE,
-        "Recycling Collection Service": RECYCLABLES,
-        "Food Waste Collection Service": FOOD_WASTE,
-        "Garden Waste Collection Service": GARDEN_WASTE,
+        "Domestic Waste Collection Service": wt.GENERAL_WASTE,
+        "Recycling Collection Service": wt.RECYCLABLES,
+        "Food Waste Collection Service": wt.FOOD_WASTE,
+        "Garden Waste Collection Service": wt.GARDEN_WASTE,
     }
 
     parse = parsers.JsonParser("collections", shape=list[_Collection])

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/real_luzern_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/real_luzern_ch.py
@@ -13,16 +13,11 @@ from urllib.parse import urlencode
 
 from bs4 import BeautifulSoup
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.retrievers import TwoStepRetriever
 from waste_collection_schedule.transformers import ICSTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.real-luzern.ch/abfall/sammeldienst/abfallkalender/"
 
@@ -96,11 +91,11 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "Kehricht": GENERAL_WASTE,
-            "Grüngut": ORGANIC,
-            "Papier": PAPER,
-            "Karton": PAPER,
-            "Altmetall": RECYCLABLES,
+            "Kehricht": wt.GENERAL_WASTE,
+            "Grüngut": wt.ORGANIC,
+            "Papier": wt.PAPER,
+            "Karton": wt.PAPER,
+            "Altmetall": wt.RECYCLABLES,
         },
         clean=label_cleaner(remap=_OLD_WASTE_NAME),
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/red_bank_tn_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/red_bank_tn_us.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
@@ -15,7 +16,6 @@ from waste_collection_schedule.preprocessors import (
 )
 from waste_collection_schedule.service import ArcGis
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 # City of Red Bank, TN "trash day" ArcGIS FeatureServer: layer 1 holds parcels
 # (STNUM/STNAME, one polygon per address), layers 2-6 are the Monday..Friday
@@ -38,7 +38,7 @@ WKID = 102100  # Web Mercator, the service's native spatial reference
 # How far ahead to project the recurring weekly schedule.
 HORIZON_DAYS = 365
 
-_TYPE_MAP = {"Trash": GENERAL_WASTE}
+_TYPE_MAP = {"Trash": wt.GENERAL_WASTE}
 
 # Street-type suffixes dropped before matching so 'Ave' vs 'Avenue' etc. don't
 # cause a miss (the parcel layer stores the bare street name in STNAME).

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/redbridge_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/redbridge_gov_uk.py
@@ -11,26 +11,21 @@ PDF reads cleanly, this is all a source needs.
 from typing import ClassVar, final
 
 from waste_collection_schedule import config_params
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.parsers import PdfTextParser
 from waste_collection_schedule.preprocessors import TextCalendarGrid
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 _API_URL = "https://my.redbridge.gov.uk/RecycleRefuse/GetFile"
 
 # The service names the PDF prints, keyed by their leading word.
 _TYPE_MAP = {
-    "REFUSE": GENERAL_WASTE,
-    "RECYCLING": RECYCLABLES,
-    "GARDEN": GARDEN_WASTE,
-    "FOOD": FOOD_WASTE,
+    "REFUSE": wt.GENERAL_WASTE,
+    "RECYCLING": wt.RECYCLABLES,
+    "GARDEN": wt.GARDEN_WASTE,
+    "FOOD": wt.FOOD_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/reso_gmbh_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/reso_gmbh_de.py
@@ -17,17 +17,12 @@ Parsing is the plain ``IcsParser`` with the same ``split_at`` the legacy
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, municipality
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.service.ICS import IcsSessionRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://reso-gmbh.abfallkalender.services/php/Kalender-2-ICS.php"
 
@@ -87,9 +82,9 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "restmüll": GENERAL_WASTE,
-            "biotonne": ORGANIC,
-            "papiertonne": PAPER,
-            "gelber-sack": RECYCLABLES,
+            "restmüll": wt.GENERAL_WASTE,
+            "biotonne": wt.ORGANIC,
+            "papiertonne": wt.PAPER,
+            "gelber-sack": wt.RECYCLABLES,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rh_entsorgung_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rh_entsorgung_de.py
@@ -1,14 +1,9 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.regions import region
 from waste_collection_schedule.source.jumomind_de import Source as JumomindSource
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Rhein-Hunsrück Entsorgung runs on Jumomind (service id "rhe"). This is the
 # same structure as jumomind_de, pinned to the "rhe" service and exposing a
@@ -25,7 +20,12 @@ class Source(JumomindSource):
 
     # Canonical types observed from the live Jumomind "rhe" service; overrides the
     # inherited ALL_TYPES fallback with the specific vocabulary this service emits.
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, ORGANIC, PAPER]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.RECYCLABLES,
+        wt.ORGANIC,
+        wt.PAPER,
+    ]
 
     REGIONS = (region("Rhein-Hunsrück Entsorgung (RHE)", url=URL),)
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rochester_ny_us.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rochester_ny_us.py
@@ -3,6 +3,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisMultiFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # Rochester publishes trash and recycling as two separate ArcGIS layers on one
 # MapServer. A point-in-polygon query against each layer returns the collection
@@ -30,8 +30,8 @@ RECYCLING_URL = f"{BASE_URL}/9"
 DAY_FIELDS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 _TYPE_MAP = {
-    "Trash": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
+    "Trash": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
 }
 
 MONTHS = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rockingham_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rockingham_wa_gov_au.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown, text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -13,13 +14,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # Suburb + street name + street number (the suburb is a fixed dropdown; the
 # combined "street_number street_name SUBURB" string is what IntraMaps expects
@@ -66,11 +60,11 @@ _RECYCLE = "Recycle (Yellow Lid)"
 _WASTE = "Waste (Red Lid)"
 
 _TYPE_MAP = {
-    _WASTE: GENERAL_WASTE,
-    _RECYCLE: RECYCLABLES,
-    _FOGO: ORGANIC,
-    _VERGE_GREEN_WASTE: GARDEN_WASTE,
-    _VERGE_GENERAL: BULKY_WASTE,
+    _WASTE: wt.GENERAL_WASTE,
+    _RECYCLE: wt.RECYCLABLES,
+    _FOGO: wt.ORGANIC,
+    _VERGE_GREEN_WASTE: wt.GARDEN_WASTE,
+    _VERGE_GENERAL: wt.BULKY_WASTE,
 }
 
 _VERGE_COLUMNS = {_VERGE_GREEN_WASTE, _VERGE_GENERAL}

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rohrbach_lafnitz_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rohrbach_lafnitz_at.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalMultiIcsParser,
     RiSKommunalMultiIcsRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import BULKY_WASTE, GARDEN_WASTE
 
 # Demonstrates: a RiSKommunal municipality that publishes one ICS feed *per
 # waste type* rather than one combined calendar. Each feed's own ICS SUMMARY is
@@ -50,6 +50,6 @@ class Source(BaseSource):
     # explicit entry.
     transform = ICSTransformer(
         type_value_map={
-            "Sperrmüll & Heckenschnitt": [BULKY_WASTE, GARDEN_WASTE],
+            "Sperrmüll & Heckenschnitt": [wt.BULKY_WASTE, wt.GARDEN_WASTE],
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rsag_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rsag_de.py
@@ -16,19 +16,13 @@ term the legacy substring-matching ICON_MAP effectively grouped it under
 import datetime
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_BASE = "https://www.rsag.de/api"
 
@@ -111,7 +105,12 @@ class Source(BaseSource):
     URL = "https://www.rsag.de"
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Königswinter, Winzerstraße": {
@@ -153,5 +152,5 @@ class Source(BaseSource):
     parse = IcsParser()
     transform = ICSTransformer(
         clean=_clean_type,
-        type_value_map={"Wertstoff": RECYCLABLES, "Weihnachtsbaum": GARDEN_WASTE},
+        type_value_map={"Wertstoff": wt.RECYCLABLES, "Weihnachtsbaum": wt.GARDEN_WASTE},
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rugby_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rugby_gov_uk.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.uk_cloud9_apps import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.uk_cloud9_apps import (
     Cloud9Retriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 
 @final
@@ -42,9 +37,9 @@ class Source(BaseSource):
     parse = Cloud9Parser()
     transform = RowTransformer(
         type_value_map={
-            "Black refuse bin": GENERAL_WASTE,
-            "Blue-lid recycling bin": RECYCLABLES,
-            "Food caddy": FOOD_WASTE,
-            "Green garden waste bin": GARDEN_WASTE,
+            "Black refuse bin": wt.GENERAL_WASTE,
+            "Blue-lid recycling bin": wt.RECYCLABLES,
+            "Food caddy": wt.FOOD_WASTE,
+            "Green garden waste bin": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rushcliffe_gov_uk.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     postcode,
@@ -10,12 +11,6 @@ from waste_collection_schedule.service.FirmstepSelfService import (
     RushcliffePanelParser,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    PAPER,
-)
 
 FORM_URL = "https://selfservice.rushcliffe.gov.uk/renderform.aspx?t=1242&k=86BDCD8DE8D868B9E23D10842A7A4FE0F1023CCA"
 ADDRESS_LOOKUP_URL = "https://selfservice.rushcliffe.gov.uk/core/addresslookup"
@@ -57,9 +52,9 @@ class Source(BaseSource):
     parse = RushcliffePanelParser()
     transform = RowTransformer(
         type_value_map={
-            "grey": GENERAL_WASTE,
-            "garden waste": GARDEN_WASTE,
-            "blue": PAPER,
-            "glass": GLASS,
+            "grey": wt.GENERAL_WASTE,
+            "garden waste": wt.GARDEN_WASTE,
+            "blue": wt.PAPER,
+            "glass": wt.GLASS,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/rv_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/rv_de.py
@@ -12,6 +12,7 @@ after both).
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -21,12 +22,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://athos-onlinedienste.rv.de/WasteManagementRavensburgPrivat/WasteManagementServlet"
 
@@ -94,9 +89,9 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "restmuelltonne": GENERAL_WASTE,
-            "biotonne": ORGANIC,
-            "papiertonne": PAPER,
-            "gelbe tonne": RECYCLABLES,
+            "restmuelltonne": wt.GENERAL_WASTE,
+            "biotonne": wt.ORGANIC,
+            "papiertonne": wt.PAPER,
+            "gelbe tonne": wt.RECYCLABLES,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/saalfelden_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.saalfelden.at"
 
@@ -24,7 +19,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Achenweg 1": {"strasse": "Achenweg", "hausnummer": 1},
@@ -71,7 +66,7 @@ class Source(BaseSource):
     # plural ("Christbäume"/"Weihnachtsbäume").
     transform = ICSTransformer(
         type_value_map={
-            "Christbaum": GARDEN_WASTE,
-            "Weihnachtsbaum": GARDEN_WASTE,
+            "Christbaum": wt.GARDEN_WASTE,
+            "Weihnachtsbaum": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sandwell_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sandwell_gov_uk.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,12 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "my.sandwell.gov.uk"
 INITIAL_URL = (
@@ -92,9 +87,9 @@ class Source(BaseSource):
     transform = RowTransformer(
         parse_date=date_parsers.for_format("%d/%m/%Y"),
         type_value_map={
-            "household waste (grey)": GENERAL_WASTE,
-            "recycling (blue)": RECYCLABLES,
-            "food waste (brown)": FOOD_WASTE,
-            "garden waste (green)": GARDEN_WASTE,
+            "household waste (grey)": wt.GENERAL_WASTE,
+            "recycling (blue)": wt.RECYCLABLES,
+            "food waste (brown)": wt.FOOD_WASTE,
+            "garden waste (green)": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schaerding_ooe_gv_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,12 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.schaerding.ooe.gv.at"
 
@@ -24,7 +19,12 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, PAPER, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
+    ]
 
     TEST_CASES: ClassVar[dict] = {
         "Adalbert-Stifter-Straße 1": {
@@ -63,9 +63,9 @@ class Source(BaseSource):
     # Tonne, Sperrmüll, Altglas and Problemstoff all resolve unmapped.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall wöchentlich": GENERAL_WASTE,
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
-            "Restabfall 6-wöchentlich": GENERAL_WASTE,
+            "Restabfall wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 6-wöchentlich": wt.GENERAL_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schlierbach_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schlierbach_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -8,7 +9,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 _BASE_URL = "https://www.schlierbach.at"
 VALID_ZONES = ["1", "Wohnhausanlagen"]
@@ -21,7 +21,7 @@ class Source(BaseSource):
     URL = _BASE_URL
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Gemeinde Alle (no zone)": {},
@@ -60,8 +60,8 @@ class Source(BaseSource):
     # Gelbe Tonne resolve unmapped.
     transform = ICSTransformer(
         type_value_map={
-            "Restabfall 2-wöchentlich": GENERAL_WASTE,
-            "Restabfall 4-wöchentlich": GENERAL_WASTE,
+            "Restabfall 2-wöchentlich": wt.GENERAL_WASTE,
+            "Restabfall 4-wöchentlich": wt.GENERAL_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/seab_biella_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/seab_biella_it.py
@@ -12,28 +12,21 @@ labels it prints and where it states the year.
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.parsers import PdfTableParser
 from waste_collection_schedule.preprocessors import PdfMonthColumns
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _TYPE_MAP = {
-    "INDIFFERENZIATO": GENERAL_WASTE,
-    "ORGANICO": ORGANIC,
-    "CARTA": PAPER,
-    "PLASTICA": RECYCLABLES,
-    "VETRO": GLASS,
-    "SFALCI": GARDEN_WASTE,
+    "INDIFFERENZIATO": wt.GENERAL_WASTE,
+    "ORGANICO": wt.ORGANIC,
+    "CARTA": wt.PAPER,
+    "PLASTICA": wt.RECYCLABLES,
+    "VETRO": wt.GLASS,
+    "SFALCI": wt.GARDEN_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/selwyn_govt_nz.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import (
@@ -16,7 +17,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisFeatureRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Selwyn's ArcGIS layer is queried with an address-prefix `where` clause, so a
 # short fragment can come back holding several distinct properties' rows.
@@ -36,9 +36,9 @@ RECYCLING = "Recycling"
 ORGANICS = "Organics"
 
 _TYPE_MAP = {
-    RUBBISH: GENERAL_WASTE,
-    RECYCLING: RECYCLABLES,
-    ORGANICS: ORGANIC,
+    RUBBISH: wt.GENERAL_WASTE,
+    RECYCLING: wt.RECYCLABLES,
+    ORGANICS: wt.ORGANIC,
 }
 
 # Number of weeks of collections to generate (matches the legacy default).

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sepan_remondis_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sepan_remondis_pl.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, house_number, street
 from waste_collection_schedule.service.Sepan import (
@@ -8,15 +9,6 @@ from waste_collection_schedule.service.Sepan import (
     SepanRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Waste-type names by report-table column position. This deployment's report
 # tables don't reliably expose parseable header text (unlike the alba_com_pl /
@@ -37,13 +29,13 @@ NAME_MAP = {
 # Not in Polish shared-vocabulary aliases (Polish isn't a resolve() language),
 # so every label is mapped explicitly.
 TYPE_VALUE_MAP = {
-    "Zmieszane odpady komunalne": GENERAL_WASTE,
-    "Papier": PAPER,
-    "Metale i tworzywa sztuczne": RECYCLABLES,
-    "Szkło": GLASS,
-    "Bioodpady": ORGANIC,
-    "Drzewka świąteczne": GARDEN_WASTE,
-    "Odpady wystawkowe": BULKY_WASTE,
+    "Zmieszane odpady komunalne": wt.GENERAL_WASTE,
+    "Papier": wt.PAPER,
+    "Metale i tworzywa sztuczne": wt.RECYCLABLES,
+    "Szkło": wt.GLASS,
+    "Bioodpady": wt.ORGANIC,
+    "Drzewka świąteczne": wt.GARDEN_WASTE,
+    "Odpady wystawkowe": wt.BULKY_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/shawinigan_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/shawinigan_ca.py
@@ -3,6 +3,7 @@ import logging
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
@@ -15,12 +16,6 @@ from waste_collection_schedule.preprocessors import (
 from waste_collection_schedule.service import ArcGis
 from waste_collection_schedule.service.ArcGis import ArcGisGeocodeError
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # Shawinigan publishes each collection type as its own ArcGIS MapServer layer.
 # A point-in-polygon query against each layer returns a feature whose SCHEDULE /
@@ -63,11 +58,11 @@ LAYERS = [
 ]
 
 _TYPE_MAP = {
-    "RECYCLAGE": RECYCLABLES,
-    "ORDURES": GENERAL_WASTE,
-    "SAPIN": GARDEN_WASTE,
-    "FEUILLES": GARDEN_WASTE,
-    "COMPOST": ORGANIC,
+    "RECYCLAGE": wt.RECYCLABLES,
+    "ORDURES": wt.GENERAL_WASTE,
+    "SAPIN": wt.GARDEN_WASTE,
+    "FEUILLES": wt.GARDEN_WASTE,
+    "COMPOST": wt.ORGANIC,
 }
 
 # Window length used by the legacy weekly/bi-weekly/irregular projection.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sjshire_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sjshire_wa_gov_au.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -12,7 +13,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # The shire moved its map off the self-hosted maps.sjshire.wa.gov.au IntraMaps
 # server onto TechnologyOne's SaaS platform (ser.spatial.t1cloud.com). The old
@@ -38,8 +38,8 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 )
 
 _TYPE_MAP = {
-    "WasteCollectionDay": GENERAL_WASTE,
-    "RecycleDay": RECYCLABLES,
+    "WasteCollectionDay": wt.GENERAL_WASTE,
+    "RecycleDay": wt.RECYCLABLES,
 }
 
 # RecycleDay reads "<day> this/next week", but the "this week" variant arrives

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southend_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southend_gov_uk.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -12,13 +13,6 @@ from waste_collection_schedule.service.uk_cloud9_apps import (
     Cloud9Retriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    PAPER,
-    RECYCLABLES,
-)
 
 
 @final
@@ -65,10 +59,10 @@ class Source(BaseSource):
     # bin and paper and card in the blue lid bin.
     transform = RowTransformer(
         type_value_map={
-            "Refuse Bin": GENERAL_WASTE,
-            "Pink Lid Recycling Bin": RECYCLABLES,
-            "Blue Lid Recycling Bin": PAPER,
-            "Food Caddy": FOOD_WASTE,
-            "Garden Waste": GARDEN_WASTE,
+            "Refuse Bin": wt.GENERAL_WASTE,
+            "Pink Lid Recycling Bin": wt.RECYCLABLES,
+            "Blue Lid Recycling Bin": wt.PAPER,
+            "Food Caddy": wt.FOOD_WASTE,
+            "Garden Waste": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southkesteven_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southkesteven_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.service.FirmstepSelfService import (
@@ -8,12 +9,6 @@ from waste_collection_schedule.service.FirmstepSelfService import (
     SouthKestevenRowClassifier,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 FORM_URL = (
     "https://selfservice.southkesteven.gov.uk/"
@@ -65,9 +60,9 @@ class Source(BaseSource):
     preprocess = SouthKestevenRowClassifier()
     transform = RowTransformer(
         type_value_map={
-            "black": GENERAL_WASTE,
-            "gray": RECYCLABLES,
-            "green": ORGANIC,
-            "purple": PAPER,
+            "black": wt.GENERAL_WASTE,
+            "gray": wt.RECYCLABLES,
+            "green": wt.ORGANIC,
+            "purple": wt.PAPER,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southperth_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southperth_wa_gov_au.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 # General waste is a bare "Every Friday" (weekly). Recycling is published as
 # a single explicit next-pickup date with no cadence, so it is emitted as one
@@ -27,8 +27,8 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 
 # IntraMaps column name -> canonical waste type.
 _TYPE_MAP = {
-    "bin_day": GENERAL_WASTE,
-    "recycling_day": RECYCLABLES,
+    "bin_day": wt.GENERAL_WASTE,
+    "recycling_day": wt.RECYCLABLES,
 }
 
 # The recycling value is free text such as "17 July 2026"; pull out just the

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/spelthorne_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/spelthorne_gov_uk.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import Any, ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -11,11 +12,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "spelthorne-self.achieveservice.com"
 BASE_URL = f"https://{HOSTNAME}"
@@ -107,8 +103,8 @@ class Source(BaseSource):
     )
     transform = RowTransformer(
         type_value_map={
-            "garden waste": GARDEN_WASTE,
-            "refuse": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
+            "garden waste": wt.GARDEN_WASTE,
+            "refuse": wt.GENERAL_WASTE,
+            "recycling": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_margarethen_salzburg_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/st_margarethen_salzburg_at.py
@@ -1,19 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    BULKY_WASTE,
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://www.st.margarethen.salzburg.at"
 
@@ -49,11 +42,11 @@ class Source(BaseSource):
     # vocabulary verbatim; all six are mapped explicitly.
     transform = ICSTransformer(
         type_value_map={
-            "Abholung BIO-Tonne": ORGANIC,
-            "Abholung Gelber Sack": RECYCLABLES,
-            "Abholung Hausmüll": GENERAL_WASTE,
-            "Abholung Altpapier": PAPER,
-            "Abholung Altglas": GLASS,
-            "Sperrmüllabfuhr": BULKY_WASTE,
+            "Abholung BIO-Tonne": wt.ORGANIC,
+            "Abholung Gelber Sack": wt.RECYCLABLES,
+            "Abholung Hausmüll": wt.GENERAL_WASTE,
+            "Abholung Altpapier": wt.PAPER,
+            "Abholung Altglas": wt.GLASS,
+            "Sperrmüllabfuhr": wt.BULKY_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadt_bamberg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadt_bamberg_de.py
@@ -27,16 +27,11 @@ production.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street, text_field
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = (
     "https://ebbweb.stadt.bamberg.de/WasteManagementBamberg/WasteManagementServlet"
@@ -101,9 +96,9 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=lambda label: label.split()[0],
         type_value_map={
-            "restmuell": GENERAL_WASTE,
-            "biomuell": ORGANIC,
-            "papier": PAPER,
-            "gelber": RECYCLABLES,
+            "restmuell": wt.GENERAL_WASTE,
+            "biomuell": wt.ORGANIC,
+            "papier": wt.PAPER,
+            "gelber": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_dresden_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_dresden_de.py
@@ -14,17 +14,12 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import location_id
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.service.ICS import IcsFeedsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _ICAL_URL = (
     "https://stadtplan.dresden.de/project/cardo3Apps/IDU_DDStadtplan/abfall/ical.ashx"
@@ -84,9 +79,9 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "bio-tonne": ORGANIC,
-            "blaue tonne": PAPER,
-            "gelbe tonne": RECYCLABLES,
-            "restabfall": GENERAL_WASTE,
+            "bio-tonne": wt.ORGANIC,
+            "blaue tonne": wt.PAPER,
+            "gelbe tonne": wt.RECYCLABLES,
+            "restabfall": wt.GENERAL_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_giessen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_giessen_de.py
@@ -15,19 +15,13 @@ the bare category before it is mapped/resolved.
 from typing import ClassVar, final
 
 from bs4 import BeautifulSoup, Tag
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _BASE_URL = "https://stadtreinigung.giessen.de/akal/akal1.php"
 
@@ -114,11 +108,11 @@ class Source(BaseSource):
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -157,7 +151,10 @@ class Source(BaseSource):
     parse = IcsParser()
     transform = ICSTransformer(
         clean=_clean_type,
-        type_value_map={"Astwerkabfuhr": GARDEN_WASTE, "Weihnachtsbaum": GARDEN_WASTE},
+        type_value_map={
+            "Astwerkabfuhr": wt.GARDEN_WASTE,
+            "Weihnachtsbaum": wt.GARDEN_WASTE,
+        },
     )
 
     def __init__(self, street: str, house_number: str):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_hamburg.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_hamburg.py
@@ -1,16 +1,11 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Demonstrates: a plain ICS feed (parsers.IcsParser + ICSTransformer) keyed by a
 # property id (hnId) carried in the query string. A configured HttpGetRetriever
@@ -36,10 +31,10 @@ def _clean(label: str) -> str:
 
 
 _TYPE_VALUE_MAP = {
-    "bioabfall": ORGANIC,
-    "wertstoff": RECYCLABLES,
-    "restmüll": GENERAL_WASTE,
-    "papier": PAPER,
+    "bioabfall": wt.ORGANIC,
+    "wertstoff": wt.RECYCLABLES,
+    "restmüll": wt.GENERAL_WASTE,
+    "papier": wt.PAPER,
 }
 
 API_URL = "https://backend.stadtreinigung.hamburg/kalender/abholtermine.ics"

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_leipzig_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_leipzig_de.py
@@ -10,6 +10,7 @@ import json
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import (
@@ -18,12 +19,6 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _STREETS_URL = "https://stadtreinigung-leipzig.de/rest/Navision/Streets"
 _ICS_URL = (
@@ -34,10 +29,10 @@ _ICS_URL = (
 # the shared vocabulary does not match. Drop the parenthetical and reduce the
 # label to its core bin term for the type_value_map.
 _TYPE_VALUE_MAP = {
-    "biotonne": ORGANIC,
-    "gelbe tonne": RECYCLABLES,
-    "blaue tonne": PAPER,
-    "restabfall": GENERAL_WASTE,
+    "biotonne": wt.ORGANIC,
+    "gelbe tonne": wt.RECYCLABLES,
+    "blaue tonne": wt.PAPER,
+    "restabfall": wt.GENERAL_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtservice_bruehl_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtservice_bruehl_de.py
@@ -14,19 +14,13 @@ from datetime import date
 from typing import ClassVar, final
 
 from bs4 import BeautifulSoup
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _DISTRICT_URL = "https://services.stadtservice-bruehl.de/abfallkalender/"
 _CALENDAR_URL = (
@@ -72,11 +66,11 @@ class Source(BaseSource):
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
     WASTE_TYPES: ClassVar[list] = [
-        GARDEN_WASTE,
-        GENERAL_WASTE,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -112,5 +106,5 @@ class Source(BaseSource):
     parse = IcsParser(regex=r"(.*?) \- ", split_at=", ")
     transform = ICSTransformer(
         clean=_clean_type,
-        type_value_map={"Straßenlaub": GARDEN_WASTE},
+        type_value_map={"Straßenlaub": wt.GARDEN_WASTE},
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/staedteservice_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/staedteservice_de.py
@@ -17,6 +17,7 @@ import json
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     dropdown,
@@ -30,14 +31,6 @@ from waste_collection_schedule.exceptions import (
 )
 from waste_collection_schedule.service.ICS import IcsFeedsParser
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://portal.staedteservice.de/api/ZeigeAbfallkalender"
 _STREETS_URL = "https://portal.staedteservice.de/api/Strassen"
@@ -118,12 +111,12 @@ class Source(BaseSource):
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        GLASS,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.GLASS,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -161,7 +154,7 @@ class Source(BaseSource):
         unwrap=_ics_from_envelope,
     )
 
-    transform = ICSTransformer(type_value_map={"blaue tonne": RECYCLABLES})
+    transform = ICSTransformer(type_value_map={"blaue tonne": wt.RECYCLABLES})
 
     def __init__(
         self,

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stevenage_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stevenage_gov_uk.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -11,11 +12,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "stevenage-self.achieveservice.com"
 BASE_URL = f"https://{HOSTNAME}"
@@ -49,7 +45,7 @@ class Source(BaseSource):
     URL = "https://www.stevenage.gov.uk/"
     COUNTRY = "uk"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [FOOD_WASTE, GENERAL_WASTE, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.FOOD_WASTE, wt.GENERAL_WASTE, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "Chepstow Close": {"uprn": "100080879233"},
@@ -83,7 +79,7 @@ class Source(BaseSource):
         type_key="bintype",
         parse_date=date_parsers.for_format("%A %d %B %Y"),
         type_value_map={
-            "general waste": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
+            "general waste": wt.GENERAL_WASTE,
+            "recycling": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/steyr_at.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.service.RiSKommunalAT import (
@@ -7,7 +8,6 @@ from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC
 
 _BASE_URL = "https://www.steyr.at"
 
@@ -20,7 +20,7 @@ class Source(BaseSource):
     COUNTRY = "at"
     SOURCE_CODEOWNERS: ClassVar[list] = ["@bbr111"]
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC]
 
     TEST_CASES: ClassVar[dict] = {
         "Wolfernstraße 7": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_wa_gov_au.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, TypedDict, final
 
 from waste_collection_schedule import parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     alternatives,
@@ -10,12 +11,6 @@ from waste_collection_schedule.config_params import (
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ArcGis import ArcGisGeocodeError, geocode
 from waste_collection_schedule.transformers import KeyValueTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 
 class _Field(TypedDict):
@@ -110,9 +105,9 @@ class Source(BaseSource):
         date_key="date",
         type_key="type",
         type_value_map={
-            "red": GENERAL_WASTE,
-            "green": ORGANIC,
-            "greenverge": GARDEN_WASTE,
-            "yellow": RECYCLABLES,
+            "red": wt.GENERAL_WASTE,
+            "green": wt.ORGANIC,
+            "greenverge": wt.GARDEN_WASTE,
+            "yellow": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stkh_hu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stkh_hu.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.parsers import PdfTextParser
 from waste_collection_schedule.preprocessors import TextGroupedDates
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GARDEN_WASTE, RECYCLABLES
 
 # Demonstrates: a text-PDF calendar read by parsers.PdfTextParser and fanned out
 # by preprocessors.TextGroupedDates. STKH (Sopron és Térsége, Hungary) publishes
@@ -25,8 +25,8 @@ from waste_collection_schedule.waste_types import GARDEN_WASTE, RECYCLABLES
 
 # Hungarian table row labels, exactly as printed in the PDF text layer.
 _TYPE_VALUE_MAP = {
-    "szelektív": RECYCLABLES,
-    "zöldhulladék": GARDEN_WASTE,
+    "szelektív": wt.RECYCLABLES,
+    "zöldhulladék": wt.GARDEN_WASTE,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stuttgart_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stuttgart_de.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     street,
@@ -10,12 +11,6 @@ from waste_collection_schedule.service.StuttgartDe import (
     StuttgartRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Declarative source on the Stuttgart components. The single HTML form is fetched
 # to discover the waste-type checkboxes, echoed back in a POST, and the resulting
@@ -31,7 +26,12 @@ class Source(BaseSource):
     COUNTRY = "de"
     # The transformer resolves open-ended German labels via the shared vocabulary;
     # these are the canonical types observed from the live provider.
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, ORGANIC, PAPER]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.RECYCLABLES,
+        wt.ORGANIC,
+        wt.PAPER,
+    ]
     # Address lookup: an empty result means the street/number didn't resolve.
     RAISE_ON_EMPTY = True
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutton_gov_uk.py
@@ -13,16 +13,11 @@ plain Recycling, unlike Bromley's Glass).
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.retrievers import PollingIcsRetriever
 from waste_collection_schedule.transformers import ICSTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GENERAL_WASTE,
-    PAPER,
-    RECYCLABLES,
-)
 
 
 @final
@@ -49,10 +44,10 @@ class Source(BaseSource):
     parse = parsers.IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "Non-Recyclable Refuse": GENERAL_WASTE,
-            "Food Waste": FOOD_WASTE,
-            "Paper & Card": PAPER,
-            "Mixed Recycling (Cans, Plastics & Glass)": RECYCLABLES,
+            "Non-Recyclable Refuse": wt.GENERAL_WASTE,
+            "Food Waste": wt.FOOD_WASTE,
+            "Paper & Card": wt.PAPER,
+            "Mixed Recycling (Cans, Plastics & Glass)": wt.RECYCLABLES,
         },
         clean=label_cleaner(strip_suffixes=[" collection"]),
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swan_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swan_wa_gov_au.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -11,7 +12,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Simplest IntraMaps shape: every collection is fortnightly with an explicit
 # "next date" value, keyed by column (IntraMapsRetriever + IntraMapsPanelParser
@@ -33,9 +33,9 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 # IntraMaps column name -> canonical waste type. One map: selects the
 # collection fields (others ignored) and types them.
 _TYPE_MAP = {
-    "Next_General_Waste_Collection": GENERAL_WASTE,
-    "Next_Recycling_Collection": RECYCLABLES,
-    "Next_FOGO_Collection": ORGANIC,
+    "Next_General_Waste_Collection": wt.GENERAL_WASTE,
+    "Next_Recycling_Collection": wt.RECYCLABLES,
+    "Next_FOGO_Collection": wt.ORGANIC,
 }
 
 # Values are free text such as "Friday, 17 July 2026"; pull out just the date

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tendring_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tendring_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,12 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "tendring-self.achieveservice.com"
 LOOKUP_COLLECTIONS = "6347acbadc425"
@@ -74,10 +69,10 @@ class Source(BaseSource):
     )
     transform = RowTransformer(
         type_value_map={
-            "residual waste": GENERAL_WASTE,
-            "green recycling box": RECYCLABLES,
-            "red recycling box": RECYCLABLES,
-            "food waste": FOOD_WASTE,
-            "garden waste": GARDEN_WASTE,
+            "residual waste": wt.GENERAL_WASTE,
+            "green recycling box": wt.RECYCLABLES,
+            "red recycling box": wt.RECYCLABLES,
+            "food waste": wt.FOOD_WASTE,
+            "garden waste": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tibi_be.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tibi_be.py
@@ -1,10 +1,10 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import text_field
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import GLASS, PAPER, RECYCLABLES
 
 # Demonstrates: a downloadable open-data CSV consumed end-to-end by the pipeline.
 # parsers.CsvParser turns the semicolon-delimited export into dict rows (one row
@@ -31,8 +31,8 @@ DATASET_URL = (
 #              same day. Mapping it to a list yields one Collection per type on
 #              that date, so both streams are represented faithfully.
 _TYPE_MAP = {
-    "PMC": RECYCLABLES,
-    "V / PC": [GLASS, PAPER],
+    "PMC": wt.RECYCLABLES,
+    "V / PC": [wt.GLASS, wt.PAPER],
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/tunbridgewells_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/tunbridgewells_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,11 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "mytwbc.tunbridgewells.gov.uk"
 INITIAL_URL = (
@@ -67,8 +63,8 @@ class Source(BaseSource):
         type_key="collectionType",
         parse_date=date_parsers.next_weekday("%A %d %B"),
         type_value_map={
-            "refuse": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
-            "garden": GARDEN_WASTE,
+            "refuse": wt.GENERAL_WASTE,
+            "recycling": wt.RECYCLABLES,
+            "garden": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ubzzw_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ubzzw_de.py
@@ -22,17 +22,11 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = (
     "https://leerungen.ubzzw.com/WasteManagementZweibruecken/WasteManagementServlet"
@@ -85,10 +79,10 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=lambda label: re.sub(r"\s+\d.*$", "", label).strip(),
         type_value_map={
-            "restabfalltonne": GENERAL_WASTE,
-            "biotonne": ORGANIC,
-            "papiertonne": PAPER,
-            "gelbe tonne / gelber sack": RECYCLABLES,
-            "problemstoff-sammlung": HAZARDOUS,
+            "restabfalltonne": wt.GENERAL_WASTE,
+            "biotonne": wt.ORGANIC,
+            "papiertonne": wt.PAPER,
+            "gelbe tonne / gelber sack": wt.RECYCLABLES,
+            "problemstoff-sammlung": wt.HAZARDOUS,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/verl_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/verl_de.py
@@ -11,20 +11,13 @@ query string and POSTs the district selection to it.
 import re
 from typing import ClassVar, NamedTuple, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import dropdown
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _CALENDAR_URL = (
     "https://www.verl.de/service/abfallentsorgung/umwelt-und-abfallkalender.html"
@@ -119,14 +112,14 @@ class Source(BaseSource):
     parse = IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "restmülltonne": GENERAL_WASTE,
-            "restmülltonne/mögliche zusatzleerung": GENERAL_WASTE,
-            "komposttonne": ORGANIC,
-            "papiertonne": PAPER,
-            "gelbe tonne": RECYCLABLES,
-            "gartenabfallannahme": GARDEN_WASTE,
-            "wertstoffhof": RECYCLABLES,
-            "giftmobil": HAZARDOUS,
+            "restmülltonne": wt.GENERAL_WASTE,
+            "restmülltonne/mögliche zusatzleerung": wt.GENERAL_WASTE,
+            "komposttonne": wt.ORGANIC,
+            "papiertonne": wt.PAPER,
+            "gelbe tonne": wt.RECYCLABLES,
+            "gartenabfallannahme": wt.GARDEN_WASTE,
+            "wertstoffhof": wt.RECYCLABLES,
+            "giftmobil": wt.HAZARDOUS,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vevg_karlsburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vevg_karlsburg_de.py
@@ -20,6 +20,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     location_id,
@@ -27,12 +28,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsSessionRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Endpoint for UHGW (Stadt Greifswald streets, kreis="H")
 _ICAL_UHGW_URL = "https://vevg-karlsburg.de/abfallkalender/ical_uhgw_get_utf8.php"
@@ -142,10 +137,10 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=_clean_label,
         type_value_map={
-            "restmülltonne": GENERAL_WASTE,
-            "gelben säcke": RECYCLABLES,
-            "papiertonne": PAPER,
-            "mobile schadstoffsammlung": HAZARDOUS,
+            "restmülltonne": wt.GENERAL_WASTE,
+            "gelben säcke": wt.RECYCLABLES,
+            "papiertonne": wt.PAPER,
+            "mobile schadstoffsammlung": wt.HAZARDOUS,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
@@ -3,12 +3,12 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
 from waste_collection_schedule.service.Pozi import PoziWfsParser, PoziWfsRetriever
 from waste_collection_schedule.transformers import RowTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, ORGANIC, RECYCLABLES
 
 # Demonstrates: a Pozi WFS spatial-query lookup by address (geocoded via the
 # shared ArcGIS World GeocodeServer). Each collection field is an HTML-ish
@@ -83,7 +83,7 @@ class Source(BaseSource):
     URL = "https://www.vincent.wa.gov.au"
     COUNTRY = "au"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, ORGANIC, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.ORGANIC, wt.RECYCLABLES]
 
     TEST_CASES: ClassVar[dict] = {
         "North Perth": {"address": "8 Kadina St, North Perth WA 6006"},

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/waipa_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/waipa_nz.py
@@ -2,6 +2,7 @@ import re
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -12,7 +13,6 @@ from waste_collection_schedule.service.IntraMaps import (
     MapsClientConfig,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GLASS, RECYCLABLES
 
 # Waipa publishes several explicit dates per field rather than a cadence
 # (e.g. "Will be collected on 15-Jul-2026, and then ... on 29-Jul-2026"), so
@@ -35,8 +35,8 @@ INTRAMAPS_CONFIG = MapsClientConfig(
 # Internal schedule keys -> canonical waste type (decoupled from the verbose
 # IntraMaps column text so the transformer's map stays short and stable).
 _TYPE_MAP = {
-    "recycling": RECYCLABLES,
-    "glass": GLASS,
+    "recycling": wt.RECYCLABLES,
+    "glass": wt.GLASS,
 }
 
 _RECYCLING_COLUMN_RE = re.compile(r"Mixed Recycling", re.IGNORECASE)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/walthamforest_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/walthamforest_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.service.AchieveForms import (
@@ -10,13 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 HOSTNAME = "portal.walthamforest.gov.uk"
 INITIAL_URL = (
@@ -78,10 +72,10 @@ class Source(BaseSource):
         parse_date=date_parsers.next_weekday("%A %d %B"),
         skip_unparseable_dates=True,
         type_value_map={
-            "Domestic Waste Collection Service": GENERAL_WASTE,
-            "Food Waste Collection Service": FOOD_WASTE,
-            "Organic Collection Service": ORGANIC,
-            "Recycling Collection Service": RECYCLABLES,
-            "Garden Waste Collection Service": GARDEN_WASTE,
+            "Domestic Waste Collection Service": wt.GENERAL_WASTE,
+            "Food Waste Collection Service": wt.FOOD_WASTE,
+            "Organic Collection Service": wt.ORGANIC,
+            "Recycling Collection Service": wt.RECYCLABLES,
+            "Garden Waste Collection Service": wt.GARDEN_WASTE,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wanneroo_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wanneroo_wa_gov_au.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers, recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import RecurrenceExpander, Schedule
@@ -12,11 +13,6 @@ from waste_collection_schedule.service.IntraMaps import (
     IntraMapsPanelParser,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # The council embeds IntraMaps' own bin-lookup widget rather than publishing a
 # static Integration API config, so there is no MapsClientConfig to declare:
@@ -45,9 +41,9 @@ INTRAMAPS_CONFIG = IntegrationWidgetConfig(
 # NEXT Week"), so the label _describe derives from that phrase (mirroring the
 # legacy source's own keyword rules) is the map's key.
 _TYPE_MAP = {
-    "General Waste": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "Garden Organics": GARDEN_WASTE,
+    "General Waste": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Garden Organics": wt.GARDEN_WASTE,
 }
 
 _THIS_NEXT_WEEK_RE = re.compile(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/watford_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/watford_gov_uk.py
@@ -13,6 +13,7 @@ import re
 from typing import Any, ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import alternatives, text_field, uprn
 from waste_collection_schedule.exceptions import SourceArgumentException
@@ -22,12 +23,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import HtmlTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Live-verified (2026-07): the standard AchieveForms handshake
 # (init_session -> authapi/isauthenticated on the service landing page)
@@ -145,10 +140,10 @@ class Source(BaseSource):
         parse_date=date_parsers.for_format("%d/%m/%Y"),
         clean=_clean_bin_label,
         type_value_map={
-            "non-recyclable waste": GENERAL_WASTE,
-            "garden waste": GARDEN_WASTE,
-            "recycling": RECYCLABLES,
-            "food waste": FOOD_WASTE,
+            "non-recyclable waste": wt.GENERAL_WASTE,
+            "garden waste": wt.GARDEN_WASTE,
+            "recycling": wt.RECYCLABLES,
+            "food waste": wt.FOOD_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/waverley_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/waverley_gov_uk.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, final
 
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     street,
@@ -12,12 +13,6 @@ from waste_collection_schedule.service.WhitespaceWRP import (
     WhitespaceRetriever,
 )
 from waste_collection_schedule.transformers import RowTransformer, label_cleaner
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 # Declarative source on the shared Whitespace WRP components (WhitespaceRetriever
 # + WhitespaceParser). A RowTransformer maps the council's open-ended type labels
@@ -25,10 +20,10 @@ from waste_collection_schedule.waste_types import (
 # existing configurations continue to work.
 
 _TYPE_MAP = {
-    "Domestic Waste": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "Garden Waste": GARDEN_WASTE,
-    "Food Waste": FOOD_WASTE,
+    "Domestic Waste": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Garden Waste": wt.GARDEN_WASTE,
+    "Food Waste": wt.FOOD_WASTE,
 }
 
 
@@ -41,7 +36,12 @@ class Source(BaseSource):
     URL = "https://waverley.gov.uk"
     COUNTRY = "uk"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, GARDEN_WASTE, FOOD_WASTE]
+    WASTE_TYPES: ClassVar[list] = [
+        wt.GENERAL_WASTE,
+        wt.RECYCLABLES,
+        wt.GARDEN_WASTE,
+        wt.FOOD_WASTE,
+    ]
     API_URL = "https://wav-wrp.whitespacews.com/"
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wellington_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wellington_govt_nz.py
@@ -14,6 +14,7 @@ shared transformer's.
 import datetime
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.collection import Collection
 from waste_collection_schedule.config_params import alternatives, location_id, street
@@ -25,7 +26,6 @@ from waste_collection_schedule.parsers import ArgumentGuard, IcsParser
 from waste_collection_schedule.preprocessors import SplitLabels
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, GLASS, RECYCLABLES
 
 _BASE_URL = "https://wellington.govt.nz"
 _STREET_LOOKUP_URL = (
@@ -45,9 +45,9 @@ _PICTURE_MAP = {
 # below doesn't have to reimplement label -> WasteType resolution.
 _TYPE_TRANSFORM = ICSTransformer(
     type_value_map={
-        "rubbish collection": GENERAL_WASTE,
-        "glass crate": GLASS,
-        "wheelie bin or recycling bags": RECYCLABLES,
+        "rubbish collection": wt.GENERAL_WASTE,
+        "glass crate": wt.GLASS,
+        "wheelie bin or recycling bags": wt.RECYCLABLES,
     }
 )
 
@@ -99,7 +99,7 @@ class Source(BaseSource):
         alternatives([location_id(field="streetId")], [street(field="streetName")]),
     )
 
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, GLASS, RECYCLABLES]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.GLASS, wt.RECYCLABLES]
 
     retrieve = LookupChainRetriever(
         steps=(_resolve_street,),

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wermelskirchen_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wermelskirchen_de.py
@@ -21,18 +21,11 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _URL = "https://abfallkalender.regioit.de/kalender-bav/downloadfile.jsp"
 
@@ -88,13 +81,13 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "restmülltonne 2-wöchentlich": GENERAL_WASTE,
-            "restmülltonne 4-wöchentlich": GENERAL_WASTE,
-            "restmülltonne 6-wöchentlich": GENERAL_WASTE,
-            "gelber sack / tonne": RECYCLABLES,
-            "papiertonne": PAPER,
-            "biotonne": ORGANIC,
-            "schadstoffmobil": HAZARDOUS,
-            "weihnachtsbaum": GARDEN_WASTE,
+            "restmülltonne 2-wöchentlich": wt.GENERAL_WASTE,
+            "restmülltonne 4-wöchentlich": wt.GENERAL_WASTE,
+            "restmülltonne 6-wöchentlich": wt.GENERAL_WASTE,
+            "gelber sack / tonne": wt.RECYCLABLES,
+            "papiertonne": wt.PAPER,
+            "biotonne": wt.ORGANIC,
+            "schadstoffmobil": wt.HAZARDOUS,
+            "weihnachtsbaum": wt.GARDEN_WASTE,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/westlothian_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/westlothian_gov_uk.py
@@ -31,17 +31,12 @@ from urllib.parse import parse_qs, urlparse
 
 from bs4 import BeautifulSoup, Tag
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import postcode, uprn
 from waste_collection_schedule.exceptions import SourceArgumentException
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsSessionRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _COLLECTION_PAGE_URL = "https://www.westlothian.gov.uk/bin-collections"
 
@@ -209,9 +204,9 @@ class Source(BaseSource):
     # corrects that rather than preserving the mistake.
     transform = ICSTransformer(
         type_value_map={
-            "grey": GENERAL_WASTE,
-            "brown": ORGANIC,
-            "green": RECYCLABLES,
-            "blue": PAPER,
+            "grey": wt.GENERAL_WASTE,
+            "brown": wt.ORGANIC,
+            "green": wt.RECYCLABLES,
+            "blue": wt.PAPER,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wrexham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wrexham_gov_uk.py
@@ -2,6 +2,7 @@ from typing import ClassVar, final
 
 from bs4 import Tag
 from waste_collection_schedule import date_parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.parsers import HtmlParser
@@ -10,12 +11,6 @@ from waste_collection_schedule.service.AchieveForms import (
     LookupStep,
 )
 from waste_collection_schedule.transformers import HtmlTransformer
-from waste_collection_schedule.waste_types import (
-    FOOD_WASTE,
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 HOSTNAME = "myaccount.wrexham.gov.uk"
 INITIAL_URL = (
@@ -86,9 +81,9 @@ class Source(BaseSource):
         parse_date=date_parsers.for_format("%d/%m/%Y"),
         # A single <li> can name a combined round ("Recycling / food").
         type_value_map={
-            "recycling / food": [RECYCLABLES, FOOD_WASTE],
-            "garden waste": GARDEN_WASTE,
-            "general waste": GENERAL_WASTE,
+            "recycling / food": [wt.RECYCLABLES, wt.FOOD_WASTE],
+            "garden waste": wt.GARDEN_WASTE,
+            "general waste": wt.GENERAL_WASTE,
         },
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarra_ranges_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarra_ranges_vic_gov_au.py
@@ -4,15 +4,11 @@ from urllib.parse import urlencode
 
 from bs4 import Tag
 from waste_collection_schedule import date_parsers, parsers, retrievers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.transformers import HtmlTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # Demonstrates: the OCAPI "myarea" two-step flow (address lookup -> geolocation
 # id -> waste services) via TwoStepRetriever, and HtmlParser(from_json_key=...)
@@ -26,9 +22,9 @@ WASTE_URL = f"{BASE}/ocapi/Public/myarea/wasteservices"
 _DATE_RE = re.compile(r"(\d{1,2}/\d{1,2}/\d{4})")
 
 _TYPE_MAP = {
-    "Rubbish Collection": GENERAL_WASTE,
-    "Recycling Collection": RECYCLABLES,
-    "New weekly FOGO collection": ORGANIC,
+    "Rubbish Collection": wt.GENERAL_WASTE,
+    "Recycling Collection": wt.RECYCLABLES,
+    "New weekly FOGO collection": wt.ORGANIC,
 }
 
 
@@ -70,7 +66,7 @@ class Source(BaseSource):
     URL = "https://www.yarraranges.vic.gov.au"
     COUNTRY = "au"
     RAISE_ON_EMPTY = True
-    WASTE_TYPES: ClassVar[list] = [GENERAL_WASTE, RECYCLABLES, ORGANIC]
+    WASTE_TYPES: ClassVar[list] = [wt.GENERAL_WASTE, wt.RECYCLABLES, wt.ORGANIC]
 
     TEST_CASES: ClassVar[dict] = {
         "Petstock Lilydale": {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
@@ -2,6 +2,7 @@ import datetime
 from typing import ClassVar, final
 
 from waste_collection_schedule import recurrence
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import street_address
 from waste_collection_schedule.preprocessors import (
@@ -15,12 +16,6 @@ from waste_collection_schedule.service.ArcGis import (
     ArcGisMultiFeatureRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    RECYCLABLES,
-)
 
 # City of Yarra publishes its collection zones on one MapServer with two
 # layers: layer 1 (waste) carries the property's collection weekday and the
@@ -51,10 +46,10 @@ LAYERS = [
 WEEKS_AHEAD = 52
 
 _TYPE_MAP = {
-    "Rubbish": GENERAL_WASTE,
-    "Recycling": RECYCLABLES,
-    "Glass": GLASS,
-    "FOGO": ORGANIC,
+    "Rubbish": wt.GENERAL_WASTE,
+    "Recycling": wt.RECYCLABLES,
+    "Glass": wt.GLASS,
+    "FOGO": wt.ORGANIC,
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zakb_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zakb_de.py
@@ -11,6 +11,7 @@ instead of the accumulated form (``"reset": True``).
 
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     house_number,
@@ -21,13 +22,6 @@ from waste_collection_schedule.config_params import (
 from waste_collection_schedule.parsers import IcsParser
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 API_URL = "https://www.zakb.de/online-service/abfallkalender/"
 
@@ -123,13 +117,13 @@ class Source(BaseSource):
     parse = IcsParser()
     transform = ICSTransformer(
         type_value_map={
-            "restabfallbehaelter": GENERAL_WASTE,
-            "restabfallcontainer": GENERAL_WASTE,
-            "bioabfallbehaelter": ORGANIC,
-            "papierbehaelter": PAPER,
-            "papiercontainer": PAPER,
-            "gelber sack": RECYCLABLES,
-            "gruensperrmuell": GARDEN_WASTE,
+            "restabfallbehaelter": wt.GENERAL_WASTE,
+            "restabfallcontainer": wt.GENERAL_WASTE,
+            "bioabfallbehaelter": wt.ORGANIC,
+            "papierbehaelter": wt.PAPER,
+            "papiercontainer": wt.PAPER,
+            "gelber sack": wt.RECYCLABLES,
+            "gruensperrmuell": wt.GARDEN_WASTE,
         }
     )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zaw_sr_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zaw_sr_de.py
@@ -28,6 +28,7 @@ instead of picked up dynamically.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -37,12 +38,6 @@ from waste_collection_schedule.config_params import (
 )
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://straubing.zaw-sr.de/WasteManagementStraubing/WasteManagementServlet"
 
@@ -119,16 +114,16 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=lambda label: label.split()[0],
         type_value_map={
-            "restmuell": GENERAL_WASTE,
-            "restmüll": GENERAL_WASTE,
-            "restmülltonne": GENERAL_WASTE,
-            "bio": ORGANIC,
-            "biotonne": ORGANIC,
-            "bioabfall": ORGANIC,
-            "papier": PAPER,
-            "papiertonne": PAPER,
-            "gelbe": RECYCLABLES,
-            "gelber": RECYCLABLES,
-            "wertstofftonne": RECYCLABLES,
+            "restmuell": wt.GENERAL_WASTE,
+            "restmüll": wt.GENERAL_WASTE,
+            "restmülltonne": wt.GENERAL_WASTE,
+            "bio": wt.ORGANIC,
+            "biotonne": wt.ORGANIC,
+            "bioabfall": wt.ORGANIC,
+            "papier": wt.PAPER,
+            "papiertonne": wt.PAPER,
+            "gelbe": wt.RECYCLABLES,
+            "gelber": wt.RECYCLABLES,
+            "wertstofftonne": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zke_sb_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zke_sb_de.py
@@ -17,16 +17,11 @@ source's "Harthweg 7" TEST_CASE exactly).
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import house_number, street
 from waste_collection_schedule.retrievers import AthosWasteManagementRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://info.zke-sb.de/WasteManagementSaarbruecken/WasteManagementServlet"
 
@@ -93,9 +88,9 @@ class Source(BaseSource):
     transform = ICSTransformer(
         clean=lambda label: label.split(":")[0].strip(),
         type_value_map={
-            "restmuell": GENERAL_WASTE,
-            "biomuell": ORGANIC,
-            "papiertonne": PAPER,
-            "gelbe tonne": RECYCLABLES,
+            "restmuell": wt.GENERAL_WASTE,
+            "biomuell": wt.ORGANIC,
+            "papiertonne": wt.PAPER,
+            "gelbe tonne": wt.RECYCLABLES,
         },
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zva_sek_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zva_sek_de.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from typing import ClassVar, final
 
 from bs4 import BeautifulSoup, Tag
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import district, street, text_field
 from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
@@ -21,13 +22,6 @@ from waste_collection_schedule.parsers import EachResponse, IcsParser
 from waste_collection_schedule.preprocessors import RowRelabel
 from waste_collection_schedule.retrievers import YearlyRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    HAZARDOUS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _SERVLET = "https://www.zva-sek.de/module/abfallkalender/generate_ical.php"
 _MAIN_URL = "https://www.zva-sek.de/online-dienste/abfallkalender-{year}/{file}"
@@ -144,11 +138,11 @@ class Source(BaseSource):
     COUNTRY = "de"
     RAISE_ON_EMPTY = True
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        HAZARDOUS,
-        ORGANIC,
-        PAPER,
-        RECYCLABLES,
+        wt.GENERAL_WASTE,
+        wt.HAZARDOUS,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.RECYCLABLES,
     ]
 
     TEST_CASES: ClassVar[dict] = {
@@ -195,12 +189,12 @@ class Source(BaseSource):
 
     transform = ICSTransformer(
         type_value_map={
-            "gelbe(r) tonne/sack": RECYCLABLES,
-            "restmüll (3-wöchentlich)": GENERAL_WASTE,
-            "restmüll 1,1 m³ (wöchentlich)": GENERAL_WASTE,
-            "restmüll 1,1 m³ (2-wöchentlich)": GENERAL_WASTE,
-            "restmüll 1,1 m³ (3-wöchentlich)": GENERAL_WASTE,
-            "restmüll 1,1 m³ (4-wöchentlich)": GENERAL_WASTE,
-            "schadstoffsammlung (achtung: nur selbstanlieferung)": HAZARDOUS,
+            "gelbe(r) tonne/sack": wt.RECYCLABLES,
+            "restmüll (3-wöchentlich)": wt.GENERAL_WASTE,
+            "restmüll 1,1 m³ (wöchentlich)": wt.GENERAL_WASTE,
+            "restmüll 1,1 m³ (2-wöchentlich)": wt.GENERAL_WASTE,
+            "restmüll 1,1 m³ (3-wöchentlich)": wt.GENERAL_WASTE,
+            "restmüll 1,1 m³ (4-wöchentlich)": wt.GENERAL_WASTE,
+            "schadstoffsammlung (achtung: nur selbstanlieferung)": wt.HAZARDOUS,
         }
     )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zva_wmk_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zva_wmk_de.py
@@ -14,17 +14,11 @@ as the legacy source did.
 from typing import ClassVar, final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import city, street
 from waste_collection_schedule.service.ICS import IcsFeedsParser, IcsYearRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GARDEN_WASTE,
-    GENERAL_WASTE,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 _API_URL = "https://www.zva-wmk.de/termine/"
 
@@ -49,11 +43,11 @@ class Source(BaseSource):
     # The ICS transformer resolves the German bin names via the shared vocabulary;
     # these are the canonical types observed from the live provider.
     WASTE_TYPES: ClassVar[list] = [
-        GENERAL_WASTE,
-        RECYCLABLES,
-        ORGANIC,
-        PAPER,
-        GARDEN_WASTE,
+        wt.GENERAL_WASTE,
+        wt.RECYCLABLES,
+        wt.ORGANIC,
+        wt.PAPER,
+        wt.GARDEN_WASTE,
     ]
 
     TEST_CASES: ClassVar[dict] = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/zys_harmonogram_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/zys_harmonogram_pl.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 from typing import ClassVar, final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import (
     city,
@@ -16,13 +17,6 @@ from waste_collection_schedule.exceptions import (
 from waste_collection_schedule.parsers import HtmlMonthRows
 from waste_collection_schedule.retrievers import LookupChainRetriever
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import (
-    GENERAL_WASTE,
-    GLASS,
-    ORGANIC,
-    PAPER,
-    RECYCLABLES,
-)
 
 # Composes: LookupChainRetriever (city -> street -> number -> report
 # descriptor, the last step handing back the rendered table's address) and
@@ -38,11 +32,11 @@ _API_URL = "https://zys-harmonogram.smok.net.pl/{commune}/{year}"
 # The Polish column headers map onto canonical waste types. The provider's
 # fractions are: mixed municipal waste, paper, metals & plastics, glass, bio.
 _TYPE_MAP = {
-    "zmieszane odpady komunalne": GENERAL_WASTE,
-    "papier": PAPER,
-    "metale i tworzywa sztuczne": RECYCLABLES,
-    "szkło": GLASS,
-    "bioodpady": ORGANIC,
+    "zmieszane odpady komunalne": wt.GENERAL_WASTE,
+    "papier": wt.PAPER,
+    "metale i tworzywa sztuczne": wt.RECYCLABLES,
+    "szkło": wt.GLASS,
+    "bioodpady": wt.ORGANIC,
 }
 
 

--- a/doc/contributing_source.md
+++ b/doc/contributing_source.md
@@ -47,11 +47,11 @@ A flat JSON API, typed by a label-to-waste-type map:
 from typing import final
 
 from waste_collection_schedule import parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE, RECYCLABLES
 
 
 @final
@@ -75,7 +75,7 @@ class Source(BaseSource):
     transform = JsonTransformer(
         date_key="date",
         type_key="binType",
-        type_value_map={"refuse": GENERAL_WASTE, "recycling": RECYCLABLES},
+        type_value_map={"refuse": wt.GENERAL_WASTE, "recycling": wt.RECYCLABLES},
     )
 ```
 
@@ -280,6 +280,14 @@ Do not carry a private weekday or month dict in your source. Use these shared, m
 
 Each collection is typed by a canonical `WasteType` from `waste_collection_schedule.waste_types`. The eleven canonical types are `GENERAL_WASTE`, `RECYCLABLES`, `ORGANIC`, `PAPER`, `GLASS`, `FOOD_WASTE`, `GARDEN_WASTE`, `BULKY_WASTE`, `HAZARDOUS`, `ELECTRONICS` and `OTHER`. Each carries its own id, colour, icon and names in en, de, fr, it and nl (the same languages as the config-flow translations). Because the type carries the icon, a pipeline source never declares an `ICON_MAP`.
 
+**Import the module, not the names:**
+
+```python
+from waste_collection_schedule import waste_types as wt
+```
+
+then write `wt.GENERAL_WASTE`. A source typically uses three to six types, and importing them by name costs one line each once `ruff` wraps the statement, which came to 1,284 lines across the sources for no benefit: the namespace form is one line however many types a source uses. `test_pipeline_sources_import_waste_types_as_a_module` enforces it.
+
 A transformer turns each record's label into a `WasteType` in this order:
 
 1. The source's `type_value_map`, if the label is listed.
@@ -326,13 +334,13 @@ Also check the existing shared YAML and EXTRA_INFO platforms (Recollect, Recycle
 ```python
 from typing import final
 
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.service.RiSKommunalAT import (
     RiSKommunalParser,
     RiSKommunalRetriever,
 )
 from waste_collection_schedule.transformers import ICSTransformer
-from waste_collection_schedule.waste_types import GENERAL_WASTE
 
 
 @final
@@ -352,7 +360,7 @@ class Source(BaseSource):
     )
     parse = RiSKommunalParser()
     transform = ICSTransformer(
-        type_value_map={"Restabfall 14-tägig": GENERAL_WASTE},
+        type_value_map={"Restabfall 14-tägig": wt.GENERAL_WASTE},
     )
 ```
 

--- a/doc/new_source_template.py
+++ b/doc/new_source_template.py
@@ -15,14 +15,11 @@ declarative class attributes, and there is no ``__init__``.
 from typing import ClassVar, TypedDict, final
 
 from waste_collection_schedule import date_parsers, parsers
+from waste_collection_schedule import waste_types as wt
 from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.config_params import uprn  # >>> pick your params
 from waste_collection_schedule.retrievers import HttpGetRetriever
 from waste_collection_schedule.transformers import JsonTransformer
-from waste_collection_schedule.waste_types import (  # >>> map only what you emit
-    GENERAL_WASTE,
-    RECYCLABLES,
-)
 
 
 class _Collection(TypedDict):
@@ -91,8 +88,8 @@ class Source(BaseSource):
         type_key="type",
         parse_date=date_parsers.for_format("%Y-%m-%d"),
         type_value_map={
-            "refuse": GENERAL_WASTE,
-            "recycling": RECYCLABLES,
+            "refuse": wt.GENERAL_WASTE,  # >>> map only what you emit
+            "recycling": wt.RECYCLABLES,
         },
     )
 

--- a/tests/test_new_architecture.py
+++ b/tests/test_new_architecture.py
@@ -4623,6 +4623,49 @@ def test_pipeline_sources_ship_a_cassette(stem: str) -> None:
 # --------------------------------------------------------------------------- #
 
 
+def _named_waste_type_imports(stem: str) -> list[str]:
+    """Names this source imports individually from waste_types."""
+    import ast
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components/waste_collection_schedule/waste_collection_schedule/source"
+        / f"{stem}.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return [
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom)
+        and (node.module or "").endswith("waste_types")
+        for alias in node.names
+    ]
+
+
+@pytest.mark.skipif(
+    len(_NEW_STYLE_SOURCES) == 0,
+    reason="No new-style sources discoverable (likely missing dependencies)",
+)
+@pytest.mark.parametrize(
+    "stem", [s[0] for s in _NEW_STYLE_SOURCES], ids=[s[0] for s in _NEW_STYLE_SOURCES]
+)
+def test_pipeline_sources_import_waste_types_as_a_module(stem: str) -> None:
+    """Import the waste_types module, not the individual type names.
+
+    A source uses three to six types, and importing them by name costs a line
+    each once ruff wraps the statement: 1,284 lines across the sources, against
+    250 for the namespace form, which is one line however many types are used.
+    """
+    named = _named_waste_type_imports(stem)
+    assert not named, (
+        f"{stem} imports {named} from waste_types by name. Use "
+        "`from waste_collection_schedule import waste_types as wt` and write "
+        "`wt.GENERAL_WASTE`, so the import stays one line however many types "
+        "the source uses."
+    )
+
+
 def _hand_rolled_standard_fields(stem: str) -> list[str]:
     """Labels in this source that duplicate a standard FieldTerm's label."""
     import ast


### PR DESCRIPTION
A source uses three to six waste types, and importing them by name costs a line each once `ruff` wraps the statement. That came to **1,284 lines across 250 sources**, against 250 for the namespace form, which is one line however many types are used. So `from waste_collection_schedule import waste_types as wt`, and `wt.GENERAL_WASTE` at the 1,288 places that referenced a type directly.

**881 code lines leave the sources** (106,639 to 105,758).

## Correcting the earlier plan

This is the lever #7118 pointed at, but not in the shape I first described. #7118 removed 271 source lines and got 206 back purely as import blocks gaining a name, netting -30, because imports are 16% of all source code and any per-source edit pays that tax.

Worth stating plainly what was wrong: **a facade re-exporting the common names would not have helped.** Merging six modules into one import still costs a line per name once the statement wraps, so the saving is in how many names a source imports, not how many modules it imports them from. The measurement that settled it: of 3,957 import lines, 1,853 are spent beyond the first line of a wrapped statement, and `waste_types` alone accounts for 1,284 of them at 5.1 lines per statement.

The alias is terse on purpose. `waste_types.GENERAL_WASTE` adds eleven characters per use, which pushes many more lines past 88 and gives much of the saving back in re-wrapping. As it is, only 32 lines re-wrap, all of them a `WASTE_TYPES: ClassVar[list] = [...]` that now spans several lines.

## Two things a reviewer should know

**Ten sources have a base other than `BaseSource`.** `offenbach_de` and `rh_entsorgung_de` subclass another *source*, so the `class Source(BaseSource)` text match that my codemod used (and that `tools/loc_report.py` uses as `PIPELINE_MARKER`) does not see them; both were done by hand. That means `loc_report`'s `--migrated` undercounts slightly. Left alone here so this change stays comparable with the three before it, but it wants fixing.

**The gate only sees importable sources.** A source whose module fails to import is never discovered by `_NEW_STYLE_SOURCES`, so it is not gated; it fails elsewhere, loudly, instead. Found while checking the gate catches a regression.

## One codemod bug worth recording

`ast`'s `col_offset` is a UTF-8 **byte** offset, not a character offset, and these files are full of German, Polish and Swedish labels. Splicing at the character offset turned `RECYCLABLES` into `Rwt.ECYCLABLES` on every line with a multi-byte character earlier in it. `ruff` caught all 172 instances as undefined names, but the next mechanical pass over these files should splice in bytes from the start.

`test_pipeline_sources_import_waste_types_as_a_module` keeps the convention, and all four worked examples are updated so nothing still models the old form.

Cumulatively across #7115, #7116, #7118 and this: migrated sources are at **-5,790** code lines against `master`, mean **86.6** per source, down from 109.2.

Full suite passes, 4,692 tests. `pre-commit` clean across ruff, ruff format, codespell, bandit, mypy and pyright.

Follows #7118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKQNey3jsRaVpHrnFjahR2
