### PR TITLE
tools: follow the base class to decide if a source is on the pipeline

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,12 @@
 addopts = -m "not live"
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test .claude .git
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py
+# An allowlist, not a pattern: the per-provider files in tests/ hit live
+# endpoints and say so in their own docstrings, so they are run explicitly rather
+# than in CI. Anything that is an ordinary offline unit test belongs here, or it
+# silently never runs. test_declared_waste_types, test_source_shell_customize and
+# test_source_shell_create_error_handling were in that position: 668 passing
+# tests that gated nothing.
+python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py test_loc_report.py test_declared_waste_types.py test_source_shell_customize.py test_source_shell_create_error_handling.py
 markers =
     live: test fetches from a live provider endpoint; excluded from gating CI (run with `-m live` locally). Replaced by offline fixtures.

--- a/tests/test_loc_report.py
+++ b/tests/test_loc_report.py
@@ -1,0 +1,120 @@
+"""Tests for tools/loc_report.py's pipeline-source detection.
+
+The interesting case is a source whose base class is *another source*. Matching
+the literal text ``class Source(BaseSource)`` counted those as legacy, which
+understated the migration by three sources; following the base class instead has
+to keep excluding the seven whose parent is itself legacy.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from loc_report import is_pipeline_source
+
+BASE = "from waste_collection_schedule.base_source import BaseSource\n"
+
+
+def test_direct_subclass_is_pipeline():
+    text = BASE + "class Source(BaseSource):\n    pass\n"
+    assert is_pipeline_source(text, {})
+
+
+def test_plain_class_is_legacy():
+    assert not is_pipeline_source("class Source:\n    def fetch(self): ...\n", {})
+
+
+def test_no_source_class_at_all():
+    assert not is_pipeline_source("PARAMS = []\n", {})
+
+
+def test_subclass_of_a_pipeline_source_is_pipeline():
+    """offenbach_de -> insert_it_de, rh_entsorgung_de -> jumomind_de."""
+    parent = BASE + "class Source(BaseSource):\n    pass\n"
+    child = (
+        "from waste_collection_schedule.source.parent_mod import Source as ParentSource\n"
+        "class Source(ParentSource):\n    pass\n"
+    )
+    assert is_pipeline_source(child, {"parent_mod": parent})
+
+
+def test_subclass_of_a_legacy_source_is_legacy():
+    """chiltern_gov_uk -> iapp_itouchvision_com, and five more like it."""
+    parent = "class Source:\n    def fetch(self): ...\n"
+    child = (
+        "from waste_collection_schedule.source.parent_mod import Source as ParentSource\n"
+        "class Source(ParentSource):\n    pass\n"
+    )
+    assert not is_pipeline_source(child, {"parent_mod": parent})
+
+
+def test_relative_import_is_followed():
+    """ssam_se and uppsalavatten_se import their base as ``from .edpevent_se``."""
+    parent = BASE + "class Source(BaseSource):\n    pass\n"
+    child = (
+        "from .parent_mod import Source as ParentSource\n"
+        "class Source(ParentSource):\n    pass\n"
+    )
+    assert is_pipeline_source(child, {"parent_mod": parent})
+
+
+def test_parenthesised_import_is_followed():
+    """Several of these imports are wrapped by the formatter."""
+    parent = BASE + "class Source(BaseSource):\n    pass\n"
+    child = (
+        "from waste_collection_schedule.source.parent_mod import (\n"
+        "    Source as ParentSource,\n"
+        ")\n"
+        "class Source(ParentSource):\n    pass\n"
+    )
+    assert is_pipeline_source(child, {"parent_mod": parent})
+
+
+def test_base_from_a_service_module_is_not_followed():
+    """mils_tirol_at subclasses RiSKommunalSource, which is a plain class."""
+    child = (
+        "from waste_collection_schedule.service.RiSKommunalAT import RiSKommunalSource\n"
+        "class Source(RiSKommunalSource):\n    pass\n"
+    )
+    assert not is_pipeline_source(child, {})
+
+
+def test_a_cycle_terminates():
+    a = (
+        "from waste_collection_schedule.source.b import Source as BSource\n"
+        "class Source(BSource):\n    pass\n"
+    )
+    b = (
+        "from waste_collection_schedule.source.a import Source as ASource\n"
+        "class Source(ASource):\n    pass\n"
+    )
+    assert not is_pipeline_source(a, {"a": a, "b": b})
+
+
+def test_missing_parent_module_is_not_pipeline():
+    child = (
+        "from waste_collection_schedule.source.gone import Source as GoneSource\n"
+        "class Source(GoneSource):\n    pass\n"
+    )
+    assert not is_pipeline_source(child, {})
+
+
+@pytest.mark.parametrize(
+    "stem",
+    ["offenbach_de", "rh_entsorgung_de", "stadt_kerpen_de"],
+)
+def test_the_three_real_indirect_pipeline_sources(stem):
+    """These are the sources the literal marker missed, checked against the tree."""
+    source_dir = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components/waste_collection_schedule/waste_collection_schedule/source"
+    )
+    texts = {p.stem: p.read_text(encoding="utf-8") for p in source_dir.glob("*.py")}
+    assert "class Source(BaseSource)" not in texts[stem], (
+        f"{stem} now subclasses BaseSource directly, so it no longer exercises "
+        "the indirect case this test exists for"
+    )
+    assert is_pipeline_source(texts[stem], texts)

--- a/tools/loc_report.py
+++ b/tools/loc_report.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import ast
 import io
+import re
 import subprocess
 import sys
 import token as token_module
@@ -197,10 +198,60 @@ def classify(source: str) -> Counts:
     return counts
 
 
-# A pipeline source declares its steps on a BaseSource subclass; a legacy one
-# is a plain class with a hand-written fetch(). The text is the signal, so this
-# works on any ref without importing anything.
-PIPELINE_MARKER = "class Source(BaseSource)"
+# A pipeline source declares its steps on a BaseSource subclass; a legacy one is
+# a plain class with a hand-written fetch(). Read from the text so any ref can be
+# measured without importing, but follow the base class rather than matching
+# ``class Source(BaseSource)`` literally: a handful of sources subclass *another
+# source*, and three of those reach BaseSource that way (offenbach_de via
+# insert_it_de, rh_entsorgung_de via jumomind_de, stadt_kerpen_de via abfall_io).
+# Matching the literal text counted those as legacy and understated the
+# migration. Seven others also subclass another source but inherit from a legacy
+# parent, so following the chain keeps excluding them, correctly.
+_CLASS_SOURCE_RE = re.compile(r"^class Source\(\s*([A-Za-z_][\w.]*)", re.MULTILINE)
+
+
+def _source_base(text: str) -> str | None:
+    """The base class name of this module's ``Source``, or None if it has none."""
+    match = _CLASS_SOURCE_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _base_module(text: str, base: str) -> str | None:
+    """The source module a base class name was imported from, if it was.
+
+    Handles both the absolute and the relative import spellings the sources use::
+
+        from waste_collection_schedule.source.jumomind_de import Source as JumomindSource
+        from .edpevent_se import Source as EdpEventSource
+    """
+    pattern = (
+        r"from\s+(?:waste_collection_schedule\.source\.|\.)([a-z0-9_]+)\s+import\s+"
+        r"(?:\(\s*)?Source\s+as\s+" + re.escape(base)
+    )
+    match = re.search(pattern, text)
+    return match.group(1) if match else None
+
+
+def is_pipeline_source(text: str, sources: dict[str, str]) -> bool:
+    """Does this module's ``Source`` reach ``BaseSource`` through its bases?
+
+    ``sources`` maps module stem to file text, so a base that is another source
+    can be followed. A base imported from anywhere else (a ``service`` module,
+    say) is not followed: ``RiSKommunalSource`` is a plain class, so a source
+    subclassing it is legacy.
+    """
+    seen: set[str] = set()
+    while True:
+        base = _source_base(text)
+        if base is None:
+            return False
+        if base == "BaseSource":
+            return True
+        stem = _base_module(text, base)
+        if stem is None or stem in seen or stem not in sources:
+            return False
+        seen.add(stem)
+        text = sources[stem]
 
 
 def _is_source(path: str) -> bool:
@@ -212,12 +263,23 @@ def report_migrated(before_ref: str, after_ref: str) -> None:
     before_reader, after_reader = BlobReader(before_ref), BlobReader(after_ref)
     try:
         before_paths = {p for p in _list_python_files(before_ref) if _is_source(p)}
+        after_paths = [p for p in _list_python_files(after_ref) if _is_source(p)]
+
+        # Read every source on the "after" ref first: resolving whether a source
+        # is on the pipeline may have to follow its base class into another
+        # module, so the whole set has to be in hand before deciding any of them.
+        after_texts: dict[str, str] = {}
+        for path in after_paths:
+            text = after_reader.read(path)
+            if text is not None:
+                after_texts[path] = text
+        by_stem = {Path(p).stem: t for p, t in after_texts.items()}
+
         rows: list[tuple[str, Counts, Counts]] = []
-        for path in _list_python_files(after_ref):
-            if not _is_source(path) or path not in before_paths:
+        for path, after_source in after_texts.items():
+            if path not in before_paths:
                 continue
-            after_source = after_reader.read(path)
-            if after_source is None or PIPELINE_MARKER not in after_source:
+            if not is_pipeline_source(after_source, by_stem):
                 continue
             before_source = before_reader.read(path)
             if before_source is None:


### PR DESCRIPTION
`loc_report` matched the literal text `class Source(BaseSource)`, which misses a source whose base is *another source*. Three reach `BaseSource` that way:

| source | via |
|---|---|
| `offenbach_de` | `insert_it_de` |
| `rh_entsorgung_de` | `jumomind_de` |
| `stadt_kerpen_de` | `abfall_io` |

They were counted as legacy, so **every migration figure the tool has reported was low by three sources**, including the ones quoted in #7115, #7116, #7118 and #7119.

Ten sources have a base other than `BaseSource`, so following the chain has to keep excluding the other seven, whose parent is itself legacy: `kaw_mainz_bingen_de`, `iapp_itouchvision_com`, `localcities_ch`, `edpevent_se` (twice), `roundlookup_uk`, and `RiSKommunalSource`, which is a plain class in a `service` module rather than a source at all.

`is_pipeline_source` walks the bases until it reaches `BaseSource`, gives up at a base it cannot resolve to another source, and terminates on a cycle. Both import spellings the sources use are followed, absolute and relative, wrapped or not. `report_migrated` now reads every source on the "after" ref before deciding any of them, since resolving one may need another.

`master -> release/3.0.0` accordingly reads **259 migrated sources rather than 256**, mean **108.3 -> 86.1** per source rather than 109.2 -> 86.6. The code delta moves slightly the other way, -5,763 against -5,790, because the three that arrived did not shrink.

The same literal match is what made the `waste_types` codemod skip those three sources in #7119, so they had to be converted by hand. Anything mechanical over the pipeline sources should use this instead.

## A second thing, found while testing this

`pytest.ini`'s `python_files` is an **allowlist, not a pattern**, so `tests/test_loc_report.py` would never have run. Neither, it turns out, were three existing files: `test_declared_waste_types`, `test_source_shell_customize` and `test_source_shell_create_error_handling`. That is **668 passing tests that gated nothing**.

All four are added, and the allowlist now carries a comment saying what belongs in it, so the next offline test file does not quietly go the same way. The per-provider files stay out on purpose: they hit live endpoints and say so in their own docstrings.

The suite goes from 4,937 to **5,618 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKQNey3jsRaVpHrnFjahR2
