### PR TITLE
docs(ics): call the yaml key regions, because that is what it is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,8 @@ If a PR diff touches any of the above, revert with `git checkout upstream/master
 - `custom_components/waste_collection_schedule/waste_collection_schedule/source/*.py` (source modules).
 - `doc/source/<id>.md`: for **legacy** sources, **must be created manually** (the update script reads but does not create these). For **pipeline** (`BaseSource`) sources, `doc_generator.py` renders this from the class metadata during the post-merge generation run, so do not hand-write it.
 - `doc/source/ics.md`, `doc/source/static.md` — manually maintained (blacklisted from generation, except for an auto-patched service-table section in each).
-- `doc/ics/yaml/*.yaml` — ICS provider definitions. Each file generates the matching `doc/ics/<name>.md`. When adding a provider, update BOTH the `extra_info` list (for the README/sources.json listing) AND the table inside the `howto.en` string (for the generated `.md`).
+- `doc/ics/yaml/*.yaml`: ICS provider definitions. Each file generates the matching `doc/ics/<name>.md`. One definition may cover several providers: list the others under `regions:` (each becomes its own README / `sources.json` listing, via `ics.REGIONS`). This key was called `extra_info:` until 2026-08, which confusingly named it after the deprecated Python `EXTRA_INFO` attribute it has nothing to do with; `ics.py` still reads the old spelling, but write `regions:`.
+  Some providers also list their per-provider **service endpoints** inside `howto`, which is a different thing from the `regions:` URL and is not generated from it: `regions[].url` is the provider's own website (for the listing), while the howto list gives the URL the user pastes as the `url` parameter. Both need maintaining where both apply.
 - `CHANGELOG.md`, `manifest.json` — manually maintained (release-time only).
 
 ---

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ics.py
@@ -259,7 +259,7 @@ def _load_ics_yaml_regions() -> "list[Region]":
     Mirrors, region for region, the listing expansion the now doc-generation-
     only update_docu_links.py:browse_ics_yaml() used to perform directly: one
     Region per YAML file, plus one additional Region per each of that file's
-    optional "extra_info" entries, so folding this into ics.REGIONS changes
+    optional ``regions:`` entries, so folding this into ics.REGIONS changes
     nothing about the generated output.
     """
     yaml_dir = Path(__file__).resolve().parents[4] / "doc" / "ics" / "yaml"
@@ -272,41 +272,55 @@ def _load_ics_yaml_regions() -> "list[Region]":
     for f in yaml_dir.glob("*.yaml"):
         with open(f, encoding="utf-8") as stream:
             data = _yaml.safe_load(stream)
+        regions.extend(_regions_from_definition(data, stem=f.stem))
+    return regions
 
-        howto_raw = data["howto"]
-        howto = {"en": howto_raw} if isinstance(howto_raw, str) else howto_raw
 
-        country = data.get("country", f.stem.split("_")[-1])
-        params = data.get("default_params", {})
-        doc_filename = f"/doc/ics/{f.stem}.md"
-        source_owners = _normalize_ics_codeowners(data.get("codeowners", []))
+def _regions_from_definition(data: dict, stem: str = "") -> "list[Region]":
+    """The Regions one ICS yaml definition covers: the file itself, then its own.
 
-        regions.append(
+    ``regions:`` lists the further providers a single definition covers, each
+    becoming its own discoverable listing pointing at this file's generated page.
+
+    That key was called ``extra_info:`` until 2026-08, which named it after the
+    deprecated Python ``EXTRA_INFO`` attribute it has nothing to do with: this key
+    has always fed ``ics.REGIONS``, the current path, while ``EXTRA_INFO`` is the
+    legacy form that ``regions.from_extra_info()`` adapts for legacy Python
+    sources. The old spelling is still read so an in-flight contribution keeps
+    working; ``regions:`` wins if somehow both are present.
+    """
+    howto_raw = data["howto"]
+    howto = {"en": howto_raw} if isinstance(howto_raw, str) else howto_raw
+
+    country = data.get("country", stem.split("_")[-1] if stem else None)
+    params = data.get("default_params", {})
+    doc_filename = f"/doc/ics/{stem}.md" if stem else None
+    source_owners = _normalize_ics_codeowners(data.get("codeowners", []))
+
+    out = [
+        Region(
+            title=data["title"],
+            params=params,
+            url=data["url"],
+            country=country,
+            doc_filename=doc_filename,
+            howto=howto,
+            source_owners=source_owners,
+        )
+    ]
+    for entry in data.get("regions", data.get("extra_info", [])):
+        out.append(
             Region(
-                title=data["title"],
+                title=entry.get("title", data["title"]),
                 params=params,
-                url=data["url"],
-                country=country,
+                url=entry.get("url", data["url"]),
+                country=entry.get("country", country),
                 doc_filename=doc_filename,
                 howto=howto,
                 source_owners=source_owners,
             )
         )
-
-        for e in data.get("extra_info", []):
-            regions.append(
-                Region(
-                    title=e.get("title", data["title"]),
-                    params=params,
-                    url=e.get("url", data["url"]),
-                    country=e.get("country", country),
-                    doc_filename=doc_filename,
-                    howto=howto,
-                    source_owners=source_owners,
-                )
-            )
-
-    return regions
+    return out
 
 
 @final

--- a/doc/contributing_ics.md
+++ b/doc/contributing_ics.md
@@ -40,6 +40,35 @@ codeowners:  # Optional — list of @handles who maintain this provider
 | howto | Dictionary[String, String] | Adictionary of `language`: A multi-line string in markdown format which describes the steps to configure the ICS source. |
 | test_cases | Dict | A dictionary with test-cases. The key of an entry represents the name of the test-case which will be displayed during testing. The item contains a dictionary of the source arguments. |
 | codeowners | List of Strings | [Optional] List of GitHub handles (e.g. `["@your-user"]`) who maintain this ICS provider. Each entry must start with `@`. Used by `update_docu_links.py` to generate `.github/source_owners.json`, which routes source-related bug reports to the right maintainer. If you add a new ICS YAML, consider adding your handle here so you are automatically notified of issues. |
+| default_params | Dict | [Optional] Source arguments pre-filled for this provider, so the user does not have to supply them. |
+| regions | List of Dicts | [Optional] Further providers this one definition covers. Each entry takes `title`, and optionally `url`, `country` and `default_params`, defaulting to the file's own values. Every entry becomes its own listing in README.md / `sources.json`, discoverable on its own name, all pointing at this file's generated `doc/ics/<name>.md`. |
+
+### More than one provider in one definition
+
+Many ICS providers run the same software under different subdomains, so one yaml
+covers all of them. List the others under `regions:`:
+
+```yaml
+title: Abfall App
+url: https://www.abfall-app.net
+regions:
+  - title: Landkreis Stendal
+    url: https://www.landkreis-stendal.de/
+  - title: Rhein-Pfalz-Kreis
+    url: https://www.rhein-pfalz-kreis.de/
+```
+
+Two things to know about it:
+
+- `regions[].url` is that provider's **own website**, used so a user searching for
+  their council's URL finds the listing. It is not the URL they configure. If your
+  provider needs a per-provider **endpoint** (a subdomain to paste as the `url`
+  parameter), that goes in the `howto` text, and it is separate information: it is
+  not generated from `regions:` and both need keeping current.
+- The key was called `extra_info:` until 2026-08. That name came from the
+  deprecated Python `EXTRA_INFO` attribute, which is a different mechanism for
+  legacy Python sources and unrelated to this file. The old spelling is still
+  read, so nothing breaks, but write `regions:`.
 
 Example:
 

--- a/doc/ics/yaml/abfall_app_net.yaml
+++ b/doc/ics/yaml/abfall_app_net.yaml
@@ -16,7 +16,7 @@ howto:
     - Landkreis Lüchow-Dannenberg: <https://luechow-dannenberg.abfall-app.net>
     - Rhein-Pfalz-Kreis: <https://rhein-pfalz-kreis.abfall-app.net>
     - Landkreis Holzminden: <https://landkreis-holzminden.abfall-app.net>
-extra_info:
+regions:
   - title: Landkreis Stendal
     url: https://www.landkreis-stendal.de/
     country: de

--- a/doc/ics/yaml/abfall_export_vcal.yaml
+++ b/doc/ics/yaml/abfall_export_vcal.yaml
@@ -2,7 +2,7 @@
 title: Abfall Export (vCal)
 url: https://example.com
 country: de
-extra_info:
+regions:
   - title: Stadt Löhne
     url: https://www.loehne.de
     country: de

--- a/doc/ics/yaml/abfall_io_ics.yaml
+++ b/doc/ics/yaml/abfall_io_ics.yaml
@@ -11,7 +11,7 @@ howto:
     - Use this link as the `url` parameter.
     - Replace the year in the URL with `{%Y}` (`...timeperiod=20240101-20241231` -> `...timeperiod={%Y}0101-{%Y}1231`).
 country: de
-extra_info:
+regions:
   - title: Abfallwirtschaft Landkreis Böblingen
     url: https://www.awb-bb.de/
     country: de

--- a/doc/ics/yaml/abfallv_zerowaste_io.yaml
+++ b/doc/ics/yaml/abfallv_zerowaste_io.yaml
@@ -7,7 +7,7 @@ howto:
     - Click on `Kalender Bo/Download` and copy the URL below `Adresse zum Abonnieren`.
     - Use this link as the `url` parameter.
 country: at
-extra_info:
+regions:
   - title: Vorarlberg
     url: https://abfallv.zerowaste.io
     country: at

--- a/doc/ics/yaml/abfuhrtermine_info.yaml
+++ b/doc/ics/yaml/abfuhrtermine_info.yaml
@@ -21,7 +21,7 @@ howto:
 
     and maybe some more.
 
-extra_info:
+regions:
   - title: Olpe
     url: https://olpe.de/
     country: de

--- a/doc/ics/yaml/gem2go_dev.yaml
+++ b/doc/ics/yaml/gem2go_dev.yaml
@@ -2,7 +2,7 @@
 title: gem2go (Abfallverband)
 url: https://gem2go.dev
 country: at
-extra_info:
+regions:
   - title: Upper Austria (Oberösterreich)
     url: https://uwpio.gem2go.dev
     country: at

--- a/doc/ics/yaml/geminfo_app.yaml
+++ b/doc/ics/yaml/geminfo_app.yaml
@@ -20,7 +20,7 @@ howto:
 test_cases:
   Thannhausen:
     url: https://graphql.sta.io/feed/c/i/5d9d1c1a5ff20a142ec8edc9/appointments.ics
-extra_info:
+regions:
   - title: Thannhausen
     url: https://www.thannhausen.at
     country: at

--- a/doc/ics/yaml/gipsprojekt_de.yaml
+++ b/doc/ics/yaml/gipsprojekt_de.yaml
@@ -19,7 +19,7 @@ description: |
   | ------ | --- |
   | Stadtwerke Speyer | <https://www.stadtwerke-speyer.de/muellkalender> |
   | Stadtwerke Aschaffenburg | <https://www.stwab.de/Abfall-Stadtreinigung/Muellabfuhr/Abfuhrtermine-und-Bezirk/> |
-extra_info:
+regions:
   - title: Stadtwerke Speyer
     url: https://www.stadtwerke-speyer.de/muellkalender
     country: de

--- a/doc/ics/yaml/mein_abfallkalender_online.yaml
+++ b/doc/ics/yaml/mein_abfallkalender_online.yaml
@@ -28,7 +28,7 @@ test_cases:
   St. Ingbert, Ackergasse, St. Ingbert-Mitte:
     url: webcal://st-ingbert.mein-abfallkalender.online/ical.ics?sid=8109&cd=inline&ft=6&fu=webcal_other&fp=next_30&wids=157,155,156,154,158&uid=167241&pwid=b3e6c5c670&cid=25
 
-extra_info:
+regions:
   - title: Eppstein
     url: https://www.eppstein.de/
   - title: St. Ingbert

--- a/doc/ics/yaml/mopage_ch.yaml
+++ b/doc/ics/yaml/mopage_ch.yaml
@@ -2,7 +2,7 @@
 title: mopage.ch
 url: https://mopage.ch
 country: ch
-extra_info:
+regions:
   - title: Wiedlisbach
     url: https://wiedlisbach.mopage.ch
     country: ch

--- a/doc/ics/yaml/muellapp_com.yaml
+++ b/doc/ics/yaml/muellapp_com.yaml
@@ -11,7 +11,7 @@ howto:
 test_cases:
   Leoben:
     url: https://app.muellapp.com/ical/241061?area_filter=174334%2C174336%2C174348%2C187236%2C187237%2C187238%2C187239&reminder
-extra_info:
+regions:
   - title: Afritz am See
     url: https://muellapp.com
     country: at

--- a/doc/ics/yaml/publicus_si.yaml
+++ b/doc/ics/yaml/publicus_si.yaml
@@ -2,7 +2,7 @@
 title: Publicus d.o.o.
 url: https://beta.smetar.si
 country: si
-extra_info:
+regions:
   - title: Kamnik
     url: https://www.kamnik.si
     country: si

--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -2,7 +2,7 @@
 title: ReCollect
 url: https://recollect.net/
 country: us
-extra_info:
+regions:
   - title: Ottawa, Canada
     url: https://ottawa.ca
     country: ca

--- a/doc/ics/yaml/recyclebycity_com.yaml
+++ b/doc/ics/yaml/recyclebycity_com.yaml
@@ -16,7 +16,7 @@ test_cases:
   Chicago:
     url: webcal://www.recyclebycity.com/chicago/schedule/e757bdb2b5a35ed18704e444714a93a3/subscribe
 
-extra_info:
+regions:
   - title: City of Flagstaff, AZ
     url: https://www.flagstaff.az.gov
   - title: City of Chicago, IL

--- a/tests/test_doc_generation.py
+++ b/tests/test_doc_generation.py
@@ -10,6 +10,7 @@ to the hand-written files, because the prose around the structure varies.
 import calendar  # noqa: F401 — stdlib calendar must be imported FIRST
 import importlib
 import os
+import pathlib
 import sys
 
 import pytest
@@ -149,3 +150,65 @@ def test_render_alternatives_source_renders_per_group():
     # Canonical 2-space mapping indentation in every config block.
     assert "\n  sources:\n" in doc
     assert "\n    sources:\n" not in doc
+
+
+# --------------------------------------------------------------------------- #
+# ICS yaml `regions:` key
+#
+# One ICS definition may cover several providers, listed under `regions:`. That
+# key was called `extra_info:` until 2026-08, which named it after the deprecated
+# Python EXTRA_INFO attribute it has nothing to do with: this key has always fed
+# ics.REGIONS, the current path, while EXTRA_INFO is the legacy form adapted by
+# regions.from_extra_info(). The old spelling is still read so an in-flight
+# contribution keeps working, but nothing in the tree should use it.
+# --------------------------------------------------------------------------- #
+
+_ICS_YAML_DIR = pathlib.Path(__file__).resolve().parent.parent / "doc" / "ics" / "yaml"
+
+
+def _ics_yaml_files():
+    return sorted(_ICS_YAML_DIR.glob("*.yaml"))
+
+
+@pytest.mark.parametrize("path", _ics_yaml_files(), ids=lambda p: p.stem)
+def test_ics_yaml_uses_the_regions_key(path):
+    """No yaml may use the old `extra_info:` spelling."""
+    import yaml
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    assert "extra_info" not in data, (
+        f"{path.name} uses the old `extra_info:` key. Rename it to `regions:`. "
+        "The old name came from the deprecated Python EXTRA_INFO attribute, "
+        "which is a different mechanism for legacy Python sources."
+    )
+
+
+def test_ics_loader_reads_both_spellings():
+    """The old spelling still works, so a pending contribution is not broken."""
+    from waste_collection_schedule.source import ics
+
+    definition = {
+        "title": "Example",
+        "url": "https://example.com",
+        "howto": {"en": "..."},
+        "extra_info": [{"title": "Second Provider"}],
+    }
+    old = ics._regions_from_definition(definition)
+    definition["regions"] = definition.pop("extra_info")
+    new = ics._regions_from_definition(definition)
+    expected = ["Example", "Second Provider"]  # the file's own region, then its own
+    assert [r.title for r in old] == [r.title for r in new] == expected
+
+
+def test_ics_regions_key_wins_when_both_are_present():
+    from waste_collection_schedule.source import ics
+
+    definition = {
+        "title": "Example",
+        "url": "https://example.com",
+        "howto": {"en": "..."},
+        "regions": [{"title": "New"}],
+        "extra_info": [{"title": "Old"}],
+    }
+    titles = [r.title for r in ics._regions_from_definition(definition)]
+    assert titles == ["Example", "New"], "the `regions:` key must win over the old one"

--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -319,7 +319,9 @@ class Section:
         return f"<!--End of {self._section} section-->"
 
 
-class ExtraInfoDict(TypedDict):
+class IcsRegionDict(TypedDict):
+    """One further provider covered by an ICS yaml definition."""
+
     title: NotRequired[str]
     url: NotRequired[str]
     country: NotRequired[str]
@@ -334,7 +336,11 @@ class IcsSourceData(TypedDict):
     country: NotRequired[str]
     default_params: NotRequired[dict[str, Any]]
     test_cases: dict[str, dict[str, Any]]
-    extra_info: NotRequired[list[ExtraInfoDict]]
+    # The providers one definition covers, beyond the file's own title/url. Named
+    # ``extra_info`` until 2026-08, after the unrelated deprecated Python
+    # attribute; that spelling is still read by ics.py but should not be written.
+    regions: NotRequired[list[IcsRegionDict]]
+    extra_info: NotRequired[list[IcsRegionDict]]
     codeowners: NotRequired[list]
 
 


### PR DESCRIPTION
An ICS yaml definition may cover several providers, and the key listing the others was called `extra_info:`. That is the name of the deprecated Python `EXTRA_INFO` attribute, which is a **different mechanism entirely**:

| | Python `EXTRA_INFO` | yaml `extra_info:` |
|---|---|---|
| read by | `update_docu_links.py` → `regions.from_extra_info()` | `ics.py` → `Region(...)` directly |
| status | legacy, gated by #7120, deleted with the last legacy source | current, feeds `ics.REGIONS` |

The names had nothing to do with each other. The name misled the maintainer into thinking current ICS definitions were writing to legacy scaffolding, which is about as clear a signal as a name can give.

So it is **`regions:`** now, matching `REGIONS` on a source: one concept, one name. The 14 files that use it are renamed, `ics.py` still reads the old spelling so an in-flight contribution keeps working, and `regions:` wins if both appear.

**468 regions load before and after, unchanged.**

The listing expansion moves into `_regions_from_definition()` so it can be tested directly rather than only through a directory scan. Three tests cover it: no yaml in the tree uses the old spelling (one case per file), both spellings still produce the same `Region`s, and the new key wins over the old.

## Two documentation defects fixed alongside it

**CLAUDE.md** said to update "BOTH the `extra_info` list AND the table inside the `howto.en` string", as though the two held the same data. They do not. `regions[].url` is the provider's own website, for the listing; the per-provider list some files keep in `howto` gives the **service endpoint the user pastes as the `url` parameter**:

| | `Landkreis Stendal` → |
|---|---|
| `regions[].url` | `https://www.landkreis-stendal.de/` |
| `howto` | `https://landkreis-stendal.abfall-app.net` |

Neither is derivable from the other, so the instruction now says what each is for rather than implying one is redundant. (I had originally planned to generate the howto table from the region list. That was wrong for exactly this reason.)

**contributing_ics.md** documented the yaml format without mentioning this key at all, nor `default_params`, so the contributor guide was silent about the mechanism 14 files depend on. Both are now in the attribute table, with a worked example and the endpoint-versus-website distinction spelled out.

## Not fixed here

Only 14 of 185 yaml files use the key, and 3 repeat their titles in the howto. `recollect` is the worst: 65 entries against a 44-row howto table overlapping on **28**, so both lists have drifted, in both directions. That is a data-correctness question about which providers are actually verified, so it is left alone rather than reconciled by guesswork, and tracked separately.

Full suite passes, 5,805 tests (up 187 from the per-file yaml checks). `pre-commit` clean.

Follows #7120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKQNey3jsRaVpHrnFjahR2
