### PR TITLE
Add Clisson Sèvre et Maine Agglo (FR) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/clissonsevremaine_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/clissonsevremaine_fr.py
@@ -1,0 +1,252 @@
+import re
+import unicodedata
+from datetime import date
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
+TITLE = "Clisson Sèvre et Maine Agglo"
+DESCRIPTION = (
+    "Source for Clisson Sèvre et Maine Agglo, the inter-municipal authority "
+    "responsible for waste collection in 18 municipalities of the "
+    "Loire-Atlantique department, France."
+)
+URL = "https://environnement.clissonsevremaine.fr"
+COUNTRY = "fr"
+
+SOURCE_CODEOWNERS = ["@JeyMuller"]
+
+CALENDAR_URL = (
+    "https://environnement.clissonsevremaine.fr"
+    "/dechets/collecte-des-dechets/calendrier-des-collectes"
+)
+CATEGORY_ARG = "tx_calendarize_calendar[customSearch][category]"
+MONTH_ARG = "tx_calendarize_calendar[month]"
+YEAR_ARG = "tx_calendarize_calendar[year]"
+
+# Number of months fetched, starting with the current one. The integration
+# refreshes once a day by default, so this stays well within reason.
+MONTHS_TO_FETCH = 12
+
+# Only used to advertise every municipality in the documentation and in the
+# configuration UI. The actual identifiers are always resolved live from the
+# drop-down on the website, so a renumbering upstream cannot break the source.
+COMMUNES = [
+    "Aigrefeuille-sur-Maine",
+    "Boussay",
+    "Château-Thébaud",
+    "Clisson",
+    "Clisson, rue Saint-Antoine",
+    "Gétigné - zone A",
+    "Gétigné - zone B",
+    "Gorges",
+    "Haute-Goulaine",
+    "La Haye-Fouassière - Zone A",
+    "La Haye-Fouassière - Zone B",
+    "La Planche",
+    "Maisdon-sur-Sèvre - zone 1",
+    "Maisdon-sur-Sèvre - zone 2",
+    "Maisdon-sur-Sèvre - zone 3",
+    "Monnières",
+    "Remouillé",
+    "Saint-Hilaire-de-Clisson - Zone A",
+    "Saint-Hilaire-de-Clisson - Zone B",
+    "Saint-Lumine-de-Clisson - Zone A",
+    "Saint-Lumine-de-Clisson - Zone B",
+    "St-Fiacre-sur-Maine",
+    "Vieillevigne",
+]
+
+EXTRA_INFO = [
+    {
+        "title": commune,
+        "url": URL,
+        "default_params": {"commune": commune},
+    }
+    for commune in COMMUNES
+]
+
+# A representative subset: a plain municipality, a zoned one, the street that
+# has its own round, and a three-zone municipality. Every entry costs
+# MONTHS_TO_FETCH requests, so testing all 23 zones would hammer the website.
+TEST_CASES = {
+    "Gorges": {"commune": "Gorges"},
+    "Maisdon-sur-Sèvre - zone 1": {"commune": "Maisdon-sur-Sèvre - zone 1"},
+    "La Haye-Fouassière - Zone B": {"commune": "La Haye-Fouassière - Zone B"},
+    "Clisson, rue Saint-Antoine": {"commune": "clisson, rue saint-antoine"},
+}
+
+ICON_MAP = {
+    "ordures menageres": Icons.GENERAL_WASTE,
+    "emballages": Icons.PLASTIC_PACKAGING,
+}
+DEFAULT_ICON = Icons.GENERAL_WASTE
+
+PARAM_TRANSLATIONS = {
+    "en": {"commune": "Municipality"},
+    "fr": {"commune": "Commune"},
+}
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "commune": (
+            "Your municipality, exactly as listed in the drop-down menu on the "
+            "collection calendar page, e.g. 'Maisdon-sur-Sèvre - zone 1'."
+        )
+    },
+    "fr": {
+        "commune": (
+            "Votre commune, telle qu'elle apparaît dans la liste déroulante de "
+            "la page du calendrier des collectes, par exemple "
+            "'Maisdon-sur-Sèvre - zone 1'."
+        )
+    },
+}
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        f"Open {CALENDAR_URL} and pick your municipality in the drop-down menu. "
+        "Use the wording shown there. Some municipalities are split into "
+        "several collection zones; the maps at the end of the downloadable PDF "
+        "calendars tell you which zone your street belongs to."
+    ),
+    "fr": (
+        f"Ouvrez {CALENDAR_URL} et choisissez votre commune dans la liste "
+        "déroulante. Reprenez le libellé affiché. Certaines communes sont "
+        "découpées en plusieurs zones de collecte ; les cartes situées à la fin "
+        "des calendriers PDF téléchargeables indiquent la zone de votre rue."
+    ),
+}
+
+FRENCH_MONTHS = [
+    "janvier",
+    "février",
+    "mars",
+    "avril",
+    "mai",
+    "juin",
+    "juillet",
+    "août",
+    "septembre",
+    "octobre",
+    "novembre",
+    "décembre",
+]
+
+# The waste type is spelled out in the calendar legend as "Collecte des
+# ordures ménagères" / "Collecte des emballages". Trim the lead-in so the
+# sensors read "Ordures ménagères" and "Emballages".
+COLLECTION_PREFIX = re.compile(r"^collecte\s+(?:des?|du|de\s+la|de\s+l')\s+", re.I)
+
+
+def _normalize(value: str) -> str:
+    """Lowercase, strip accents and reduce punctuation to single spaces."""
+    decomposed = unicodedata.normalize("NFKD", value)
+    without_accents = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", " ", without_accents.lower()).strip()
+
+
+class Source:
+    def __init__(self, commune: str):
+        self._commune: str = commune.strip()
+
+    def _get_categories(self, session: requests.Session) -> dict[str, str]:
+        """Map every municipality label of the drop-down to its category id."""
+        r = session.get(CALENDAR_URL, timeout=30)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        select = soup.find("select", attrs={"name": CATEGORY_ARG})
+        if select is None:
+            raise Exception("Could not find the municipality selector on the page")
+
+        return {
+            option.get_text(strip=True): option["value"]
+            for option in select.find_all("option")
+            if option.get("value")
+        }
+
+    def _parse_month(
+        self, session: requests.Session, category: str, year: int, month: int
+    ) -> list[Collection]:
+        params = {CATEGORY_ARG: category, YEAR_ARG: year, MONTH_ARG: month}
+        r = session.get(CALENDAR_URL, params=params, timeout=30)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        # Guard against the website ignoring the month/year arguments, which
+        # would otherwise yield the same month over and over again.
+        header = soup.find(id="month-header")
+        expected = _normalize(f"{FRENCH_MONTHS[month - 1]} {year}")
+        if header is None or expected not in _normalize(
+            header.get_text(" ", strip=True)
+        ):
+            return []
+
+        # The legend maps a CSS colour prefix to a human readable waste type.
+        legend: dict[str, str] = {}
+        for span in soup.select("#month-legend span[class*=_catheader_text]"):
+            for css_class in span.get("class", []):
+                if css_class.endswith("_catheader_text"):
+                    label = COLLECTION_PREFIX.sub("", span.get_text(strip=True))
+                    legend[css_class.removesuffix("_catheader_text")] = (
+                        label[:1].upper() + label[1:]
+                    )
+
+        entries: list[Collection] = []
+        for day_cell in soup.select("td.day.hasEvents"):
+            classes = day_cell.get("class", [])
+            if "not-current-month" in classes:
+                continue
+            day = int(day_cell.get_text(strip=True))
+
+            # A single day can carry several collections, one CSS colour each.
+            for css_class in classes:
+                if not css_class.endswith("_catheader_bullet"):
+                    continue
+                colour = css_class.removesuffix("_catheader_bullet")
+                if colour not in legend:
+                    continue
+                waste_type = legend[colour]
+                entries.append(
+                    Collection(
+                        date=date(year, month, day),
+                        t=waste_type,
+                        icon=ICON_MAP.get(_normalize(waste_type), DEFAULT_ICON),
+                    )
+                )
+        return entries
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update({"User-Agent": "Mozilla/5.0"})
+
+        categories = self._get_categories(session)
+        wanted = _normalize(self._commune)
+        category = next(
+            (
+                value
+                for label, value in categories.items()
+                if _normalize(label) == wanted
+            ),
+            None,
+        )
+        if category is None:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "commune", self._commune, sorted(categories)
+            )
+
+        today = date.today()
+        entries: list[Collection] = []
+        for offset in range(MONTHS_TO_FETCH):
+            month_index = today.month - 1 + offset
+            entries += self._parse_month(
+                session, category, today.year + month_index // 12, month_index % 12 + 1
+            )
+
+        if not entries:
+            raise Exception(
+                f"No collection found for {self._commune}, "
+                "the website layout may have changed"
+            )
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/clissonsevremaine_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/clissonsevremaine_fr.py
@@ -158,7 +158,7 @@ class Source:
 
         select = soup.find("select", attrs={"name": CATEGORY_ARG})
         if select is None:
-            raise Exception("Could not find the municipality selector on the page")
+            raise RuntimeError("Could not find the municipality selector on the page")
 
         return {
             option.get_text(strip=True): value
@@ -248,7 +248,7 @@ class Source:
             )
 
         if not entries:
-            raise Exception(
+            raise RuntimeError(
                 f"No collection found for {self._commune}, "
                 "the website layout may have changed"
             )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/clissonsevremaine_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/clissonsevremaine_fr.py
@@ -161,9 +161,9 @@ class Source:
             raise Exception("Could not find the municipality selector on the page")
 
         return {
-            option.get_text(strip=True): option["value"]
+            option.get_text(strip=True): value
             for option in select.find_all("option")
-            if option.get("value")
+            if isinstance(value := option.get("value"), str) and value
         }
 
     def _parse_month(
@@ -186,7 +186,10 @@ class Source:
         # The legend maps a CSS colour prefix to a human readable waste type.
         legend: dict[str, str] = {}
         for span in soup.select("#month-legend span[class*=_catheader_text]"):
-            for css_class in span.get("class", []):
+            span_classes = span.get("class") or []
+            if not isinstance(span_classes, list):
+                span_classes = [span_classes]
+            for css_class in span_classes:
                 if css_class.endswith("_catheader_text"):
                     label = COLLECTION_PREFIX.sub("", span.get_text(strip=True))
                     legend[css_class.removesuffix("_catheader_text")] = (
@@ -195,7 +198,7 @@ class Source:
 
         entries: list[Collection] = []
         for day_cell in soup.select("td.day.hasEvents"):
-            classes = day_cell.get("class", [])
+            classes = day_cell.get("class") or []
             if "not-current-month" in classes:
                 continue
             day = int(day_cell.get_text(strip=True))

--- a/doc/source/clissonsevremaine_fr.md
+++ b/doc/source/clissonsevremaine_fr.md
@@ -1,0 +1,65 @@
+# Clisson Sèvre et Maine Agglo
+
+Support for schedules provided by [Clisson Sèvre et Maine Agglo](https://environnement.clissonsevremaine.fr), serving the 18 municipalities of the agglomeration in the Loire-Atlantique department, France.
+
+Two waste streams are collected door-to-door and reported by this source:
+
+- `Ordures ménagères` (residual household waste)
+- `Emballages` (recyclable packaging)
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: clissonsevremaine_fr
+      args:
+        commune: COMMUNE
+```
+
+### Configuration Variables
+
+**commune**  
+*(String) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: clissonsevremaine_fr
+      args:
+        commune: Maisdon-sur-Sèvre - zone 1
+```
+
+## How to get the source argument
+
+Open the [collection calendar page](https://environnement.clissonsevremaine.fr/dechets/collecte-des-dechets/calendrier-des-collectes) and pick your municipality in the drop-down menu. Use the wording shown there; matching is case- and accent-insensitive.
+
+Several municipalities are split into collection zones, and one street in Clisson has its own round. The maps at the end of the downloadable PDF calendars, linked from the same page, tell you which zone your street belongs to.
+
+Accepted values:
+
+- `Aigrefeuille-sur-Maine`
+- `Boussay`
+- `Château-Thébaud`
+- `Clisson`
+- `Clisson, rue Saint-Antoine`
+- `Gétigné - zone A`
+- `Gétigné - zone B`
+- `Gorges`
+- `Haute-Goulaine`
+- `La Haye-Fouassière - Zone A`
+- `La Haye-Fouassière - Zone B`
+- `La Planche`
+- `Maisdon-sur-Sèvre - zone 1`
+- `Maisdon-sur-Sèvre - zone 2`
+- `Maisdon-sur-Sèvre - zone 3`
+- `Monnières`
+- `Remouillé`
+- `Saint-Hilaire-de-Clisson - Zone A`
+- `Saint-Hilaire-de-Clisson - Zone B`
+- `Saint-Lumine-de-Clisson - Zone A`
+- `Saint-Lumine-de-Clisson - Zone B`
+- `St-Fiacre-sur-Maine`
+- `Vieillevigne`


### PR DESCRIPTION
## Summary

New source for [Clisson Sèvre et Maine Agglo](https://environnement.clissonsevremaine.fr), the inter-municipal authority in charge of waste collection for 18 municipalities in the Loire-Atlantique department, France. A single `commune` argument covers all 23 collection zones.

Two door-to-door streams are reported: `Ordures ménagères` and `Emballages`.

The provider publishes its calendar through the TYPO3 *calendarize* extension, whose municipality selector is a plain GET form — so no API, PDF parsing or browser automation is needed:

```
/dechets/collecte-des-dechets/calendrier-des-collectes
  ?tx_calendarize_calendar[customSearch][category]=<id>
  &tx_calendarize_calendar[year]=<year>
  &tx_calendarize_calendar[month]=<month>
```

The source requests 12 monthly views and parses the marked days. Three choices worth flagging:

- **Category ids are resolved live** from the drop-down instead of being hardcoded, so a renumbering on the provider's side cannot break the source. The list in `COMMUNES` only populates `EXTRA_INFO`.
- **Waste types come from the calendar legend**, mapped through the CSS colour prefix carried by each day cell. A third stream added later would be picked up without a code change. A day can carry several collections — one street in Clisson has both streams on the same day — and this is handled.
- **`TEST_CASES` covers 4 of the 23 zones** rather than all of them: a plain municipality, a zoned one, a three-zone one, and the Clisson street with its own round. Each case costs 12 requests, so the full set would mean 276 requests against the provider on every run. Happy to expand it if you prefer.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (35 passed)
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own) — they are municipality labels taken straight from the public drop-down, no street-level data involved

## Test output

<details>
<summary><code>python test_sources.py -s clissonsevremaine_fr -l</code></summary>

```
Testing source clissonsevremaine_fr ...
  found 52 entries for Gorges
    2026-08-12 : Emballages
    2026-08-13 : Ordures ménagères
    2026-08-26 : Emballages
    2026-08-27 : Ordures ménagères
    2026-09-09 : Emballages
    2026-09-10 : Ordures ménagères
    2026-09-23 : Emballages
    2026-09-24 : Ordures ménagères
    2026-10-07 : Emballages
    2026-10-08 : Ordures ménagères
    2026-10-21 : Emballages
    2026-10-22 : Ordures ménagères
    2026-11-04 : Emballages
    2026-11-05 : Ordures ménagères
    2026-11-18 : Emballages
    2026-11-19 : Ordures ménagères
    2026-12-02 : Emballages
    2026-12-03 : Ordures ménagères
    2026-12-16 : Emballages
    2026-12-17 : Ordures ménagères
    2026-12-30 : Emballages
    2026-12-31 : Ordures ménagères
    2027-01-13 : Emballages
    2027-01-14 : Ordures ménagères
    2027-01-27 : Emballages
    2027-01-28 : Ordures ménagères
    2027-02-10 : Emballages
    2027-02-11 : Ordures ménagères
    2027-02-24 : Emballages
    2027-02-25 : Ordures ménagères
    2027-03-10 : Emballages
    2027-03-11 : Ordures ménagères
    2027-03-24 : Emballages
    2027-03-25 : Ordures ménagères
    2027-04-07 : Emballages
    2027-04-08 : Ordures ménagères
    2027-04-21 : Emballages
    2027-04-22 : Ordures ménagères
    2027-05-05 : Emballages
    2027-05-06 : Ordures ménagères
    2027-05-19 : Emballages
    2027-05-20 : Ordures ménagères
    2027-06-02 : Emballages
    2027-06-03 : Ordures ménagères
    2027-06-16 : Emballages
    2027-06-17 : Ordures ménagères
    2027-06-30 : Emballages
    2027-07-01 : Ordures ménagères
    2027-07-14 : Emballages
    2027-07-15 : Ordures ménagères
    2027-07-28 : Emballages
    2027-07-29 : Ordures ménagères
  found 52 entries for Maisdon-sur-Sèvre - zone 1
    2026-08-10 : Ordures ménagères
    2026-08-12 : Emballages
    2026-08-24 : Ordures ménagères
    2026-08-26 : Emballages
    2026-09-07 : Ordures ménagères
    2026-09-09 : Emballages
    2026-09-21 : Ordures ménagères
    2026-09-23 : Emballages
    2026-10-05 : Ordures ménagères
    2026-10-07 : Emballages
    2026-10-19 : Ordures ménagères
    2026-10-21 : Emballages
    2026-11-02 : Ordures ménagères
    2026-11-04 : Emballages
    2026-11-16 : Ordures ménagères
    2026-11-18 : Emballages
    2026-11-30 : Ordures ménagères
    2026-12-02 : Emballages
    2026-12-14 : Ordures ménagères
    2026-12-16 : Emballages
    2026-12-28 : Ordures ménagères
    2026-12-30 : Emballages
    2027-01-11 : Ordures ménagères
    2027-01-13 : Emballages
    2027-01-25 : Ordures ménagères
    2027-01-27 : Emballages
    2027-02-08 : Ordures ménagères
    2027-02-10 : Emballages
    2027-02-22 : Ordures ménagères
    2027-02-24 : Emballages
    2027-03-08 : Ordures ménagères
    2027-03-10 : Emballages
    2027-03-22 : Ordures ménagères
    2027-03-24 : Emballages
    2027-04-05 : Ordures ménagères
    2027-04-07 : Emballages
    2027-04-19 : Ordures ménagères
    2027-04-21 : Emballages
    2027-05-03 : Ordures ménagères
    2027-05-05 : Emballages
    2027-05-17 : Ordures ménagères
    2027-05-19 : Emballages
    2027-05-31 : Ordures ménagères
    2027-06-02 : Emballages
    2027-06-14 : Ordures ménagères
    2027-06-16 : Emballages
    2027-06-28 : Ordures ménagères
    2027-06-30 : Emballages
    2027-07-12 : Ordures ménagères
    2027-07-14 : Emballages
    2027-07-26 : Ordures ménagères
    2027-07-28 : Emballages
  found 52 entries for La Haye-Fouassière - Zone B
    2026-08-03 : Emballages
    2026-08-10 : Ordures ménagères
    2026-08-17 : Emballages
    2026-08-24 : Ordures ménagères
    2026-08-31 : Emballages
    2026-09-07 : Ordures ménagères
    2026-09-14 : Emballages
    2026-09-21 : Ordures ménagères
    2026-09-28 : Emballages
    2026-10-05 : Ordures ménagères
    2026-10-12 : Emballages
    2026-10-19 : Ordures ménagères
    2026-10-26 : Emballages
    2026-11-02 : Ordures ménagères
    2026-11-09 : Emballages
    2026-11-16 : Ordures ménagères
    2026-11-23 : Emballages
    2026-11-30 : Ordures ménagères
    2026-12-07 : Emballages
    2026-12-14 : Ordures ménagères
    2026-12-21 : Emballages
    2026-12-28 : Ordures ménagères
    2027-01-04 : Emballages
    2027-01-11 : Ordures ménagères
    2027-01-18 : Emballages
    2027-01-25 : Ordures ménagères
    2027-02-01 : Emballages
    2027-02-08 : Ordures ménagères
    2027-02-15 : Emballages
    2027-02-22 : Ordures ménagères
    2027-03-01 : Emballages
    2027-03-08 : Ordures ménagères
    2027-03-15 : Emballages
    2027-03-22 : Ordures ménagères
    2027-03-29 : Emballages
    2027-04-05 : Ordures ménagères
    2027-04-12 : Emballages
    2027-04-19 : Ordures ménagères
    2027-04-26 : Emballages
    2027-05-03 : Ordures ménagères
    2027-05-10 : Emballages
    2027-05-17 : Ordures ménagères
    2027-05-24 : Emballages
    2027-05-31 : Ordures ménagères
    2027-06-07 : Emballages
    2027-06-14 : Ordures ménagères
    2027-06-21 : Emballages
    2027-06-28 : Ordures ménagères
    2027-07-05 : Emballages
    2027-07-12 : Ordures ménagères
    2027-07-19 : Emballages
    2027-07-26 : Ordures ménagères
  found 52 entries for Clisson, rue Saint-Antoine
    2026-08-04 : Emballages
    2026-08-04 : Ordures ménagères
    2026-08-18 : Emballages
    2026-08-18 : Ordures ménagères
    2026-09-01 : Emballages
    2026-09-01 : Ordures ménagères
    2026-09-15 : Emballages
    2026-09-15 : Ordures ménagères
    2026-09-29 : Emballages
    2026-09-29 : Ordures ménagères
    2026-10-13 : Emballages
    2026-10-13 : Ordures ménagères
    2026-10-27 : Emballages
    2026-10-27 : Ordures ménagères
    2026-11-10 : Emballages
    2026-11-10 : Ordures ménagères
    2026-11-24 : Emballages
    2026-11-24 : Ordures ménagères
    2026-12-08 : Emballages
    2026-12-08 : Ordures ménagères
    2026-12-22 : Emballages
    2026-12-22 : Ordures ménagères
    2027-01-05 : Emballages
    2027-01-05 : Ordures ménagères
    2027-01-19 : Emballages
    2027-01-19 : Ordures ménagères
    2027-02-02 : Emballages
    2027-02-02 : Ordures ménagères
    2027-02-16 : Emballages
    2027-02-16 : Ordures ménagères
    2027-03-02 : Emballages
    2027-03-02 : Ordures ménagères
    2027-03-16 : Emballages
    2027-03-16 : Ordures ménagères
    2027-03-30 : Emballages
    2027-03-30 : Ordures ménagères
    2027-04-13 : Emballages
    2027-04-13 : Ordures ménagères
    2027-04-27 : Emballages
    2027-04-27 : Ordures ménagères
    2027-05-11 : Emballages
    2027-05-11 : Ordures ménagères
    2027-05-25 : Emballages
    2027-05-25 : Ordures ménagères
    2027-06-08 : Emballages
    2027-06-08 : Ordures ménagères
    2027-06-22 : Emballages
    2027-06-22 : Ordures ménagères
    2027-07-06 : Emballages
    2027-07-06 : Ordures ménagères
    2027-07-20 : Emballages
    2027-07-20 : Ordures ménagères
```

</details>
