### PR TITLE
fix(swale_gov_uk): preserve form state during lookup

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -1,6 +1,8 @@
 import logging
+import re
 from datetime import date, datetime, timedelta
 from time import sleep
+from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 from curl_cffi import requests
@@ -12,7 +14,7 @@ TITLE = "Swale Borough Council"
 DESCRIPTION = "Source for swale.gov.uk services for Swale, UK."
 URL = "https://swale.gov.uk"
 API_URL = (
-    "https://swale.gov.uk/bins-littering-and-the-environment/bins/my-collection-day"
+    "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day"
 )
 ICON_MAP = {
     "Refuse": Icons.GENERAL_WASTE,
@@ -56,36 +58,117 @@ class Source:
             dt = dt.replace(year=dt.year + 1)
         return dt
 
+    @staticmethod
+    def _lookup_form(soup: BeautifulSoup):
+        """Return the council lookup form without depending on its numeric ID."""
+        for form in soup.find_all("form"):
+            if form.find("input", {"name": re.compile(r"^SQ_FORM_\d+_PAGE$")}):
+                return form
+        return None
+
+    @staticmethod
+    def _field_name(form, label_text: str, fallback_tag: str | None = None) -> str:
+        label = next(
+            (
+                item
+                for item in form.find_all("label")
+                if label_text in item.get_text(" ", strip=True).lower()
+            ),
+            None,
+        )
+        if label and (field_id := label.get("for")):
+            field = form.find(id=field_id)
+            if field and field.get("name"):
+                return field["name"]
+
+        if fallback_tag:
+            for field in form.find_all(fallback_tag, {"name": True}):
+                if field.get("type") not in {"hidden", "submit"}:
+                    return field["name"]
+
+        raise ValueError(f"Swale lookup form is missing its {label_text} control.")
+
+    @staticmethod
+    def _submit_control(form) -> tuple[str, str]:
+        control = form.find(
+            "input", {"type": "submit", "name": True, "value": True}
+        )
+        if not control:
+            raise ValueError("Swale lookup form is missing its submit control.")
+        return control["name"], control["value"]
+
+    @staticmethod
+    def _hidden_data(soup: BeautifulSoup) -> dict[str, str]:
+        # Squiz currently places its token outside the form, so collect page state.
+        return {
+            field["name"]: field.get("value", "")
+            for field in soup.select('input[type="hidden"][name]')
+        }
+
+    @staticmethod
+    def _raise_for_unexpected_page(soup: BeautifulSoup, stage: str) -> None:
+        title = soup.title.get_text(" ", strip=True).lower() if soup.title else ""
+        content = soup.get_text(" ", strip=True).lower()
+        if "just a moment" in title or "challenges.cloudflare.com" in content:
+            raise ValueError("Swale lookup was blocked by a Cloudflare challenge.")
+
+        errors = soup.select(
+            ".sq-form-error, .sq-form-error-message, .validation-error, "
+            ".alert-danger, [role='alert']"
+        )
+        if errors:
+            raise ValueError(f"Swale {stage} submission returned a validation error.")
+
+    @staticmethod
+    def _submit(session, response, form, payload: dict[str, str]):
+        method = form.get("method", "get").lower()
+        request = getattr(session, method, None)
+        if request is None:
+            raise ValueError(f"Swale lookup form uses unsupported method {method!r}.")
+
+        action = urljoin(response.url, form.get("action") or response.url)
+        if method == "get":
+            return request(action, params=payload)
+        return request(action, data=payload)
+
     def fetch(self) -> list[Collection]:
         s = requests.Session(impersonate="chrome")
 
-        # mimic postcode search
-        payload: dict = {
-            "SQ_FORM_535662_PAGE": "1",
-            "form_email_535662_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
-            "q535679:q1": self._postcode,
-            "form_email_535662_submit": "Choose Your Address &#10140;",
-        }
-        r = s.post(
-            "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day",
-            data=payload,
-        )
+        # Load the form first so its token, cookies, and current field names are used.
+        r = s.get(API_URL)
+        r.raise_for_status()
+        soup: BeautifulSoup = BeautifulSoup(r.content, "html.parser")
+        self._raise_for_unexpected_page(soup, "initial")
+        form = self._lookup_form(soup)
+        if not form:
+            raise ValueError("Swale lookup page did not contain an input form.")
+
+        payload = self._hidden_data(soup)
+        payload[self._field_name(form, "postcode", "input")] = self._postcode
+        submit_name, submit_value = self._submit_control(form)
+        payload[submit_name] = submit_value
+        r = self._submit(s, r, form, payload)
         r.raise_for_status()
         sleep(5)
 
-        # mimic address selection
-        payload = {
-            "SQ_FORM_535662_PAGE": "2",
-            "form_email_535662_referral_url": "https://swale.gov.uk/bins-littering-and-the-environment/bins",
-            "q535685:q1": self._uprn,
-            "form_email_535662_submit": "Get Bin Days &#10140;",
-        }
-        r = s.post(
-            "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day",
-            data=payload,
-        )
+        soup = BeautifulSoup(r.content, "html.parser")
+        self._raise_for_unexpected_page(soup, "postcode")
+        form = self._lookup_form(soup)
+        if not form:
+            raise ValueError("Swale postcode submission did not return an address form.")
+
+        payload = self._hidden_data(soup)
+        payload[self._field_name(form, "address", "select")] = self._uprn
+        submit_name, submit_value = self._submit_control(form)
+        payload[submit_name] = submit_value
+        r = self._submit(s, r, form, payload)
         r.raise_for_status()
         soup: BeautifulSoup = BeautifulSoup(r.content, "html.parser")
+        self._raise_for_unexpected_page(soup, "UPRN")
+        if self._lookup_form(soup):
+            raise ValueError(
+                "Swale UPRN submission returned an input form instead of results."
+            )
         temp_list: list = []
 
         # Get details of next collection

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -90,9 +90,7 @@ class Source:
 
     @staticmethod
     def _submit_control(form) -> tuple[str, str]:
-        control = form.find(
-            "input", {"type": "submit", "name": True, "value": True}
-        )
+        control = form.find("input", {"type": "submit", "name": True, "value": True})
         if not control:
             raise ValueError("Swale lookup form is missing its submit control.")
         return control["name"], control["value"]
@@ -155,7 +153,9 @@ class Source:
         self._raise_for_unexpected_page(soup, "postcode")
         form = self._lookup_form(soup)
         if not form:
-            raise ValueError("Swale postcode submission did not return an address form.")
+            raise ValueError(
+                "Swale postcode submission did not return an address form."
+            )
 
         payload = self._hidden_data(soup)
         payload[self._field_name(form, "address", "select")] = self._uprn

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/swale_gov_uk.py
@@ -110,10 +110,16 @@ class Source:
         if "just a moment" in title or "challenges.cloudflare.com" in content:
             raise ValueError("Swale lookup was blocked by a Cloudflare challenge.")
 
-        errors = soup.select(
-            ".sq-form-error, .sq-form-error-message, .validation-error, "
-            ".alert-danger, [role='alert']"
-        )
+        # Only treat an error container as an error if it actually carries text:
+        # empty aria-live regions are always present on the results page.
+        errors = [
+            error
+            for error in soup.select(
+                ".sq-form-error, .sq-form-error-message, .validation-error, "
+                ".alert-danger, [role='alert']"
+            )
+            if error.get_text(" ", strip=True)
+        ]
         if errors:
             raise ValueError(f"Swale {stage} submission returned a validation error.")
 
@@ -163,7 +169,7 @@ class Source:
         payload[submit_name] = submit_value
         r = self._submit(s, r, form, payload)
         r.raise_for_status()
-        soup: BeautifulSoup = BeautifulSoup(r.content, "html.parser")
+        soup = BeautifulSoup(r.content, "html.parser")
         self._raise_for_unexpected_page(soup, "UPRN")
         if self._lookup_form(soup):
             raise ValueError(

--- a/tests/test_swale_gov_uk.py
+++ b/tests/test_swale_gov_uk.py
@@ -52,7 +52,7 @@ UPRN_FORM = """
   <input type="hidden" name="SQ_FORM_999_PAGE" value="2">
   <input type="hidden" name="state" value="second-state">
   <label for="address">Choose your address</label>
-  <select id="address" name="q999:q2"><option value="[redacted]">Address</option></select>
+  <select id="address" name="q999:q2"><option value="100062375927">Address</option></select>
   <input type="submit" name="submit_999" value="Get Bin Days">
 </form></html>
 """
@@ -73,7 +73,7 @@ def fetch_with(responses: list[Response]) -> tuple[list, Session]:
         patch.object(swale_gov_uk.requests, "Session", return_value=session),
         patch.object(swale_gov_uk, "sleep"),
     ):
-        entries = swale_gov_uk.Source("[redacted]", "AA1 1AA").fetch()
+        entries = swale_gov_uk.Source("100062375927", "AA1 1AA").fetch()
     return entries, session
 
 
@@ -107,7 +107,7 @@ def test_fetch_preserves_dynamic_form_state_and_parses_results() -> None:
                 "token": "token-two",
                 "SQ_FORM_999_PAGE": "2",
                 "state": "second-state",
-                "q999:q2": "[redacted]",
+                "q999:q2": "100062375927",
                 "submit_999": "Get Bin Days",
             },
         ),

--- a/tests/test_swale_gov_uk.py
+++ b/tests/test_swale_gov_uk.py
@@ -69,8 +69,9 @@ RESULTS = """
 
 def fetch_with(responses: list[Response]) -> tuple[list, Session]:
     session = Session(responses)
-    with patch.object(swale_gov_uk.requests, "Session", return_value=session), patch.object(
-        swale_gov_uk, "sleep"
+    with (
+        patch.object(swale_gov_uk.requests, "Session", return_value=session),
+        patch.object(swale_gov_uk, "sleep"),
     ):
         entries = swale_gov_uk.Source("[redacted]", "AA1 1AA").fetch()
     return entries, session
@@ -121,14 +122,20 @@ def test_fetch_rejects_cloudflare_challenge() -> None:
 
 
 def test_fetch_rejects_postcode_validation() -> None:
-    validation = Response("<html><div class='sq-form-error'>Invalid postcode</div></html>")
+    validation = Response(
+        "<html><div class='sq-form-error'>Invalid postcode</div></html>"
+    )
 
-    with pytest.raises(ValueError, match="postcode submission returned a validation error"):
+    with pytest.raises(
+        ValueError, match="postcode submission returned a validation error"
+    ):
         fetch_with([Response(INITIAL_FORM), validation])
 
 
 def test_fetch_rejects_uprn_validation() -> None:
-    validation = Response("<html><div class='sq-form-error'>Invalid address</div></html>")
+    validation = Response(
+        "<html><div class='sq-form-error'>Invalid address</div></html>"
+    )
 
     with pytest.raises(ValueError, match="UPRN submission returned a validation error"):
         fetch_with([Response(INITIAL_FORM), Response(UPRN_FORM), validation])
@@ -148,4 +155,6 @@ def test_fetch_rejects_missing_postcode_control() -> None:
 
 def test_fetch_rejects_returned_form() -> None:
     with pytest.raises(ValueError, match="input form instead of results"):
-        fetch_with([Response(INITIAL_FORM), Response(UPRN_FORM), Response(INITIAL_FORM)])
+        fetch_with(
+            [Response(INITIAL_FORM), Response(UPRN_FORM), Response(INITIAL_FORM)]
+        )

--- a/tests/test_swale_gov_uk.py
+++ b/tests/test_swale_gov_uk.py
@@ -1,0 +1,151 @@
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(
+    str(Path(__file__).parents[1] / "custom_components" / "waste_collection_schedule")
+)
+
+from waste_collection_schedule.source import swale_gov_uk
+
+
+class Response:
+    def __init__(self, html: str, url: str = "https://swale.gov.uk/check-your-bin-day"):
+        self.content = html.encode()
+        self.url = url
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class Session:
+    def __init__(self, responses: list[Response]):
+        self.responses = iter(responses)
+        self.calls: list[tuple[str, str, dict[str, str] | None]] = []
+
+    def get(self, url: str, params=None):
+        self.calls.append(("get", url, params))
+        return next(self.responses)
+
+    def post(self, url: str, data=None):
+        self.calls.append(("post", url, data))
+        return next(self.responses)
+
+
+INITIAL_FORM = """
+<html><input type="hidden" name="token" value="token-one">
+<form action="/lookup" method="post">
+  <input type="hidden" name="SQ_FORM_999_PAGE" value="1">
+  <input type="hidden" name="state" value="first-state">
+  <label for="postcode">Enter your postcode</label>
+  <input id="postcode" name="q999:q1">
+  <input type="submit" name="submit_999" value="Choose Your Address">
+</form></html>
+"""
+
+UPRN_FORM = """
+<html><input type="hidden" name="token" value="token-two">
+<form action="/lookup" method="post">
+  <input type="hidden" name="SQ_FORM_999_PAGE" value="2">
+  <input type="hidden" name="state" value="second-state">
+  <label for="address">Choose your address</label>
+  <select id="address" name="q999:q2"><option value="[redacted]">Address</option></select>
+  <input type="submit" name="submit_999" value="Get Bin Days">
+</form></html>
+"""
+
+RESULTS = """
+<html>
+  <strong id="SBC-YBD-collectionDate">Friday, 8 August</strong>
+  <div id="SBCFirstBins"><li>blue bin</li><li>food waste</li></div>
+  <div id="FutureCollections"><p>Friday, 15 August</p></div>
+  <ul id="FirstFutureBins"><li>green bin</li></ul>
+</html>
+"""
+
+
+def fetch_with(responses: list[Response]) -> tuple[list, Session]:
+    session = Session(responses)
+    with patch.object(swale_gov_uk.requests, "Session", return_value=session), patch.object(
+        swale_gov_uk, "sleep"
+    ):
+        entries = swale_gov_uk.Source("[redacted]", "AA1 1AA").fetch()
+    return entries, session
+
+
+def test_fetch_preserves_dynamic_form_state_and_parses_results() -> None:
+    entries, session = fetch_with(
+        [Response(INITIAL_FORM), Response(UPRN_FORM), Response(RESULTS)]
+    )
+
+    assert [(entry.date, entry.type) for entry in entries] == [
+        (date(date.today().year, 8, 8), "Recycling"),
+        (date(date.today().year, 8, 8), "Food"),
+        (date(date.today().year, 8, 15), "Refuse"),
+    ]
+    assert session.calls == [
+        ("get", swale_gov_uk.API_URL, None),
+        (
+            "post",
+            "https://swale.gov.uk/lookup",
+            {
+                "token": "token-one",
+                "SQ_FORM_999_PAGE": "1",
+                "state": "first-state",
+                "q999:q1": "AA1 1AA",
+                "submit_999": "Choose Your Address",
+            },
+        ),
+        (
+            "post",
+            "https://swale.gov.uk/lookup",
+            {
+                "token": "token-two",
+                "SQ_FORM_999_PAGE": "2",
+                "state": "second-state",
+                "q999:q2": "[redacted]",
+                "submit_999": "Get Bin Days",
+            },
+        ),
+    ]
+
+
+def test_fetch_rejects_cloudflare_challenge() -> None:
+    challenge = "<html><title>Just a moment...</title>challenges.cloudflare.com</html>"
+
+    with pytest.raises(ValueError, match="Cloudflare challenge"):
+        fetch_with([Response(challenge)])
+
+
+def test_fetch_rejects_postcode_validation() -> None:
+    validation = Response("<html><div class='sq-form-error'>Invalid postcode</div></html>")
+
+    with pytest.raises(ValueError, match="postcode submission returned a validation error"):
+        fetch_with([Response(INITIAL_FORM), validation])
+
+
+def test_fetch_rejects_uprn_validation() -> None:
+    validation = Response("<html><div class='sq-form-error'>Invalid address</div></html>")
+
+    with pytest.raises(ValueError, match="UPRN submission returned a validation error"):
+        fetch_with([Response(INITIAL_FORM), Response(UPRN_FORM), validation])
+
+
+def test_fetch_rejects_missing_postcode_control() -> None:
+    missing_control = """
+    <form action="/lookup" method="post">
+      <input type="hidden" name="SQ_FORM_999_PAGE" value="1">
+      <input type="submit" name="submit_999" value="Choose Your Address">
+    </form>
+    """
+
+    with pytest.raises(ValueError, match="missing its postcode control"):
+        fetch_with([Response(missing_control)])
+
+
+def test_fetch_rejects_returned_form() -> None:
+    with pytest.raises(ValueError, match="input form instead of results"):
+        fetch_with([Response(INITIAL_FORM), Response(UPRN_FORM), Response(INITIAL_FORM)])


### PR DESCRIPTION
## Summary Swale's bin-day lookup is now handled as a stateful form flow. 

The previous direct POST implementation hard-coded numeric form field names and did not load or preserve the page's hidden state. This became unreliable when Swale returned a non-results page after submission. 

This change: 
- Fetches the public bin-day form through the existing `curl_cffi` session. 
- Preserves hidden fields, including the page token, across both submissions. 
- Discovers the live postcode, address/UPRN, submit-control, method, and action fields from returned forms. 
- Retains the existing collection-result selectors. 
- Raises descriptive errors for Cloudflare challenges, validation errors, returned input forms, and missing controls. 
- Adds mocked coverage for successful stateful lookup and error paths. 

- ## Verification 
- A live Swale refresh completed successfully after reloading the integration. 
- The calendar and configured Recycling and Refuse sensors populated correctly. 

- ## Local Test Status 
- Python syntax compilation passed for both changed files. Pytest and Ruff are unavailable in the current container, so no dependencies were installed into Home Assistant. 
- GitHub Actions should run the repository's Ruff, pre-commit, and pytest validation after the branch is pushed.