### PR TITLE
Add Stadt Löhne (32584) ICS configuration

### DIFF
--- a/doc/ics/yaml/loehne_de.yaml
+++ b/doc/ics/yaml/loehne_de.yaml
@@ -1,0 +1,31 @@
+---
+title: Stadt Löhne
+url: https://www.loehne.de/
+country: de
+howto:
+  en: |
+    - Go to <https://www.loehne.de/Leben-Entdecken/Stadtinfos/Abfall-/Abfallkalender/> and select your street.
+    - Copy the link of `Export in Kalenderanwendung`
+    - Use this link as the `url` parameter.
+    - Replace the year in the `url` with `{%Y}`.  
+      This will be replaced by the current year.
+    - you might want to keep the regex as it removes the city name from the title.
+  de: |
+    - Öffne <https://www.loehne.de/Leben-Entdecken/Stadtinfos/Abfall-/Abfallkalender/> und wähle deine Straße aus.
+    - Kopiere den Link von `Export in Kalenderanwendung`
+    - Verwende diesen Link als `url` Parameter.
+    - Ersetze die Jahreszahl in der `url` durch `{%Y}`.  
+      Diese wird durch das aktuelle Jahr ersetzt.
+    - Die `regex` sollte beibehalten werden, da sie den Städtenamen aus dem Titel entfernt.
+default_params:
+  regex: "(.*?): Löhne"
+test_cases:
+  Ackerweg:
+    url: https://www.loehne.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.4&strasse=430.1.1&vtyp=2&vMo=01&vJ={%Y}&bMo=12
+    regex: "(.*?): Löhne"
+  Bahnhofstraße:
+    url: https://www.loehne.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.4&strasse=430.110.1&vtyp=2&vMo=01&vJ={%Y}&bMo=12
+    regex: "(.*?): Löhne"
+  Königstraße:
+    url: https://www.loehne.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.4&strasse=430.419.1&vtyp=2&vMo=01&vJ={%Y}&bMo=12
+    regex: "(.*?): Löhne"

--- a/doc/ics/yaml/loehne_de.yaml
+++ b/doc/ics/yaml/loehne_de.yaml
@@ -7,25 +7,25 @@ howto:
     - Go to <https://www.loehne.de/Leben-Entdecken/Stadtinfos/Abfall-/Abfallkalender/> and select your street.
     - Copy the link of `Export in Kalenderanwendung`
     - Use this link as the `url` parameter.
-    - Replace the year in the `url` with `{%Y}`.  
+    - Replace the year in the `url` with `{%Y}`.
       This will be replaced by the current year.
     - you might want to keep the regex as it removes the city name from the title.
   de: |
     - Öffne <https://www.loehne.de/Leben-Entdecken/Stadtinfos/Abfall-/Abfallkalender/> und wähle deine Straße aus.
     - Kopiere den Link von `Export in Kalenderanwendung`
     - Verwende diesen Link als `url` Parameter.
-    - Ersetze die Jahreszahl in der `url` durch `{%Y}`.  
+    - Ersetze die Jahreszahl in der `url` durch `{%Y}`.
       Diese wird durch das aktuelle Jahr ersetzt.
     - Die `regex` sollte beibehalten werden, da sie den Städtenamen aus dem Titel entfernt.
 default_params:
-  regex: "(.*?): Löhne"
+  regex: '(.*?): Löhne'
 test_cases:
   Ackerweg:
     url: https://www.loehne.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.4&strasse=430.1.1&vtyp=2&vMo=01&vJ={%Y}&bMo=12
-    regex: "(.*?): Löhne"
+    regex: '(.*?): Löhne'
   Bahnhofstraße:
     url: https://www.loehne.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.4&strasse=430.110.1&vtyp=2&vMo=01&vJ={%Y}&bMo=12
-    regex: "(.*?): Löhne"
+    regex: '(.*?): Löhne'
   Königstraße:
     url: https://www.loehne.de/output/abfall_export.php?csv_export=1&mode=vcal&ort=393.4&strasse=430.419.1&vtyp=2&vMo=01&vJ={%Y}&bMo=12
-    regex: "(.*?): Löhne"
+    regex: '(.*?): Löhne'


### PR DESCRIPTION
Adds generic ICS support for **Stadt Löhne** (North Rhine-Westphalia, Kreis Herford, 32584).

The city runs the same Advantic CMS waste calendar as the already supported `swk_herford_de`, so the generic ICS source works without a dedicated module. The VCAL export endpoint is stable and takes a street ID plus year.

Waste types returned: Restmülltonne, Biotonne, Blaue Tonne (Papier+Pappe), Grüne Tonne (Verpackungen), Elektroschrottannahme, Schadstoffsammlung, Sondertermine. The regex `(.*?): Löhne` strips the trailing city name from the event titles.

Only the YAML is included — `doc/ics/*.md`, `README.md` and `info.md` are generated by CI after merge.

Test results:

```
Testing ICS loehne_de
  found 57 entries for Ackerweg
  found 56 entries for Bahnhofstraße
  found 57 entries for Königstraße
```

`pytest`: 39 passed.

Note: Schadstoffsammlung and Elektroschrottannahme legitimately return several events on the same day — these are the different stops of the mobile collection vehicle, as published by the city.
