### PR TITLE
fix(config flow): pipeline membership is the base class, not a truthy PARAMS

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -39,6 +39,7 @@ from homeassistant.helpers.selector import (
 from homeassistant.helpers.translation import async_get_translations
 from voluptuous.schema_builder import UNDEFINED
 
+from waste_collection_schedule.base_source import BaseSource
 from waste_collection_schedule.collection import Collection
 from waste_collection_schedule.config_params import ConfigParam
 from waste_collection_schedule.exceptions import (
@@ -183,8 +184,17 @@ SUPPORTED_ARG_TYPES = {
 
 
 def _is_new_style_source(source_cls) -> bool:
-    """Check if a source uses the new PARAMS-based architecture."""
-    return bool(getattr(source_cls, "PARAMS", None))
+    """Check if a source uses the new pipeline architecture.
+
+    Membership is decided by the base class, not by whether PARAMS happens to be
+    non-empty. A pipeline source that takes no arguments declares ``PARAMS = ()``,
+    which is falsy, so a truthiness test sent it down the legacy
+    ``__init__``-introspection path; having no ``__init__`` of its own, it
+    inherited ``BaseSource.__init__(self, **kwargs)`` and the form rendered a
+    single bogus text field called ``kwargs`` (#7142). The right form for those
+    sources has no argument fields at all.
+    """
+    return isinstance(source_cls, type) and issubclass(source_cls, BaseSource)
 
 
 def _build_schema_from_params(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,6 @@
+import asyncio
 import calendar  # noqa: F401 — must import stdlib calendar FIRST
+import importlib
 import os
 import sys
 
@@ -30,14 +32,18 @@ from waste_collection_schedule.config_params import (  # isort:skip
     integer,
     uprn,
 )
+from waste_collection_schedule.source_shell import SourceShell  # isort:skip
 from custom_components.waste_collection_schedule.config_flow import (  # isort:skip
+    WasteCollectionConfigFlow,
     WasteCollectionOptionsFlow,
     _build_schema_from_params,
+    _is_new_style_source,
 )
 from custom_components.waste_collection_schedule.const import (  # isort:skip
     CONF_COLLECTION_TYPES,
     CONF_CUSTOMIZE,
     CONF_SENSORS,
+    CONF_SOURCE_CALENDAR_TITLE,
 )
 
 
@@ -113,3 +119,85 @@ def test_options_flow_gathers_sensor_collection_types() -> None:
 
     assert {"General Waste", "Recycling"} <= types  # sensor types now included
     assert "Glass" in types  # customisation keys still included
+
+
+# --- #7142: a zero-argument pipeline source must render an empty form ---------
+#
+# koppl_at is one of the 20 pipeline sources that take no arguments at all, so
+# each declares PARAMS = (). That is falsy, and the config flow decided "is this
+# a pipeline source?" by testing PARAMS truthiness, so all 20 fell through to
+# the legacy __init__-introspection path. A pipeline source has no __init__ of
+# its own, so introspection found BaseSource.__init__(self, **kwargs) and the
+# form offered a single text box literally named "kwargs".
+
+
+class _StubHass:
+    """The slice of HomeAssistant that __get_arg_schema actually touches."""
+
+    class config:
+        language = "en"
+
+    @staticmethod
+    async def async_add_executor_job(func, *args):
+        return func(*args)
+
+
+def _arg_schema(source: str, include_title: bool = True) -> vol.Schema:
+    """Build the real config-flow argument schema for ``source``."""
+    flow = WasteCollectionConfigFlow()
+    flow.hass = cast(Any, _StubHass())
+    schema, _module = asyncio.run(
+        # Name-mangled private method: this is the code path the form is built
+        # from, and the branch under test lives inside it.
+        flow._WasteCollectionConfigFlow__get_arg_schema(  # type: ignore[attr-defined]
+            source, {}, None, include_title
+        )
+    )
+    return schema
+
+
+def _field_names(schema: vol.Schema) -> set[str]:
+    return {str(getattr(marker, "schema", marker)) for marker in schema.schema}
+
+
+def test_a_zero_argument_pipeline_source_is_recognised_as_new_style() -> None:
+    module = importlib.import_module("waste_collection_schedule.source.koppl_at")
+
+    assert module.Source.PARAMS == ()  # falsy, which is what caused #7142
+    assert _is_new_style_source(module.Source)
+
+
+def test_a_legacy_source_is_not_recognised_as_new_style() -> None:
+    module = importlib.import_module("waste_collection_schedule.source.static")
+
+    assert not _is_new_style_source(module.Source)
+
+
+def test_a_zero_argument_pipeline_source_renders_no_argument_fields() -> None:
+    schema = _arg_schema("koppl_at")
+
+    # The calendar title is the only thing to fill in; there are no arguments.
+    assert _field_names(schema) == {CONF_SOURCE_CALENDAR_TITLE}
+
+
+def test_a_zero_argument_pipeline_source_accepts_the_empty_form() -> None:
+    schema = _arg_schema("koppl_at", include_title=False)
+
+    assert _field_names(schema) == set()
+    assert schema({}) == {}
+
+    # ...and the flow builds the source from that empty submission.
+    module = importlib.import_module("waste_collection_schedule.source.koppl_at")
+    instance = WasteCollectionConfigFlow()._get_source_instance(module, {})
+
+    assert instance.params == {}
+
+
+def test_an_entry_stored_before_the_fix_still_loads() -> None:
+    # Anyone who added one of these sources through the broken form has
+    # {"kwargs": ...} sitting in their entry's source args. validate() only
+    # checks the fields a source declares and ignores the rest, so the stray
+    # value is inert: the entry still constructs and no migration is needed.
+    shell = SourceShell.create("koppl_at", {}, {"kwargs": ""})
+
+    assert shell is not None

--- a/tests/test_source_shell_customize.py
+++ b/tests/test_source_shell_customize.py
@@ -1,6 +1,9 @@
+import calendar  # noqa: F401 - import stdlib calendar before the package path
 import os
 import sys
 from datetime import date
+
+import pytest
 
 # Make the core library importable as `waste_collection_schedule`.
 sys.path.append(
@@ -9,16 +12,20 @@ sys.path.append(
     )
 )
 
+import cassette
+
 # Use the package-level Collection factory so the legacy ``t=`` keyword
 # dispatches to a LegacyCollection (the new-style collection.Collection
 # requires waste_type=).
 from waste_collection_schedule import Collection
 from waste_collection_schedule.source_shell import (
     Customize,
+    SourceShell,
     customize_function,
     filter_function,
     match_customize,
 )
+from waste_collection_schedule.waste_types import set_display_language
 
 D = date(2024, 1, 1)
 
@@ -83,3 +90,101 @@ def test_question_mark_and_charclass_patterns():
     assert filter_function(_coll("Bin 12"), customize) is True  # ? matches one char
     assert match_customize(customize, "Recycling A").alias == "Recycling"
     assert match_customize(customize, "Recycling C") is None
+
+
+# ---------------------------------------------------------------------------
+# #7117 / #6950: customising a pipeline source by the label the user sees.
+#
+# A pipeline entry carries a canonical WasteType, so it has two names: the
+# locale-independent ``WasteType.id`` ("recyclables") and the localised display
+# label the sensor shows ("Differenziata" in Italian). ``_customize_keys``
+# returns *both*, and it has to: the config flow presents, stores and builds
+# sensors from display labels, so every customise key the UI writes is a display
+# name and never an id, while the library's own callers and tests key on the id.
+#
+# Before #6950 the lookup used the id alone, so a customise entry written by the
+# UI never matched and an alias silently did nothing, which is what a user
+# reported as #7117. #6950 landed the day after v3.0.0-alpha.1 was tagged and so
+# has never shipped; nothing guarded it until these tests. Do not "simplify"
+# _customize_keys down to one key in either direction.
+#
+# Driven off the committed junker_app cassette, so there is no live dependency:
+# it is a real pipeline source, in Italian, producing exactly the reporter's
+# labels.
+# ---------------------------------------------------------------------------
+
+_JUNKER_FIXTURE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "junker_app", "udine.json"
+)
+_JUNKER_ARGS = {"municipality": "Udine", "area": "Zona 2-4-5-6 - Utenze domestiche"}
+
+
+@pytest.fixture
+def italian_display():
+    """Run the test with collection labels localised to Italian, as #7117 was."""
+    set_display_language("it")
+    try:
+        yield
+    finally:
+        set_display_language("en")
+
+
+def _junker_labels(customize: dict[str, Customize]) -> set[str]:
+    """Replay the Udine cassette through SourceShell and return the labels shown."""
+    shell = SourceShell.create("junker_app", customize, _JUNKER_ARGS)
+    assert shell is not None
+    with cassette.replaying(_JUNKER_FIXTURE):
+        assert shell.fetch(), "cassette replay produced no collections"
+    return {entry.type for entry in shell._entries}
+
+
+def test_junker_cassette_shows_the_reporters_italian_labels(italian_display):
+    """Guard the premise of the tests below: these are the labels #7117 is about."""
+    labels = _junker_labels({})
+
+    # Localised display name of the canonical RECYCLABLES type...
+    assert "Differenziata" in labels
+    # ...and an unresolved label carried through verbatim as a preserved type.
+    assert "Napkins" in labels
+
+
+def test_alias_keyed_on_the_display_label_applies(italian_display):
+    # The exact #7117 scenario: the user sees "Differenziata" and aliases it.
+    labels = _junker_labels(
+        {"Differenziata": Customize("Differenziata", alias="Plastica e metallo")}
+    )
+
+    assert "Plastica e metallo" in labels
+    assert "Differenziata" not in labels
+
+
+def test_alias_keyed_on_the_canonical_id_still_applies(italian_display):
+    # The other half of the pair, and the only one that worked before #6950.
+    labels = _junker_labels(
+        {"recyclables": Customize("recyclables", alias="Plastica e metallo")}
+    )
+
+    assert "Plastica e metallo" in labels
+    assert "Differenziata" not in labels
+
+
+def test_a_preserved_type_is_customisable_by_both_of_its_keys(italian_display):
+    # A preserved type reaches the same fallback by a different route: the id is
+    # "preserved:Napkins" and the display label is the bare "Napkins".
+    by_label = _junker_labels({"Napkins": Customize("Napkins", alias="Tovaglioli")})
+    by_id = _junker_labels(
+        {"preserved:Napkins": Customize("preserved:Napkins", alias="Tovaglioli")}
+    )
+
+    assert "Tovaglioli" in by_label
+    assert "Napkins" not in by_label
+    assert "Tovaglioli" in by_id
+    assert "Napkins" not in by_id
+
+
+def test_hiding_a_type_by_its_display_label_applies(italian_display):
+    # filter_function shares the same key lookup, so it has the same exposure.
+    labels = _junker_labels({"Differenziata": Customize("Differenziata", show=False)})
+
+    assert "Differenziata" not in labels
+    assert "Organico" in labels  # unrelated types are untouched

--- a/update_docu_links.py
+++ b/update_docu_links.py
@@ -464,8 +464,12 @@ def get_source_by_file(file: str) -> tuple[ModuleType, list[SourceInfo]]:
     # (self, **kwargs), so introspection yields ["kwargs"] rather than the real
     # fields (e.g. the generic ics engine). For a pipeline source the
     # authoritative param list is PARAMS, so use its field names instead, so the
-    # listing/translation keys match the source's actual parameters.
-    if params == ["kwargs"] and getattr(source_cls, "PARAMS", None):
+    # listing/translation keys match the source's actual parameters. Decide that
+    # on the base class, not on PARAMS truthiness: a zero-argument pipeline
+    # source declares PARAMS = (), and testing truthiness left it with the
+    # literal ["kwargs"], which is how a "Kwargs" label reached the generated
+    # translations for 20 sources (#7142). Its real param list is empty.
+    if params == ["kwargs"] and _is_base_source(source_cls):
         params = [field for p in source_cls.PARAMS for field in p.fields]
     # New-style (BaseSource) sources carry per-field labels/descriptions on
     # their typed PARAMS instead of PARAM_TRANSLATIONS/PARAM_DESCRIPTIONS dicts.


### PR DESCRIPTION
Fixes #7142. Verifies and guards the fix for #7117.

## The proxy, one more time

`config_flow.py:187` decided whether a source is v3 by testing `PARAMS` truthiness. A zero-parameter pipeline source declares `PARAMS = ()`, which is falsy, so **20 sources** took the legacy `__init__`-introspection branch. A pipeline source has no `__init__`, so it inherits `BaseSource.__init__`, whose signature is `**kwargs`, and the config form rendered a single text field literally named `kwargs`. These sources take no parameters at all, so the correct form has none.

The count is 20, not the 21 in the issue: `berndorf_gv_at` dropped out when #7145 gave it real `strasse`/`hausnummer` params. The list was re-derived from code rather than taken from the issue.

Fixed the same way the test-side proxies were in #7143: `issubclass(source_cls, BaseSource)`.

## The instance that reached users

Grepping for the same proxy found a fifth site: `update_docu_links.py:468`.

```python
if params == ["kwargs"] and getattr(source_cls, "PARAMS", None)
```

Because that got the wrong answer, `params` stayed as the literal `["kwargs"]` and a **`"Kwargs"` form label was written into the generated `translations/*.json`: 36 keys across 18 sources, in all five languages.** So this was not merely an ugly field, it was a translated one. Fixed to use `_is_base_source()`, the correct helper already imported at line 17 of that file and already used correctly at line 504. The stale keys clear themselves on the next post-merge generation run.

Everything else matching `getattr(..., "PARAMS", ...)` just iterates the params, where empty iteration is already correct.

## Upgrade path: no migration, stated rather than hidden

An entry added through the broken form carries `{"kwargs": ""}` in `CONF_SOURCE_ARGS`. `config_params.validate()` only checks declared fields and ignores the rest, so those entries still load; verified for all 20. The stray value is inert until the user reconfigures.

One cosmetic knock-on, worth naming: `unique_id` is `source + json.dumps(args)`, so an old entry is `koppl_at{"kwargs": ""}` and a new one is `koppl_at{}`. No collision, but a user could add the same source twice without the duplicate check firing. Not worth a migration.

## A second caller changes behaviour, deliberately

`config_flow.py:1079` (`_get_description_placeholders`) also consults the predicate. For these 20, `docs_url` was the `doc/source/<id>.md` page and is now `Source.URL`, the provider's own website. That is what the other 246 pipeline sources already get, so this brings the 20 into line. `HOWTO` is preserved.

## #7117 is fixed, and now guarded

#7117 reports an alias doing nothing on a v3 source. It was already fixed by #6950, which landed the day after `v3.0.0-alpha.1` was tagged and has never shipped. Confirmed here rather than assumed: the reporter's scenario replayed offline against the committed `junker_app` Udine cassette, Italian display language, a `Differenziata` customise entry with alias `Plastica e metallo`.

```
labels shown in Italian: ['Carta e cartone', 'Differenziata', 'Napkins', ...]
labels after alias:      ['Carta e cartone', 'Napkins', ..., 'Plastica e metallo']
```

Then, to prove #6950 is what does the work, `_customize_keys` was monkeypatched back to its pre-#6950 form and the reporter's symptom returned exactly.

**Nothing guarded that fix.** It shipped broken once, went unnoticed until a user filed a bug, and `tests/test_source_shell_customize.py` covered glob matching but never the display-name fallback. Five tests added, driven off the committed cassette with no live dependency, and they fail in **both** directions:

- reverting to the canonical id alone: 3 fail
- collapsing to the display label alone: 2 fail

so neither half of `_customize_keys` can be "simplified" away. One covers `filter_function`, which shares the lookup and therefore the exposure, and one covers a `preserved:` type through both of its keys.

## Verification

`pytest` 7122 passed, 8 skipped. `pre-commit run --all-files` clean including pinned pyright. `git status --short tests/fixtures/` empty, no cassette touched. Nothing added to any allowlist.

The three new config-flow tests drive the real name-mangled `__get_arg_schema`, so the branch under test is genuinely exercised; against the old predicate 3 of 5 fail, including `assert {'calendar_title', 'kwargs'} == {'calendar_title'}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
