### PR TITLE
fix(eastdevon_gov_uk): migrate to shared Cloud9 API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdevon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdevon_gov_uk.py
@@ -1,51 +1,42 @@
-import json
-from datetime import datetime
-
-import requests
-from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.uk_cloud9_apps import Cloud9Client
 
 TITLE = "East Devon District Council"
 DESCRIPTION = "Source for East Devon services for East Devon District Council, UK."
 URL = "https://eastdevon.gov.uk/"
+COUNTRY = "uk"
 TEST_CASES = {
     "Test_001": {"uprn": "010000246114"},
     "Test_002": {"uprn": 10000272679},
 }
-ICON_MAP = {
-    "RUBBISH": Icons.GENERAL_WASTE,
-    "RECYCLING AND FOOD WASTE": Icons.BIO_KITCHEN,
-    "GREEN WASTE": Icons.GARDEN,
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "You can find your UPRN by visiting [Find My Address](https://www.findmyaddress.co.uk) and entering your address details, or from the UPRN query parameter on the East Devon bin collection page."
 }
+PARAM_TRANSLATIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number (UPRN)",
+    }
+}
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "uprn": "Unique Property Reference Number (UPRN)",
+    }
+}
+ICON_MAP = {
+    "refuse": Icons.GENERAL_WASTE,
+    "rubbish": Icons.GENERAL_WASTE,
+    "recycl": Icons.RECYCLING,
+    "food": Icons.BIO_KITCHEN,
+    "green": Icons.GARDEN,
+    "garden": Icons.GARDEN,
+}
+SOURCE_CODEOWNERS = ["@SimonRice"]
 
 
 class Source:
-    def __init__(self, uprn):
+    def __init__(self, uprn: str | int):
+        self._client = Cloud9Client("eastdevon", icon_keywords=ICON_MAP)
         self._uprn = str(uprn).zfill(12)
 
-    def fetch(self):
-        s = requests.Session()
-        r = s.get(
-            "https://eastdevon.gov.uk/addressfinder/",
-            params={"qsource": "UPRN", "qtype": "bins", "term": self._uprn},
-        )
-
-        json_data = json.loads(r.text)[0]["Results"]
-        soup = BeautifulSoup(json_data, "html.parser")
-        bins = soup.findAll("h2")
-        dates = soup.findAll("em")
-
-        entries = []
-        for b, d in zip(bins, dates, strict=False):
-            # check cases where no date is given for a collection
-            if d:
-                bin_type = b.text.replace(" collection", "").replace("Your ", "")
-                entries.append(
-                    Collection(
-                        date=datetime.strptime(d.text, "%A%d %B %Y").date(),
-                        t=bin_type,
-                        icon=ICON_MAP.get(bin_type.upper()),
-                    )
-                )
-
-        return entries
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch_by_uprn(self._uprn)

--- a/doc/source/eastdevon_gov_uk.md
+++ b/doc/source/eastdevon_gov_uk.md
@@ -2,6 +2,8 @@
 
 Support for schedules provided by [East Devon District Council](https://eastdevon.gov.uk/), serving East Devon, UK.
 
+Data is retrieved from East Devon's Cloud9 citizen mobile API (same backend as the official East Devon app).
+
 ## Configuration via configuration.yaml
 
 ```yaml
@@ -30,10 +32,10 @@ waste_collection_schedule:
 
 ## How to find your UPRN
 
-An easy way to discover your Unique Property Reference Number (UPRN) is by looking at the url of you collection schedule on the East Devon District Council website. The set of numbers at the end of the url are your uprn.
+An easy way to discover your Unique Property Reference Number (UPRN) is by looking at the url of your collection schedule on the East Devon District Council website. The set of numbers at the end of the url are your uprn.
 
 For example: 
 eastdevon.gov.uk/recycling-and-waste/recycling-and-waste-information/when-is-my-bin-collected/?UPRN=`010000246114`_
 
-Alternatively, you can go to  to [Find My Address](https://www.findmyaddress.co.uk/) and search for
+Alternatively, you can go to [Find My Address](https://www.findmyaddress.co.uk/) and search for
 your address.


### PR DESCRIPTION
## Summary
East Devon’s website address-finder endpoint (`/addressfinder/`) now 404s.

Rather than update the URLs to match say Exeter, I've replaced the website address-finder scrape with the existing uk_cloud9_apps Cloud9Client, as used by other Cloud9 councils. East Devon publishes the same citizen mobile API as their official app (authority slug: `eastdevon`).

There are also a couple of amended minor typos in the docs for East Devon, probably mine!

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
