### PR TITLE
was_wolfsburg_de: adapt to new abfuhrtermine.waswob.de API

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/was_wolfsburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/was_wolfsburg_de.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 
 import requests
@@ -38,21 +37,16 @@ class Source:
             raise ValueError("Number must be set")
 
     def fetch(self) -> list[Collection]:
-        # get token
-        js = requests.get("https://abfuhrtermine.waswob.de/js/main.js")
-        token = re.search(r"token=([^\"\n\`]*)", js.text)
-        if token is None:
-            raise ValueError("Token not found")
-
         entries = []
         r = requests.get(
-            "https://apiabfuhrtermine.waswob.de/api/download-json",
-            {
+            "https://abfuhrtermine.waswob.de/php/abfuhr_api.php",
+            params={
+                "action": "termine",
                 "strasse": self._street,
                 "hausnummer": self._number,
-                "token": token.group(1),
             },
         )
+        r.raise_for_status()
         answer = r.json()
 
         for name, icon in ICON_MAP.items():


### PR DESCRIPTION
## Summary
- WAS Wolfsburg rebuilt their frontend and retired the old token/session flow (fetching a token embedded in `abfuhrtermine.waswob.de/js/main.js`, then calling `apiabfuhrtermine.waswob.de/api/download-json` with it). The source has been failing with `ValueError: Token not found` since the token is no longer present in `main.js`.
- The new API needs no token:
  - `GET https://abfuhrtermine.waswob.de/php/abfuhr_api.php?action=strassen` → list of streets with valid house numbers
  - `GET https://abfuhrtermine.waswob.de/php/abfuhr_api.php?action=termine&strasse=<street>&hausnummer=<number>` → collection dates, same response shape as before (`answer[0][WasteType]` = list of `YYYY-MM-DD` strings)
- Updated `fetch()` to call the new endpoint directly; `ICON_MAP`, the `Collection` loop, and `__init__` are unchanged. Also added `raise_for_status()` so a future API-side failure surfaces clearly instead of a confusing downstream JSON-parsing error.

## Test plan
- [x] Tested against a real Wolfsburg address on a live Home Assistant instance — `fetch()` now returns collection entries instead of raising.
- [x] Confirmed the `TEST_CASES` addresses (`Barnstorf`/`Bahnhofspassage`, `Sülfeld`/`Bärheide`) are unrelated to the changed code path (no changes to `__init__`/validation).