### PR TITLE
fix(recycleapp_be): switch to Fostplus /public/v1 endpoint

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recycleapp_be.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recycleapp_be.py
@@ -61,16 +61,11 @@ class Source:
         self._add_events = add_events
 
     def fetch(self):
-        url = "https://api.fostplus.be/recyclecms/app/v1"
+        url = "https://api.fostplus.be/recyclecms/public/v1"
         headers = {
-            "x-secret": "Op2tDi2pBmh1wzeC5TaN2U3knZan7ATcfOQgxh4vqC0mDKmnPP2qzoQusmInpglfIkxx8SZrasBqi5zgMSvyHggK9j6xCQNQ8xwPFY2o03GCcQfcXVOyKsvGWLze7iwcfcgk2Ujpl0dmrt3hSJMCDqzAlvTrsvAEiaSzC9hKRwhijQAFHuFIhJssnHtDSB76vnFQeTCCvwVB27DjSVpDmq8fWQKEmjEncdLqIsRnfxLcOjGIVwX5V0LBntVbeiBvcjyKF2nQ08rIxqHHGXNJ6SbnAmTgsPTg7k6Ejqa7dVfTmGtEPdftezDbuEc8DdK66KDecqnxwOOPSJIN0zaJ6k2Ye2tgMSxxf16gxAmaOUqHS0i7dtG5PgPSINti3qlDdw6DTKEPni7X0rxM",
             "x-consumer": "recycleapp.be",
             "User-Agent": "",
-            "Authorization": "",
         }
-        r = requests.get(f"{url}/access-token", headers=headers)
-        r.raise_for_status()
-        headers["Authorization"] = r.json()["accessToken"]
 
         params = {"q": self._postcode}
         r = requests.get(f"{url}/zipcodes", params=params, headers=headers)


### PR DESCRIPTION
Fixes #7152

## What's happening

Fostplus retired the `/recyclecms/app/v1` endpoint (secret + access-token exchange) in favor of `/recyclecms/public/v1`, which needs only the `x-consumer` header and no access token. Every `app/v1` call now 401s, breaking the `recycleapp_be` source ("Recycle!") entirely.

## The fix

In `recycleapp_be.py`'s `Source.fetch()`:
- Base URL changed from `.../recyclecms/app/v1` to `.../recyclecms/public/v1`
- Dropped the `x-secret` header and the `GET /access-token` → `Authorization` header exchange (no longer needed/valid)
- Kept `x-consumer` + `User-Agent` headers, and the rest of `fetch()` / `_fetch_zipcode()` unchanged

Same shape of fix as a prior URL migration for this source (#1971).

## Files changed

- `custom_components/waste_collection_schedule/waste_collection_schedule/source/recycleapp_be.py`

## Testing

`ruff check` / `ruff format` clean, and `pytest tests/test_source_components.py` passes (35/35).

Live-tested against the real API with `test_sources.py -s recycleapp_be -l`:

```
Testing source recycleapp_be ...
  1140 Evere, Bazellaan 1 failed: No data found for the postcode
  found 20 entries for 3001, Waversebaan 276 with events
    2026-08-12 : Paper-cardboard
    2026-08-13 : PMD
    2026-08-15 : Repair Café Maakleerplek
    2026-08-18 : Huisvuil
    2026-08-18 : Gft
    2026-08-27 : PMD
    2026-09-01 : Gft
    2026-09-01 : Huisvuil
    2026-09-08 : Tegeltaxi Leuven
    2026-09-09 : Paper-cardboard
    2026-09-10 : PMD
    2026-09-10 : Repair Café Hal5
    2026-09-12 : Repair Café Heverlee
    2026-09-15 : Huisvuil
    2026-09-15 : Gft
    2026-09-19 : Repair Café Maakleerplek
    2026-09-24 : PMD
    2026-09-29 : Huisvuil
    2026-09-29 : Gft
    2026-10-05 : Tegeltaxi Leuven
  found 16 entries for 3001, Waversebaan 276 without events
    2026-08-12 : Paper-cardboard
    2026-08-13 : PMD
    2026-08-18 : Huisvuil
    2026-08-18 : Gft
    2026-08-27 : PMD
    2026-09-01 : Gft
    2026-09-01 : Huisvuil
    2026-09-08 : Tegeltaxi Leuven
    2026-09-09 : Paper-cardboard
    2026-09-10 : PMD
    2026-09-15 : Huisvuil
    2026-09-15 : Gft
    2026-09-24 : PMD
    2026-09-29 : Huisvuil
    2026-09-29 : Gft
    2026-10-05 : Tegeltaxi Leuven
  found 20 entries for 1400, Rue de namur 1 with events
    2026-08-06 : Déchets organiques
    2026-08-07 : PMD
    2026-08-13 : Déchets organiques
    2026-08-13 : Déchets ménagers résiduels
    2026-08-20 : Déchets organiques
    2026-08-21 : PMD
    2026-08-27 : Déchets organiques
    2026-08-27 : Déchets ménagers résiduels
    2026-08-28 : Paper-cardboard
    2026-09-03 : Déchets organiques
    2026-09-04 : PMD
    2026-09-10 : Déchets ménagers résiduels
    2026-09-10 : Déchets organiques
    2026-09-17 : Déchets organiques
    2026-09-18 : PMD
    2026-09-24 : Déchets ménagers résiduels
    2026-09-24 : Déchets organiques
    2026-09-25 : Paper-cardboard
    2026-10-01 : Déchets organiques
    2026-10-02 : PMD
  found 20 entries for 3200 Th. De Beckerstraat 1
    2026-08-07 : PMD
    2026-08-07 : Huisvuil DifTar
    2026-08-14 : Gft-DifTar
    2026-08-21 : Huisvuil DifTar
    2026-08-21 : PMD
    2026-08-26 : Grofvuil (op afroep)
    2026-08-28 : Paper-cardboard
    2026-08-28 : Gft-DifTar
    2026-09-04 : Huisvuil DifTar
    2026-09-04 : PMD
    2026-09-11 : Gft-DifTar
    2026-09-18 : Huisvuil DifTar
    2026-09-18 : PMD
    2026-09-25 : Gft-DifTar
    2026-09-25 : Paper-cardboard
    2026-10-02 : Huisvuil DifTar
    2026-10-02 : PMD
    2026-10-09 : Gft-DifTar
    2026-10-09 : Grofvuil (op afroep)
    2026-10-16 : Huisvuil DifTar
  found 20 entries for 9180 Lokeren, Abelendreef 1
    2026-08-11 : Groente, fruit- en tuinafval
    2026-08-18 : Restafval
    2026-08-18 : PMD
    2026-08-25 : Groente, fruit- en tuinafval
    2026-08-27 : Paper-cardboard
    2026-09-01 : Restafval
    2026-09-01 : PMD
    2026-09-08 : Groente, fruit- en tuinafval
    2026-09-15 : Restafval
    2026-09-15 : PMD
    2026-09-22 : Groente, fruit- en tuinafval
    2026-09-24 : Paper-cardboard
    2026-09-29 : Restafval
    2026-09-29 : PMD
    2026-10-06 : Groente, fruit- en tuinafval
    2026-10-08 : Snoeihout
    2026-10-13 : PMD
    2026-10-13 : Restafval
    2026-10-20 : Groente, fruit- en tuinafval
    2026-10-22 : Paper-cardboard
  found 20 entries for 8700 Abeelstraat 1
    2026-08-06 : Organic waste
    2026-08-13 : Residual waste
    2026-08-13 : Paper-cardboard
    2026-08-18 : PMD
    2026-08-20 : Organic waste
    2026-08-27 : Residual waste
    2026-08-30 : Grofvuil ophaling (op aanvraag)
    2026-09-01 : PMD
    2026-09-03 : Organic waste
    2026-09-10 : Paper-cardboard
    2026-09-10 : Residual waste
    2026-09-15 : PMD
    2026-09-17 : Organic waste
    2026-09-24 : Residual waste
    2026-09-29 : PMD
    2026-10-01 : Organic waste
    2026-10-08 : Paper-cardboard
    2026-10-08 : Residual waste
    2026-10-13 : PMD
    2026-10-15 : Organic waste
```

6 of 7 `TEST_CASES` return current, real collection data. The 7th (`1140 Evere, Bazellaan 1`) returns 0 collection entries — I traced this manually through `/public/v1` (zipcode lookup → street lookup → collections, all succeed) and Fostplus's own backend has no collection data for that specific address/date-range. Not a fetch error and not something this endpoint migration touches — a pre-existing data-coverage gap, unrelated to this fix.