### PR TITLE
fix(impactapps_com_au): correct two misspelled council names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/impactapps_com_au.py
@@ -225,7 +225,7 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
         "website": "https://www.burwood.nsw.gov.au",
     },
     {
-        "name": "Campbeltown City Council",
+        "name": "Campbelltown City Council",
         "url": "https://campbelltown.waste-info.com.au",
         "website": "https://www.campbelltown.nsw.gov.au",
     },
@@ -345,7 +345,7 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
         "website": "https://www.hrcc.vic.gov.au",
     },
     {
-        "name": "Murrindindi Shire Counci",
+        "name": "Murrindindi Shire Council",
         "url": "https://murrindindi.waste-info.com.au",
         "website": "https://www.murrindindi.vic.gov.au",
     },
@@ -357,6 +357,17 @@ SERVICE_MAP = [  # supported calendars can be found at https://calendars.impacta
 ]
 
 SERVICE_MAP_LOOKUP = {council["name"]: council for council in SERVICE_MAP}
+
+# Misspelled SERVICE_MAP names that shipped previously, mapped to the corrected
+# name. EXTRA_INFO() publishes each council's name as its `service` default_param,
+# so the config flow stored the misspelling verbatim in existing config entries.
+# Without this, correcting SERVICE_MAP would drop those users through to the
+# "assume the service is a council name" branch below and build a nonsense host
+# ("https://Murrindindi Shire Counci.waste-info.com.au").
+LEGACY_SERVICE_NAMES = {
+    "Murrindindi Shire Counci": "Murrindindi Shire Council",
+    "Campbeltown City Council": "Campbelltown City Council",
+}
 
 
 def EXTRA_INFO():
@@ -500,6 +511,7 @@ class Source:
         street_name: str | None = None,
         street_number: str | None = None,
     ):
+        service = LEGACY_SERVICE_NAMES.get(service, service)
         if service in SERVICE_MAP_LOOKUP:
             api_url = SERVICE_MAP_LOOKUP[service]["url"]
         else:


### PR DESCRIPTION
## Summary

`SERVICE_MAP` in `impactapps_com_au.py` spells two councils with a letter missing:

| Current | Corrected |
|---|---|
| `Murrindindi Shire Counci` | `Murrindindi Shire Council` |
| `Campbeltown City Council` | `Campbelltown City Council` |

Both are already spelled correctly in `doc/source/impactapps_com_au.md`, and each entry's own `url`/`website` use the correct spelling (`murrindindi.waste-info.com.au`, `www.campbelltown.nsw.gov.au`) — the `name` field is the outlier.

These names are user-visible rather than cosmetic: `EXTRA_INFO()` publishes each one as the council's title, so they flow into `README.md`, `info.md`, `sources.json` and the config-flow picker. They also break anything that matches councils by name rather than by the `service` slug.

## Why the rename needs an alias

Renaming alone would be a breaking change for existing users. `EXTRA_INFO()` publishes the name as the `service` default_param, so anyone who configured these councils through the wizard has the misspelling stored in their config entry. After a bare rename that stored value would miss `SERVICE_MAP_LOOKUP` and fall through to the "assume the service is a council name" branch, building:

```
https://Murrindindi Shire Counci.waste-info.com.au
```

`LEGACY_SERVICE_NAMES` maps the two old strings to the corrected ones so existing config entries keep resolving. It is a two-entry dict consulted once in `__init__`.

## Verification

Live against the API, using the corrected names, the legacy names, and the existing slugs:

| `service` value | Result |
|---|---|
| `Murrindindi Shire Council` | 120 collections |
| `Campbelltown City Council` | 159 collections |
| `Murrindindi Shire Counci` (legacy) | 120 collections |
| `Campbeltown City Council` (legacy) | resolves to `campbelltown.waste-info.com.au` |

`TEST_CASES` are unaffected — they pass the short slugs (`murrindindi`, `campbelltown`), which take the fallback path either way.

- `python -m pytest tests/ -q` → 39 passed
- `ruff check` / `ruff format --check` → clean
- No generated files touched; the diff is one source module.