### PR TITLE
Fix waste icons for Cranendonck NL (hvcgroep provider)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hvcgroep_nl.py
@@ -84,8 +84,10 @@ SERVICE_MAP = [
         "api_url": "https://afvalkalender.cranendonck.nl",
         "icons": {
             "zak-geel-blik-drank": Icons.RECYCLING,
-            "gft": Icons.ORGANIC,
-            "doos-karton-papier-avond": Icons.PAPER,
+            "appel-gft": Icons.ORGANIC,
+            "doos-karton-papier": Icons.PAPER,
+            "doos-karton-papier-1800": Icons.PAPER,
+            "doos-karton-papier-vr0800-za1330": Icons.PAPER,
             "kliko-grijs-rest": Icons.GENERAL_WASTE,
         },
     },


### PR DESCRIPTION
Some of the icons changed when Remondis took over trash collections in Cranendonck (NL) at the start of this year. This should fix them.

## Type of change

- [ ] New source
- [X] Bug fix / source fix
- [ ] Documentation update
- [ ] Other