### PR TITLE
Update mohu_bp_hu.py - Fix new API response format

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
@@ -71,7 +71,7 @@ class Source:
         )
         r.raise_for_status()
         soup = BeautifulSoup(
-            json.loads(r.text)["ajax/publicPlaces"], features="html.parser"
+            json.loads(r.text)[".publicPlaces"], features="html.parser"
         )
 
         if soup.find("div", attrs={"class": "alert"}) is not None:
@@ -99,7 +99,7 @@ class Source:
                 "street", self._street, available_streets
             ) from e
         soup = BeautifulSoup(
-            json.loads(r.text)["ajax/houseNumbers"], features="html.parser"
+            json.loads(r.text)[".houseNumbers"], features="html.parser"
         )
 
         if (
@@ -128,7 +128,7 @@ class Source:
         )
         r.raise_for_status()
         soup = BeautifulSoup(
-            json.loads(r.text)["ajax/calSearchResults"], features="html.parser"
+            json.loads(r.text)[".results"], features="html.parser"
         )
 
         if soup.find("div", attrs={"class": "alert"}) is not None:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
@@ -127,9 +127,7 @@ class Source:
             verify=self._verify,
         )
         r.raise_for_status()
-        soup = BeautifulSoup(
-            json.loads(r.text)[".results"], features="html.parser"
-        )
+        soup = BeautifulSoup(json.loads(r.text)[".results"], features="html.parser")
 
         if soup.find("div", attrs={"class": "alert"}) is not None:
             raise SourceArgumentNotFoundWithSuggestions(


### PR DESCRIPTION
Due to changes on the mohu website, the json object which is containing the html answer is not valid anymore. I adopted the json paths acording to the new structure.
For the street name list and the list of house numbers, the `ajax/` prefix has been removed. The result json has a complete different name `.results`.

## Summary

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
