### PR TITLE
Fix available collection types in options flow

### DIFF
--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -1169,8 +1169,8 @@ class WasteCollectionOptionsFlow(OptionsFlow):
 
         return self.async_show_form(step_id="init", data_schema=SCHEMA, errors=errors)
 
-    def get_types_of_sensors_and_customizations(self):
-        fetched_types = []
+    def get_types_of_sensors_and_customizations(self) -> list[str]:
+        fetched_types: list[str] = []
 
         coordinator: WCSCoordinator = self.hass.data.get(DOMAIN, {}).get(
             self._entry.entry_id
@@ -1189,7 +1189,7 @@ class WasteCollectionOptionsFlow(OptionsFlow):
             elif collection_types:
                 fetched_types.append(collection_types)
 
-        return sorted(set(fetched_types))
+        return sorted({t for t in fetched_types if t})
 
     async def async_step_customize(self, user_input: dict[str, Any] | None = None):
         if self._customize_select is None or self._customize_select_idx >= len(

--- a/custom_components/waste_collection_schedule/config_flow.py
+++ b/custom_components/waste_collection_schedule/config_flow.py
@@ -1170,13 +1170,26 @@ class WasteCollectionOptionsFlow(OptionsFlow):
         return self.async_show_form(step_id="init", data_schema=SCHEMA, errors=errors)
 
     def get_types_of_sensors_and_customizations(self):
-        fetched_types = list(self._entry.options.get(CONF_CUSTOMIZE, {}).keys())
+        fetched_types = []
+
+        coordinator: WCSCoordinator = self.hass.data.get(DOMAIN, {}).get(
+            self._entry.entry_id
+        )
+
+        if coordinator and isinstance(coordinator, WCSCoordinator):
+            fetched_types.extend(coordinator._aggregator.types)
+
+        fetched_types.extend(self._entry.options.get(CONF_CUSTOMIZE, {}).keys())
+
         for c in self._entry.options.get(CONF_SENSORS, []):
-            if CONF_TYPE in c:
-                fetched_types.extend(
-                    c[CONF_TYPE] if isinstance(c[CONF_TYPE], list) else [c[CONF_TYPE]]
-                )
-        return list(set(fetched_types))
+            collection_types = c.get(CONF_COLLECTION_TYPES, [])
+
+            if isinstance(collection_types, list):
+                fetched_types.extend(collection_types)
+            elif collection_types:
+                fetched_types.append(collection_types)
+
+        return sorted(set(fetched_types))
 
     async def async_step_customize(self, user_input: dict[str, Any] | None = None):
         if self._customize_select is None or self._customize_select_idx >= len(


### PR DESCRIPTION
## Summary

Fix the options flow so that all collection types currently provided by the source are available when creating or editing sensors.

Previously, `get_types_of_sensors_and_customizations()` only collected types from existing customizations and sensor configuration. This could hide collection types that were returned by the source but had not yet been configured as a sensor.

The sensor configuration was also checked using `CONF_TYPE`, while the current sensor configuration stores its selected collection types in `CONF_COLLECTION_TYPES`.

This change:

- includes the collection types currently known by the coordinator/aggregator
- reads existing sensor types from `CONF_COLLECTION_TYPES`
- keeps customization types included
- removes duplicates and returns the result sorted

This was reproduced with the `awido_de` source, where additional collection types returned by the provider were not available in the sensor type selector until this change was applied.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)

### Test result

```text
35 passed in 6.72s
All checks passed!