### PR TITLE
Add SkyCMS (PL) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/skycms_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/skycms_pl.py
@@ -1,0 +1,97 @@
+import datetime
+import logging
+
+import requests
+
+from ..collection import Collection
+from ..icons import Icons
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "SkyCMS (PL)"
+DESCRIPTION = "Source for SkyCMS-powered municipal waste collection schedules (Poland)"
+URL = "https://api.skycms.com.pl"
+COUNTRY = "pl"
+
+TEST_CASES = {
+    "Trzebnica - Brzyków (Sołectwa 8)": {"region_id": 88},
+    "Trzebnica 2": {"region_id": 8},
+}
+
+API_BASE = "https://api.skycms.com.pl/api/v1/rest"
+API_KEY = "a90a376c6b19307acf1334b1a3937235"
+
+HEADERS = {
+    "x-skycms-key": API_KEY,
+    "x-skycms-device": "waste-collection-schedule",
+    "x-skycms-type": "web",
+    "x-skycms-model": "waste-collection-schedule",
+    "x-skycms-version": "1.0.0",
+    "x-skycms-app-version": "1.0.0",
+    "x-skycms-language": "pl",
+}
+
+ICON_MAP = {
+    "Zmieszane": Icons.GENERAL_WASTE,
+    "Papier": Icons.PAPER,
+    "Tworzywa sztuczne": Icons.PLASTIC_PACKAGING,
+    "Szkło": Icons.GLASS,
+    "Odpady Zielone": Icons.GARDEN,
+    "Odpady Zielone / Kuchenne": Icons.BIO_KITCHEN,
+    "Bio": Icons.BIO_KITCHEN,
+    "Wielkogabarytowe": Icons.BULKY,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Install the 'Gmina Trzebnica' app (or another SkyCMS-powered municipal app) and look up your waste collection region. The region ID can be found in the app's waste calendar section.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "region_id": "Waste collection region ID from the SkyCMS API",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "region_id": "Region ID",
+    },
+}
+
+
+class Source:
+    def __init__(self, region_id):
+        self._region_id = int(region_id)
+
+    def fetch(self):
+        session = requests.Session()
+        session.headers.update(HEADERS)
+
+        url = f"{API_BASE}/garbage/disposals/{self._region_id}"
+        response = session.get(url, timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+        if not data.get("success"):
+            raise Exception(f"API returned error: {data}")
+
+        garbage_kinds = data["data"].get("garbage_kinds", [])
+        entries = []
+
+        for waste in garbage_kinds:
+            waste_name = waste["name"]
+            icon = None
+            for key, val in ICON_MAP.items():
+                if key.lower() in waste_name.lower():
+                    icon = val
+                    break
+
+            for disposal in waste.get("disposals", []):
+                try:
+                    pickup_date = datetime.date.fromisoformat(disposal["id"])
+                except ValueError:
+                    _LOGGER.warning("Invalid date: %s", disposal["id"])
+                    continue
+                entries.append(Collection(pickup_date, waste_name, icon=icon))
+
+        return entries

--- a/doc/source/skycms_pl.md
+++ b/doc/source/skycms_pl.md
@@ -1,0 +1,86 @@
+# SkyCMS (PL)
+
+Support for waste collection schedules provided by SkyCMS-powered municipal apps in Poland.
+
+This source uses the SkyCMS API (same as the "Gmina Trzebnica" and other municipal waste apps). You need to find your region ID from the API.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: skycms_pl
+      args:
+        region_id: REGION_ID
+```
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: skycms_pl
+      args:
+        region_id: 8
+```
+
+## How to get your region ID
+
+Install the municipal waste collection app for your area (e.g., "Gmina Trzebnica" from Google Play) and look up the region ID in the app's waste calendar section. Alternatively, you can query the API directly:
+
+```bash
+curl -H "x-skycms-key: a90a376c6b19307acf1334b1a3937235" \
+     -H "x-skycms-device: waste-collection-schedule" \
+     -H "x-skycms-type: web" \
+     -H "x-skycms-model: waste-collection-schedule" \
+     -H "x-skycms-version: 1.0.0" \
+     -H "x-skycms-app-version: 1.0.0" \
+     -H "x-skycms-language: pl" \
+     "https://api.skycms.com.pl/api/v1/rest/garbage/regions"
+```
+
+## Supported municipalities
+
+### Trzebnica city zones
+
+| Region ID | Zone |
+|-----------|------|
+| 4 | Trzebnica 1: Alpejska, Brzoskwiniowa, Agrestowa, Chmielna, Gliniana, Bolesława Chrobrego, Grabowa, Jarzębinowa, Kolejowa, Kwiatowa, Marii Leszczyńskiej, Łączna, Miodowa, Mostowa, Nektarowa, Na Wzgórzach, Ogrodowa, Owocowa, Parkowa, Przemysłowa, Różana, Sportowa, Św. Jadwigi, Węgrzynowska, Widokowa, Wrocławska, Stefana Żeromskiego, Żołnierzy Września |
+| 8 | Trzebnica 2: Zaułek Aleksandry, Borówkowa, Henryka Brodatego, Fryderyka Chopina, Czereśniowa, Grunwaldzka, Harcerka, Władysława Jagiełły, Jagodowa, Kazimierza Wielkiego, Władysława Łokietka, Malinowa, Stanisława Moniuszki, Oleśnicka, Ignacego Paderewskiego, Piastowska, Porzeczkowa, Poziomkowa, Samarytańska, Truskawkowa, Wesoła, Winna, Zielonego Dębu |
+| 69 | Trzebnica 3.1: Elizy Orzeszkowej, gen. Grota-Roweckiego, gen. Leopolda Okulickiego, gen. Władysława Sikorskiego, Rotmistrza Witolda Pileckiego, gen. Stanisława Maczka, Baśniowa, Janusza Korczaka, Łąkowa, Nowa, gen. Władysława Andersa, Szarych Szeregów, Słowiańska, 1 Maja |
+| 70 | Trzebnica 3.2: 3 Maja, Armii Krajowej, Henryka Pobożnego, Jana Pawła II, Świętojańska, Jana Kilińskiego, Jana Olszewskiego, Krakowska, Wincentego Witosa, Władysława Stanisława Reymonta |
+| 28 | Trzebnica 4: Adama Asnyka, gen. Józefa Bema, Władysława Broniewskiego, Chabrowa, Cicha, Marii Dąbrowskiej, Fiołkowa, Jaśminowa, Jędrzejowska, Marii Konopnickiej, Krótka, Adama Mickiewicza, Makowa, Cypriana Kamila Norwida, Pogodna, Prusicka, Siostry Hilgi Brzoski, Juliusza Słowackiego, Teatralna, Wojska Polskiego, Wrzosowa |
+| 37 | Trzebnica 5: Akacjowa, Brama Trębaczy, Graniczna, Kosmonautów, Lawendowa, Ledowa, Marcinowska, Młynarska, Morelowa, Obornicka, Orzechowa, Piaskowskiego, Polna, Rynek, Sadowa, Słoneczna, Spokojna, Wałowa, Wiosenna, Wiśniowa, Zielona |
+| 71 | Trzebnica 6.1: Henryka Sienkiewicza, Ignacego Daszyńskiego, ks. Dziekana Wawrzyńca Bochenka, Milicka, Piwniczna, Pl. M. J. Piłsudskiego, Solna, Stawowa, Tadeusza Kościuszki |
+| 72 | Trzebnica 6.2: Drukarska, Bartosza Głowackiego, pl. Włostowica, Jana Matejki, Kościelna, Leśna, Lipowa, Michała Drzymały, Obrońców Pokoju |
+
+### Sołectwa (villages/districts)
+
+| Region ID | Zone |
+|-----------|------|
+| 95 | Sołectwa 1: Masłów, Cerekwica, Sulisławice, Świątniki, Węgrzynów, Droszów, Malczów, Marcinowo, Rzepotowice, Nowy Dwór |
+| 7 | Sołectwa 2: Brzezie, Biedaszków Wielki, Janiszów, Ujeździec Mały, Ujeździec Wielki, Koniowo, Domanowice |
+| 6 | Sołectwa 3: Piersno, Boleścin, Skarszyn, Głuchów Górny, Taczów Mały, Taczów Wielki, Brochocin, Będkowo |
+| 3 | Sołectwa 4: Skoroszów, Koczurki, Biedaszków Mały, Komorówko, Komorowo, Szczytkowice |
+| 74 | Sołectwa 5: Ligota, Księginice, Kobylice, Jaszyce, Małuszyn |
+| 79 | Sołectwa 6: Blizocin, Jaźwiny |
+| 84 | Sołectwa 7: Masłowiec, Kuźniczysko |
+| 88 | Sołectwa 8: Brzyków |
+| 93 | Sołectwa 9: Raszów |
+
+### Wielkogabarytowe (bulky waste)
+
+| Region ID | Zone |
+|-----------|------|
+| 100 | Wielkogabarytowe: Biedaszków Wielki, Brzezie, Brzyków, Domanowice, Janiszów |
+| 101 | Wielkogabarytowe: Cerekwica, Marcinow, Sulisławice, Świątniki, Węgrzynów |
+| 102 | Wielkogabarytowe: Droszów, Malczów, Masłów, Nowy Dwór, Rzepotowice |
+| 103 | Wielkogabarytowe: Głuchów Górny, Skarszyn, Taczów Mały, Taczów Wielki |
+| 104 | Wielkogabarytowe: Będkowo, Boleścin, Brochocin, Piersno, Raszów |
+| 105 | Wielkogabarytowe: Jaszyce, Masłowiec, Skoroszów, Kuźniczysko, Małuszyn |
+| 106 | Wielkogabarytowe: Blizocin, Jaźwiny, Szczytkowice |
+| 107 | Wielkogabarytowe: Biedaszków Mały, Koczurki, Komorowo, Komorówko |
+| 108 | Wielkogabarytowe: Kobylice, Księginice, Ligota |
+| 99 | Wielkogabarytowe: Koniowo, Ujeździec Mały, Ujeździec Wielki |
+
+Additional regions may be added to the API in the future.


### PR DESCRIPTION
Add a new source for waste collection schedules provided by SkyCMS-powered municipal apps in Poland.

The source uses the SkyCMS REST API to fetch schedules by region ID. Tested with the Gmina Trzebnica app.

## Changes
- Added  source module
- Added documentation with all available regions for Gmina Trzebnica

## Testing
Tested with region IDs 88 (Brzyków) and 8 (Trzebnica 2) - both returning valid schedules.