### PR TITLE
Add Mirabel (QC) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
@@ -3,6 +3,7 @@ from typing import Literal, TypedDict
 
 import requests
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 
 
 class Zone(TypedDict):
@@ -64,8 +65,8 @@ ICON_MAP = {
 
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
-    "en": "You can find your collection zone number using the webpage ; https://mirabel.ca/services/services-en-ligne/trouver-ma-zone-de-collecte",
-    "fr": "Vous pouvez trouver votre numéro de zone de collecte sur l'adresse suivante :  https://mirabel.ca/services/services-en-ligne/trouver-ma-zone-de-collecte",
+    "en": "You can find your collection zone number using the webpage: https://mirabel.ca/services/services-en-ligne/trouver-ma-zone-de-collecte",
+    "fr": "Vous pouvez trouver votre numéro de zone de collecte sur l'adresse suivante : https://mirabel.ca/services/services-en-ligne/trouver-ma-zone-de-collecte",
 }
 
 PARAM_DESCRIPTIONS = {
@@ -130,14 +131,14 @@ class Source:
                 r.raise_for_status()
             except requests.HTTPError as e:
                 raise RuntimeError(
-                    f"Failed to fetch collections for zone '{self._id}'{e}"
+                    f"Failed to fetch collections for zone '{self._id}': {e}"
                 ) from e
 
             payload = r.json()
             if "errors" in payload:
                 raise RuntimeError(f"GraphQL errors: {payload['errors']}")
 
-            events = payload.get("data", {}).get("events", {}).get("nodes")
+            events = payload.get("data", {}).get("events", {}).get("nodes") or []
             for event in events:
                 event_type = event.get("type")
                 entries.append(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
@@ -135,9 +135,9 @@ class Source:
                 ) from e
 
             payload = r.json()
-            if "errors" in payload:
-                raise RuntimeError(f"GraphQL errors: {payload['errors']}")
-
+            graphql_errors = payload.get("errors")
+            if graphql_errors:
+                raise RuntimeError(f"GraphQL errors: {graphql_errors}")
             events = payload.get("data", {}).get("events", {}).get("nodes") or []
             for event in events:
                 event_type = event.get("type")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
@@ -59,7 +59,7 @@ API_URL = "https://mviv2.mirabel.ca/graphql"
 ICON_MAP = {
     "dechets": Icons.GENERAL_WASTE,
     "recyclage": Icons.RECYCLING,
-    "composte": Icons.ORGANIC,
+    "composte": Icons.ORGANIC,  # codespell:ignore composte
     "encombrants": Icons.BULKY,
 }
 
@@ -105,11 +105,11 @@ ZONES: dict[str, Zone] = {name: {"id": zid} for name, zid in _ZONE_INFO.items()}
 
 
 class Source:
-    def __init__(self, zone: ZONE_LITERALS):
+    def __init__(self, zone: ZONE_LITERALS):  # type: ignore
         zone = str(zone)
         if zone not in ZONES:
-            raise ValueError(
-                f"Unknown zone: '{zone}'. Must be one of: {', '.join(ZONES.keys())}"
+            raise SourceArgumentNotFoundWithSuggestions(
+                "zone", zone, suggestions=ZONES.keys()
             )
         self._id = ZONES[zone]["id"]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mirabel_ca.py
@@ -1,0 +1,151 @@
+from datetime import datetime
+from typing import Literal, TypedDict
+
+import requests
+from waste_collection_schedule import Collection, Icons
+
+
+class Zone(TypedDict):
+    id: int
+
+
+TITLE = "Mirabel (QC)"
+DESCRIPTION = "Source script for mirabel.ca/collectes"
+URL = "https://mirabel.ca/collectes"
+COUNTRY = "ca"
+
+TEST_CASES = {
+    "Mirabel-en-Haut": {"zone": 1},
+    "Saint-Antoine": {"zone": 2},
+    "Sainte-Monique": {"zone": 3},
+    "Domaine-Vert Nord": {"zone": 4},
+    "Saint-Janvier": {"zone": 5},
+    "Saint-Augustin": {"zone": 6},
+    "Saint-Canut": {"zone": 7},
+    "St-Benoit": {"zone": 8},
+}
+
+
+EVENT_QUERY = """
+query eventTypes($month: Int, $year: Int, $zoneId: Int) {
+    events(year: $year, month: $month, zoneId: $zoneId) {
+        nodes {
+            date
+            id
+            type {
+                color
+                id
+                text: name
+                slug
+                __typename
+            }
+            zone {
+                id
+                name
+                slug
+                __typename
+            }
+            __typename
+        }
+    __typename
+    }
+}
+"""
+
+API_URL = "https://mviv2.mirabel.ca/graphql"
+
+
+ICON_MAP = {
+    "dechets": Icons.GENERAL_WASTE,
+    "recyclage": Icons.RECYCLING,
+    "composte": Icons.ORGANIC,
+    "encombrants": Icons.BULKY,
+}
+
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "You can find your collection zone number using the webpage ; https://mirabel.ca/services/services-en-ligne/trouver-ma-zone-de-collecte",
+    "fr": "Vous pouvez trouver votre numéro de zone de collecte sur l'adresse suivante :  https://mirabel.ca/services/services-en-ligne/trouver-ma-zone-de-collecte",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "zone": "Collection zone number",
+    },
+    "fr": {
+        "zone": "Numéro de la zone de collecte",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "zone": "Collection zone number",
+    },
+    "fr": {
+        "zone": "Zone de collecte",
+    },
+}
+
+# The id differ a bit from the zone official zone number.
+_ZONE_INFO = {
+    "1": 121,
+    "2": 122,
+    "3": 123,
+    "4": 124,
+    "5": 125,
+    "6": 126,
+    "7": 127,
+    "8": 128,
+}
+
+ZONE_LITERALS = Literal[tuple(_ZONE_INFO.keys())]
+
+ZONES: dict[str, Zone] = {name: {"id": zid} for name, zid in _ZONE_INFO.items()}
+
+
+class Source:
+    def __init__(self, zone: ZONE_LITERALS):
+        zone = str(zone)
+        if zone not in ZONES:
+            raise ValueError(
+                f"Unknown zone: '{zone}'. Must be one of: {', '.join(ZONES.keys())}"
+            )
+        self._id = ZONES[zone]["id"]
+
+    def fetch(self) -> list[Collection]:
+
+        entries = []
+
+        with requests.Session() as session:
+            session.headers.update({"Content-Type": "application/json"})
+            r = session.post(
+                API_URL,
+                json={
+                    "query": EVENT_QUERY,
+                    "variables": {"zoneId": self._id},
+                },
+                timeout=15,
+            )
+            try:
+                r.raise_for_status()
+            except requests.HTTPError as e:
+                raise RuntimeError(
+                    f"Failed to fetch collections for zone '{self._id}'{e}"
+                ) from e
+
+            payload = r.json()
+            if "errors" in payload:
+                raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+
+            events = payload.get("data", {}).get("events", {}).get("nodes")
+            for event in events:
+                event_type = event.get("type")
+                entries.append(
+                    Collection(
+                        date=datetime.fromisoformat(event.get("date")).date(),
+                        t=event_type.get("text"),
+                        icon=ICON_MAP.get(event_type.get("slug")),
+                    )
+                )
+
+        return entries

--- a/doc/source/mirabel_ca.md
+++ b/doc/source/mirabel_ca.md
@@ -1,0 +1,41 @@
+# Mirabel
+
+Waste collection schedules provided by [Collectes et écocentres](https://mirabel.ca/collectes).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: mirabel_ca
+      args:
+        zone: ZONE
+```
+
+### Configuration Variables
+* **zone** *(string or int) (required)*
+
+**Accepted values:**
+- `1`
+- `2`
+- `3`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+
+**How do I find my zone number?**
+
+* Visit https://mirabel.ca/services/services-en-ligne/trouver-ma-zone-de-collecte
+* Use the search function to display your zone number
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mirabel_ca
+      args:
+        zone: 1
+```

--- a/doc/source/mirabel_ca.md
+++ b/doc/source/mirabel_ca.md
@@ -6,7 +6,7 @@ Waste collection schedules provided by [Collectes et écocentres](https://mirabe
 
 ```yaml
 waste_collection_schedule:
-    sources:
+  sources:
     - name: mirabel_ca
       args:
         zone: ZONE


### PR DESCRIPTION
## Summary

- Add a new source for waste collection schedules for Mirabel (QC), Canada.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/mirabel_ca.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
