### PR TITLE
fix(ics): preserve event-local collection dates

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -30,6 +30,50 @@ def _event_location_description(e: Any) -> tuple[str | None, str | None]:
     return loc, desc
 
 
+def _event_start_date(e: Any) -> datetime.date | None:
+    """Return the calendar date an event starts on.
+
+    icalevents normalises event start times to UTC. Reducing those straight to a
+    date shifts the day for any feed whose DTSTART sits close to midnight in a
+    timezone other than UTC: ``DTSTART;TZID=Australia/Brisbane:20251002T000000``
+    arrives as ``14:00Z`` on the *previous* day, and even
+    ``DTSTART;TZID=Europe/Berlin`` is reported a day early.
+
+    The date the feed intended is the one in the timezone the feed declared, so
+    convert back into that timezone before taking the date. Deliberately not
+    ``astimezone()`` without an argument: the host/Home Assistant timezone is
+    unrelated to the calendar, and using it both fails to fix the bug when the
+    host runs in UTC and breaks all-day events when the host is behind UTC.
+    """
+    start = getattr(e, "start", None)
+
+    if not isinstance(start, datetime.datetime):
+        # Plain date (all-day) - already the value we want.
+        return start if isinstance(start, datetime.date) else None
+
+    if start.tzinfo is None:
+        # Floating time: the wall clock date is authoritative.
+        return start.date()
+
+    # Recover the timezone declared by the original DTSTART property. icalendar
+    # has already resolved TZID to a tzinfo object, which also handles Windows
+    # style zone names such as "AUS Eastern Standard Time" that ZoneInfo would
+    # reject.
+    component = getattr(e, "component", None)
+    dtstart_prop = component.get("DTSTART") if component is not None else None
+    original = getattr(dtstart_prop, "dt", None)
+
+    if isinstance(original, datetime.datetime):
+        if original.tzinfo is not None:
+            return start.astimezone(original.tzinfo).date()
+    elif isinstance(original, datetime.date):
+        # VALUE=DATE all-day event. icalevents still hands back a UTC midnight
+        # datetime, so its UTC date is the literal date from the feed.
+        return start.date()
+
+    return start.date()
+
+
 class ICS:
     def __init__(
         self,
@@ -106,16 +150,7 @@ class ICS:
 
         for e in events:
             # calculate date
-            dtstart: datetime.date | None = None
-
-            if isinstance(e.start, datetime.datetime):
-                # icalevents normalises event times to UTC. Reducing straight to
-                # a date loses a day for timezones ahead of UTC: a DTSTART of
-                # midnight Australia/Brisbane arrives as 14:00Z on the previous
-                # day. Convert back to local time before taking the date.
-                dtstart = e.start.astimezone().date()
-            elif isinstance(e.start, datetime.date):
-                dtstart = e.start
+            dtstart: datetime.date | None = _event_start_date(e)
 
             # Only continue if a start date can be found in the entry
             if dtstart is not None:
@@ -193,16 +228,7 @@ class ICS:
 
         for e in events:
             # calculate date
-            dtstart: datetime.date | None = None
-
-            if isinstance(e.start, datetime.datetime):
-                # icalevents normalises event times to UTC. Reducing straight to
-                # a date loses a day for timezones ahead of UTC: a DTSTART of
-                # midnight Australia/Brisbane arrives as 14:00Z on the previous
-                # day. Convert back to local time before taking the date.
-                dtstart = e.start.astimezone().date()
-            elif isinstance(e.start, datetime.date):
-                dtstart = e.start
+            dtstart: datetime.date | None = _event_start_date(e)
 
             # Only continue if a start date can be found in the entry
             if dtstart is not None:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -109,7 +109,11 @@ class ICS:
             dtstart: datetime.date | None = None
 
             if isinstance(e.start, datetime.datetime):
-                dtstart = e.start.date()
+                # icalevents normalises event times to UTC. Reducing straight to
+                # a date loses a day for timezones ahead of UTC: a DTSTART of
+                # midnight Australia/Brisbane arrives as 14:00Z on the previous
+                # day. Convert back to local time before taking the date.
+                dtstart = e.start.astimezone().date()
             elif isinstance(e.start, datetime.date):
                 dtstart = e.start
 
@@ -192,7 +196,11 @@ class ICS:
             dtstart: datetime.date | None = None
 
             if isinstance(e.start, datetime.datetime):
-                dtstart = e.start.date()
+                # icalevents normalises event times to UTC. Reducing straight to
+                # a date loses a day for timezones ahead of UTC: a DTSTART of
+                # midnight Australia/Brisbane arrives as 14:00Z on the previous
+                # day. Convert back to local time before taking the date.
+                dtstart = e.start.astimezone().date()
             elif isinstance(e.start, datetime.date):
                 dtstart = e.start
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -31,47 +31,16 @@ def _event_location_description(e: Any) -> tuple[str | None, str | None]:
 
 
 def _event_start_date(e: Any) -> datetime.date | None:
-    """Return the calendar date an event starts on.
+    """Extract the calendar date from an event parsed with strict=True.
 
-    icalevents normalises event start times to UTC. Reducing those straight to a
-    date shifts the day for any feed whose DTSTART sits close to midnight in a
-    timezone other than UTC: ``DTSTART;TZID=Australia/Brisbane:20251002T000000``
-    arrives as ``14:00Z`` on the *previous* day, and even
-    ``DTSTART;TZID=Europe/Berlin`` is reported a day early.
-
-    The date the feed intended is the one in the timezone the feed declared, so
-    convert back into that timezone before taking the date. Deliberately not
-    ``astimezone()`` without an argument: the host/Home Assistant timezone is
-    unrelated to the calendar, and using it both fails to fix the bug when the
-    host runs in UTC and breaks all-day events when the host is behind UTC.
+    Keep the occurrence's wall-clock date. Converting to the original DTSTART
+    tzinfo can shift recurring Windows-TZID events across midnight when the
+    recurrence timezone and the embedded VTIMEZONE have different DST rules.
     """
     start = getattr(e, "start", None)
-
-    if not isinstance(start, datetime.datetime):
-        # Plain date (all-day) - already the value we want.
-        return start if isinstance(start, datetime.date) else None
-
-    if start.tzinfo is None:
-        # Floating time: the wall clock date is authoritative.
+    if isinstance(start, datetime.datetime):
         return start.date()
-
-    # Recover the timezone declared by the original DTSTART property. icalendar
-    # has already resolved TZID to a tzinfo object, which also handles Windows
-    # style zone names such as "AUS Eastern Standard Time" that ZoneInfo would
-    # reject.
-    component = getattr(e, "component", None)
-    dtstart_prop = component.get("DTSTART") if component is not None else None
-    original = getattr(dtstart_prop, "dt", None)
-
-    if isinstance(original, datetime.datetime):
-        if original.tzinfo is not None:
-            return start.astimezone(original.tzinfo).date()
-    elif isinstance(original, datetime.date):
-        # VALUE=DATE all-day event. icalevents still hands back a UTC midnight
-        # datetime, so its UTC date is the literal date from the feed.
-        return start.date()
-
-    return start.date()
+    return start if isinstance(start, datetime.date) else None
 
 
 class ICS:
@@ -130,7 +99,12 @@ class ICS:
 
         # parse ics data
         events: list[Any] = icalevents.events(
-            start=start_date, end=end_date, string_content=ics_data.encode()
+            start=start_date,
+            end=end_date,
+            string_content=ics_data.encode(),
+            # Preserve each event's calendar date/time instead of normalising
+            # all events to a calendar-wide timezone (UTC by default).
+            strict=True,
         )
 
         # Inherit summary for recurrence exceptions that lack one.
@@ -208,7 +182,12 @@ class ICS:
 
         # parse ics data
         events: list[Any] = icalevents.events(
-            start=start_date, end=end_date, string_content=ics_data.encode()
+            start=start_date,
+            end=end_date,
+            string_content=ics_data.encode(),
+            # Preserve each event's calendar date/time instead of normalising
+            # all events to a calendar-wide timezone (UTC by default).
+            strict=True,
         )
 
         # Inherit summary for recurrence exceptions that lack one.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_fetch_retry.py
+python_files = test_source_components.py test_fetch_retry.py test_ics_timezone.py

--- a/tests/test_ics_timezone.py
+++ b/tests/test_ics_timezone.py
@@ -1,0 +1,146 @@
+"""Regression tests for timezone handling in the shared ICS service.
+
+icalevents normalises event start times to UTC. Reducing those straight to a
+date silently shifts the collection day for feeds whose DTSTART is anchored at
+midnight in a timezone other than UTC. The resulting date must depend only on
+the timezone declared by the feed, never on the timezone the host happens to
+run in.
+"""
+
+import datetime
+import os
+import sys
+
+import pytest
+
+sys.path.append(
+    os.path.join(
+        os.path.dirname(__file__), "../custom_components/waste_collection_schedule"
+    )
+)
+
+from waste_collection_schedule.service.ICS import ICS  # isort:skip
+
+_HEAD = "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//wcs-test//EN\n"
+_TAIL = "END:VCALENDAR\n"
+
+_WINDOWS_VTIMEZONE = (
+    "BEGIN:VTIMEZONE\n"
+    "TZID:AUS Eastern Standard Time\n"
+    "BEGIN:STANDARD\n"
+    "DTSTART:16010101T000000\n"
+    "TZOFFSETFROM:+1000\n"
+    "TZOFFSETTO:+1000\n"
+    "END:STANDARD\n"
+    "END:VTIMEZONE\n"
+)
+
+
+def _weekly_calendar(dtstart_line: str, vtimezone: str = "") -> str:
+    """Build a calendar with a weekly recurring event starting on a Thursday."""
+    return (
+        _HEAD + vtimezone + "BEGIN:VEVENT\n"
+        "UID:wcs-test\n"
+        f"{dtstart_line}\n"
+        "RRULE:FREQ=WEEKLY;BYDAY=TH\n"
+        "SUMMARY:General waste\n"
+        "END:VEVENT\n" + _TAIL
+    )
+
+
+# 2 Oct 2025 is a Thursday. Every occurrence of the weekly rule must land on a
+# Thursday, whatever the feed's timezone and whatever the host's timezone.
+CALENDARS = {
+    "brisbane": _weekly_calendar(
+        "DTSTART;TZID=Australia/Brisbane:20251002T000000"
+    ),  # UTC+10
+    "sydney": _weekly_calendar(
+        "DTSTART;TZID=Australia/Sydney:20251002T000000"
+    ),  # UTC+10/+11
+    "auckland": _weekly_calendar(
+        "DTSTART;TZID=Pacific/Auckland:20251002T000000"
+    ),  # UTC+12/+13
+    "berlin": _weekly_calendar(
+        "DTSTART;TZID=Europe/Berlin:20251002T000000"
+    ),  # UTC+1/+2
+    "new_york": _weekly_calendar(
+        "DTSTART;TZID=America/New_York:20251002T000000"
+    ),  # UTC-5/-4
+    "all_day": _weekly_calendar("DTSTART;VALUE=DATE:20251002"),
+    "floating": _weekly_calendar("DTSTART:20251002T000000"),
+    "utc": _weekly_calendar("DTSTART:20251002T060000Z"),
+    "windows_tzid": _weekly_calendar(
+        "DTSTART;TZID=AUS Eastern Standard Time:20251002T000000",
+        vtimezone=_WINDOWS_VTIMEZONE,
+    ),
+}
+
+# Home Assistant containers default to UTC; the others span both sides of UTC.
+HOST_TIMEZONES = [
+    "UTC",
+    "Australia/Brisbane",
+    "Europe/Berlin",
+    "Pacific/Auckland",
+    "America/Los_Angeles",
+]
+
+
+@pytest.fixture
+def host_timezone(request, monkeypatch):
+    """Pin the process-local timezone for the duration of a test."""
+    import time
+
+    monkeypatch.setenv("TZ", request.param)
+    time.tzset()
+    yield request.param
+    monkeypatch.undo()
+    time.tzset()
+
+
+@pytest.mark.parametrize("host_timezone", HOST_TIMEZONES, indirect=True)
+@pytest.mark.parametrize("name", sorted(CALENDARS))
+def test_convert_keeps_the_calendar_day_of_the_feed(name, host_timezone) -> None:
+    entries = ICS().convert(CALENDARS[name])
+
+    assert entries, f"{name}: no entries returned"
+    wrong = [d for d, _title in entries if d.weekday() != 3]  # 3 == Thursday
+    assert not wrong, (
+        f"{name}: {len(wrong)} of {len(entries)} entries shifted off Thursday "
+        f"under TZ={host_timezone} (first bad date: {wrong[0]})"
+    )
+
+
+@pytest.mark.parametrize("host_timezone", HOST_TIMEZONES, indirect=True)
+@pytest.mark.parametrize("name", sorted(CALENDARS))
+def test_convert_events_agrees_with_convert(name, host_timezone) -> None:
+    dates_convert = [d for d, _title in ICS().convert(CALENDARS[name])]
+    dates_events = [event.date for event in ICS().convert_events(CALENDARS[name])]
+
+    assert dates_convert == dates_events
+
+
+def test_dst_transition_does_not_shift_the_day() -> None:
+    """A feed anchored in summer time must stay correct once DST ends."""
+    entries = ICS().convert(
+        _weekly_calendar("DTSTART;TZID=Europe/Berlin:20250703T000000")
+    )
+
+    assert entries
+    assert all(d.weekday() == 3 for d, _title in entries)
+
+
+def test_all_day_events_keep_their_literal_date() -> None:
+    """VALUE=DATE events carry no timezone and must never be converted."""
+    entries = ICS().convert(
+        _HEAD + "BEGIN:VEVENT\n"
+        "UID:wcs-test-all-day\n"
+        "DTSTART;VALUE=DATE:20251002\n"
+        "DTEND;VALUE=DATE:20251003\n"
+        "RRULE:FREQ=WEEKLY;BYDAY=TH\n"
+        "SUMMARY:General waste\n"
+        "END:VEVENT\n" + _TAIL
+    )
+
+    assert entries
+    assert all(isinstance(d, datetime.date) for d, _title in entries)
+    assert all(d.weekday() == 3 for d, _title in entries)

--- a/tests/test_ics_timezone.py
+++ b/tests/test_ics_timezone.py
@@ -77,7 +77,7 @@ CALENDARS = {
 }
 
 # Home Assistant containers default to UTC; the others span both sides of UTC.
-HOST_TIMEZONES = [
+HOST_TIMEZONES: list[str | None] = [
     "UTC",
     "Australia/Brisbane",
     "Europe/Berlin",

--- a/tests/test_ics_timezone.py
+++ b/tests/test_ics_timezone.py
@@ -1,6 +1,6 @@
 """Regression tests for timezone handling in the shared ICS service.
 
-icalevents normalises event start times to UTC. Reducing those straight to a
+By default icalevents can normalise event start times to UTC. Reducing these to a
 date silently shifts the collection day for feeds whose DTSTART is anchored at
 midnight in a timezone other than UTC. The resulting date must depend only on
 the timezone declared by the feed, never on the timezone the host happens to
@@ -10,6 +10,7 @@ run in.
 import datetime
 import os
 import sys
+import time
 
 import pytest
 
@@ -83,18 +84,25 @@ HOST_TIMEZONES = [
     "Pacific/Auckland",
     "America/Los_Angeles",
 ]
+if not hasattr(time, "tzset"):
+    # Windows cannot select IANA process timezones with time.tzset(). Still
+    # exercise every calendar shape under the native host timezone.
+    HOST_TIMEZONES = [None]
 
 
 @pytest.fixture
 def host_timezone(request, monkeypatch):
     """Pin the process-local timezone for the duration of a test."""
-    import time
-
-    monkeypatch.setenv("TZ", request.param)
-    time.tzset()
-    yield request.param
-    monkeypatch.undo()
-    time.tzset()
+    if request.param is None:
+        yield "native"
+        return
+    try:
+        with monkeypatch.context() as patch:
+            patch.setenv("TZ", request.param)
+            time.tzset()
+            yield request.param
+    finally:
+        time.tzset()
 
 
 @pytest.mark.parametrize("host_timezone", HOST_TIMEZONES, indirect=True)
@@ -144,3 +152,36 @@ def test_all_day_events_keep_their_literal_date() -> None:
     assert entries
     assert all(isinstance(d, datetime.date) for d, _title in entries)
     assert all(d.weekday() == 3 for d, _title in entries)
+
+
+@pytest.mark.parametrize("name", sorted(CALENDARS))
+@pytest.mark.parametrize("method", ["convert", "convert_events"])
+def test_nonrecurring_events_keep_their_literal_date(name, method) -> None:
+    """Single events must keep their date, including embedded Windows zones."""
+    expected = datetime.datetime.now(datetime.timezone.utc).date()
+    expected += datetime.timedelta(days=7)
+    calendar = CALENDARS[name].replace("20251002", expected.strftime("%Y%m%d"))
+    calendar = calendar.replace("RRULE:FREQ=WEEKLY;BYDAY=TH\n", "")
+
+    entries = getattr(ICS(), method)(calendar)
+
+    assert [entry[0] for entry in entries] == [expected]
+
+
+@pytest.mark.parametrize("method", ["convert", "convert_events"])
+def test_calendar_timezone_does_not_override_event_timezone(method) -> None:
+    """An explicit UTC event keeps its date despite the calendar's default zone."""
+    expected = datetime.datetime.now(datetime.timezone.utc).date()
+    expected += datetime.timedelta(days=7)
+    calendar = (
+        _HEAD + "X-WR-TIMEZONE:Pacific/Auckland\n"
+        "BEGIN:VEVENT\n"
+        "UID:wcs-test-explicit-utc\n"
+        f"DTSTART:{expected:%Y%m%d}T233000Z\n"
+        "SUMMARY:General waste\n"
+        "END:VEVENT\n" + _TAIL
+    )
+
+    entries = getattr(ICS(), method)(calendar)
+
+    assert [entry[0] for entry in entries] == [expected]


### PR DESCRIPTION
## Summary

Preserve the collection date declared by each ICS event, independently of the host timezone. Midnight events in Brisbane, Sydney, Auckland and Berlin must stay on their intended calendar day instead of shifting to the previous UTC date.

Both `convert()` and `convert_events()` now call `icalevents.events(strict=True)`, which retains event-local date/time values instead of normalising every event to the calendar-wide timezone (UTC by default). The shared date helper extracts the occurrence's own calendar date without a second timezone conversion. The option is available in the supported minimum version, icalevents 0.2.1.

### Windows-TZID regression

Converting an expanded occurrence back to the original DTSTART tzinfo can shift it across midnight when the recurrence timezone and the embedded VTIMEZONE have different daylight-saving rules. The supplied `AUS Eastern Standard Time` fixture reproduced this on both Windows and Linux: 26 of 52 Thursdays became Wednesdays, for example 8 October 2026 became 7 October.

Keeping the occurrence's wall-clock date avoids that additional shift. “Windows timezone” refers to the name in the calendar, not the host operating system.

## Tests

- Include `test_ics_timezone.py` in `pytest.ini`; previously normal CI collected only the 39 existing tests.
- Retain the nine calendar shapes, five Linux host timezones, both conversion paths, DST transition and all-day regression cases.
- Add 20 cases covering nonrecurring events and explicit UTC events whose date differs from the calendar-wide timezone.
- On Windows, where `time.tzset()` is unavailable, run every calendar shape under the native host timezone. Linux continues to exercise the full five-zone matrix.
- Restore the process timezone even if a test fails.

### Validation

| Runtime | icalevents | icalendar | Timezone tests |
| --- | --- | --- | --- |
| Windows 11 / Python 3.13 | 0.3.1 | 7.3.0 | 40 passed |
| Debian / WSL2 / Python 3.11 | 0.3.1 | 7.3.0 | 112 passed |
| Windows 11 / Python 3.13 | 0.2.1 | 7.3.0 | 40 passed |
| Debian / WSL2 / Python 3.11 | 0.2.1 | 7.3.0 | 112 passed |

The tests above were run with the ICS module loaded in isolation from Home Assistant. The old PR implementation still fails the Windows-TZID regression in the same harness. Ruff check and format passed using the repository configuration. For final commit eb9399d, the full PR CI passed on both Python 3.12 and Python 3.14: **158 tests passed in each job**, including the timezone tests. Ruff, all applicable pre-commit hooks (including mypy), and hassfest passed. CI run: https://github.com/mampfes/hacs_waste_collection_schedule/actions/runs/34720179250

With strict parsing, custom title templates also receive the original event date/time types rather than calendar-normalised datetimes.

## Release branch

`release/3.0.0` at `2d6f2ceb53843ee57183896b8ca263d1de60640c` still uses the old date extraction in both conversion paths. Its newer parsers call those same methods, so the final fix and tests are needed there as well. This PR does not modify the release branch.

## Type of change

- [x] Bug fix
- [x] Regression tests and CI test discovery
- [x] No generated files changed
