### PR TITLE
docs(ics): update the Moreton Bay test case to the calendar the council now issues

### DIFF
--- a/doc/ics/yaml/moretonbay_qld_gov_au.yaml
+++ b/doc/ics/yaml/moretonbay_qld_gov_au.yaml
@@ -3,9 +3,20 @@ title: Moreton Bay
 url: https://www.moretonbay.qld.gov.au
 howto:
   en: |
-    - Go to <https://www.moretonbay.qld.gov.au/Services/Waste-Recycling/Collections/Bin-Days> and select your location.  
+    - Go to <https://www.moretonbay.qld.gov.au/Services/Waste-Recycling/Collections/Bin-Days> and select your location.
     - Click on `Subscribe to a personalised calendar` to get a webcal link.
     - Use this link as the `url` parameter.
+
+    The link is one of ten per-run calendars on the council's CDN, named
+    `waste-calendar-<day>-week<N>.ics`, where `<day>` is your collection weekday
+    (`monday`-`friday`) and `<N>` is your recycling fortnight (`1` or `2`). Both
+    are property-specific, so use the link generated for your own address rather
+    than copying the example below.
+
+    Older `webcal://www.moretonbay.qld.gov.au/bincal?externalId=...` links are no
+    longer issued by the council, and that host rejects the integration's HTTP
+    client with `HTTP Error 403`. Replace any such link with the one the Bin Days
+    page gives you now.
 test_cases:
   18 Mainsail Drive, CABOOLTURE SOUTH Queensland 4510:
-    url: webcal://www.moretonbay.qld.gov.au/bincal?externalId=459739
+    url: webcal://cdn.services-v2.moretonbay.qld.gov.au/bin-days/icals/waste-calendar-thursday-week1.ics


### PR DESCRIPTION
## Summary

The Moreton Bay ICS test case points at a URL form the council no longer issues, on a host that returns 403 to this integration. Anyone following the doc hits a hard failure at setup.

```yaml
url: webcal://www.moretonbay.qld.gov.au/bincal?externalId=459739
```

The `howto` text itself is correct and is kept — "select your location, click Subscribe to a personalised calendar" is still exactly right. Only the URL that link now produces has changed.

## What the Bin Days page does today

The page loads `cdn.services-v2.moretonbay.qld.gov.au/bin-days/embed-bins-calendar.js`, which hooks the OpenCities address picker:

1. `GET /api/v1/myarea/search?keywords=<address>` → candidates, each with a GUID `Id`
2. `GET /api/v1/myarea/GetFullServiceDetailsForAddress?addressId=<GUID>` → the three services, each with a `Schedule.ApiAlias` (`gen-<day>`, `rec-wk<N>-<day>`, `go-wk<N>-<day>`)
3. the script maps the **recycling** alias only — `rec-wk<N>-<day>` — to `webcal://cdn.services-v2.moretonbay.qld.gov.au/bin-days/icals/waste-calendar-<day>-week<N>.ics`

So "Subscribe to a personalised calendar" yields one of ten static per-run feeds (mon–fri × week 1/2), keyed by the recycling fortnight. Each carries all three collections; general waste is weekly and garden organics falls on the opposite fortnight to recycling.

`bincal` appears nowhere on the current site — 0 occurrences in the page HTML, in `cdn.services.moretonbay.qld.gov.au/auth-scripts/main.js`, or in the OpenCities combined script bundle.

## The old host also 403s this integration

`www.moretonbay.qld.gov.au` sits behind an edge that fingerprints the client and rejects `curl_cffi`:

```
curl_cffi.requests.exceptions.HTTPError: HTTP Error 403:
```

The block is on the client, not the path — default `curl` gets 200, while a Chrome User-Agent *without* matching `sec-ch-ua` client hints also gets 403. The data is not gone: `/bincal?externalId=<id>` still 302s to an API Gateway endpoint serving valid iCal. Only the documented hop is unusable from here.

Tested through the ics source's own fetch path:

| URL | Result |
|---|---|
| `www.moretonbay.qld.gov.au/bincal?externalId=<id>` (documented) | **403** |
| `yih63jcwe7.execute-api.ap-southeast-2.amazonaws.com/Prod/bins/address/?externalId=<id>` (its redirect target) | OK, 55 entries |
| `cdn.services-v2.moretonbay.qld.gov.au/bin-days/icals/waste-calendar-thursday-week1.ics` | OK, 106 entries |

## Change

`doc/ics/yaml/moretonbay_qld_gov_au.yaml`:

- test case URL → `waste-calendar-thursday-week1.ics`. The address it is labelled with, 18 Mainsail Drive Caboolture South, is `gen-thursday` / `rec-wk1-thursday` / `go-wk2-thursday` per the council API, so the example stays faithful to its label.
- `howto` gains a note that `<day>` and `<N>` are property-specific, so users take the link generated for their own address rather than copying the example, plus a line telling existing users why an old `bincal` link stopped working.

Fetched through the ics source, the new URL returns 106 entries — general waste Thu 2026-08-13 weekly, recycling Thu 2026-08-13 fortnightly, garden organics Thu 2026-08-20 fortnightly — matching the council API for that address exactly.

`doc/ics/moretonbay_qld_gov_au.md` is generated from this file and is left for CI to regenerate post-merge.

## Note for reviewers

City of Moreton Bay also has a dedicated address-based source (`moretonbay_qld_gov_au`, ArcGIS-backed), so the ICS route is the secondary option here.

Separately, and out of scope for this PR: the council serves the standard OpenCities `/ocapi/Public/myarea/wasteservices` endpoint that `service/OpenCities.py` already speaks, so Moreton Bay could plausibly move to that shared platform. Happy to open an issue if that's of interest.
