### PR TITLE
Move ASO-OHZ to abfallio_graphql

### DIFF
--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -8376,11 +8376,11 @@
     },
     {
       "title": "ASO Abfall-Service Osterholz",
-      "module": "abfall_io",
+      "module": "abfall_io_graphql",
       "default_params": {
-        "key": "040b38fe83f026f161f30f282b2748c0"
+        "key": "8b016df0116d1d5094fa339bebea0c65"
       },
-      "id": "abfall_io"
+      "id": "abfall_io_graphql"
     },
     {
       "title": "ASR Stadt Chemnitz",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -13,11 +13,6 @@ SERVICE_MAP = [
         "service_id": "9583a2fa1df97ed95363382c73b41b1b",
     },
     {
-        "title": "ASO Abfall-Service Osterholz",
-        "url": "https://www.aso-ohz.de/",
-        "service_id": "040b38fe83f026f161f30f282b2748c0",
-    },
-    {
         "title": "Landkreis Bayreuth",
         "url": "https://www.landkreis-bayreuth.de/",
         "service_id": "951da001077dc651a3bf437bc829964e",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIOGraphQL.py
@@ -50,4 +50,9 @@ SERVICE_MAP = [
         "url": "https://www.lrasbk.de/",
         "service_id": "30628292bdd8b43db86a48f7e0d85f85",
     },
+    {
+        "title": "ASO Abfall-Service Osterholz",
+        "url": "https://www.aso-ohz.de/",
+        "service_id": "8b016df0116d1d5094fa339bebea0c65",
+    },
 ]


### PR DESCRIPTION
ASO was added in e24632485a9e54963155c63b48e70215228947e9.

## Summary

Move ASO from abfall_io to abfall_io_graphql as it seems they switch to graphql.

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
