### PR TITLE
Fix City of Yarra v3 port and release discovery

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -3,7 +3,7 @@ name: Update Documentation
 
 on:
   push:
-    branches: [master]
+    branches: [master, release/**]
 
 permissions:
   contents: write

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ArcGis.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ArcGis.py
@@ -886,6 +886,10 @@ class ArcGisMultiFeatureRetriever(RetrieverFunc):
             anything. A failing layer then aborts the scan rather than being
             skipped, because an ordered scan that skipped a layer could report
             a later layer's answer as if it were the first.
+        require_all: abort when any queried layer fails. The default keeps the
+            tolerant behaviour used by councils where each layer is optional;
+            enable this when every queried layer is required for a complete
+            schedule.
         argument: with ``first_match``, the ``source.params`` field to blame
             when no layer matched. Leave unset to return no responses.
     """
@@ -903,6 +907,7 @@ class ArcGisMultiFeatureRetriever(RetrieverFunc):
         where: str | Callable[..., str | None] | None = None,
         count_only: bool = False,
         first_match: bool = False,
+        require_all: bool = False,
         argument: str | None = None,
     ):
         # Normalise to (label, url, out_fields) triples.
@@ -924,6 +929,7 @@ class ArcGisMultiFeatureRetriever(RetrieverFunc):
         self.where = where
         self.count_only = count_only
         self.first_match = first_match
+        self.require_all = require_all
         self.argument = argument
 
     def _where_for(self, label: Any, params: dict[str, Any]) -> str | None:
@@ -972,7 +978,7 @@ class ArcGisMultiFeatureRetriever(RetrieverFunc):
                 )
                 response.raise_for_status()
             except requests.RequestException as err:
-                if self.first_match:
+                if self.first_match or self.require_all:
                     raise
                 _LOGGER.debug("ArcGIS layer %s failed, skipping: %s", url, err)
                 last_error = err

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
@@ -22,9 +22,9 @@ from waste_collection_schedule.transformers import ICSTransformer
 # anchor date that fixes its fortnightly recycling phase, layer 0 (glass)
 # carries an independent anchor plus the glass cycle length in days. Both are
 # point-in-polygon lookups from a single geocode, which is exactly what the
-# shared multi-layer ArcGIS retriever does, so the only source-specific code
-# is _describe() (reading those fields) and _adjust() (the council's own
-# public-holiday rule).
+# shared multi-layer ArcGIS retriever does. The source-specific code validates
+# those required fields, projects their recurrences, and applies the council's
+# own public-holiday rule.
 
 MAP_SERVER_URL = (
     "https://yccgis-prd.esriaustraliaonline.com.au/arcgis/rest/services/"
@@ -37,8 +37,8 @@ WASTE_LAYER = "waste"
 # (label, feature_url, out_fields) per layer; the label is carried through to
 # each parsed record so _describe() knows which fields it is looking at.
 LAYERS = [
-    (GLASS_LAYER, f"{MAP_SERVER_URL}/0", "anchor_date,frequency_days"),
     (WASTE_LAYER, f"{MAP_SERVER_URL}/1", "collection_day,recycling_anchor_date"),
+    (GLASS_LAYER, f"{MAP_SERVER_URL}/0", "anchor_date,frequency_days"),
 ]
 
 # How many weekly collections to project; the fortnightly and glass cycles
@@ -61,10 +61,94 @@ def _geocode_address(address: str) -> str:
 def _to_date(value: object) -> datetime.date | None:
     """Read an ArcGIS date field, which these layers publish as an ISO string."""
     if isinstance(value, str) and value:
-        return datetime.date.fromisoformat(value[:10])
-    if isinstance(value, (int, float)):
-        return datetime.date.fromtimestamp(value / 1000)
+        return datetime.date.fromisoformat(value)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return datetime.datetime.fromtimestamp(value / 1000, tz=datetime.UTC).date()
     return None
+
+
+def _required_date(attrs: dict, field: str, layer: str) -> datetime.date:
+    """Read a required provider date, failing instead of hiding a bin stream."""
+    value = attrs.get(field)
+    try:
+        parsed = _to_date(value)
+    except (OSError, OverflowError, ValueError) as err:
+        raise ValueError(
+            f"City of Yarra {layer} layer returned invalid {field}: {value!r}"
+        ) from err
+    if parsed is None:
+        raise ValueError(f"City of Yarra {layer} layer did not return required {field}")
+    return parsed
+
+
+def _required_frequency(attrs: dict) -> int:
+    """Read the required positive glass cadence published by the provider."""
+    value = attrs.get("frequency_days")
+    try:
+        if isinstance(value, bool) or (
+            isinstance(value, float) and not value.is_integer()
+        ):
+            raise ValueError
+        frequency = int(value)
+    except (TypeError, ValueError) as err:
+        raise ValueError(
+            f"City of Yarra glass layer returned invalid frequency_days: {value!r}"
+        ) from err
+    if frequency <= 0:
+        raise ValueError(
+            f"City of Yarra glass layer returned invalid frequency_days: {value!r}"
+        )
+    return frequency
+
+
+def _is_delayed_collection_day(collection_date: datetime.date) -> bool:
+    """Whether Yarra moves this scheduled collection forward by one day.
+
+    Good Friday affects that Friday alone. Christmas delays cascade through
+    the remaining weekday rounds: when Christmas is on a Monday, for example,
+    every Monday-to-Friday round moves one day; when it is on a Thursday, both
+    Thursday and Friday move. A weekend Christmas does not affect a weekday
+    round.
+    """
+    if collection_date == recurrence.good_friday(collection_date.year):
+        return True
+
+    christmas = datetime.date(collection_date.year, 12, 25)
+    if christmas.weekday() > 4:
+        return False
+    last_weekday = christmas + datetime.timedelta(days=4 - christmas.weekday())
+    return christmas <= collection_date <= last_weekday
+
+
+def _anchored_schedule(
+    key: str,
+    anchor: datetime.date,
+    step: datetime.timedelta,
+    count: int,
+) -> Schedule:
+    """Build a projection that retains yesterday when it shifts onto today.
+
+    The shared recurrence expander normally starts on or after today. On the
+    day after Good Friday or Christmas that would discard yesterday before the
+    holiday stage can move it to today. Add that one in-phase occurrence back,
+    reducing the ordinary projection by one so the published horizon stays the
+    requested ``count``.
+    """
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+    shifted_today = (
+        yesterday >= anchor
+        and _is_delayed_collection_day(yesterday)
+        and (yesterday - anchor) % step == datetime.timedelta(0)
+    )
+    extra = (yesterday,) if shifted_today else ()
+    return Schedule(
+        key,
+        anchor,
+        step,
+        count - len(extra),
+        anchor=True,
+        extra=extra,
+    )
 
 
 def _describe(record, source):
@@ -78,49 +162,50 @@ def _describe(record, source):
     label, attrs = record
 
     if label == WASTE_LAYER:
-        weekday = recurrence.weekday(attrs.get("collection_day") or "")
-        if weekday is not None:
-            # Rubbish and FOGO both run weekly on the property's collection
-            # day, today's collection included when that day is today.
-            start = recurrence.most_recent_weekday(weekday)
-            yield Schedule(
-                "Rubbish", start, recurrence.WEEKLY, WEEKS_AHEAD, anchor=True
+        collection_day = attrs.get("collection_day")
+        weekday = recurrence.weekday(collection_day or "")
+        if weekday is None:
+            raise ValueError(
+                "City of Yarra waste layer returned invalid collection_day: "
+                f"{collection_day!r}"
             )
-            yield Schedule("FOGO", start, recurrence.WEEKLY, WEEKS_AHEAD, anchor=True)
+
+        # Rubbish and FOGO both run weekly on the property's collection day,
+        # today's collection included when that day is today.
+        start = recurrence.most_recent_weekday(weekday)
+        yield _anchored_schedule("Rubbish", start, recurrence.WEEKLY, WEEKS_AHEAD)
+        yield _anchored_schedule("FOGO", start, recurrence.WEEKLY, WEEKS_AHEAD)
 
         # Recycling alternates fortnightly between zones; the layer's anchor
         # date fixes this property's phase.
-        recycling_anchor = _to_date(attrs.get("recycling_anchor_date"))
-        if recycling_anchor is not None:
-            yield Schedule(
-                "Recycling",
-                recycling_anchor,
-                recurrence.FORTNIGHTLY,
-                WEEKS_AHEAD // 2,
-                anchor=True,
-            )
+        recycling_anchor = _required_date(attrs, "recycling_anchor_date", WASTE_LAYER)
+        yield _anchored_schedule(
+            "Recycling",
+            recycling_anchor,
+            recurrence.FORTNIGHTLY,
+            WEEKS_AHEAD // 2,
+        )
         return
+
+    if label != GLASS_LAYER:
+        raise ValueError(f"City of Yarra returned unexpected layer label: {label!r}")
 
     # Glass runs on its own cycle (currently every 28 days) with an
     # independent per-polygon anchor and cycle length.
-    glass_anchor = _to_date(attrs.get("anchor_date"))
-    frequency = attrs.get("frequency_days")
-    if glass_anchor is not None and frequency:
-        yield Schedule(
-            "Glass",
-            glass_anchor,
-            datetime.timedelta(days=int(frequency)),
-            WEEKS_AHEAD // 4,
-            anchor=True,
-        )
+    glass_anchor = _required_date(attrs, "anchor_date", GLASS_LAYER)
+    frequency = _required_frequency(attrs)
+    yield _anchored_schedule(
+        "Glass",
+        glass_anchor,
+        datetime.timedelta(days=frequency),
+        WEEKS_AHEAD // 4,
+    )
 
 
 def _adjust(collection_date: datetime.date, key: str, source) -> datetime.date:
     """Council rule: collections run on every public holiday except Good
     Friday and Christmas Day, when they happen one day later."""
-    if collection_date == recurrence.good_friday(collection_date.year) or (
-        collection_date.month == 12 and collection_date.day == 25
-    ):
+    if _is_delayed_collection_day(collection_date):
         return collection_date + datetime.timedelta(days=1)
     return collection_date
 
@@ -151,7 +236,15 @@ class Source(BaseSource):
     # Declarative pipeline: geocode once, spatially query both layers, tag each
     # response with its label, then project each match into concrete dates and
     # defer the two days the council does not collect on.
-    retrieve = ArcGisMultiFeatureRetriever(LAYERS, address=_geocode_address)
-    parse = ArcGisMultiFeatureParser()
+    retrieve = ArcGisMultiFeatureRetriever(
+        LAYERS,
+        address=_geocode_address,
+        require_all=True,
+    )
+    parse = ArcGisMultiFeatureParser(
+        first_per_layer=True,
+        argument="address",
+        hint="the address must be within the City of Yarra.",
+    )
     preprocess = Compose(RecurrenceExpander(_describe), HolidayShift(_adjust))
     transform = ICSTransformer(type_value_map=_TYPE_MAP)

--- a/tests/test_doc_generation.py
+++ b/tests/test_doc_generation.py
@@ -212,3 +212,23 @@ def test_ics_regions_key_wins_when_both_are_present():
     }
     titles = [r.title for r in ics._regions_from_definition(definition)]
     assert titles == ["Example", "New"], "the `regions:` key must win over the old one"
+
+
+def test_update_docs_workflow_runs_for_release_branches():
+    """A release branch must regenerate runtime source-discovery catalogues."""
+    import yaml
+
+    workflow_path = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / ".github"
+        / "workflows"
+        / "update-docs.yaml"
+    )
+    workflow = yaml.load(
+        workflow_path.read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+    branches = workflow["on"]["push"]["branches"]
+    assert "master" in branches
+    assert "release/**" in branches

--- a/tests/test_new_architecture.py
+++ b/tests/test_new_architecture.py
@@ -948,6 +948,91 @@ class TestArcGisComponents:
         resp.json.return_value = {"features": []}
         assert ArcGis.ArcGisFeatureParser()(resp) == []
 
+    @staticmethod
+    def _feature_response(*attributes):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "features": [{"attributes": attrs} for attrs in attributes]
+        }
+        return response
+
+    def test_multi_retriever_default_skips_one_failed_layer(self):
+        """Optional layers retain the existing tolerant default."""
+        from waste_collection_schedule.service import ArcGis
+
+        source = MagicMock()
+        source.params = {}
+        good = self._feature_response({"round": "glass"})
+        retriever = ArcGis.ArcGisMultiFeatureRetriever(
+            [("waste", "https://x/MapServer/1"), ("glass", "https://x/MapServer/0")],
+            address=None,
+            where="1=1",
+        )
+
+        with patch.object(
+            ArcGis,
+            "feature_query",
+            side_effect=[ArcGis.requests.ConnectionError("offline"), good],
+        ):
+            assert retriever(source) == [("glass", good)]
+
+    def test_multi_retriever_required_layer_failure_aborts(self):
+        """A required layer must never become a plausible partial schedule."""
+        from waste_collection_schedule.service import ArcGis
+
+        source = MagicMock()
+        source.params = {}
+        retriever = ArcGis.ArcGisMultiFeatureRetriever(
+            [("waste", "https://x/MapServer/1"), ("glass", "https://x/MapServer/0")],
+            address=None,
+            where="1=1",
+            require_all=True,
+        )
+
+        with (
+            patch.object(
+                ArcGis,
+                "feature_query",
+                side_effect=ArcGis.requests.ConnectionError("offline"),
+            ),
+            pytest.raises(ArcGis.requests.ConnectionError, match="offline"),
+        ):
+            retriever(source)
+
+    @pytest.mark.parametrize("empty_index", [0, 1])
+    def test_multi_parser_required_empty_layer_blames_address(self, empty_index):
+        from waste_collection_schedule.exceptions import SourceArgumentNotFound
+        from waste_collection_schedule.service import ArcGis
+
+        source = MagicMock()
+        source.params = {"address": "1 Test Street"}
+        responses = [
+            ("waste", self._feature_response({"round": "waste"})),
+            ("glass", self._feature_response({"round": "glass"})),
+        ]
+        responses[empty_index] = (responses[empty_index][0], self._feature_response())
+        parser = ArcGis.ArcGisMultiFeatureParser(
+            argument="address",
+            hint="the address must be in the service area.",
+        )
+
+        with pytest.raises(SourceArgumentNotFound):
+            parser(responses, source)
+
+    def test_multi_parser_can_keep_only_the_first_feature_per_layer(self):
+        from waste_collection_schedule.service import ArcGis
+
+        responses = [
+            ("waste", self._feature_response({"id": 1}, {"id": 2})),
+            ("glass", self._feature_response({"id": 3}, {"id": 4})),
+        ]
+
+        assert ArcGis.ArcGisMultiFeatureParser(first_per_layer=True)(responses) == [
+            ("waste", {"id": 1}),
+            ("glass", {"id": 3}),
+        ]
+
     # --- two-step lookup across two layers (fredrikstad_no) ---------------- #
 
     @staticmethod
@@ -1178,6 +1263,193 @@ class TestArcGisComponents:
                 (datetime.date(2026, 6, 30), "ORDURES"),
                 (datetime.date(2026, 6, 30), "COMPOST"),
             ]
+
+
+class TestYarraCitySource:
+    """City of Yarra must fail closed when provider data is incomplete."""
+
+    def test_pipeline_requires_both_layers_and_one_feature_per_layer(self):
+        from waste_collection_schedule.source import yarracity_vic_gov_au as yarra
+
+        assert yarra.Source.retrieve.layers == [
+            (
+                yarra.WASTE_LAYER,
+                f"{yarra.MAP_SERVER_URL}/1",
+                "collection_day,recycling_anchor_date",
+            ),
+            (
+                yarra.GLASS_LAYER,
+                f"{yarra.MAP_SERVER_URL}/0",
+                "anchor_date,frequency_days",
+            ),
+        ]
+        assert yarra.Source.retrieve.require_all is True
+        assert yarra.Source.parse.first_per_layer is True
+        assert yarra.Source.parse.argument == "address"
+
+    @pytest.mark.parametrize(
+        "attributes,field",
+        [
+            ({"recycling_anchor_date": "2026-08-12"}, "collection_day"),
+            (
+                {
+                    "collection_day": "Notaday",
+                    "recycling_anchor_date": "2026-08-12",
+                },
+                "collection_day",
+            ),
+            ({"collection_day": "Wednesday"}, "recycling_anchor_date"),
+            (
+                {
+                    "collection_day": "Wednesday",
+                    "recycling_anchor_date": "not-a-date",
+                },
+                "recycling_anchor_date",
+            ),
+        ],
+    )
+    def test_invalid_waste_layer_fields_raise(self, attributes, field):
+        from waste_collection_schedule.source import yarracity_vic_gov_au as yarra
+
+        with pytest.raises(ValueError, match=field):
+            list(yarra._describe((yarra.WASTE_LAYER, attributes), None))
+
+    @pytest.mark.parametrize(
+        "attributes,field",
+        [
+            ({"frequency_days": 28}, "anchor_date"),
+            ({"anchor_date": True, "frequency_days": 28}, "anchor_date"),
+            ({"anchor_date": "not-a-date", "frequency_days": 28}, "anchor_date"),
+            (
+                {"anchor_date": "2026-08-12garbage", "frequency_days": 28},
+                "anchor_date",
+            ),
+            ({"anchor_date": "2026-08-12"}, "frequency_days"),
+            (
+                {"anchor_date": "2026-08-12", "frequency_days": "unknown"},
+                "frequency_days",
+            ),
+            ({"anchor_date": "2026-08-12", "frequency_days": 28.5}, "frequency_days"),
+            ({"anchor_date": "2026-08-12", "frequency_days": True}, "frequency_days"),
+            ({"anchor_date": "2026-08-12", "frequency_days": 0}, "frequency_days"),
+        ],
+    )
+    def test_invalid_glass_layer_fields_raise(self, attributes, field):
+        from waste_collection_schedule.source import yarracity_vic_gov_au as yarra
+
+        with pytest.raises(ValueError, match=field):
+            list(yarra._describe((yarra.GLASS_LAYER, attributes), None))
+
+    def test_unknown_layer_label_raises(self):
+        from waste_collection_schedule.source import yarracity_vic_gov_au as yarra
+
+        with pytest.raises(ValueError, match="unexpected layer label"):
+            list(yarra._describe(("unknown", {}), None))
+
+    @pytest.mark.parametrize(
+        "today,scheduled_date,collection_day,next_by_key",
+        [
+            (
+                "2025-12-26",
+                datetime.date(2025, 12, 25),
+                "Thursday",
+                {
+                    "Rubbish": datetime.date(2026, 1, 1),
+                    "FOGO": datetime.date(2026, 1, 1),
+                    "Recycling": datetime.date(2026, 1, 8),
+                    "Glass": datetime.date(2026, 1, 22),
+                },
+            ),
+            (
+                "2025-12-27",
+                datetime.date(2025, 12, 26),
+                "Friday",
+                {
+                    "Rubbish": datetime.date(2026, 1, 2),
+                    "FOGO": datetime.date(2026, 1, 2),
+                    "Recycling": datetime.date(2026, 1, 9),
+                    "Glass": datetime.date(2026, 1, 23),
+                },
+            ),
+            (
+                "2026-12-26",
+                datetime.date(2026, 12, 25),
+                "Friday",
+                {
+                    "Rubbish": datetime.date(2027, 1, 1),
+                    "FOGO": datetime.date(2027, 1, 1),
+                    "Recycling": datetime.date(2027, 1, 8),
+                    "Glass": datetime.date(2027, 1, 22),
+                },
+            ),
+            (
+                "2027-03-27",
+                datetime.date(2027, 3, 26),
+                "Friday",
+                {
+                    "Rubbish": datetime.date(2027, 4, 2),
+                    "FOGO": datetime.date(2027, 4, 2),
+                    "Recycling": datetime.date(2027, 4, 9),
+                    "Glass": datetime.date(2027, 4, 23),
+                },
+            ),
+        ],
+    )
+    def test_day_after_holiday_keeps_collection_shifted_to_today(
+        self, today, scheduled_date, collection_day, next_by_key
+    ):
+        from waste_collection_schedule.source import yarracity_vic_gov_au as yarra
+
+        records = [
+            (
+                yarra.WASTE_LAYER,
+                {
+                    "collection_day": collection_day,
+                    "recycling_anchor_date": scheduled_date.isoformat(),
+                },
+            ),
+            (
+                yarra.GLASS_LAYER,
+                {"anchor_date": scheduled_date.isoformat(), "frequency_days": 28},
+            ),
+        ]
+        with freeze_time(today):
+            rows = list(yarra.Source.preprocess(records))
+
+        expected_counts = {
+            "Rubbish": 52,
+            "FOGO": 52,
+            "Recycling": 26,
+            "Glass": 13,
+        }
+        today_date = datetime.date.fromisoformat(today)
+        for key, count in expected_counts.items():
+            dates = sorted(date for date, row_key in rows if row_key == key)
+            assert len(dates) == count
+            assert dates[:2] == [today_date, next_by_key[key]]
+            assert scheduled_date not in dates
+
+    def test_day_after_holiday_does_not_invent_an_off_phase_collection(self):
+        from waste_collection_schedule.source import yarracity_vic_gov_au as yarra
+
+        records = [
+            (
+                yarra.WASTE_LAYER,
+                {
+                    "collection_day": "Thursday",
+                    "recycling_anchor_date": "2026-12-24",
+                },
+            ),
+            (
+                yarra.GLASS_LAYER,
+                {"anchor_date": "2026-12-24", "frequency_days": 28},
+            ),
+        ]
+        with freeze_time("2026-12-26"):
+            rows = list(yarra.Source.preprocess(records))
+
+        assert len(rows) == 143
+        assert datetime.date(2026, 12, 26) not in {date for date, _ in rows}
 
 
 class TestPreprocessors:

--- a/tests/test_offline_fixtures.py
+++ b/tests/test_offline_fixtures.py
@@ -13,6 +13,8 @@ import datetime
 import json
 import os
 import sys
+from collections import Counter
+from itertools import pairwise
 
 import dateutil.parser  # noqa: F401
 import pytest
@@ -31,6 +33,7 @@ import cassette
 from fixtures_support import (
     discover_choice_fixtures,
     discover_fixtures,
+    fixture_path,
     slug,
 )
 from waste_collection_schedule.collection import Collection
@@ -111,6 +114,63 @@ def test_offline_replay(module_name, case_slug, path):
         assert isinstance(r.date, datetime.date)
         assert r.waste_type is not None
     _COMPLETED.add(os.path.abspath(path))
+
+
+@pytest.mark.parametrize(
+    "case_name,first_dates",
+    [
+        (
+            "Fitzroy Town Hall",
+            {
+                "general_waste": datetime.date(2026, 8, 5),
+                "organic": datetime.date(2026, 8, 5),
+                "recyclables": datetime.date(2026, 8, 12),
+                "glass": datetime.date(2026, 8, 12),
+            },
+        ),
+        (
+            "Richmond Town Hall",
+            {
+                "general_waste": datetime.date(2026, 8, 4),
+                "organic": datetime.date(2026, 8, 4),
+                "recyclables": datetime.date(2026, 8, 11),
+                "glass": datetime.date(2026, 8, 11),
+            },
+        ),
+    ],
+)
+def test_yarra_replay_preserves_types_dates_and_cadence(case_name, first_dates):
+    """Yarra cassettes pin the schedule contract, not merely a non-empty result."""
+    module = import_module("waste_collection_schedule.source.yarracity_vic_gov_au")
+    path = fixture_path("yarracity_vic_gov_au", case_name)
+
+    with cassette.replaying(path):
+        results = module.Source(**module.Source.TEST_CASES[case_name]).fetch()
+
+    expected_counts = {
+        "general_waste": 52,
+        "organic": 52,
+        "recyclables": 26,
+        "glass": 13,
+    }
+    assert len(results) == 143
+    assert Counter(result.waste_type.id for result in results) == expected_counts
+
+    expected_cadence = {
+        "general_waste": datetime.timedelta(days=7),
+        "organic": datetime.timedelta(days=7),
+        "recyclables": datetime.timedelta(days=14),
+        "glass": datetime.timedelta(days=28),
+    }
+    for waste_type, first_date in first_dates.items():
+        dates = sorted(
+            result.date for result in results if result.waste_type.id == waste_type
+        )
+        assert dates[0] == first_date
+        assert all(
+            later - earlier == expected_cadence[waste_type]
+            for earlier, later in pairwise(dates)
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- Added an opt-in `require_all` mode to `ArcGisMultiFeatureRetriever`; its default remains tolerant for existing sources.
- Made City of Yarra require both waste and glass layers and keep only the first polygon match per layer.
- Restored the legacy waste-before-glass layer order.
- Fail closed when required Yarra weekday, anchor, frequency, or layer-label data is absent or invalid.
- Parse numeric ArcGIS timestamps in UTC and reject booleans/non-integral frequencies.
- Preserve collections shifted onto today after Good Friday or Christmas.
- Apply Yarra's published cascading Christmas delay through the remaining weekday rounds (including Thursday 25 -> Friday 26 and Friday 26 -> Saturday 27 in 2025).
- Added exact cassette assertions for all four canonical waste types, 143-event totals, first dates, and 7/14/28-day cadence for both recorded addresses.
- Run the supported documentation/catalogue generator on `release/**` pushes so v3 release branches generate runtime discovery artefacts after merge.

## Why

The initial v3 Yarra port inherited tolerant multi-layer defaults. A failed/empty layer or malformed provider field could therefore produce a plausible but incomplete calendar, and overlapping polygons could duplicate schedules. The release branch also contains the source but not its generated `sources.json` entry, so a HACS install cannot select City of Yarra in config flow.

The holiday correction follows City of Yarra's [general collection rule](https://www.yarracity.vic.gov.au/residents/bins-waste-recycling-and-cleansing/recycling-and-rubbish/bin-collection) and its [published 2025 Christmas timetable](https://www.yarracity.vic.gov.au/about-us/news-and-media/council-services-christmas-and-holiday-opening-hours-2025).

## User impact

- Provider failures no longer silently hide Glass, General Waste, Organic Waste, or Recycling.
- Boundary overlaps no longer create duplicate schedules.
- Christmas/Good Friday collections remain visible when shifted onto the current day.
- After merge and the generator bot commit, City of Yarra becomes discoverable from a clean v3 HACS install.

This does not change v3's intentional canonical labels: `General Waste` and `Organic Waste` remain the v3 display names.

## Validation

- Focused ArcGIS/Yarra unit suite: 37 passed.
- Yarra cassette suite: 6 passed.
- Release-workflow regression: 1 passed.
- Complete offline suite: 7,698 passed, 8 skipped, 2,248 deselected. The only excluded test is an unrelated Windows newline assertion that fails identically on the clean `release/3.0.0` base.
- CI syntax/undefined-name lint and Home Assistant config-flow import passed.
- Ruff lint/format, codespell, Bandit, and Pyright passed.
- The repository YAML formatter passed when invoked directly (the Windows pre-commit launcher path is malformed).
- Local MyPy reports two existing integration-layer errors and reports the same errors on the clean base; Linux CI remains authoritative.
- The supported generator was run locally and produced the Yarra source page and catalogue/metadata/README/info/owner entries; those generated changes were then restored because repository policy requires the workflow to own them.

## Independent review

An independent adversarial review initially found the cascading Christmas delay gap. That finding was accepted and fixed. The final re-review passed with no remaining actionable findings, including ArcGIS backwards compatibility, cadence/year-boundary behaviour, Good Friday, weekend/off-phase protection, and workflow security.

## Post-merge release gate

Do not tag the next v3 prerelease until the `Update Documentation` workflow succeeds on `release/3.0.0` and its bot commit adds City of Yarra to the generated runtime catalogue and documentation.