### PR TITLE
Add source for Central Otago District Council

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/codc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/codc_govt_nz.py
@@ -12,6 +12,23 @@ URL = "https://www.codc.govt.nz/"
 TEST_CASES = {
     "Alexandra": {"address": "5 Campbell Street Alexandra"},
 }
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Use the CODC Bin App (https://play.google.com/store/apps/details?id=nz.co.environz.codc) and search for your address. The address argument should match how the app displays your address alongside your next collection details.",
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Address",
+    }
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Full street address as displayed in the CODC Bin App, e.g. '5 Campbell Street Alexandra'",
+    }
+}
+
 HEADERS = {
     "user-agent": "Mozilla/5.0",
 }
@@ -55,7 +72,7 @@ class Source:
             "postcode": "",
         }
 
-        r = requests.get(API_URL, params=params, headers=HEADERS)
+        r = requests.get(API_URL, params=params, headers=HEADERS, timeout=30)
         if r.status_code == 400:
             raise SourceArgumentNotFound(
                 argument="address",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/codc_govt_nz.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/codc_govt_nz.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timedelta
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+TITLE = "Central Otago District Council"
+DESCRIPTION = (
+    "Source for Central Otago District Council Rubbish & Recycling collection."
+)
+URL = "https://www.codc.govt.nz/"
+TEST_CASES = {
+    "Alexandra": {"address": "5 Campbell Street Alexandra"},
+}
+HEADERS = {
+    "user-agent": "Mozilla/5.0",
+}
+ICON_MAP = {
+    "RED BIN": Icons.GENERAL_WASTE,
+    "BLUE BIN": Icons.GLASS,
+    "YELLOW BIN": Icons.PLASTIC_PACKAGING,
+    "GREEN BIN": Icons.ORGANIC,
+}
+
+# CODC's API returns "ORG" for organics rather than "FOD" (used by some other
+# councils on the same Environz backend), so both are mapped for safety.
+OLD_BIN_MAP = {
+    "REC": "YELLOW BIN",
+    "GLA": "BLUE BIN",
+    "REF": "RED BIN",
+    "ORG": "GREEN BIN",
+    "FOD": "GREEN BIN",
+}
+
+API_URL = "https://environz-api.azurewebsites.net/api/codc/nextservicedate"
+API_KEY = "bPLjJjgubEyQ3ruJqjhFenL1SoHCTzNEVGoLY5MJpP9AAzFuj8pSzA=="
+
+SOURCE_CODEOWNERS = ["@soasmileynz"]
+
+
+class Source:
+    def __init__(self, address):
+        self._address = str(address).strip()
+        split = self._address.split("-")
+        if len(split) > 1 and split[0].strip().isdigit():
+            split = [split[0].strip() + "/" + split[1].strip(), *split[2:]]
+            self._address = "-".join(split)
+
+    def fetch(self):
+        end_date = (datetime.now() + timedelta(days=365)).strftime("%d/%m/%Y")
+        params = {
+            "code": API_KEY,
+            "address": self._address,
+            "endDate": end_date,
+            "postcode": "",
+        }
+
+        r = requests.get(API_URL, params=params, headers=HEADERS)
+        if r.status_code == 400:
+            raise SourceArgumentNotFound(
+                argument="address",
+                value=self._address,
+                message_addition="make sure the address matches an address that has a schedule in the CODC Bin App.",
+            )
+
+        r.raise_for_status()
+
+        data = r.json()
+
+        entries = []
+        for key, value in data.items():
+            if not key.startswith("route") or not value:
+                continue
+            collection_type = key.removeprefix("route").strip()
+            collection_type = OLD_BIN_MAP.get(collection_type, collection_type)
+            for date in value.values():
+                entries.append(
+                    Collection(
+                        date=datetime.strptime(date, "%d/%m/%Y").date(),
+                        t=collection_type,
+                        icon=ICON_MAP.get(collection_type.upper()),
+                    )
+                )
+        return entries

--- a/doc/source/codc_govt_nz.md
+++ b/doc/source/codc_govt_nz.md
@@ -1,0 +1,34 @@
+# Central Otago District Council
+
+Support for schedules provided by [Central Otago District Council](https://www.codc.govt.nz/) Rubbish & Recycling collection. It uses the endpoint of the [CODC Bin App](https://play.google.com/store/apps/details?id=nz.co.environz.codc) (built by Environz, the same backend used by Dunedin, Waitaki and Timaru's council bin apps).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: codc_govt_nz
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: codc_govt_nz
+      args:
+        address: "5 Campbell Street Alexandra"
+```
+
+## How to get the source argument
+
+Use the [CODC Bin App](https://play.google.com/store/apps/details?id=nz.co.environz.codc) and search for your address. The `address` argument should match how the app displays your address alongside your next collection details.
+
+---

--- a/doc/source/codc_govt_nz.md
+++ b/doc/source/codc_govt_nz.md
@@ -30,5 +30,3 @@ waste_collection_schedule:
 ## How to get the source argument
 
 Use the [CODC Bin App](https://play.google.com/store/apps/details?id=nz.co.environz.codc) and search for your address. The `address` argument should match how the app displays your address alongside your next collection details.
-
----


### PR DESCRIPTION
Adds support for Central Otago District Council (New Zealand) rubbish and recycling collection schedules.

Uses the same Environz API backend as the existing Dunedin District Council source (`dunedin_govt_nz.py`), with CODC's own API key and endpoint path (`/api/codc/nextservicedate`).

**Testing**
- `pytest tests/test_source_components.py`: 35 passed
- `test_sources.py -s codc_govt_nz`: 117 entries found for the Alexandra test case (5 Campbell Street Alexandra), correctly split across all four bin types (yellow/red/blue/green)
- `ruff`, `mypy`, `bandit`, `codespell`: clean on the new files

- [x] `codc_govt_nz.py` added
- [x] `doc/source/codc_govt_nz.md` added
- [x] `test_sources.py -s codc_govt_nz` passes locally
- [x] `pytest tests/test_source_components.py` passes locally