### PR TITLE
fix(service/OpenCities): encode search address spaces as %20

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Any, Literal
+from urllib.parse import quote
 
 import requests
 from bs4 import BeautifulSoup
@@ -232,10 +233,15 @@ class OpenCitiesClient:
 
     def _search(self, address: str) -> list[dict[str, Any]]:
         path = "searchfuzzy" if self._cfg.search_fuzzy else "search"
-        params: dict[str, Any] = {"keywords": address}
+        # Pre-encode the address with urllib.parse.quote() so spaces are sent
+        # as %20 (not '+'); requests' own param encoding would render spaces
+        # as '+', which the OpenCities API backend rejects. The search URL is
+        # therefore built manually to avoid double-encoding.
+        query = [f"keywords={quote(address, safe='')}"]
         if self._cfg.max_results is not None:
-            params["maxresults"] = self._cfg.max_results
-        response = self._get(f"{self._cfg.domain}/api/v1/myarea/{path}", params)
+            query.append(f"maxresults={self._cfg.max_results}")
+        url = f"{self._cfg.domain}/api/v1/myarea/{path}?{'&'.join(query)}"
+        response = self._get(url)
 
         fmt = self._cfg.search_response_format
         if fmt == "xml":


### PR DESCRIPTION
# fix(service/OpenCities): encode search address spaces as %20

## Summary

The OpenCities API backend rejects URL-encoded spaces when they are formatted
as `+` (e.g. `12+Ashton+Street+Kingston`). This broke address resolution for
sources built on the shared `OpenCitiesClient`, including
`logan_qld_gov_au`.

This PR passes the search address through `urllib.parse.quote()` so spaces are
sent as `%20` instead of `+`, and builds the search URL manually to avoid
`requests` re-encoding (and re-expanding) the already-quoted value.

Verified live against the Logan City Council API — all three `TEST_CASES`
resolve to their geolocations and return valid collection entries.

## Type of change

- [x] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)