### PR TITLE
Add Partille kommun waste collection source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
@@ -9,6 +9,20 @@ DESCRIPTION = "Source for Partille kommun waste collection."
 URL = "https://vatjanst.partille.se"
 SOURCE_CODEOWNERS = ["@sadjad1"]
 
+COUNTRY = "se"
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "street_address": "Street address",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street_address": "Street address including house number, e.g. 'Tiondevägen 6, Partille'",
+    },
+}
+
 TEST_CASES = {
     "Tiondevägen 6": {"street_address": "Tiondevägen 6, Partille"},
 }

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+
+TITLE = "Partille kommun"
+DESCRIPTION = "Source for Partille kommun waste collection."
+URL = "https://vatjanst.partille.se"
+SOURCE_CODEOWNERS = ["@sadjad1"]
+
+TEST_CASES = {
+    "Partille kommunhus": {"street_address": "Gamla Kronvägen 34, Partille"},
+}
+
+SEARCH_URL = "https://vatjanst.partille.se/FutureWeb/SimpleWastePickup/SearchAdress"
+SCHEDULE_URL = (
+    "https://vatjanst.partille.se/FutureWeb/SimpleWastePickup/GetWastePickupSchedule"
+)
+
+
+class Source:
+    def __init__(self, street_address):
+        self._street_address = street_address
+
+    def fetch(self):
+        r = requests.post(SEARCH_URL, {"searchText": self._street_address})
+        r.raise_for_status()
+
+        address_data = r.json()
+        address = None
+
+        if address_data["Succeeded"] is True and len(address_data["Buildings"]) > 0:
+            address = address_data["Buildings"][0]
+
+        if address is None:
+            raise SourceArgumentNotFound("street_address", self._street_address)
+
+        r = requests.get(SCHEDULE_URL, params={"address": address})
+        r.raise_for_status()
+
+        data = r.json()
+
+        entries = []
+
+        for item in data["RhServices"]:
+            waste_type = item["WasteType"]
+            next_pickup_date = datetime.fromisoformat(
+                item["NextWastePickup"]
+            ).date()
+
+            entries.append(
+                Collection(
+                    date=next_pickup_date,
+                    t=waste_type,
+                    icon=Icons.GENERAL_WASTE,
+                )
+            )
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
@@ -38,7 +38,11 @@ class Source:
         self._street_address = street_address
 
     def fetch(self):
-        r = requests.post(SEARCH_URL, {"searchText": self._street_address})
+        r = requests.post(
+            SEARCH_URL,
+            {"searchText": self._street_address},
+            timeout=30,
+        )
         r.raise_for_status()
 
         address_data = r.json()
@@ -50,7 +54,7 @@ class Source:
         if address is None:
             raise SourceArgumentNotFound("street_address", self._street_address)
 
-        r = requests.get(SCHEDULE_URL, params={"address": address})
+        r = requests.get(SCHEDULE_URL, params={"address": address}, timeout=30)
         r.raise_for_status()
 
         data = r.json()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
@@ -45,9 +45,7 @@ class Source:
 
         for item in data["RhServices"]:
             waste_type = item["WasteType"]
-            next_pickup_date = datetime.fromisoformat(
-                item["NextWastePickup"]
-            ).date()
+            next_pickup_date = datetime.fromisoformat(item["NextWastePickup"]).date()
 
             entries.append(
                 Collection(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/partille_se.py
@@ -10,7 +10,7 @@ URL = "https://vatjanst.partille.se"
 SOURCE_CODEOWNERS = ["@sadjad1"]
 
 TEST_CASES = {
-    "Partille kommunhus": {"street_address": "Gamla Kronvägen 34, Partille"},
+    "Tiondevägen 6": {"street_address": "Tiondevägen 6, Partille"},
 }
 
 SEARCH_URL = "https://vatjanst.partille.se/FutureWeb/SimpleWastePickup/SearchAdress"

--- a/doc/source/partille_se.md
+++ b/doc/source/partille_se.md
@@ -1,0 +1,12 @@
+# Partille kommun
+
+Support for waste collection schedules provided by [Partille kommun](https://vatjanst.partille.se/FutureWeb/SimpleWastePickup/SimpleWastePickup), serving the municipality of Partille, Sweden.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: partille_se
+      args:
+        street_address: STREET_ADDRESS

--- a/doc/source/partille_se.md
+++ b/doc/source/partille_se.md
@@ -10,3 +10,23 @@ waste_collection_schedule:
     - name: partille_se
       args:
         street_address: STREET_ADDRESS
+```
+
+### Configuration Variables
+
+**street_address**  
+*(string) (required)*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: partille_se
+      args:
+        street_address: Tiondevägen 6, Partille
+```
+
+## How to get the source argument
+
+The source argument is the address of the property with waste collection. The address can be tested [here](https://vatjanst.partille.se/FutureWeb/SimpleWastePickup/SimpleWastePickup).


### PR DESCRIPTION
## Summary

Adds waste collection schedule support for Partille kommun, Sweden, using Partille's FutureWeb SimpleWastePickup service.

The implementation uses the same API structure as the existing Lerum source:
- SearchAdress to resolve the supplied street address
- GetWastePickupSchedule to retrieve the collection schedule

Tested successfully against Partille's live service.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses