### PR TITLE
Add City of Kamloops, BC to ReCollect ICS provider

### DIFF
--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -200,6 +200,9 @@ extra_info:
   - title: City of Raleigh, NC
     url: https://raleighnc.gov/landfill-and-reuse/services/raleigh-reuse-web-tool-and-mobile-app
     country: us
+  - title: City of Kamloops, BC
+    url: https://www.kamloops.ca
+    country: ca
 
 howto:
   en: |
@@ -257,6 +260,7 @@ howto:
     |Newcastle upon Tyne|UK|[new.newcastle.gov.uk](https://new.newcastle.gov.uk/recycling-waste/check-your-bin-collection-day)|
     |City of Apopka, FL|USA|[apopka.gov](https://www.apopka.gov/319/Solid-Waste)|
     |City of Raleigh, NC|USA|[raleighnc.gov](https://raleighnc.gov/landfill-and-reuse/services/raleigh-reuse-web-tool-and-mobile-app)|
+    |City of Kamloops, BC|Canada|[kamloops.ca](https://www.kamloops.ca/city-services/recycling-garbage-organics/residential-collection-schedule)|
 
     and probably a lot more.
 
@@ -315,4 +319,7 @@ test_cases:
     split_at: '\, (?:and )?|(?: and )'
   1402 Lansdowne Dr, Coquitlam, BC, Canada:
     url: https://recollect-us.global.ssl.fastly.net/api/places/60B07F16-912F-11E2-91C6-912BB3DE4739/services/202/events.en.ics
+    split_at: '\, (?:and )?|(?: and )'
+  100 Sunset Crt, Kamloops, BC, Canada:
+    url: https://recollect.a.ssl.fastly.net/api/places/CA6C8A4C-A85B-11E7-960A-90E7FC0D224B/services/671/events.en.ics
     split_at: '\, (?:and )?|(?: and )'


### PR DESCRIPTION
## Summary

Adds **City of Kamloops, BC (Canada)** to the ReCollect ICS provider — area `KamloopsBC`, service `671`. The city's site embeds the ReCollect widget and its app is `net.recollect.kamloopsbc.waste`, so it's already covered by the generic `ics` source; no new source module needed.

Collections parse into `Garbage`, `Organics`, and `Recycling` with the existing ReCollect `split_at` pattern.

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (35 passed)
- [x] `ruff check --fix` and `ruff format` run on changed source files — N/A, no `.py` changed
- [x] No generated files in diff
- [x] `doc/source/<name>.md` created for new sources — N/A, not a new source
- [x] TEST_CASES use real, publicly accessible addresses (not my own)

`python test_sources.py -y recollect` → `found 37 entries for 100 Sunset Crt, Kamloops, BC, Canada`