### PR TITLE
fix(yarracity_vic_gov_au): handle joined ArcGIS layer attribute names

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
@@ -70,6 +70,15 @@ _WEEKDAYS = {
 }
 
 
+def _attr(attributes: dict, name: str):
+    # Joined ArcGIS layers qualify attribute names ("<join>.<field>");
+    # match a bare field name against either scheme.
+    for key, value in attributes.items():
+        if key == name or key.endswith("." + name):
+            return value
+    raise KeyError(name)
+
+
 def _holiday_shift(d: date) -> date:
     # Council rule: collections run on all public holidays except Good Friday
     # and Christmas Day, when the collection happens one day later.
@@ -89,15 +98,21 @@ class Source:
             raise SourceArgumentNotFound("address", self._address) from e
 
         try:
+            # 2026-08: the council rebuilt the glass layer as a joined layer
+            # whose attributes carry fully-qualified names (e.g.
+            # "internal.gdo.Glass_Collection_Zones.anchor_date"), and a
+            # bare-name out_fields now fails with HTTP 400. Fetch all fields
+            # and resolve names via _attr so either scheme works on either
+            # layer.
             waste = query_feature_layer(
                 WASTE_LAYER_URL,
                 geometry=location,
-                out_fields="collection_day,recycling_anchor_date",
+                out_fields="*",
             )[0]
             glass = query_feature_layer(
                 GLASS_LAYER_URL,
                 geometry=location,
-                out_fields="anchor_date,frequency_days",
+                out_fields="*",
             )[0]
         except ArcGisError as e:
             raise SourceArgumentNotFound(
@@ -106,7 +121,7 @@ class Source:
                 "the address must be within the City of Yarra.",
             ) from e
 
-        day_name = waste["collection_day"]
+        day_name = _attr(waste, "collection_day")
         if day_name not in _WEEKDAYS:
             raise ValueError(f"Unexpected collection day: {day_name!r}")
 
@@ -123,7 +138,7 @@ class Source:
         # Recycling alternates fortnightly between zones; the layer's anchor
         # date fixes this property's phase. DateOnly fields are ISO strings.
         for d in get_next_n_dates(
-            date.fromisoformat(waste["recycling_anchor_date"]),
+            date.fromisoformat(_attr(waste, "recycling_anchor_date")),
             WEEKS_AHEAD // 2,
             timedelta(days=14),
         ):
@@ -134,9 +149,9 @@ class Source:
         # Glass runs on its own cycle (currently every 28 days) with an
         # independent per-polygon anchor.
         for d in get_next_n_dates(
-            date.fromisoformat(glass["anchor_date"]),
+            date.fromisoformat(_attr(glass, "anchor_date")),
             WEEKS_AHEAD // 4,
-            timedelta(days=int(glass["frequency_days"])),
+            timedelta(days=int(_attr(glass, "frequency_days"))),
         ):
             entries.append(Collection(_holiday_shift(d), "Glass", ICON_MAP["Glass"]))
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/yarracity_vic_gov_au.py
@@ -72,9 +72,14 @@ _WEEKDAYS = {
 
 def _attr(attributes: dict, name: str):
     # Joined ArcGIS layers qualify attribute names ("<join>.<field>");
-    # match a bare field name against either scheme.
+    # match a bare field name against either scheme. An exact match wins so
+    # the result never depends on attribute ordering. The required "."
+    # separator keeps e.g. "recycling_anchor_date" from matching "anchor_date".
+    if name in attributes:
+        return attributes[name]
+    suffix = "." + name
     for key, value in attributes.items():
-        if key == name or key.endswith("." + name):
+        if key.endswith(suffix):
             return value
     raise KeyError(name)
 


### PR DESCRIPTION
## Problem

Every City of Yarra install currently fails on fetch with:

> We could not find values for the argument 'address' with the value '…', the address must be within the City of Yarra.

The council rebuilt their waste MapServer. The service's layers are now named **"Collection Zones"** (layer 0, glass) and **"Collection Day"** (layer 1, waste/recycling/FOGO), and layer 0 has been rebuilt as a **joined** ArcGIS layer (`Glass_Collection_Zones` joined with `Waste_Recycle_FOGO_Collection_Zones`), so its attributes now carry fully-qualified names:

```text
internal.gdo.Glass_Collection_Zones.anchor_date
internal.gdo.Glass_Collection_Zones.frequency_days
internal.gdo.Waste_Recycle_FOGO_Collection_Zones.recycling_anchor_date
…
```

(visible at <https://yccgis-prd.esriaustraliaonline.com.au/arcgis/rest/services/Waste_Services/CW_FC_PRD_Waste_Collection/MapServer/0?f=json>)

The source's bare-name glass query, `out_fields="anchor_date,frequency_days"`, is therefore rejected:

```text
$ curl ".../MapServer/0/query?f=json&where=1%3D1&outFields=anchor_date,frequency_days&resultRecordCount=1"
{"error":{"code":400,"message":"Failed to execute query.","details":[]}}
```

`query_feature_layer` surfaces the 400 as an `ArcGisError`, which the source maps to "address must be within the City of Yarra" — hence the misleading error for every valid address.

## Fix

- Query with `out_fields="*"` and resolve bare field names through a small `_attr` helper that accepts either bare or dot-qualified attribute keys (`key == name or key.endswith("." + name)`), so the source works under both naming schemes.
- The waste layer (layer 1, "Collection Day") still uses bare attribute names today, but it gets the same treatment so the source survives an equivalent rework of that layer. The cost is negligible — the query returns a single feature with ~14 scalar fields.
- The required `"."` separator means `…recycling_anchor_date` can never falsely satisfy a lookup for `anchor_date`.

With `out_fields="*"` the joined layer responds normally; the qualified keys resolve via `_attr`:

```text
"internal.gdo.Glass_Collection_Zones.anchor_date": "2026-07-10",
"internal.gdo.Glass_Collection_Zones.frequency_days": 28
```

## Test output

```text
$ test_sources.py -s yarracity_vic_gov_au -i -l
Testing source yarracity_vic_gov_au ...
  found 143 entries for Fitzroy Town Hall
    2026-08-19 : Rubbish [mdi:trash-can]
    2026-08-19 : FOGO [mdi:food-apple]
    2026-08-26 : Rubbish [mdi:trash-can]
    …
  found 143 entries for Richmond Town Hall
```

(143 entries per address matches the totals asserted in the cassette tests of #7180.)

Also run: `pytest tests/test_source_components.py` — 35 passed; `ruff check` / `ruff format --check` — clean. No doc changes needed: the source's arguments and usage are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
