### PR TITLE
Update waste_havant_gov_uk mapping

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/waste_havant_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/waste_havant_gov_uk.py
@@ -17,8 +17,8 @@ TEST_CASES = {
 }
 
 ICON_MAP = {
-    "Residual 240L": Icons.GENERAL_WASTE,
-    "Recycling 240L": Icons.RECYCLING,
+    "Residual": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
 }
 
 EVENTS_REGEX = re.compile(


### PR DESCRIPTION
## Summary

Havant's waste calendar subject names have been updated, stripping the size from the name. This change updates the names for waste type mapping.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
