### PR TITLE
Fix Broxtowe Firmstep workflow

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxtowe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxtowe_gov_uk.py
@@ -30,7 +30,7 @@ ICON_MAP = {
 }
 
 
-API_URL = "https://selfservice.broxtowe.gov.uk/renderform?t=217&k=9D2EF214E144EE796430597FB475C3892C43C528"
+API_URL = "https://selfservice.broxtowe.gov.uk/renderform?t=217&amp;k=9D2EF214E144EE796430597FB475C3892C43C528"
 ADDRESS_LOOKUP_URL = "https://selfservice.broxtowe.gov.uk/core/addresslookup"
 SUBMIT_URL = "https://selfservice.broxtowe.gov.uk/RenderForm"
 
@@ -80,6 +80,7 @@ class Source:
                 "FF5683lbltxt": address_label,
                 "FF5683-text": self._postcode,
             },
+            timeout=30,
         )
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
@@ -87,13 +88,13 @@ class Source:
         table = soup.find("table", class_="bartec")
 
         if table is None or isinstance(table, NavigableString):
-            raise Exception("could not get valid data from ashford.gov.uk")
+            raise Exception("could not get valid data from broxtowe.gov.uk")
 
         entries = []
         trs = table.find_all("tr")
 
         if not trs or len(trs) < 2:
-            raise Exception("could not get valid data from ashford.gov.uk")
+            raise Exception("could not get valid data from broxtowe.gov.uk")
 
         for row in trs[1:]:
             bint_type = row.find("td")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxtowe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxtowe_gov_uk.py
@@ -30,7 +30,7 @@ ICON_MAP = {
 }
 
 
-API_URL = "https://selfservice.broxtowe.gov.uk/renderform?t=217&amp;k=9D2EF214E144EE796430597FB475C3892C43C528"
+API_URL = "https://selfservice.broxtowe.gov.uk/renderform?t=217&k=9D2EF214E144EE796430597FB475C3892C43C528"
 ADDRESS_LOOKUP_URL = "https://selfservice.broxtowe.gov.uk/core/addresslookup"
 SUBMIT_URL = "https://selfservice.broxtowe.gov.uk/RenderForm"
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxtowe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/broxtowe_gov_uk.py
@@ -2,9 +2,13 @@ import datetime
 import logging
 
 import requests
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import BeautifulSoup, NavigableString
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentException
+from waste_collection_schedule.service.FirmstepSelfService import (
+    get_hidden_form_inputs,
+    lookup_addresses,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,24 +30,9 @@ ICON_MAP = {
 }
 
 
-API_URL = "https://selfservice.broxtowe.gov.uk/renderform.aspx?t=217&k=9D2EF214E144EE796430597FB475C3892C43C528"
-
-
-POSTCODE_ARGS = {
-    "ctl00$ScriptManager1": "ctl00$ContentPlaceHolder1$APUP_5683|ctl00$ContentPlaceHolder1$FF5683BTN",
-    "__EVENTTARGET": "ctl00$ContentPlaceHolder1$FF5683BTN",
-    "__ASYNCPOST": "true",
-}
-
-UPRN_ARGS = {
-    "ctl00$ScriptManager1": "ctl00$ContentPlaceHolder1$APUP_5683|ctl00$ContentPlaceHolder1$FF5683DDL",
-    "__EVENTTARGET": "ctl00$ContentPlaceHolder1$FF5683DDL",
-    "__ASYNCPOST": "true",
-}
-
-SUBMIT_ARGS = {
-    "__EVENTTARGET": "ctl00$ContentPlaceHolder1$btnSubmit",
-}
+API_URL = "https://selfservice.broxtowe.gov.uk/renderform?t=217&k=9D2EF214E144EE796430597FB475C3892C43C528"
+ADDRESS_LOOKUP_URL = "https://selfservice.broxtowe.gov.uk/core/addresslookup"
+SUBMIT_URL = "https://selfservice.broxtowe.gov.uk/RenderForm"
 
 
 class Source:
@@ -53,72 +42,46 @@ class Source:
             self._uprn = self._uprn[1:].strip()
 
         self._postcode: str = str(postcode)
-        self._uprn_args = UPRN_ARGS.copy()
-        self._postcode_args = POSTCODE_ARGS.copy()
-        self._submit_args = SUBMIT_ARGS.copy()
-        self._uprn_args["ctl00$ContentPlaceHolder1$FF5683DDL"] = f"U{self._uprn}"
-        self._postcode_args["ctl00$ContentPlaceHolder1$FF5683TB"] = f"{self._postcode}"
-
-    def __get_hidden_fiels(
-        self, response: requests.Response, to_update: dict[str, str]
-    ):
-        response.raise_for_status()
-        r_list = response.text.split("|")
-
-        if r_list[1] == "error":
-            raise Exception("could not get valid data from ashford.gov.uk")
-
-        indexes = [
-            index for index, value in enumerate(r_list) if value == "hiddenField"
-        ]
-
-        for index in indexes:
-            key = r_list[index + 1]
-            value = r_list[index + 2]
-            to_update[key] = value
 
     def fetch(self):
         s = requests.Session()
         headers = {"User-Agent": "Mozilla/5.0"}
         s.headers.update(headers)
 
-        r = s.get(API_URL)
-        r.raise_for_status()
-
-        soup = BeautifulSoup(r.text, "html.parser")
-        for key in ["__VIEWSTATE", "__VIEWSTATEGENERATOR", "__EVENTVALIDATION"]:
-            search = soup.find(id=key)
-            if not search or not isinstance(search, Tag):
-                continue
-
-            self._postcode_args[key] = search.attrs["value"]
-
-        r = s.post(API_URL, data=self._postcode_args)
-        r.raise_for_status()
-
-        if "No addresses were found for the post code you entered." in r.text:
+        form_inputs = get_hidden_form_inputs(s, API_URL)
+        addresses = lookup_addresses(s, ADDRESS_LOOKUP_URL, self._postcode)
+        if not addresses:
             raise SourceArgumentException(
                 "postcode", "No addresses were found for the post code you entered."
             )
 
-        self.__get_hidden_fiels(r, self._uprn_args)
-
-        r = s.post(API_URL, data=self._uprn_args)
-        r.raise_for_status()
-
-        self.__get_hidden_fiels(r, self._submit_args)
-
-        self._submit_args["ctl00$ContentPlaceHolder1$btnSubmit"] = (
-            "ctl00$ContentPlaceHolder1$btnSubmit"
+        address = next(
+            (
+                (key, value)
+                for key, value in addresses.items()
+                if key.strip().upper().removeprefix("U") == self._uprn
+            ),
+            None,
         )
-        r = s.post(API_URL, data=self._submit_args)
-        r.raise_for_status()
-
-        if "No collection calendars are available for the selected property." in r.text:
-            raise Exception(
-                f"No collection calendars are available for the selected property. Make sure your address returns entries on the council website ({API_URL})."
+        if address is None:
+            raise SourceArgumentException(
+                "uprn",
+                "No address was found for the UPRN and postcode you entered.",
             )
 
+        address_key, address_label = address
+        r = s.post(
+            SUBMIT_URL,
+            data={
+                **form_inputs,
+                "Trigger": "submit",
+                "TriggerCtl": "",
+                "FF5683": address_key,
+                "FF5683lbltxt": address_label,
+                "FF5683-text": self._postcode,
+            },
+        )
+        r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 
         table = soup.find("table", class_="bartec")

--- a/doc/source/broxtowe_gov_uk.md
+++ b/doc/source/broxtowe_gov_uk.md
@@ -42,10 +42,9 @@ Use your postcode as postcode argument
 
 An easy way to find your Unique Property Reference Number (UPRN) is by going to <https://www.findmyaddress.co.uk/> and entering your address details.
 
-### Get Your UPRN analysing browser traffic
+### Get Your UPRN by analysing browser traffic
 
-- Fill out your postcode at https://selfservice.broxtowe.gov.uk/renderform.aspx?t=217&k=9D2EF214E144EE796430597FB475C3892C43C528 and press `Search`.
+- Fill out your postcode at https://selfservice.broxtowe.gov.uk/renderform?t=217&k=9D2EF214E144EE796430597FB475C3892C43C528 and press `Find address`.
 - Open your browser developer tools (in most browser `F12` or `right click -> inspect`) and open the `network` tab.
-- Select your address.
-- Your network tab should receive a new request, open it.
-- Select `request`. You should now see the argument `ctl00$ContentPlaceHolder1$FF5683DDL` containing your UPRN with a U as prefix (example: `ctl00$ContentPlaceHolder1$FF5683DDL: U100031343805` means your UPRN is `100031343805`).
+- Open the `core/addresslookup` request and inspect its JSON response.
+- Find your address. Its `Key` value contains your UPRN with a `U` prefix (for example, `U100031343805` means your UPRN is `100031343805`).


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [X] Bug fix / source fix
- [X] Documentation update
- [ ] Other

## Checklist

- [X] `python -m pytest tests/test_source_components.py -q` passes
- [X] `ruff check --fix` and `ruff format` run on changed source files
- [X] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [X] `doc/source/<name>.md` created for new sources
- [X] TEST_CASES use real, publicly accessible addresses (not my own)

---

Fixes Broxtowe Borough Council collection lookup after the self-service form moved from the legacy ASP flow to the new Firmstep address lookup/submit flow.

Validation:
- `python -m pytest tests/test_source_components.py -q`
- `ruff check --fix` / `ruff format`
- `test_sources.py -s broxtowe_gov_uk -l`