### PR TITLE
Add Municipium (it) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
@@ -44,6 +44,7 @@ TEST_CASES = {
 # comuni work, because the source resolves the comune against the platform
 # directory at runtime. More comuni can be added here as they are verified.
 COMUNI = [
+    ("Acate", "RG"),
     ("Serrastretta", "CZ"),
 ]
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
@@ -20,6 +20,10 @@ SOURCE_CODEOWNERS = ["@fedfus"]
 # Central directory of every municipality on the platform.
 CLOUD_URL = "https://cloud.municipiumapp.it"
 
+# Network timeout (seconds) for every outbound request, so an unresponsive
+# endpoint cannot occupy a Home Assistant executor worker indefinitely.
+TIMEOUT = 30
+
 TEST_CASES = {
     "Serrastretta (CZ) - Zona 2 Migliuso": {
         "municipality": "Serrastretta",
@@ -35,17 +39,11 @@ TEST_CASES = {
 }
 
 # Municipalities on the platform that expose a waste calendar, as (name,
-# province). This is only used to advertise coverage in the docs; it does not
-# limit which comuni work. The full list must be produced with a throttled scan
-# of the /municipalities directory (the platform WAF rate-limits bulk requests),
-# via tools/municipium_scan.py before opening the PR. The few below are the ones
-# verified end-to-end during development.
+# province). This only advertises coverage in the docs; it does NOT limit which
+# comuni work, because the source resolves the comune against the platform
+# directory at runtime. More comuni can be added here as they are verified.
 COMUNI = [
     ("Serrastretta", "CZ"),
-    ("Acate", "RG"),
-    ("Affi", "VR"),
-    ("Acquanegra Cremonese", "CR"),
-    ("Adrara San Rocco", "BG"),
 ]
 
 
@@ -79,10 +77,10 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "(area), the error message will list the available zone names; pass the one "
     "that matches your address as 'area'. A partial name (e.g. 'Zona 2') is "
     "enough, or you can pass the numeric calendar id.",
-    "it": "Inserisci il nome del tuo comune cosi come appare nell'app Municipium. "
-    "Se il comune ha piu di una zona di raccolta (area), il messaggio di errore "
-    "elenchera i nomi delle zone disponibili; indica come 'area' quella che "
-    "corrisponde al tuo indirizzo. E sufficiente un nome parziale (es. 'Zona 2'), "
+    "it": "Inserisci il nome del tuo comune così come appare nell'app Municipium. "
+    "Se il comune ha più di una zona di raccolta (area), il messaggio di errore "
+    "elencherà i nomi delle zone disponibili; indica come 'area' quella che "
+    "corrisponde al tuo indirizzo. È sufficiente un nome parziale (es. 'Zona 2'), "
     "oppure puoi passare l'id numerico del calendario.",
 }
 
@@ -95,7 +93,7 @@ PARAM_DESCRIPTIONS = {
     "it": {
         "municipality": "Il comune, ad esempio 'Serrastretta'.",
         "area": "Il nome della zona di raccolta (o una parte), oppure l'id "
-        "numerico del calendario. Serve solo se il comune ha piu di una zona.",
+        "numerico del calendario. Serve solo se il comune ha più di una zona.",
     },
 }
 
@@ -119,7 +117,7 @@ class Source:
         self._area = area
 
     def _find_municipality(self, session: requests.Session) -> dict:
-        r = session.get(f"{CLOUD_URL}/api/v2/municipalities")
+        r = session.get(f"{CLOUD_URL}/api/v2/municipalities", timeout=TIMEOUT)
         r.raise_for_status()
         comuni = r.json()
 
@@ -144,13 +142,18 @@ class Source:
             )
 
         muni_id = matches[0]["id"]
-        r = session.get(f"{CLOUD_URL}/api/v2/municipalities/show_mobile/{muni_id}")
+        r = session.get(
+            f"{CLOUD_URL}/api/v2/municipalities/show_mobile/{muni_id}",
+            timeout=TIMEOUT,
+        )
         r.raise_for_status()
         return r.json()
 
     def _pick_calendar(self, calendars: "list[dict]") -> dict:
         if not calendars:
             raise SourceArgumentNotFoundWithSuggestions("area", self._area, [])
+
+        names = [c["name"] for c in calendars]
 
         # Explicit calendar id.
         if isinstance(self._area, int) or (
@@ -159,14 +162,10 @@ class Source:
             wanted_id = int(self._area)
             found = next((c for c in calendars if c["id"] == wanted_id), None)
             if found is None:
-                raise SourceArgumentNotFoundWithSuggestions(
-                    "area",
-                    self._area,
-                    [f"{c['name']} (id {c['id']})" for c in calendars],
-                )
+                # Suggest the zone names: they are valid `area` inputs (an
+                # id label like "Name (id 123)" would be rejected on re-entry).
+                raise SourceArgumentNotFoundWithSuggestions("area", self._area, names)
             return found
-
-        names = [c["name"] for c in calendars]
 
         if self._area is None:
             if len(calendars) == 1:
@@ -203,7 +202,7 @@ class Source:
             )
         api = f"https://{subdomain}/api/v2"
 
-        r = session.get(f"{api}/calendars")
+        r = session.get(f"{api}/calendars", timeout=TIMEOUT)
         r.raise_for_status()
         calendar = self._pick_calendar(r.json())
 
@@ -223,6 +222,7 @@ class Source:
         r = session.get(
             f"{api}/calendars/{calendar['id']}",
             params={"start": start, "end": end},
+            timeout=TIMEOUT,
         )
         r.raise_for_status()
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
@@ -4,6 +4,7 @@ from difflib import get_close_matches
 import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
     SourceArgumentNotFoundWithSuggestions,
     SourceArgumentRequiredWithSuggestions,
 )
@@ -137,7 +138,7 @@ class Source:
         if len(matches) > 1:
             # Same comune name in several provinces: disambiguate by province.
             labels = [f"{c['name']} ({c.get('province_initials')})" for c in matches]
-            raise SourceArgumentNotFoundWithSuggestions(
+            raise SourceArgAmbiguousWithSuggestions(
                 "municipality", self._municipality, labels
             )
 
@@ -181,6 +182,10 @@ class Source:
             subs = [c for c in calendars if wanted in c["name"].casefold()]
             if len(subs) == 1:
                 found = subs[0]
+            elif len(subs) > 1:
+                raise SourceArgAmbiguousWithSuggestions(
+                    "area", self._area, [c["name"] for c in subs]
+                )
         if found is None:
             suggestions = get_close_matches(str(self._area), names, n=5, cutoff=0.3)
             raise SourceArgumentNotFoundWithSuggestions(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
@@ -1,0 +1,233 @@
+import datetime
+from difflib import get_close_matches
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequiredWithSuggestions,
+)
+
+TITLE = "Municipium"
+DESCRIPTION = (
+    "Source for the Municipium app (Maggioli S.p.A.), used by many Italian "
+    "municipalities to publish their door-to-door waste collection calendar."
+)
+URL = "https://www.municipiumapp.it"
+COUNTRY = "it"
+SOURCE_CODEOWNERS = ["@fedfus"]
+
+# Central directory of every municipality on the platform.
+CLOUD_URL = "https://cloud.municipiumapp.it"
+
+TEST_CASES = {
+    "Serrastretta (CZ) - Zona 2 Migliuso": {
+        "municipality": "Serrastretta",
+        "area": "Zona 2",
+    },
+    "Serrastretta (CZ) - by calendar id": {
+        "municipality": "Serrastretta",
+        "area": 10325,
+    },
+    "Acate (RG)": {
+        "municipality": "Acate",
+    },
+}
+
+# Municipalities on the platform that expose a waste calendar, as (name,
+# province). This is only used to advertise coverage in the docs; it does not
+# limit which comuni work. The full list must be produced with a throttled scan
+# of the /municipalities directory (the platform WAF rate-limits bulk requests),
+# via tools/municipium_scan.py before opening the PR. The few below are the ones
+# verified end-to-end during development.
+COMUNI = [
+    ("Serrastretta", "CZ"),
+    ("Acate", "RG"),
+    ("Affi", "VR"),
+    ("Acquanegra Cremonese", "CR"),
+    ("Adrara San Rocco", "BG"),
+]
+
+
+def EXTRA_INFO():
+    for name, province in COMUNI:
+        yield {"title": f"{name} ({province})", "country": "it"}
+
+
+# Municipium categories vary per municipality; match on a normalised keyword.
+ICON_MAP = {
+    "umido": Icons.BIO_KITCHEN,
+    "organico": Icons.BIO_KITCHEN,
+    "secco": Icons.GENERAL_WASTE,
+    "indifferenziato": Icons.GENERAL_WASTE,
+    "residuo": Icons.GENERAL_WASTE,
+    "carta": Icons.PAPER,
+    "cartone": Icons.PAPER,
+    "vetro": Icons.GLASS,
+    "plastica": Icons.PLASTIC_PACKAGING,
+    "lattine": Icons.METAL,
+    "metallo": Icons.METAL,
+    "multimateriale": Icons.RECYCLING,
+    "verde": Icons.GARDEN,
+    "sfalci": Icons.GARDEN,
+    "vegetale": Icons.GARDEN,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter the name of your municipality (comune) as it appears in the "
+    "Municipium app. If the municipality has more than one collection zone "
+    "(area), the error message will list the available zone names; pass the one "
+    "that matches your address as 'area'. A partial name (e.g. 'Zona 2') is "
+    "enough, or you can pass the numeric calendar id.",
+    "it": "Inserisci il nome del tuo comune cosi come appare nell'app Municipium. "
+    "Se il comune ha piu di una zona di raccolta (area), il messaggio di errore "
+    "elenchera i nomi delle zone disponibili; indica come 'area' quella che "
+    "corrisponde al tuo indirizzo. E sufficiente un nome parziale (es. 'Zona 2'), "
+    "oppure puoi passare l'id numerico del calendario.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "municipality": "The municipality (comune), e.g. 'Serrastretta'.",
+        "area": "The collection zone name (or a part of it), or the numeric "
+        "calendar id. Only needed when the municipality has more than one zone.",
+    },
+    "it": {
+        "municipality": "Il comune, ad esempio 'Serrastretta'.",
+        "area": "Il nome della zona di raccolta (o una parte), oppure l'id "
+        "numerico del calendario. Serve solo se il comune ha piu di una zona.",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {"municipality": "Municipality", "area": "Zone / Calendar"},
+    "it": {"municipality": "Comune", "area": "Zona / Calendario"},
+}
+
+
+def _icon_for(name: str):
+    low = name.casefold()
+    for key, icon in ICON_MAP.items():
+        if key in low:
+            return icon
+    return None
+
+
+class Source:
+    def __init__(self, municipality: str, area: "str | int | None" = None):
+        self._municipality: str = municipality
+        self._area = area
+
+    def _find_municipality(self, session: requests.Session) -> dict:
+        r = session.get(f"{CLOUD_URL}/api/v2/municipalities")
+        r.raise_for_status()
+        comuni = r.json()
+
+        wanted = self._municipality.strip().casefold()
+        matches = [c for c in comuni if c["name"].casefold() == wanted]
+        if not matches:
+            names = [c["name"] for c in comuni]
+            suggestions = get_close_matches(self._municipality, names, n=5, cutoff=0.4)
+            raise SourceArgumentNotFoundWithSuggestions(
+                "municipality", self._municipality, suggestions
+            )
+        if len(matches) > 1:
+            # Same comune name in several provinces: disambiguate by province.
+            labels = [f"{c['name']} ({c.get('province_initials')})" for c in matches]
+            raise SourceArgumentNotFoundWithSuggestions(
+                "municipality", self._municipality, labels
+            )
+
+        muni_id = matches[0]["id"]
+        r = session.get(f"{CLOUD_URL}/api/v2/municipalities/show_mobile/{muni_id}")
+        r.raise_for_status()
+        return r.json()
+
+    def _pick_calendar(self, calendars: "list[dict]") -> dict:
+        if not calendars:
+            raise SourceArgumentNotFoundWithSuggestions("area", self._area, [])
+
+        # Explicit calendar id.
+        if isinstance(self._area, int) or (
+            isinstance(self._area, str) and self._area.isdigit()
+        ):
+            wanted_id = int(self._area)
+            found = next((c for c in calendars if c["id"] == wanted_id), None)
+            if found is None:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "area",
+                    self._area,
+                    [f"{c['name']} (id {c['id']})" for c in calendars],
+                )
+            return found
+
+        names = [c["name"] for c in calendars]
+
+        if self._area is None:
+            if len(calendars) == 1:
+                return calendars[0]
+            raise SourceArgumentRequiredWithSuggestions(
+                "area", "this municipality has more than one collection zone", names
+            )
+
+        wanted = self._area.strip().casefold()
+        # Exact match, then unambiguous substring, then fuzzy suggestions.
+        found = next((c for c in calendars if c["name"].casefold() == wanted), None)
+        if found is None:
+            subs = [c for c in calendars if wanted in c["name"].casefold()]
+            if len(subs) == 1:
+                found = subs[0]
+        if found is None:
+            suggestions = get_close_matches(str(self._area), names, n=5, cutoff=0.3)
+            raise SourceArgumentNotFoundWithSuggestions(
+                "area", self._area, suggestions or names
+            )
+        return found
+
+    def fetch(self) -> "list[Collection]":
+        session = requests.Session()
+        session.headers["Accept"] = "application/json"
+        # The platform WAF rejects the default python-requests User-Agent.
+        session.headers["User-Agent"] = "Mozilla/5.0 (waste_collection_schedule)"
+
+        details = self._find_municipality(session)
+        subdomain = details.get("subdomain")
+        if not subdomain or not details.get("enable_garbage_calendar"):
+            raise SourceArgumentNotFoundWithSuggestions(
+                "municipality", self._municipality, []
+            )
+        api = f"https://{subdomain}/api/v2"
+
+        r = session.get(f"{api}/calendars")
+        r.raise_for_status()
+        calendar = self._pick_calendar(r.json())
+
+        # The calendar endpoint filters events by a [start, end] epoch-second window.
+        today = datetime.date.today()
+        start = int(
+            datetime.datetime.combine(
+                today - datetime.timedelta(days=30), datetime.time()
+            ).timestamp()
+        )
+        end = int(
+            datetime.datetime.combine(
+                today + datetime.timedelta(days=365), datetime.time()
+            ).timestamp()
+        )
+
+        r = session.get(
+            f"{api}/calendars/{calendar['id']}",
+            params={"start": start, "end": end},
+        )
+        r.raise_for_status()
+
+        entries: list[Collection] = []
+        for ev in r.json():
+            title = (ev.get("category") or {}).get("name") or ev.get("title")
+            date_str = ev.get("start")
+            if not title or not date_str:
+                continue
+            date = datetime.datetime.fromisoformat(date_str).date()
+            entries.append(Collection(date=date, t=title, icon=_icon_for(title)))
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py
@@ -124,7 +124,12 @@ class Source:
         comuni = r.json()
 
         wanted = self._municipality.strip().casefold()
-        matches = [c for c in comuni if c["name"].casefold() == wanted]
+        matches = [
+            c
+            for c in comuni
+            if c["name"].casefold() == wanted
+            or f"{c['name']} ({c.get('province_initials')})".casefold() == wanted
+        ]
         if not matches:
             names = [c["name"] for c in comuni]
             suggestions = get_close_matches(self._municipality, names, n=5, cutoff=0.4)

--- a/doc/source/municipium_it.md
+++ b/doc/source/municipium_it.md
@@ -1,0 +1,61 @@
+# Municipium
+
+Support for waste collection schedules published through the [Municipium](https://www.municipiumapp.it) app (Maggioli S.p.A.), used by many Italian municipalities for their door-to-door (porta a porta) collection calendar.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: municipium_it
+      args:
+        municipality: "Serrastretta"
+        area: "Zona 2"
+```
+
+### Configuration Variables
+
+**municipality**
+*(string) (required)*
+
+The municipality (comune) as it appears in the Municipium app, e.g. `Serrastretta`. If the same name exists in more than one province, the integration raises an error listing the matches with their province so you can tell them apart.
+
+**area**
+*(string | integer) (optional)*
+
+The collection zone. Only needed when the municipality has more than one zone (many have a single one). You can pass:
+
+- the full zone name, e.g. `Utenza Domestica - Zona 2 - Frazioni Angoli, Migliuso, Cancello ed altri`,
+- a unique part of it, e.g. `Zona 2` or `Migliuso`, or
+- the numeric calendar id, e.g. `10326`.
+
+If the municipality has several zones and `area` is omitted (or doesn't match), the integration raises an error listing the available zone names.
+
+## How to find your municipality and area
+
+1. Open the Municipium app (or your comune's Municipium page) and go to the waste section (*Rifiuti*).
+2. Note the name of your comune and, if asked to choose one, your collection zone (*zona* / *utenza*).
+3. Use those values for `municipality` and `area`. Partial names are matched, so `Zona 2` is usually enough.
+
+## Supported municipalities
+
+Any Italian municipality on the Municipium platform that has published a waste calendar is supported — the source resolves the comune against the platform's own directory at runtime, so it is not limited to a fixed list. Examples verified during development: Serrastretta (CZ), Acate (RG), Affi (VR), Acquanegra Cremonese (CR), Adrara San Rocco (BG).
+
+The `EXTRA_INFO` coverage list in the source can be regenerated with `tools/municipium_scan.py` (it runs slowly because the platform rate-limits bulk requests).
+
+## Bin types returned
+
+The returned collection type (`t`) is the category name reported by Municipium for that comune (e.g. `Umido`, `Vetro`, `Plastica/Lattine`). Category names differ between municipalities, so icons are assigned by matching a keyword in the name:
+
+| Keyword in category name | Icon |
+|---|---|
+| umido, organico | `Icons.BIO_KITCHEN` |
+| secco, indifferenziato, residuo | `Icons.GENERAL_WASTE` |
+| carta, cartone | `Icons.PAPER` |
+| vetro | `Icons.GLASS` |
+| plastica | `Icons.PLASTIC_PACKAGING` |
+| lattine, metallo | `Icons.METAL` |
+| multimateriale | `Icons.RECYCLING` |
+| verde, sfalci, vegetale | `Icons.GARDEN` |
+
+Any category whose name matches no keyword is returned without an icon.

--- a/doc/source/municipium_it.md
+++ b/doc/source/municipium_it.md
@@ -39,7 +39,7 @@ If the municipality has several zones and `area` is omitted (or doesn't match), 
 
 ## Supported municipalities
 
-Any Italian municipality on the Municipium platform that has published a waste calendar is supported — the source resolves the comune against the platform's own directory at runtime, so it is not limited to a fixed list. The `EXTRA_INFO` list in the source (currently Serrastretta, CZ) only advertises verified coverage in the README and can be extended as more comuni are confirmed.
+Any Italian municipality on the Municipium platform that has published a waste calendar is supported — the source resolves the comune against the platform's own directory at runtime, so it is not limited to a fixed list. The `EXTRA_INFO` list in the source (currently Acate, RG and Serrastretta, CZ) only advertises verified coverage in the README and can be extended as more comuni are confirmed.
 
 ## Bin types returned
 

--- a/doc/source/municipium_it.md
+++ b/doc/source/municipium_it.md
@@ -39,9 +39,7 @@ If the municipality has several zones and `area` is omitted (or doesn't match), 
 
 ## Supported municipalities
 
-Any Italian municipality on the Municipium platform that has published a waste calendar is supported — the source resolves the comune against the platform's own directory at runtime, so it is not limited to a fixed list. Examples verified during development: Serrastretta (CZ), Acate (RG), Affi (VR), Acquanegra Cremonese (CR), Adrara San Rocco (BG).
-
-The `EXTRA_INFO` coverage list in the source can be regenerated with `tools/municipium_scan.py` (it runs slowly because the platform rate-limits bulk requests).
+Any Italian municipality on the Municipium platform that has published a waste calendar is supported — the source resolves the comune against the platform's own directory at runtime, so it is not limited to a fixed list. The `EXTRA_INFO` list in the source (currently Serrastretta, CZ) only advertises verified coverage in the README and can be extended as more comuni are confirmed.
 
 ## Bin types returned
 


### PR DESCRIPTION
Adds a new dedicated source for the **Municipium** app (Maggioli S.p.A.), the platform many Italian municipalities use to publish their door-to-door (*porta a porta*) waste collection calendar. Provider website: https://www.municipiumapp.it

**Why a dedicated source** — Municipium offers no ICS/webcal subscription or stable static file, so the generic ICS route doesn't apply. The data is only available through the app's JSON API (`/api/v2`), which this source consumes.

**How it works**
- Resolves the municipality by name against the platform directory (`cloud.municipiumapp.it/api/v2/municipalities`) at runtime → not limited to a fixed list of comuni.
- Reads events from the comune's subdomain (`<comune>-api.municipiumapp.it/api/v2/calendars/<id>`), filtered by a `[start, end]` epoch-second window.
- Zone selected by full name, unique partial name (`Zona 2`, `Migliuso`), or numeric calendar id; single-zone comuni need no `area`.
- Duplicate comune name across provinces, unknown comune, or multi-zone with missing/ambiguous `area` → `SourceArgument*WithSuggestions`, so the HA UI shows valid options.

**Files added**
- `custom_components/waste_collection_schedule/waste_collection_schedule/source/municipium_it.py`
- `doc/source/municipium_it.md`

No generated files included (left to post-merge CI).

**Test output** — `python test_sources.py -s municipium_it`:
```
Testing source municipium_it ...
  found 140 entries for Serrastretta (CZ) - Zona 2 Migliuso
  found 138 entries for Serrastretta (CZ) - by calendar id
  found 186 entries for Acate (RG)
```
Structural suite: `pytest tests/test_source_components.py -q` → `35 passed`.