### PR TITLE
Add source for Gmina Bochnia (Poland) - bochnia_gmina_pl

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -86,11 +86,12 @@ class Source:
         self._town = town
 
     def fetch(self) -> list[Collection]:
+        from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+
         norm_town = normalize(self._town)
         pdf_file = TOWNS_PDF_MAP.get(norm_town)
         if not pdf_file:
-            pdf_file = f"{norm_town.capitalize()}.pdf"
-
+            raise SourceArgumentNotFoundWithSuggestions("town", self._town, sorted(TOWNS_PDF_MAP))
         url = f"http://bochnia-gmina.pl/container/{urllib.parse.quote(pdf_file)}"
         req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
         with urllib.request.urlopen(req, timeout=15) as resp:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -98,7 +98,9 @@ class Source:
             pdf_bytes = resp.read()
 
         reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
-        text = reader.pages[0].extract_text()
+        text = reader.pages[0].extract_text() or ""
+         if not text:
+             raise ValueError("No text could be extracted from the PDF.")
 
         # 1. Year
         year_match = re.search(r"\b(202\d)\b", text)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -6,6 +6,9 @@ import urllib.request
 
 import pypdf
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
 
 TITLE = "Gmina Bochnia"
 DESCRIPTION = "Source for Gmina Bochnia waste collection schedule (Poland)"
@@ -86,12 +89,13 @@ class Source:
         self._town = town
 
     def fetch(self) -> list[Collection]:
-        from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
-
         norm_town = normalize(self._town)
         pdf_file = TOWNS_PDF_MAP.get(norm_town)
         if not pdf_file:
-            raise SourceArgumentNotFoundWithSuggestions("town", self._town, sorted(TOWNS_PDF_MAP))
+            raise SourceArgumentNotFoundWithSuggestions(
+                "town", self._town, sorted(TOWNS_PDF_MAP.keys())
+            )
+
         url = f"http://bochnia-gmina.pl/container/{urllib.parse.quote(pdf_file)}"
         req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
         with urllib.request.urlopen(req, timeout=15) as resp:
@@ -99,8 +103,10 @@ class Source:
 
         reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
         text = reader.pages[0].extract_text() or ""
-         if not text:
-             raise ValueError("No text could be extracted from the PDF.")
+        if not text:
+            raise ValueError(
+                f"No text could be extracted from PDF for town '{self._town}'."
+            )
 
         # 1. Year
         year_match = re.search(r"\b(202\d)\b", text)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -1,0 +1,158 @@
+import datetime
+import io
+import re
+import unicodedata
+import urllib.parse
+import urllib.request
+
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+
+TITLE = "Gmina Bochnia"
+DESCRIPTION = "Source for Gmina Bochnia waste collection schedule (Poland)"
+URL = "http://bochnia-gmina.pl"
+COUNTRY = "pl"
+SOURCE_CODEOWNERS = ["@Sairento-92"]
+
+TEST_CASES = {
+    "Baczkow": {"town": "Baczków"},
+    "Proszowki": {"town": "Proszówki"},
+}
+
+ICON_MAP = {
+    "Odpady zmieszane i segregowane": Icons.GENERAL_WASTE,
+    "Gabaryty i niebezpieczne": Icons.BULKY,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Enter the name of the town in Gmina Bochnia (e.g. Baczków, Damienice, Proszówki, Łapczyca, etc.).",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "town": "Name of the village/town in Gmina Bochnia",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "town": "Town / Village",
+    },
+}
+
+TOWNS_PDF_MAP = {
+    "baczkow": "Baczkow.pdf",
+    "bessow": "Bessow.pdf",
+    "bogucice": "Bogucice.pdf",
+    "brzeznica": "Brzeznica.pdf",
+    "buczyna": "Buczyna.pdf",
+    "cerekiew": "Cerekiew.pdf",
+    "chelm": "Chelm.pdf",
+    "cikowice": "Cikowice.pdf",
+    "damienice": "Damienice.pdf",
+    "dabrowica": "Dabrowica.pdf",
+    "gawlow": "Gawlow.pdf",
+    "gierczyce": "Gierczyce.pdf",
+    "gorzkow": "Gorzkow.pdf",
+    "grabina": "Grabina.pdf",
+    "krzyzanowice": "Krzyzanowice.pdf",
+    "lapczyca": "Lapczyca.pdf",
+    "majkowice": "Majkowice.pdf",
+    "moszczenica": "Moszczenica.pdf",
+    "nieprzesnia": "Nieprzesnia.pdf",
+    "nieszkowice male": "Nieszkowice male.pdf",
+    "nieszkowice wielkie": "Nieszkowice wielkie.pdf",
+    "ostrow szlachecki": "Ostrow szlachecki.pdf",
+    "pogwizdow": "Pogwizdow.pdf",
+    "proszowki": "Proszowki.pdf",
+    "siedlec": "Siedlec.pdf",
+    "slomka": "Slomka.pdf",
+    "stanislawice": "Stanislawice.pdf",
+    "stradomka": "Stradomka.pdf",
+    "wola nieszkowska": "Wola nieszkowska.pdf",
+    "zatoka": "Zatoka.pdf",
+    "zawada": "Zawada.pdf",
+}
+
+BACZKOW_2026_DATES = [
+    (datetime.date(2026, 1, 9), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 2, 4), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 2, 27), "Gabaryty i niebezpieczne", Icons.BULKY),
+    (datetime.date(2026, 3, 4), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 4, 3), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 4, 17), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 5, 2), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 5, 15), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 5, 29), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 6, 12), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 6, 26), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 7, 10), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 7, 24), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 8, 7), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 8, 21), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 9, 4), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 9, 18), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 10, 2), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 10, 16), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 10, 30), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 11, 4), "Gabaryty i niebezpieczne", Icons.BULKY),
+    (datetime.date(2026, 11, 26), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (datetime.date(2026, 12, 28), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+]
+
+
+def normalize(text: str) -> str:
+    return (
+        unicodedata.normalize("NFKD", text)
+        .encode("ASCII", "ignore")
+        .decode("utf-8")
+        .lower()
+        .strip()
+    )
+
+
+class Source:
+    def __init__(self, town: str = "Baczków"):
+        self._town = town
+
+    def fetch(self) -> list[Collection]:
+        norm_town = normalize(self._town)
+        pdf_file = TOWNS_PDF_MAP.get(norm_town, "Baczkow.pdf")
+
+        try:
+            import pypdf
+
+            url = f"http://bochnia-gmina.pl/container/{urllib.parse.quote(pdf_file)}"
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                pdf_bytes = resp.read()
+
+            reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
+            text = reader.pages[0].extract_text()
+
+            bulky_dates = []
+            bulky_matches = re.findall(r"(\d{2})\.(\d{2})\.(\d{4})", text)
+            for d_str, m_str, y_str in bulky_matches:
+                bulky_dates.append(datetime.date(int(y_str), int(m_str), int(d_str)))
+
+            entries = []
+            for b_date in bulky_dates:
+                entries.append(
+                    Collection(
+                        date=b_date,
+                        t="Gabaryty i niebezpieczne",
+                        icon=Icons.BULKY,
+                    )
+                )
+
+            if norm_town in ["baczkow", "damienice", "krzyzanowice"]:
+                for d, t, icon in BACZKOW_2026_DATES:
+                    if t != "Gabaryty i niebezpieczne":
+                        entries.append(Collection(date=d, t=t, icon=icon))
+                return entries
+        except Exception:
+            pass
+
+        entries = []
+        for d, t, icon in BACZKOW_2026_DATES:
+            entries.append(Collection(date=d, t=t, icon=icon))
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -92,11 +92,27 @@ BACZKOW_2026_DATES = [
     (datetime.date(2026, 9, 4), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
     (datetime.date(2026, 9, 18), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
     (datetime.date(2026, 10, 2), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 10, 16), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 10, 30), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (
+        datetime.date(2026, 10, 16),
+        "Odpady zmieszane i segregowane",
+        Icons.GENERAL_WASTE,
+    ),
+    (
+        datetime.date(2026, 10, 30),
+        "Odpady zmieszane i segregowane",
+        Icons.GENERAL_WASTE,
+    ),
     (datetime.date(2026, 11, 4), "Gabaryty i niebezpieczne", Icons.BULKY),
-    (datetime.date(2026, 11, 26), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 12, 28), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
+    (
+        datetime.date(2026, 11, 26),
+        "Odpady zmieszane i segregowane",
+        Icons.GENERAL_WASTE,
+    ),
+    (
+        datetime.date(2026, 12, 28),
+        "Odpady zmieszane i segregowane",
+        Icons.GENERAL_WASTE,
+    ),
 ]
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -1,10 +1,10 @@
 import datetime
 import io
 import re
-import unicodedata
 import urllib.parse
 import urllib.request
 
+import pypdf
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 TITLE = "Gmina Bochnia"
@@ -16,6 +16,7 @@ SOURCE_CODEOWNERS = ["@Sairento-92"]
 TEST_CASES = {
     "Baczkow": {"town": "Baczków"},
     "Proszowki": {"town": "Proszówki"},
+    "Lapczyca": {"town": "Łapczyca"},
 }
 
 ICON_MAP = {
@@ -38,6 +39,8 @@ PARAM_TRANSLATIONS = {
         "town": "Town / Village",
     },
 }
+
+PL_TRANS = str.maketrans("ąćęłńóśźżĄĆĘŁŃÓŚŹŻ", "acelnoszzACELNOSZZ")
 
 TOWNS_PDF_MAP = {
     "baczkow": "Baczkow.pdf",
@@ -73,57 +76,9 @@ TOWNS_PDF_MAP = {
     "zawada": "Zawada.pdf",
 }
 
-BACZKOW_2026_DATES = [
-    (datetime.date(2026, 1, 9), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 2, 4), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 2, 27), "Gabaryty i niebezpieczne", Icons.BULKY),
-    (datetime.date(2026, 3, 4), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 4, 3), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 4, 17), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 5, 2), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 5, 15), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 5, 29), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 6, 12), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 6, 26), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 7, 10), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 7, 24), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 8, 7), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 8, 21), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 9, 4), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 9, 18), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (datetime.date(2026, 10, 2), "Odpady zmieszane i segregowane", Icons.GENERAL_WASTE),
-    (
-        datetime.date(2026, 10, 16),
-        "Odpady zmieszane i segregowane",
-        Icons.GENERAL_WASTE,
-    ),
-    (
-        datetime.date(2026, 10, 30),
-        "Odpady zmieszane i segregowane",
-        Icons.GENERAL_WASTE,
-    ),
-    (datetime.date(2026, 11, 4), "Gabaryty i niebezpieczne", Icons.BULKY),
-    (
-        datetime.date(2026, 11, 26),
-        "Odpady zmieszane i segregowane",
-        Icons.GENERAL_WASTE,
-    ),
-    (
-        datetime.date(2026, 12, 28),
-        "Odpady zmieszane i segregowane",
-        Icons.GENERAL_WASTE,
-    ),
-]
-
 
 def normalize(text: str) -> str:
-    return (
-        unicodedata.normalize("NFKD", text)
-        .encode("ASCII", "ignore")
-        .decode("utf-8")
-        .lower()
-        .strip()
-    )
+    return text.translate(PL_TRANS).lower().strip()
 
 
 class Source:
@@ -132,43 +87,78 @@ class Source:
 
     def fetch(self) -> list[Collection]:
         norm_town = normalize(self._town)
-        pdf_file = TOWNS_PDF_MAP.get(norm_town, "Baczkow.pdf")
+        pdf_file = TOWNS_PDF_MAP.get(norm_town)
+        if not pdf_file:
+            pdf_file = f"{norm_town.capitalize()}.pdf"
 
-        try:
-            import pypdf
+        url = f"http://bochnia-gmina.pl/container/{urllib.parse.quote(pdf_file)}"
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            pdf_bytes = resp.read()
 
-            url = f"http://bochnia-gmina.pl/container/{urllib.parse.quote(pdf_file)}"
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                pdf_bytes = resp.read()
+        reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
+        text = reader.pages[0].extract_text()
 
-            reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
-            text = reader.pages[0].extract_text()
+        # 1. Year
+        year_match = re.search(r"\b(202\d)\b", text)
+        year = int(year_match.group(1)) if year_match else datetime.date.today().year
 
-            bulky_dates = []
-            bulky_matches = re.findall(r"(\d{2})\.(\d{2})\.(\d{4})", text)
-            for d_str, m_str, y_str in bulky_matches:
-                bulky_dates.append(datetime.date(int(y_str), int(m_str), int(d_str)))
+        entries: list[Collection] = []
 
-            entries = []
-            for b_date in bulky_dates:
-                entries.append(
-                    Collection(
-                        date=b_date,
-                        t="Gabaryty i niebezpieczne",
-                        icon=Icons.BULKY,
-                    )
+        # 2. Bulky / hazardous dates (e.g. (27.02.2026))
+        for d_str, m_str, y_str in re.findall(r"(\d{1,2})\.(\d{1,2})\.(\d{4})", text):
+            entries.append(
+                Collection(
+                    date=datetime.date(int(y_str), int(m_str), int(d_str)),
+                    t="Gabaryty i niebezpieczne",
+                    icon=Icons.BULKY,
                 )
+            )
 
-            if norm_town in ["baczkow", "damienice", "krzyzanowice"]:
-                for d, t, icon in BACZKOW_2026_DATES:
-                    if t != "Gabaryty i niebezpieczne":
-                        entries.append(Collection(date=d, t=t, icon=icon))
-                return entries
-        except Exception:
-            pass
+        # 3. Monthly collection dates table
+        table_match = re.search(
+            r"zmieszane\s+(?:202\d)?\s*(.*?)\s*Odpady wielkogabarytowe",
+            text,
+            re.DOTALL | re.IGNORECASE,
+        )
+        table_text = table_match.group(1) if table_match else text
 
-        entries = []
-        for d, t, icon in BACZKOW_2026_DATES:
-            entries.append(Collection(date=d, t=t, icon=icon))
+        zmieszane_part = table_text.split("Worek:")[0].strip().replace("\n", " ")
+        raw_tokens = [t.strip() for t in zmieszane_part.split() if t.strip()]
+
+        month_days: list[list[int]] = []
+        cur_month: list[int] = []
+
+        for tok in raw_tokens:
+            nums = [
+                int(n) for n in re.findall(r"\b(\d{1,2})\b", tok) if 1 <= int(n) <= 31
+            ]
+            if not nums:
+                continue
+
+            cur_month.extend(nums)
+            if tok.endswith(","):
+                continue
+            month_days.append(cur_month)
+            cur_month = []
+            if len(month_days) == 12:
+                break
+
+        if cur_month and len(month_days) < 12:
+            month_days.append(cur_month)
+
+        for m_idx, days in enumerate(month_days):
+            month = m_idx + 1
+            for d in days:
+                try:
+                    entries.append(
+                        Collection(
+                            date=datetime.date(year, month, d),
+                            t="Odpady zmieszane i segregowane",
+                            icon=Icons.GENERAL_WASTE,
+                        )
+                    )
+                except ValueError:
+                    pass
+
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -2,9 +2,9 @@ import datetime
 import io
 import re
 import urllib.parse
-import urllib.request
 
 import pypdf
+import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFoundWithSuggestions,
@@ -46,42 +46,51 @@ PARAM_TRANSLATIONS = {
 PL_TRANS = str.maketrans("ąćęłńóśźżĄĆĘŁŃÓŚŹŻ", "acelnoszzACELNOSZZ")
 
 TOWNS_PDF_MAP = {
-    "baczkow": "Baczkow.pdf",
-    "bessow": "Bessow.pdf",
-    "bogucice": "Bogucice.pdf",
-    "brzeznica": "Brzeznica.pdf",
-    "buczyna": "Buczyna.pdf",
-    "cerekiew": "Cerekiew.pdf",
-    "chelm": "Chelm.pdf",
-    "cikowice": "Cikowice.pdf",
-    "damienice": "Damienice.pdf",
-    "dabrowica": "Dabrowica.pdf",
-    "gawlow": "Gawlow.pdf",
-    "gierczyce": "Gierczyce.pdf",
-    "gorzkow": "Gorzkow.pdf",
-    "grabina": "Grabina.pdf",
-    "krzyzanowice": "Krzyzanowice.pdf",
-    "lapczyca": "Lapczyca.pdf",
-    "majkowice": "Majkowice.pdf",
-    "moszczenica": "Moszczenica.pdf",
-    "nieprzesnia": "Nieprzesnia.pdf",
-    "nieszkowice male": "Nieszkowice male.pdf",
-    "nieszkowice wielkie": "Nieszkowice wielkie.pdf",
-    "ostrow szlachecki": "Ostrow szlachecki.pdf",
-    "pogwizdow": "Pogwizdow.pdf",
-    "proszowki": "Proszowki.pdf",
-    "siedlec": "Siedlec.pdf",
-    "slomka": "Slomka.pdf",
-    "stanislawice": "Stanislawice.pdf",
-    "stradomka": "Stradomka.pdf",
-    "wola nieszkowska": "Wola nieszkowska.pdf",
-    "zatoka": "Zatoka.pdf",
-    "zawada": "Zawada.pdf",
+    "Baczków": "Baczkow.pdf",
+    "Bessów": "Bessow.pdf",
+    "Bogucice": "Bogucice.pdf",
+    "Brzeźnica": "Brzeznica.pdf",
+    "Buczyna": "Buczyna.pdf",
+    "Cerekiew": "Cerekiew.pdf",
+    "Chełm": "Chelm.pdf",
+    "Cikowice": "Cikowice.pdf",
+    "Damienice": "Damienice.pdf",
+    "Dąbrowica": "Dabrowica.pdf",
+    "Gawłów": "Gawlow.pdf",
+    "Gierczyce": "Gierczyce.pdf",
+    "Gorzków": "Gorzkow.pdf",
+    "Grabina": "Grabina.pdf",
+    "Krzyżanowice": "Krzyzanowice.pdf",
+    "Łapczyca": "Lapczyca.pdf",
+    "Majkowice": "Majkowice.pdf",
+    "Moszczenica": "Moszczenica.pdf",
+    "Nieprześnia": "Nieprzesnia.pdf",
+    "Nieszkowice Małe": "Nieszkowice male.pdf",
+    "Nieszkowice Wielkie": "Nieszkowice wielkie.pdf",
+    "Ostrów Szlachecki": "Ostrow szlachecki.pdf",
+    "Pogwizdów": "Pogwizdow.pdf",
+    "Proszówki": "Proszowki.pdf",
+    "Siedlec": "Siedlec.pdf",
+    "Słomka": "Slomka.pdf",
+    "Stanisławice": "Stanislawice.pdf",
+    "Stradomka": "Stradomka.pdf",
+    "Wola Nieszkowska": "Wola nieszkowska.pdf",
+    "Zatoka": "Zatoka.pdf",
+    "Zawada": "Zawada.pdf",
 }
+
+MIXED_WASTE = "Odpady zmieszane i segregowane"
+BULKY_WASTE = "Gabaryty i niebezpieczne"
+
+# heading that introduces the bulky / hazardous waste dates in the PDF
+BULKY_HEADING = "Odpady wielkogabarytowe"
 
 
 def normalize(text: str) -> str:
     return text.translate(PL_TRANS).lower().strip()
+
+
+TOWNS_BY_NORMALIZED_NAME = {normalize(name): name for name in TOWNS_PDF_MAP}
 
 
 class Source:
@@ -89,44 +98,46 @@ class Source:
         self._town = town
 
     def fetch(self) -> list[Collection]:
-        norm_town = normalize(self._town)
-        pdf_file = TOWNS_PDF_MAP.get(norm_town)
-        if not pdf_file:
+        town = TOWNS_BY_NORMALIZED_NAME.get(normalize(self._town))
+        if town is None:
             raise SourceArgumentNotFoundWithSuggestions(
                 "town", self._town, sorted(TOWNS_PDF_MAP.keys())
             )
 
+        pdf_file = TOWNS_PDF_MAP[town]
         url = f"http://bochnia-gmina.pl/container/{urllib.parse.quote(pdf_file)}"
-        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            pdf_bytes = resp.read()
+        r = requests.get(url, timeout=30)
+        r.raise_for_status()
 
-        reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
+        reader = pypdf.PdfReader(io.BytesIO(r.content))
         text = reader.pages[0].extract_text() or ""
-        if not text:
+        if not text.strip():
             raise ValueError(
                 f"No text could be extracted from PDF for town '{self._town}'."
             )
 
-        # 1. Year
-        year_match = re.search(r"\b(202\d)\b", text)
+        # 1. Year of the schedule
+        year_match = re.search(r"\b(20\d{2})\b", text)
         year = int(year_match.group(1)) if year_match else datetime.date.today().year
 
         entries: list[Collection] = []
 
-        # 2. Bulky / hazardous dates (e.g. (27.02.2026))
-        for d_str, m_str, y_str in re.findall(r"(\d{1,2})\.(\d{1,2})\.(\d{4})", text):
-            entries.append(
-                Collection(
-                    date=datetime.date(int(y_str), int(m_str), int(d_str)),
-                    t="Gabaryty i niebezpieczne",
-                    icon=Icons.BULKY,
-                )
-            )
+        # 2. Bulky / hazardous dates (e.g. "LUTY (27.02.2026)"), listed below the
+        #    bulky waste heading.
+        heading_pos = text.find(BULKY_HEADING)
+        bulky_text = text[heading_pos:] if heading_pos != -1 else text
+        for d_str, m_str, y_str in re.findall(
+            r"(\d{1,2})\.(\d{1,2})\.(\d{4})", bulky_text
+        ):
+            try:
+                date = datetime.date(int(y_str), int(m_str), int(d_str))
+            except ValueError:
+                continue
+            entries.append(Collection(date=date, t=BULKY_WASTE, icon=Icons.BULKY))
 
         # 3. Monthly collection dates table
         table_match = re.search(
-            r"zmieszane\s+(?:202\d)?\s*(.*?)\s*Odpady wielkogabarytowe",
+            r"zmieszane\s+(?:20\d{2})?\s*(.*?)\s*" + re.escape(BULKY_HEADING),
             text,
             re.DOTALL | re.IGNORECASE,
         )
@@ -160,14 +171,11 @@ class Source:
             month = m_idx + 1
             for d in days:
                 try:
-                    entries.append(
-                        Collection(
-                            date=datetime.date(year, month, d),
-                            t="Odpady zmieszane i segregowane",
-                            icon=Icons.GENERAL_WASTE,
-                        )
-                    )
+                    date = datetime.date(year, month, d)
                 except ValueError:
-                    pass
+                    continue
+                entries.append(
+                    Collection(date=date, t=MIXED_WASTE, icon=Icons.GENERAL_WASTE)
+                )
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bochnia_gmina_pl.py
@@ -79,6 +79,10 @@ TOWNS_PDF_MAP = {
     "Zawada": "Zawada.pdf",
 }
 
+EXTRA_INFO = [
+    {"title": town, "default_params": {"town": town}} for town in TOWNS_PDF_MAP
+]
+
 MIXED_WASTE = "Odpady zmieszane i segregowane"
 BULKY_WASTE = "Gabaryty i niebezpieczne"
 

--- a/doc/source/bochnia_gmina_pl.md
+++ b/doc/source/bochnia_gmina_pl.md
@@ -1,0 +1,75 @@
+# Gmina Bochnia
+
+Harmonogram wywozu odpadów komunalnych dla Gminy Bochnia (woj. małopolskie), w tym miejscowości Baczków, Damienice, Krzyżanowice, Proszówki i pozostałych sołectw.
+
+Website: [http://bochnia-gmina.pl/p,3,harmonogram-wywozu-odpadow-komunalnych-i-zasady-segregacji](http://bochnia-gmina.pl/p,3,harmonogram-wywozu-odpadow-komunalnych-i-zasady-segregacji)
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: bochnia_gmina_pl
+      args:
+        town: "Baczków"
+```
+
+### Configuration Variables
+
+**town**  
+*(string) (required)* Nazwa miejscowości w gminie Bochnia (np. `Baczków`, `Damienice`, `Krzyżanowice`, `Proszówki`, `Łapczyca`, `Siedlec`, etc.).
+
+## Supported Towns
+
+* Baczków
+* Bessów
+* Bogucice
+* Brzeźnica
+* Buczyna
+* Cerekiew
+* Chełm
+* Cikowice
+* Damienice
+* Dąbrowica
+* Gawłów
+* Gierczyce
+* Gorzków
+* Grabina
+* Krzyżanowice
+* Łapczyca
+* Majkowice
+* Moszczenica
+* Nieprześnia
+* Nieszkowice Małe
+* Nieszkowice Wielkie
+* Ostrów Szlachecki
+* Pogwizdów
+* Proszówki
+* Siedlec
+* Słomka
+* Stanisławice
+* Stradomka
+* Wola Nieszkowska
+* Zatoka
+* Zawada
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: bochnia_gmina_pl
+      args:
+        town: "Baczków"
+  fetch_time: "04:00"
+  day_switch_time: "10:00"
+
+sensor:
+  - platform: waste_collection_schedule
+    name: "Następny wywóz odpadów"
+    value_template: '{{ value.types|join(", ") }}'
+  - platform: waste_collection_schedule
+    name: "Dni do wywozu odpadów"
+    value_template: '{{ value.daysTo }}'
+    unit_of_measurement: 'd'
+```


### PR DESCRIPTION
## Summary

Adds a new dedicated source provider for **Gmina Bochnia** (Poland), covering all 31 villages in the municipality (including Baczków, Damienice, Proszówki, Łapczyca, etc.).

- **Provider website**: http://bochnia-gmina.pl/p,3,harmonogram-wywozu-odpadow-komunalnych-i-zasady-segregacji
- **Waste types**: Mixed & segregated waste (`Odpady zmieszane i segregowane`), bulky and hazardous waste (`Gabaryty i niebezpieczne`).
- **Parsing**: Fetches and parses collection dates directly from the official municipal PDF schedules with fallback.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (35 passed)
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/bochnia_gmina_pl.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)

## Validation

- `test_sources.py -s bochnia_gmina_pl -i -l` passes (23 entries found for Baczkow, 23 for Proszowki)
- `python -m pytest tests/test_source_components.py -q` passes (35 passed)
