### PR TITLE
Add bonnorange AöR (Bonn, Germany) source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bonnorange_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bonnorange_de.py
@@ -1,0 +1,146 @@
+import html
+import re
+from html.parser import HTMLParser
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "bonnorange AöR"
+DESCRIPTION = (
+    "Source for bonnorange AöR, the waste management company of Bonn, Germany."
+)
+URL = "https://www.bonnorange.de"
+COUNTRY = "de"
+TEST_CASES = {
+    "Altes Rathaus, Markt 1": {"street": "Markt", "house_number": 1},
+    "Stadthaus, Berliner Platz 2": {"street": "Berliner Platz", "house_number": 2},
+    "Münsterplatz 1": {
+        "street": "Münsterplatz",
+        "house_number": 1,
+        "address_suffix": "",
+    },
+}
+
+ICON_MAP = {
+    "Restabfallbehaelter": Icons.GENERAL_WASTE,
+    "Bioabfallbehaelter": Icons.BIO_KITCHEN,
+    "Papierbehaelter": Icons.PAPER,
+    "Gelbe Behaelter": Icons.PLASTIC_PACKAGING,
+    "Gelbe Grossbehaelter": Icons.PLASTIC_PACKAGING,
+    "Sperrmuell": Icons.BULKY,
+    "Weihnachtsbaeume": Icons.CHRISTMAS_TREE,
+}
+
+PARAM_TRANSLATIONS = {
+    "de": {
+        "street": "Straße",
+        "house_number": "Hausnummer",
+        "address_suffix": "Hausnummerzusatz",
+    }
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Look up your address at https://www5.bonn.de/WasteManagementBonnOrange/WasteManagementServlet?SubmitAction=wasteDisposalServices and use the street name exactly as it is spelled in the drop-down list.",
+    "de": "Adresse unter https://www5.bonn.de/WasteManagementBonnOrange/WasteManagementServlet?SubmitAction=wasteDisposalServices nachschlagen und den Straßennamen genau so angeben, wie er in der Auswahlliste steht.",
+}
+
+SERVLET = "https://www5.bonn.de/WasteManagementBonnOrange/WasteManagementServlet"
+
+# Part of the form is delivered as a JavaScript string instead of plain markup.
+TEXT_REGEX = re.compile(r"var\s*text\s*=\s*'(.*?)'\s*;", re.DOTALL)
+OPTION_REGEX = re.compile(r'<OPTION VALUE="([^"]+)"', re.IGNORECASE)
+
+
+class HiddenInputParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._args: dict[str, str] = {}
+
+    @property
+    def args(self) -> dict[str, str]:
+        return self._args
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "input":
+            d = dict(attrs)
+            if str(d.get("type", "")).lower() == "hidden":
+                self._args[d["name"]] = d.get("value", "")
+
+
+def _hidden_args(text: str) -> dict[str, str]:
+    parser = HiddenInputParser()
+    parser.feed(text)
+    match = TEXT_REGEX.search(text)
+    if match:
+        parser.feed(match.group(1).encode().decode("unicode-escape"))
+    return parser.args
+
+
+def _streets(text: str) -> list[str]:
+    # The drop-down separates street name and type with a non-breaking space.
+    return [
+        html.unescape(o).replace("\xa0", " ") for o in OPTION_REGEX.findall(text) if o
+    ]
+
+
+class Source:
+    def __init__(self, street: str, house_number: int, address_suffix: str = ""):
+        self._street: str = street
+        self._house_number: int = house_number
+        self._address_suffix: str = address_suffix
+        self._ics = ICS()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        r = session.get(SERVLET, params={"SubmitAction": "wasteDisposalServices"})
+        r.raise_for_status()
+        r.encoding = "utf-8"
+
+        args = _hidden_args(r.text)
+        args["Ort"] = self._street[0]
+        args["Strasse"] = self._street
+        args["Hausnummer"] = str(self._house_number)
+        args["Hausnummerzusatz"] = self._address_suffix
+        args["SubmitAction"] = "CITYCHANGED"
+        for i in range(1, 6):
+            args[f"ContainerGewaehlt_{i}"] = "on"
+
+        r = session.post(SERVLET, data=args)
+        r.raise_for_status()
+        r.encoding = "utf-8"
+
+        streets = _streets(r.text)
+        if streets and self._street not in streets:
+            raise SourceArgumentNotFoundWithSuggestions("street", self._street, streets)
+
+        # Every step hands out fresh session tokens, so the hidden fields have to
+        # be picked up again from each response.
+        args.update(_hidden_args(r.text))
+        args["SubmitAction"] = "forward"
+        r = session.post(SERVLET, data=args)
+        r.raise_for_status()
+        r.encoding = "utf-8"
+
+        # The result page switches ApplicationName to the collection-date model,
+        # which the iCal download depends on.
+        args.update(_hidden_args(r.text))
+        args["SubmitAction"] = "filedownload_ICAL"
+        args["ICalErinnerung"] = "keine Erinnerung"
+        args["ICalZeit"] = "18:00 Uhr"
+        r = session.post(SERVLET, data=args)
+        r.raise_for_status()
+        r.encoding = "utf-8"
+
+        if "BEGIN:VCALENDAR" not in r.text:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "house_number", self._house_number, []
+            )
+
+        entries = []
+        for d in self._ics.convert(r.text):
+            bin_type = d[1].strip()
+            entries.append(Collection(d[0], bin_type, ICON_MAP.get(bin_type)))
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bonnorange_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bonnorange_de.py
@@ -50,7 +50,6 @@ SERVLET = "https://www5.bonn.de/WasteManagementBonnOrange/WasteManagementServlet
 
 # Part of the form is delivered as a JavaScript string instead of plain markup.
 TEXT_REGEX = re.compile(r"var\s*text\s*=\s*'(.*?)'\s*;", re.DOTALL)
-OPTION_REGEX = re.compile(r'<OPTION VALUE="([^"]+)"', re.IGNORECASE)
 
 
 class HiddenInputParser(HTMLParser):
@@ -78,11 +77,39 @@ def _hidden_args(text: str) -> dict[str, str]:
     return parser.args
 
 
+class StreetOptionParser(HTMLParser):
+    """Collects the options of the street drop-down only.
+
+    The page contains several selects (e.g. the first-letter chooser), so
+    grabbing every option would mix unrelated values into the suggestions.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._streets: list[str] = []
+        self._in_street_select = False
+
+    @property
+    def streets(self) -> list[str]:
+        return self._streets
+
+    def handle_starttag(self, tag, attrs):
+        d = dict(attrs)
+        if tag == "select":
+            self._in_street_select = d.get("name") == "Strasse"
+        elif tag == "option" and self._in_street_select and d.get("value"):
+            # Street name and type are separated by a non-breaking space.
+            self._streets.append(html.unescape(d["value"]).replace("\xa0", " "))
+
+    def handle_endtag(self, tag):
+        if tag == "select":
+            self._in_street_select = False
+
+
 def _streets(text: str) -> list[str]:
-    # The drop-down separates street name and type with a non-breaking space.
-    return [
-        html.unescape(o).replace("\xa0", " ") for o in OPTION_REGEX.findall(text) if o
-    ]
+    parser = StreetOptionParser()
+    parser.feed(text)
+    return parser.streets
 
 
 class Source:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bonnorange_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bonnorange_de.py
@@ -77,39 +77,40 @@ def _hidden_args(text: str) -> dict[str, str]:
     return parser.args
 
 
-class StreetOptionParser(HTMLParser):
-    """Collects the options of the street drop-down only.
+class SelectOptionParser(HTMLParser):
+    """Collects the options of one named drop-down.
 
     The page contains several selects (e.g. the first-letter chooser), so
     grabbing every option would mix unrelated values into the suggestions.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, name: str) -> None:
         super().__init__()
-        self._streets: list[str] = []
-        self._in_street_select = False
+        self._name = name
+        self._options: list[str] = []
+        self._in_select = False
 
     @property
-    def streets(self) -> list[str]:
-        return self._streets
+    def options(self) -> list[str]:
+        return self._options
 
     def handle_starttag(self, tag, attrs):
         d = dict(attrs)
         if tag == "select":
-            self._in_street_select = d.get("name") == "Strasse"
-        elif tag == "option" and self._in_street_select and d.get("value"):
-            # Street name and type are separated by a non-breaking space.
-            self._streets.append(html.unescape(d["value"]).replace("\xa0", " "))
+            self._in_select = d.get("name") == self._name
+        elif tag == "option" and self._in_select and d.get("value"):
+            # Values carry non-breaking spaces: street name and type, number ranges.
+            self._options.append(html.unescape(d["value"]).replace("\xa0", " "))
 
     def handle_endtag(self, tag):
         if tag == "select":
-            self._in_street_select = False
+            self._in_select = False
 
 
-def _streets(text: str) -> list[str]:
-    parser = StreetOptionParser()
+def _options(text: str, name: str) -> list[str]:
+    parser = SelectOptionParser(name)
     parser.feed(text)
-    return parser.streets
+    return parser.options
 
 
 class Source:
@@ -139,7 +140,7 @@ class Source:
         r.raise_for_status()
         r.encoding = "utf-8"
 
-        streets = _streets(r.text)
+        streets = _options(r.text, "Strasse")
         if streets and self._street not in streets:
             raise SourceArgumentNotFoundWithSuggestions("street", self._street, streets)
 
@@ -151,6 +152,14 @@ class Source:
         r.raise_for_status()
         r.encoding = "utf-8"
 
+        # An address the portal does not serve comes back with a drop-down of
+        # the house numbers that are actually registered for this street.
+        house_numbers = _options(r.text, "Hausnummernwahl")
+        if house_numbers:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "house_number", self._house_number, house_numbers
+            )
+
         # The result page switches ApplicationName to the collection-date model,
         # which the iCal download depends on.
         args.update(_hidden_args(r.text))
@@ -161,9 +170,11 @@ class Source:
         r.raise_for_status()
         r.encoding = "utf-8"
 
-        if "BEGIN:VCALENDAR" not in r.text:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "house_number", self._house_number, []
+        if not r.text.lstrip().startswith("BEGIN:VCALENDAR"):
+            raise ValueError(
+                "Expected an iCalendar file from the bonnorange portal but got "
+                f"{r.headers.get('Content-Type', 'an unknown content type')}, "
+                "the portal may be unavailable or may have changed."
             )
 
         entries = []

--- a/doc/source/bonnorange_de.md
+++ b/doc/source/bonnorange_de.md
@@ -1,0 +1,46 @@
+# bonnorange AöR
+
+Support for schedules provided by [bonnorange AöR](https://www.bonnorange.de), the waste management company of Bonn, Germany.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: bonnorange_de
+      args:
+        street: STREET
+        house_number: HOUSE_NUMBER
+        address_suffix: ADDRESS_SUFFIX
+```
+
+### Configuration Variables
+
+**street**  
+*(string) (required)*
+
+**house_number**  
+*(integer) (required)*
+
+**address_suffix**  
+*(string) (optional) (default: "")*
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: bonnorange_de
+      args:
+        street: "Markt"
+        house_number: 1
+```
+
+## How to get the source arguments
+
+Look up your address in the official collection-date search at
+`https://www5.bonn.de/WasteManagementBonnOrange/WasteManagementServlet?SubmitAction=wasteDisposalServices`.
+
+Pick the first letter of your street, then select the street from the drop-down list. Use the street name **exactly** as it is spelled there — for example `Markt`, `Berliner Platz` or `Münsterstr.` (abbreviated, not `Straße`). If the street cannot be found, the error message lists the available street names for that letter.
+
+`house_number` expects a numeric value. Any suffix, such as `A` or `1/2`, has to be passed separately via `address_suffix`.


### PR DESCRIPTION
Adds a source for bonnorange AöR, the waste management company of Bonn, Germany.

Bonn was not covered yet. The provider does not expose a stable ICS URL — the calendar download only works inside a session — so a generic `ics` YAML was not an option and a source module is needed.

### Notes on the provider

Bonn runs the same athos-based portal software as e.g. `bielefeld_de` (`WasteManagementServlet`), but with two twists that are worth knowing:

- Session tokens (`SessionId`, `latestChangeId`) are rotated on **every** step, so the hidden form fields must be re-read from each response.
- The result page switches `ApplicationName` to the collection-date model; without picking that up, `filedownload_ICAL` returns HTML instead of `text/calendar`.

Both are commented in the source.

### Behaviour

- Covers all seven collection types: residual, bio, paper, yellow bin, large yellow bin, bulky waste and christmas trees.
- Street names are validated against the portal's drop-down list; a misspelled street raises `SourceArgumentNotFoundWithSuggestions` listing the valid names for that letter.
- Icons use the canonical `Icons` enum.

### Checklist

- [x] `test_sources.py -s bonnorange_de` passes (3 test cases, all public addresses: Altes Rathaus, Stadthaus, Münsterplatz)
- [x] `doc/source/bonnorange_de.md` added
- [x] `python -m pytest tests/` passes (39 passed)
- [x] `ruff check --fix` + `ruff format` clean
- [x] No generated files touched (README, info.md, sources.json, source_metadata.json, translations, doc/ics)
