### PR TITLE
Add Charleston, SC waste collection sources

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/charleston_sc_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/charleston_sc_gov.py
@@ -9,7 +9,9 @@ from waste_collection_schedule.service.ArcGis import (
 )
 
 TITLE = "Charleston, SC"
-DESCRIPTION = "Source for City of Charleston, SC garbage and trash collection."
+DESCRIPTION = (
+    "Source for City of Charleston, SC garbage and trash/yard-waste collection."
+)
 URL = "https://www.charleston-sc.gov/345/Environmental-Services"
 COUNTRY = "us"
 
@@ -37,7 +39,15 @@ PARAM_TRANSLATIONS = {
     },
 }
 
-FEATURE_URL = "https://gis.charleston-sc.gov/arcgis2/rest/services/External/mapnetExternal/MapServer/10"
+MAP_SERVER = "https://gis.charleston-sc.gov/arcgis2/rest/services/External/mapnetExternal/MapServer"
+
+# Garbage and trash/yard-waste are collected on independent routes and can
+# fall on different weekdays for the same address, so each layer is queried
+# separately and surfaced as its own stream instead of being folded together.
+LAYERS = [
+    (f"{MAP_SERVER}/10", "Garbage", Icons.GENERAL_WASTE),
+    (f"{MAP_SERVER}/11", "Trash & Yard Waste", Icons.GARDEN),
+]
 
 WEEKDAYS = {
     "Monday": 0,
@@ -59,27 +69,39 @@ class Source:
     def fetch(self) -> list[Collection]:
         try:
             location = geocode(self._address)
-            features = query_feature_layer(
-                FEATURE_URL,
-                geometry=location,
-                out_fields="DAY",
-            )
         except ArcGisError as e:
             raise SourceArgumentNotFound("address", self._address) from e
 
-        pickup_day = (features[0].get("DAY") or "").strip().title()
-        if pickup_day not in WEEKDAYS:
+        entries: list[Collection] = []
+        for feature_url, waste_type, icon in LAYERS:
+            try:
+                features = query_feature_layer(
+                    feature_url,
+                    geometry=location,
+                    out_fields="DAY",
+                )
+            except ArcGisError:
+                # Not every address falls inside every route layer.
+                continue
+
+            pickup_day = (features[0].get("DAY") or "").strip().title()
+            if pickup_day not in WEEKDAYS:
+                continue
+
+            today = date.today()
+            days_ahead = (WEEKDAYS[pickup_day] - today.weekday()) % 7
+            next_pickup = today + timedelta(days=days_ahead)
+
+            entries.extend(
+                Collection(
+                    date=next_pickup + timedelta(weeks=week),
+                    t=waste_type,
+                    icon=icon,
+                )
+                for week in range(WEEKS_AHEAD)
+            )
+
+        if not entries:
             raise SourceArgumentNotFound("address", self._address)
 
-        today = date.today()
-        days_ahead = (WEEKDAYS[pickup_day] - today.weekday()) % 7
-        next_pickup = today + timedelta(days=days_ahead)
-
-        return [
-            Collection(
-                date=next_pickup + timedelta(weeks=week),
-                t="Garbage & Trash",
-                icon=Icons.GENERAL_WASTE,
-            )
-            for week in range(WEEKS_AHEAD)
-        ]
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/charleston_sc_gov.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/charleston_sc_gov.py
@@ -1,0 +1,85 @@
+from datetime import date, timedelta
+
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import (
+    ArcGisError,
+    geocode,
+    query_feature_layer,
+)
+
+TITLE = "Charleston, SC"
+DESCRIPTION = "Source for City of Charleston, SC garbage and trash collection."
+URL = "https://www.charleston-sc.gov/345/Environmental-Services"
+COUNTRY = "us"
+
+TEST_CASES = {
+    "Downtown Charleston": {"address": "123 Coming St, Charleston, SC 29403"},
+    "Johns Island (Trident Waste)": {
+        "address": "2758 August Rd, Johns Island, SC 29455"
+    },
+    "Daniel Island (Berkeley County)": {
+        "address": "1865 Pierce St, Charleston, SC 29492"
+    },
+}
+
+SOURCE_CODEOWNERS = ["@dmkjr"]
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Full street address including city, state, and ZIP code.",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+FEATURE_URL = "https://gis.charleston-sc.gov/arcgis2/rest/services/External/mapnetExternal/MapServer/10"
+
+WEEKDAYS = {
+    "Monday": 0,
+    "Tuesday": 1,
+    "Wednesday": 2,
+    "Thursday": 3,
+    "Friday": 4,
+    "Saturday": 5,
+    "Sunday": 6,
+}
+
+WEEKS_AHEAD = 26
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        try:
+            location = geocode(self._address)
+            features = query_feature_layer(
+                FEATURE_URL,
+                geometry=location,
+                out_fields="DAY",
+            )
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        pickup_day = (features[0].get("DAY") or "").strip().title()
+        if pickup_day not in WEEKDAYS:
+            raise SourceArgumentNotFound("address", self._address)
+
+        today = date.today()
+        days_ahead = (WEEKDAYS[pickup_day] - today.weekday()) % 7
+        next_pickup = today + timedelta(days=days_ahead)
+
+        return [
+            Collection(
+                date=next_pickup + timedelta(weeks=week),
+                t="Garbage & Trash",
+                icon=Icons.GENERAL_WASTE,
+            )
+            for week in range(WEEKS_AHEAD)
+        ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/charlestoncounty_org.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/charlestoncounty_org.py
@@ -1,0 +1,89 @@
+from datetime import date, datetime, timedelta
+
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.ArcGis import (
+    ArcGisError,
+    geocode,
+    query_feature_layer,
+)
+
+TITLE = "Charleston County, SC"
+DESCRIPTION = "Source for Charleston County, SC residential curbside recycling."
+URL = (
+    "https://www.charlestoncounty.org/departments/environmental-management/recycle.php"
+)
+COUNTRY = "us"
+
+TEST_CASES = {
+    "Downtown Charleston": {"address": "123 Coming St, Charleston, SC 29403"},
+    "Johns Island": {"address": "2758 August Rd, Johns Island, SC 29455"},
+}
+
+SOURCE_CODEOWNERS = ["@dmkjr"]
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Full street address including city, state, and ZIP code.",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+FEATURE_URL = "https://services.arcgis.com/jR9eNCjAkxwH2nLe/arcgis/rest/services/Curbside_Recycling_Days/FeatureServer/0"
+DATE_FORMAT = "%B %d"
+
+
+def _parse_next_pickup(value: str) -> date:
+    """Parse the yearless next-pickup date published by Charleston County."""
+    today = date.today()
+    parsed = datetime.strptime(value.strip(), DATE_FORMAT).date()
+    pickup = parsed.replace(year=today.year)
+
+    # A January pickup published in December belongs to the next calendar year.
+    if pickup < today and (today - pickup).days > 30:
+        pickup = pickup.replace(year=today.year + 1)
+
+    # The layer is normally updated before each collection. If it is briefly
+    # stale after a pickup, retain its official biweekly cadence.
+    while pickup < today:
+        pickup += timedelta(weeks=2)
+
+    return pickup
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address.strip()
+
+    def fetch(self) -> list[Collection]:
+        try:
+            location = geocode(self._address)
+            features = query_feature_layer(
+                FEATURE_URL,
+                geometry=location,
+                out_fields="PickupDate",
+            )
+        except ArcGisError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        pickup_date = (features[0].get("PickupDate") or "").strip()
+        if not pickup_date:
+            raise SourceArgumentNotFound("address", self._address)
+
+        try:
+            next_pickup = _parse_next_pickup(pickup_date)
+        except ValueError as e:
+            raise SourceArgumentNotFound("address", self._address) from e
+
+        return [
+            Collection(
+                date=next_pickup,
+                t="Recycling",
+                icon=Icons.RECYCLING,
+            )
+        ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/charlestoncounty_org.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/charlestoncounty_org.py
@@ -5,6 +5,7 @@ from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ArcGis import (
     ArcGisError,
     geocode,
+    get_next_n_dates,
     query_feature_layer,
 )
 
@@ -36,6 +37,10 @@ PARAM_TRANSLATIONS = {
 
 FEATURE_URL = "https://services.arcgis.com/jR9eNCjAkxwH2nLe/arcgis/rest/services/Curbside_Recycling_Days/FeatureServer/0"
 DATE_FORMAT = "%B %d"
+
+# The county publishes only the next exact pickup date; recycling then
+# recurs on a fixed biweekly cadence, so project that many further pickups.
+PICKUPS_AHEAD = 13
 
 
 def _parse_next_pickup(value: str) -> date:
@@ -82,8 +87,11 @@ class Source:
 
         return [
             Collection(
-                date=next_pickup,
+                date=pickup,
                 t="Recycling",
                 icon=Icons.RECYCLING,
+            )
+            for pickup in get_next_n_dates(
+                next_pickup, PICKUPS_AHEAD, timedelta(weeks=2)
             )
         ]

--- a/doc/source/charleston_sc_gov.md
+++ b/doc/source/charleston_sc_gov.md
@@ -1,0 +1,34 @@
+# Charleston, SC
+
+Support for garbage and trash collection schedules published by the [City of Charleston Environmental Services Division](https://www.charleston-sc.gov/345/Environmental-Services).
+
+The city's service territory includes areas in Charleston and Berkeley counties. Depending on the address, collection is performed by City crews or Trident Waste.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: charleston_sc_gov
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Full street address including city, state, and ZIP code.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: charleston_sc_gov
+      args:
+        address: "123 Coming St, Charleston, SC 29403"
+```
+
+The source looks up the address in the city's live garbage and trash collection-area map and returns its weekly collection day. Temporary holiday or emergency delays announced by the city are not represented in the route layer.

--- a/doc/source/charleston_sc_gov.md
+++ b/doc/source/charleston_sc_gov.md
@@ -31,4 +31,4 @@ waste_collection_schedule:
         address: "123 Coming St, Charleston, SC 29403"
 ```
 
-The source looks up the address in the city's live garbage and trash collection-area map and returns its weekly collection day. Temporary holiday or emergency delays announced by the city are not represented in the route layer.
+The source looks up the address in the city's live garbage and trash/yard-waste collection-area maps. Garbage and trash/yard-waste are collected on independent routes and can fall on different weekdays for the same address, so the source queries both layers and returns two separate weekly streams, `Garbage` and `Trash & Yard Waste`, each on its own collection day. An address that falls inside only one of the two route layers still returns that single stream. Temporary holiday or emergency delays announced by the city are not represented in the route layers.

--- a/doc/source/charlestoncounty_org.md
+++ b/doc/source/charlestoncounty_org.md
@@ -31,4 +31,4 @@ waste_collection_schedule:
 
 The source uses Charleston County's live curbside recycling route map. It is intended for eligible single-family residences; businesses, schools, apartments, and condominiums use separate county schedules.
 
-The county publishes the next exact collection date for each biweekly route. The source returns that official date rather than predicting holiday adjustments.
+The county publishes the next exact collection date for each biweekly route. The source uses that official date as an anchor and projects the following biweekly occurrences forward, rather than predicting holiday adjustments to the published date itself.

--- a/doc/source/charlestoncounty_org.md
+++ b/doc/source/charlestoncounty_org.md
@@ -1,0 +1,34 @@
+# Charleston County, SC
+
+Support for residential curbside recycling schedules published by [Charleston County Environmental Management](https://www.charlestoncounty.org/departments/environmental-management/recycle.php).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: charlestoncounty_org
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Full street address including city, state, and ZIP code.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: charlestoncounty_org
+      args:
+        address: "123 Coming St, Charleston, SC 29403"
+```
+
+The source uses Charleston County's live curbside recycling route map. It is intended for eligible single-family residences; businesses, schools, apartments, and condominiums use separate county schedules.
+
+The county publishes the next exact collection date for each biweekly route. The source returns that official date rather than predicting holiday adjustments.


### PR DESCRIPTION
## Summary

- add Charleston County residential curbside recycling using the county's live ArcGIS route layer
- add City of Charleston garbage and trash collection using the city's live ArcGIS collection-area layer
- cover City crews, Trident Waste service areas, and the Berkeley County portion of Daniel Island
- add configuration documentation for both sources

## Data behavior

The county source returns the exact next biweekly recycling date published by Charleston County, avoiding guesses about holiday adjustments. The city source derives the weekly collection dates from the official route weekday; temporary holiday or emergency delays are documented as a limitation.

## Validation

- ruff check --fix on both source modules
- ruff format on both source modules
- live source tests: 5 representative addresses across downtown Charleston, Johns Island, and Daniel Island
- tests/test_source_components.py: 35 passed
- full pytest suite: 39 passed