### PR TITLE
Add 'Lu e Cuccaro Monferrato' to city list

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/junker_app.py
@@ -329,6 +329,7 @@ SERVICE_PROVIDERS = {
     "Torre de' Passeri",
     "Scalea",
     "San Giovanni Teatino",
+    "Lu e Cuccaro Monferrato",
 }
 
 


### PR DESCRIPTION
## Summary

- Lu e Cuccaro Monferrato (Italy) is already served by the existing generic Junker APP source (`junker_app.py` / `service/junker_app.py`) — no new integration code needed.
- Adds it to the `SERVICE_PROVIDERS` documentation list (drives the `EXTRA_INFO` README/sources.json listing).

Add "Lu e Cuccaro Monferrato" to junker_app source file SERVICE_PROVIDERS

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [x] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
