### PR TITLE
Updated ffv parser from PDF to default

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/affaldonline_dk.py
@@ -66,7 +66,7 @@ AFFALDONLINE_MUNICIPALITIES = {
     "ffv": {
         "title": "Faaborg Forsynings Virksomhed",
         "url": "https://www.ffv.dk/",
-        "parser": "pdf",
+        "parser": "default",
         "values": "Marsk Billesvej|18||||5672|Broby|36193544|576846|0",
     },
     "fredericia": {


### PR DESCRIPTION
## Summary

After having FFV adding next schedule to affaldonline, I found that PDF is not the right parser, but comparing to the output of assens it should be default. My tests with the regex seems to correspond.

I think I have done this incorrectly. I am not used to doing this. I made a commit (push/pull?) of this code earlier. It didn't work. Therefore I have worked on getting the info on the homepage. The data is now there but I cannot remember how I committed the last time. If this is totally wrong, please delete this. I can't seem to do it myself. I apologize for any inconvenience.

I also guess that if this is accepted, that the doc/source/affaldonline_dk.md, should be updated to reflect the changes. I will of course do this and try to do it the right way, this time.

## Type of change

- [ ] New source
- [ x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [x ] TEST_CASES use real, publicly accessible addresses (not my own)
