### PR TITLE
Fix Ipswich WhatBinDay lookup

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_qld_gov_au.py
@@ -28,7 +28,7 @@ ICON_MAP = {
 BIN_NAMES = {
     "WasteBin": "Waste Bin",
     "RecycleBin": "Recycle Bin",
-    "GreenBin": "GO Bin",
+    "GreenBin": "Garden Organics (GO)",
     "GlassBin": "Glass Bin",
 }
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_qld_gov_au.py
@@ -15,6 +15,24 @@ TEST_CASES = {
     "Random": {"street": "50 Brisbane Road", "suburb": "Redbank"},
 }
 
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Use your street number and street name (including the street type, e.g. Road, Street, Avenue) for `street`, and the suburb name only for `suburb`. Do not add QLD or Australia."
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street": "Street number and street name, e.g. 50 Brisbane Road.",
+        "suburb": "Suburb name, e.g. Redbank.",
+    }
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "street": "Street",
+        "suburb": "Suburb",
+    }
+}
+
 APP_PACKAGE = "com.socketsoftware.whatbinday.ipswich"
 CONFIG_URL = "https://api.whatbinday.com/V3/Device/{}/Config"
 
@@ -55,7 +73,8 @@ class Source:
         config_payload = config_response.json()
         if not config_payload.get("success"):
             raise RuntimeError(
-                f"Device configuration failed: {config_payload.get('info', '')}"
+                "Device configuration failed: "
+                f"{config_payload.get('info') or 'Unknown error'}"
             )
 
         search_url = config_payload["data"]["config"]["googleAddressSearchURL"]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ipswich_qld_gov_au.py
@@ -1,203 +1,86 @@
-import datetime
-import json
-from html.parser import HTMLParser
+from urllib.parse import quote
 
 import requests
 from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.service.WhatBinDay import WhatBinDayService
 
 TITLE = "Ipswich City Council"
 DESCRIPTION = "Source for Ipswich City Council rubbish collection."
 URL = "https://www.ipswich.qld.gov.au"
+COUNTRY = "au"
+SOURCE_CODEOWNERS = ["@CRZTFR"]
 TEST_CASES = {
     "Camira State School": {"street": "184-202 Old Logan Rd", "suburb": "Camira"},
     "Random": {"street": "50 Brisbane Road", "suburb": "Redbank"},
 }
 
+APP_PACKAGE = "com.socketsoftware.whatbinday.ipswich"
+CONFIG_URL = "https://api.whatbinday.com/V3/Device/{}/Config"
 
 ICON_MAP = {
-    "Waste Bin": Icons.GENERAL_WASTE,
-    "Recycle Bin": Icons.RECYCLING,
-    "FOGO Bin": Icons.BIO_KITCHEN,
-    "GO Bin": Icons.BIO_KITCHEN,
+    "WasteBin": Icons.GENERAL_WASTE,
+    "RecycleBin": Icons.RECYCLING,
+    "GreenBin": Icons.ORGANIC,
+    "GlassBin": Icons.GLASS,
 }
 
-
-def toDate(dateStr: str):
-    items = dateStr.split("-")
-    return datetime.date(int(items[1]), int(items[2]), int(items[3]))
-
-
-class IpswichGovAuParser(HTMLParser):
-    def __init__(self):
-        super().__init__()
-        self._entries = []
-        self._state = None
-        self._level = 0
-        self._class = ""
-        self._li_level = 0
-        self._li_valid = False
-        self._span_level = 0
-        self._load_date = False
-        self._load_bin = False
-        self._loaded_date = None
-
-    @property
-    def entries(self):
-        return self._entries
-
-    def handle_endtag(self, tag):
-
-        if tag == "li":
-            self._li_level -= 1
-            self._loaded_date = None
-
-        if tag == "span":
-            self._span_level -= 1
-
-    def handle_starttag(self, tag, attrs):
-
-        d = dict(attrs)
-        cls = d.get("class", "")
-
-        if tag == "li":
-            self._li_level += 1
-            if self._li_level == 1 and cls == "WBD-result-item":
-                self._li_valid = True
-            else:
-                self._li_valid = False
-                self._loaded_date = None
-
-        if tag == "span":
-            self._span_level += 1
-            if self._li_valid and self._span_level == 1 and cls == "WBD-event-date":
-                self._load_date = True
-
-            if self._li_valid and self._span_level == 3 and cls == "WBD-bin-text":
-                self._load_bin = True
-
-    def handle_data(self, data):
-        if not self._li_valid:
-            return
-
-        if self._load_date:
-            self._load_date = False
-
-            value = data.strip()
-
-            try:
-                self._loaded_date = datetime.datetime.strptime(value, "%Y-%m-%d").date()
-            except ValueError:
-                self._loaded_date = datetime.datetime.strptime(
-                    value, "%A+%d+%b+%Y"
-                ).date()
-
-        if self._load_bin:
-            self._load_bin = False
-
-            self._entries.append(
-                Collection(self._loaded_date, data, icon=ICON_MAP.get(data))
-            )
+BIN_NAMES = {
+    "WasteBin": "Waste Bin",
+    "RecycleBin": "Recycle Bin",
+    "GreenBin": "GO Bin",
+    "GlassBin": "Glass Bin",
+}
 
 
 class Source:
     def __init__(self, street, suburb):
-        self._street = street
-        self._suburb = suburb
+        self._street = " ".join(str(street).split())
+        self._suburb = " ".join(str(suburb).split())
+        self._service = WhatBinDayService(
+            location_key="ipswich_city_council",
+            icon_map=ICON_MAP,
+            bin_names=BIN_NAMES,
+            app_package=APP_PACKAGE,
+        )
 
-    def fetch(self):
-        geocode_params = {
-            "SingleLine": f"{self._street}, {self._suburb}, QLD Australia",
-            "outSR": '{"wkid":4326}',
-            "maxLocations": 1,
-            "outFields": "*",
-            "f": "json",
-        }
+    def _geocode(self) -> dict:
+        device_key = self._service.register_device()
+        config_response = requests.get(
+            CONFIG_URL.format(device_key),
+            headers=self._service.HEADERS,
+            timeout=30,
+        )
+        config_response.raise_for_status()
+        config_payload = config_response.json()
+        if not config_payload.get("success"):
+            raise RuntimeError(
+                f"Device configuration failed: {config_payload.get('info', '')}"
+            )
 
+        search_url = config_payload["data"]["config"]["googleAddressSearchURL"]
+        address = f"{self._street}, {self._suburb} QLD, Australia"
         geocode_response = requests.get(
-            "https://geocode.arcgis.com/arcgis/rest/services/"
-            "World/GeocodeServer/findAddressCandidates",
-            params=geocode_params,
-            timeout=20,
+            search_url.replace("%s", quote(address, safe="")),
+            headers=self._service.HEADERS,
+            timeout=30,
         )
         geocode_response.raise_for_status()
+        geocode_payload = geocode_response.json()
 
-        candidates = geocode_response.json().get("candidates", [])
-        if not candidates:
-            raise SourceArgumentNotFound(
-                "street",
-                f"{self._street}, {self._suburb}",
-                "please check the spelling of the street and suburb and try again.",
-            )
+        for result in geocode_payload.get("results", []):
+            component_types = {
+                component_type
+                for component in result.get("address_components", [])
+                for component_type in component.get("types", [])
+            }
+            if {"street_number", "route", "locality"}.issubset(component_types):
+                return result
 
-        candidate = candidates[0]
-        attributes = candidate.get("attributes", {})
-        postcode = attributes.get("Postal")
+        raise SourceArgumentNotFound("street", self._street)
 
-        if not postcode:
-            raise SourceArgumentNotFound(
-                "street",
-                f"{self._street}, {self._suburb}",
-                "the address could not be resolved to a postcode, "
-                "please check the spelling and try again.",
-            )
-
-        street_number, _, street_name = self._street.partition(" ")
-
-        route = (
-            " ".join(
-                part
-                for part in (
-                    attributes.get("StPreDir"),
-                    attributes.get("StPreType"),
-                    attributes.get("StName"),
-                    attributes.get("StType"),
-                    attributes.get("StDir"),
-                )
-                if part
-            )
-            or street_name
-        )
-
-        locality = attributes.get("Nbrhd") or self._suburb
-        state = attributes.get("Region") or "Queensland"
-
-        address_data = {
-            "address": {
-                "street_number": street_number,
-                "route": route,
-                "locality": locality,
-                "administrative_area_level_1": state,
-                "postal_code": postcode,
-                "part": "",
-                "subpremise": "",
-                "formatted_address": (
-                    f"{self._street}, {locality} {state} {postcode}, Australia"
-                ),
-            },
-            "geometry": {
-                "location": {
-                    "lat": candidate["location"]["y"],
-                    "lng": candidate["location"]["x"],
-                }
-            },
-        }
-
-        params = {
-            "apiKey": "b8dbca0c-ad9c-4f8a-8b9c-080fd435c5e7",
-            "agendaResultLimit": "3",
-            "dateFormat": "yyyy-MM-dd",
-            "displayFormat": "agenda",
-            "address": json.dumps(address_data, separators=(",", ":")),
-        }
-
-        response = requests.post(
-            "https://console.whatbinday.com/api/search",
-            data=params,
-            timeout=20,
-        )
-        response.raise_for_status()
-
-        parser = IpswichGovAuParser()
-        parser.feed(response.text)
-        return parser.entries
+    def fetch(self) -> list[Collection]:
+        entries = self._service.get_collection_schedule(self._geocode())
+        if not entries:
+            raise SourceArgumentNotFound("street", self._street)
+        return entries


### PR DESCRIPTION
Summary:`n- replace the retired console HTML GET lookup with the current Ipswich WhatBinDay V3 app API`n- resolve addresses through the council app bounded geocoder configuration`n- preserve the existing street and suburb arguments and return explicit not-found errors`n`nVerification:`n- Ruff check and format passed`n- live source cases returned 208 Camira events and 210 Redbank events`n- invalid-address control raises SourceArgumentNotFound