### PR TITLE
add Stirling Council, UK (stirling_gov_uk)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_gov_uk.py
@@ -98,6 +98,10 @@ class Source:
         for event in events:
             collection_date = date.fromisoformat(event["day"])
             for flag in event.get("flags", []):
+                # Skip non-pickup flags (e.g. holiday notices) so they don't
+                # surface as bogus collection types.
+                if flag.get("event_type") != "pickup":
+                    continue
                 waste_type = flag.get("subject") or flag.get("name")
                 if not waste_type:
                     continue

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_gov_uk.py
@@ -17,7 +17,8 @@ TEST_CASES = {
 
 # Stirling Council uses Routeware's ReCollect platform (area "StirlingUK").
 # The address lookup and collection events are provided by the ReCollect API.
-API_URL = "https://api.eu.recollect.net/api/areas/StirlingUK/services/waste"
+API_BASE = "https://api.eu.recollect.net/api"
+AREA_URL = f"{API_BASE}/areas/StirlingUK/services/waste"
 
 # Waste types returned by Stirling's ReCollect service (flag name -> icon).
 ICON_MAP = {
@@ -52,7 +53,7 @@ class Source:
     def _resolve_place_id(self) -> str:
         """Resolve the configured address to a ReCollect place ID."""
         response = requests.get(
-            f"{API_URL}/address-suggest",
+            f"{AREA_URL}/address-suggest",
             params={"q": self._address, "locale": "en-GB"},
             timeout=30,
         )
@@ -82,7 +83,7 @@ class Source:
         place_id = self._resolve_place_id()
 
         response = requests.get(
-            f"https://api.eu.recollect.net/api/places/{place_id}/services/waste/events",
+            f"{API_BASE}/places/{place_id}/services/waste/events",
             params={
                 "hide": "reminder_only",
                 "after": (date.today() - timedelta(days=30)).isoformat(),
@@ -94,7 +95,7 @@ class Source:
         response.raise_for_status()
         events = response.json().get("events", [])
 
-        entries = []
+        entries: list[Collection] = []
         for event in events:
             collection_date = date.fromisoformat(event["day"])
             for flag in event.get("flags", []):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/stirling_gov_uk.py
@@ -1,0 +1,111 @@
+from datetime import date, timedelta
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+)
+
+TITLE = "Stirling Council"
+DESCRIPTION = "Source for Stirling Council waste collection services."
+URL = "https://www.stirling.gov.uk/"
+TEST_CASES = {
+    "Kildean Road 38": {"address": "38 Kildean Road"},
+    "Merlo Buchanan Castle Estate": {"address": "Merlo"},
+}
+
+# Stirling Council uses Routeware's ReCollect platform (area "StirlingUK").
+# The address lookup and collection events are provided by the ReCollect API.
+API_URL = "https://api.eu.recollect.net/api/areas/StirlingUK/services/waste"
+
+# Waste types returned by Stirling's ReCollect service (flag name -> icon).
+ICON_MAP = {
+    "REFUSE": Icons.GENERAL_WASTE,
+    "GARDEN": Icons.ORGANIC,
+    "RECYCLING": Icons.PAPER,
+    "PLASTIC": Icons.RECYCLING,
+    "GLASS": Icons.GLASS,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Visit https://www.stirling.gov.uk/bins-and-recycling/bin-collection-dates-search/ and type your address into the search to see the exact wording, then use the same here. House number and street (e.g. '38 Kildean Road'), property name (e.g. 'Merlo'), or a single-dwelling postcode work.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": "Your address as entered on the Stirling Council bin collection dates search (house number and street, property name, or single-dwelling postcode)",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {"address": "Address"},
+}
+
+SOURCE_CODEOWNERS = ["@nagug"]
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = address
+
+    def _resolve_place_id(self) -> str:
+        """Resolve the configured address to a ReCollect place ID."""
+        response = requests.get(
+            f"{API_URL}/address-suggest",
+            params={"q": self._address, "locale": "en-GB"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        suggestions = response.json()
+
+        if not suggestions:
+            raise SourceArgumentNotFound("address", self._address)
+
+        if len(suggestions) > 1:
+            raise SourceArgAmbiguousWithSuggestions(
+                "address", self._address, [s["name"] for s in suggestions]
+            )
+
+        suggestion = suggestions[0]
+        if suggestion.get("type") != "parcel" or "place_id" not in suggestion:
+            # Multi-dwelling postcodes return a "place_qualifier" which needs a
+            # more specific address to resolve to a single property.
+            raise SourceArgumentNotFound(
+                "address",
+                self._address,
+                "this looks like a multi-dwelling postcode, please add your house number or property name.",
+            )
+        return suggestion["place_id"]
+
+    def fetch(self) -> list[Collection]:
+        place_id = self._resolve_place_id()
+
+        response = requests.get(
+            f"https://api.eu.recollect.net/api/places/{place_id}/services/waste/events",
+            params={
+                "hide": "reminder_only",
+                "after": (date.today() - timedelta(days=30)).isoformat(),
+                "before": (date.today() + timedelta(days=365)).isoformat(),
+                "locale": "en-GB",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        events = response.json().get("events", [])
+
+        entries = []
+        for event in events:
+            collection_date = date.fromisoformat(event["day"])
+            for flag in event.get("flags", []):
+                waste_type = flag.get("subject") or flag.get("name")
+                if not waste_type:
+                    continue
+                entries.append(
+                    Collection(
+                        date=collection_date,
+                        t=waste_type,
+                        icon=ICON_MAP.get(flag.get("name")),
+                    )
+                )
+        return entries

--- a/doc/source/stirling_gov_uk.md
+++ b/doc/source/stirling_gov_uk.md
@@ -1,0 +1,84 @@
+# Stirling Council
+
+Support for schedules provided by [Stirling Council](https://www.stirling.gov.uk/bins-and-recycling/bin-collection-dates-search/), serving Stirlingshire, UK.
+
+Stirling Council publishes its collection calendar via Routeware's ReCollect platform. This source looks up your address through the same API used by the council's bin collection dates search, so you only need to provide your address as you would type it there — no need to extract a calendar URL manually.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: stirling_gov_uk
+      args:
+        address: "38 Kildean Road"
+```
+
+### Configuration Variables
+
+**address**
+*(string) (required)*
+
+Your address as entered on the [Stirling Council bin collection dates search](https://www.stirling.gov.uk/bins-and-recycling/bin-collection-dates-search/). All of the following resolve to a single property:
+
+- house number and street: `38 Kildean Road`
+- property name: `Merlo`
+- a single-dwelling postcode: `FK8 1TB`
+
+For multi-dwelling postcodes the search returns a postcode rather than a property — add your house number or property name to make it unique.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: stirling_gov_uk
+      args:
+        address: "38 Kildean Road"
+```
+
+returns collections for `38 Kildean Road, Kildean, Stirling, FK8 1TB` with the waste types `Non-recyclable Waste`, `Food and Garden`, `Paper & Cardboard`, `Plastic, cans and cartons` and `Glass`.
+
+## Suggested Lovelace card setup
+
+The integration populates the built-in Home Assistant calendar with one event per waste type. If you use [TrashCard](https://github.com/idaho/hassio-trash-card), the following patterns match the waste type names exactly (`pattern_exact: true`, to avoid e.g. `recycle` matching `Non-recyclable`) and colour the chips like the corresponding Stirling bin lids (grey, brown, green, blue, purple):
+
+```yaml
+ type: custom:trash-card
+ entities:
+   - calendar.stirling_council
+ event_grouping: true
+ next_days: 6
+ with_label: true
+ pattern:
+   - type: waste
+     pattern: "Non-recyclable Waste"
+     pattern_exact: true
+     icon: mdi:trash-can
+     color: grey
+     label: General waste
+   - type: organic
+     pattern: "Food and Garden"
+     pattern_exact: true
+     icon: mdi:leaf
+     color: brown
+     label: Food & garden
+   - type: paper
+     pattern: "Paper & Cardboard"
+     pattern_exact: true
+     icon: mdi:package-variant
+     color: green
+     label: Paper & card
+   - type: recycle
+     pattern: "Plastic, cans and cartons"
+     pattern_exact: true
+     icon: mdi:recycle-variant
+     color: blue
+     label: Cans & plastics
+   - type: custom
+     pattern: "Glass"
+     pattern_exact: true
+     icon: mdi:bottle-soda
+     color: purple
+     label: Glass
+```

--- a/doc/source/stirling_gov_uk.md
+++ b/doc/source/stirling_gov_uk.md
@@ -80,4 +80,5 @@ pattern:
     pattern_exact: true
     icon: mdi:bottle-soda
     color: purple
-    label: Glass```
+    label: Glass
+```

--- a/doc/source/stirling_gov_uk.md
+++ b/doc/source/stirling_gov_uk.md
@@ -44,41 +44,40 @@ returns collections for `38 Kildean Road, Kildean, Stirling, FK8 1TB` with the w
 The integration populates the built-in Home Assistant calendar with one event per waste type. If you use [TrashCard](https://github.com/idaho/hassio-trash-card), the following patterns match the waste type names exactly (`pattern_exact: true`, to avoid e.g. `recycle` matching `Non-recyclable`) and colour the chips like the corresponding Stirling bin lids (grey, brown, green, blue, purple):
 
 ```yaml
- type: custom:trash-card
- entities:
-   - calendar.stirling_council
- event_grouping: true
- next_days: 6
- with_label: true
- pattern:
-   - type: waste
-     pattern: "Non-recyclable Waste"
-     pattern_exact: true
-     icon: mdi:trash-can
-     color: grey
-     label: General waste
-   - type: organic
-     pattern: "Food and Garden"
-     pattern_exact: true
-     icon: mdi:leaf
-     color: brown
-     label: Food & garden
-   - type: paper
-     pattern: "Paper & Cardboard"
-     pattern_exact: true
-     icon: mdi:package-variant
-     color: green
-     label: Paper & card
-   - type: recycle
-     pattern: "Plastic, cans and cartons"
-     pattern_exact: true
-     icon: mdi:recycle-variant
-     color: blue
-     label: Cans & plastics
-   - type: custom
-     pattern: "Glass"
-     pattern_exact: true
-     icon: mdi:bottle-soda
-     color: purple
-     label: Glass
-```
+type: custom:trash-card
+entities:
+  - calendar.stirling_council
+event_grouping: true
+next_days: 6
+with_label: true
+pattern:
+  - type: waste
+    pattern: "Non-recyclable Waste"
+    pattern_exact: true
+    icon: mdi:trash-can
+    color: grey
+    label: General waste
+  - type: organic
+    pattern: "Food and Garden"
+    pattern_exact: true
+    icon: mdi:leaf
+    color: brown
+    label: Food & garden
+  - type: paper
+    pattern: "Paper & Cardboard"
+    pattern_exact: true
+    icon: mdi:package-variant
+    color: green
+    label: Paper & card
+  - type: recycle
+    pattern: "Plastic, cans and cartons"
+    pattern_exact: true
+    icon: mdi:recycle-variant
+    color: blue
+    label: Cans & plastics
+  - type: custom
+    pattern: "Glass"
+    pattern_exact: true
+    icon: mdi:bottle-soda
+    color: purple
+    label: Glass```


### PR DESCRIPTION
## Summary

Adds a dedicated source for Stirling Council, UK, replacing the route-based `stirling_uk` source that was removed in #5976 after the council moved their bin collection lookup to Routeware's ReCollect platform.

Closes #5624 (source request: Stirling Council Change of Source).

### How it works

- Users configure a single `address` argument exactly as they would type it into the [council's bin collection dates search](https://www.stirling.gov.uk/bins-and-recycling/bin-collection-dates-search/) — house number + street (`38 Kildean Road`), property name (`Merlo`), or a single-dwelling postcode.
- The source resolves the address to a ReCollect place ID via `/api/areas/StirlingUK/services/waste/address-suggest`, then fetches events from `/api/places/{place_id}/services/waste/events` (~30 days back, 365 days forward).
- The events JSON keeps all five Stirling waste types separate (`Non-recyclable Waste`, `Food and Garden`, `Paper & Cardboard`, `Plastic, cans and cartons`, `Glass`), unlike the ICS feed which merges same-day collections into combined summaries like "Refuse and garden" — so this is an improvement over the generic ReCollect ICS route currently listed in `doc/ics/recollect.md`.
- Helpful errors: not-found, ambiguous-with-suggestions, and a hint when a multi-dwelling postcode needs a house number/property name added.

Tested working on a live Home Assistant install (Stirling address, TrashCard UI).

## Type of change

- [x] New source
- [x] Bug fix / source fix
- [x] Documentation update
- [x] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (full suite: 35 passed; the 3 `test_fetch_retry` failures are pre-existing on master when the `homeassistant` package is not installed in the venv)
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/stirling_gov_uk.md` created for new source (includes an optional TrashCard pattern example colour-matched to Stirling's bin lids)
- [x] TEST_CASES use real, publicly accessible addresses (not my own)