### PR TITLE
Fix Coventry table calendar parsing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 import requests
 from bs4 import BeautifulSoup
@@ -28,9 +28,10 @@ TEST_CASES = {
 }
 _LOGGER = logging.getLogger(__name__)
 ICON_MAP = {
-    "green-lidded (rubbish) bin": Icons.GENERAL_WASTE,
-    "blue-lidded (recycling) bin": Icons.RECYCLING,
-    "brown-lidded (garden waste) bin": Icons.GARDEN,
+    "Recycling (blue-lidded bin)": Icons.RECYCLING,
+    "Household waste (green-lidded bin)": Icons.GENERAL_WASTE,
+    "Garden waste (brown-lidded bin)": Icons.GARDEN,
+    "Food waste caddy": Icons.BIO_KITCHEN,
 }
 
 PARAM_TRANSLATIONS = {
@@ -52,19 +53,6 @@ def _normalize_space(text: str) -> str:
 class Source:
     def __init__(self, street: str):
         self._street: str = street
-
-    def append_year(self, d: str) -> date:
-        # Website dates don't have the year.
-        # Append the current year, and then check to see if the date is in the past.
-        # If it is, increment the year by 1.
-        d = _normalize_space(d)
-
-        today: date = datetime.now().date()
-        this_year: int = today.year
-        dt: date = datetime.strptime(f"{d} {this_year}", "%A %d %B %Y").date()
-        if (dt - today) < timedelta(days=-31):
-            dt = dt.replace(year=dt.year + 1)
-        return dt
 
     def fetch(self) -> list[Collection]:
         s = requests.Session()
@@ -105,51 +93,57 @@ class Source:
                 f"No bin collection calendar link found for '{self._street}'"
             )
 
-        # use collction day to get schedule
+        # Use the collection calendar link to get the current schedule.
         r = s.get(schedule, headers=HEADERS, timeout=30)
+        r.raise_for_status()
         soup = BeautifulSoup(r.content, "html.parser")
         entries: list[Collection] = []
 
-        # Schedule page contains month widgets with <div class="editor"> text and <br> separators.
-        for editor in soup.select("div.widget--content div.widget-content div.editor"):
-            current_date_part: str | None = None
-            current_types_parts: list[str] = []
+        # Coventry changed its calendars from colon-delimited prose to one
+        # table per month. Each waste column contains Yes/No for every date.
+        today = date.today()
+        for table in soup.select("div.editor table"):
+            heading = table.find_previous(["h2", "h3"])
+            year_match = re.search(
+                r"\b(20\d{2})\b", heading.get_text() if heading else ""
+            )
+            if year_match is None:
+                continue
+            year = year_match.group(1)
 
-            def flush(date_part: str | None, types_parts: list[str]) -> None:
-                if date_part is None:
-                    return
+            headers = [
+                _normalize_space(cell.get_text(" ", strip=True))
+                for cell in table.select("thead th")
+            ]
+            if len(headers) < 2:
+                continue
 
+            for row in table.select("tbody tr"):
+                cells = row.find_all(["th", "td"])
+                if len(cells) != len(headers):
+                    continue
+                date_text = _normalize_space(cells[0].get_text(" ", strip=True))
                 try:
-                    waste_date = self.append_year(date_part)
-                    types_part = _normalize_space(" ".join(types_parts))
-                    for waste_type in (
-                        t.strip()
-                        for t in re.split(r"\s+and\s+", types_part)
-                        if t.strip()
-                    ):
-                        entries.append(
-                            Collection(
-                                date=waste_date,
-                                t=waste_type,
-                                icon=ICON_MAP.get(waste_type, "mdi:trash-can"),
-                            )
-                        )
-                except Exception as e:
-                    _LOGGER.warning(f"Error processing item '{date_part}': {e}")
-
-            for raw_line in editor.get_text("\n", strip=True).splitlines():
-                line = _normalize_space(raw_line)
-                if not line:
+                    waste_date = datetime.strptime(
+                        f"{date_text} {year}", "%A %d %B %Y"
+                    ).date()
+                except ValueError:
+                    _LOGGER.warning(
+                        "Could not parse Coventry collection date '%s'", date_text
+                    )
+                    continue
+                if waste_date < today:
                     continue
 
-                if ":" in line:
-                    flush(current_date_part, current_types_parts)
-                    date_part, types_part = (p.strip() for p in line.split(":", 1))
-                    current_date_part = date_part
-                    current_types_parts = [types_part] if types_part else []
-                elif current_date_part is not None:
-                    current_types_parts.append(line)
-
-            flush(current_date_part, current_types_parts)
+                for waste_type, cell in zip(headers[1:], cells[1:], strict=True):
+                    if not re.search(r"\byes\b", cell.get_text(" ", strip=True), re.I):
+                        continue
+                    entries.append(
+                        Collection(
+                            date=waste_date,
+                            t=waste_type,
+                            icon=ICON_MAP.get(waste_type),
+                        )
+                    )
 
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
@@ -142,7 +142,7 @@ class Source:
                         Collection(
                             date=waste_date,
                             t=waste_type,
-                            icon=ICON_MAP.get(waste_type),
+                            icon=ICON_MAP.get(waste_type, Icons.GENERAL_WASTE),
                         )
                     )
 


### PR DESCRIPTION
## Summary

- parse Coventry's new monthly collection tables instead of the retired prose layout
- support recycling, household, garden and food waste columns
- ignore past dates and retain canonical waste icons

Closes #7082

## Verification

- python -m ruff check --fix custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py`n- python -m ruff format custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py`n- python custom_components/waste_collection_schedule/waste_collection_schedule/test/test_sources.py -s coventry_gov_uk -l (all three live cases return 32 future collections)
- python -m pytest tests/test_source_components.py -q (35 passed)