### PR TITLE
Fix castlepoint_gov_uk returning the wrong street when a name is not unique

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/castlepoint_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/castlepoint_gov_uk.py
@@ -5,8 +5,9 @@ import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
     SourceArgumentExceptionMultiple,
-    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
 )
 
 TITLE = "Castle Point Borough Council"
@@ -18,6 +19,16 @@ TEST_CASES = {
     "ABBOTSWOOD": {"roadID": "4448"},
     "Ash Road": {"street_name": "Ash Road"},
     "St Marys Road": {"street_name": "St Marys Road"},
+    # "Ash Road" also matches "ASH ROAD - HADLEIGH" once the district suffix is
+    # dropped; naming the suffixed street picks that one instead.
+    "Ash Road, Hadleigh": {"street_name": "ASH ROAD - HADLEIGH"},
+    # HIGH STREET exists in both Benfleet and Canvey Island, on different
+    # rounds, so bare "High Street" is genuinely ambiguous. This covers the
+    # town-qualified form the ambiguity error hands back.
+    "High Street (Canvey Island)": {"street_name": "HIGH STREET (CANVEY ISLAND)"},
+    # A house number in front of the street is what a resident naturally types;
+    # the council's own search returns nothing at all for it.
+    "12 Ash Road": {"street_name": "12 Ash Road"},
 }
 
 API_URLS = {
@@ -46,53 +57,165 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
 PARAM_DESCRIPTIONS = {
     "en": {
         "roadID": "Your roadID retrieved from the URL after selecting your street.",
-        "street_name": "The name of your street (only needed if you don't provide roadID).",
+        "street_name": (
+            "The name of your street (only needed if you don't provide roadID). "
+            "If two towns in the borough share a street name, add the town in "
+            "brackets, e.g. 'HIGH STREET (CANVEY ISLAND)'."
+        ),
     }
 }
 
 PARAM_TRANSLATIONS = {"en": {"roadID": "Road ID", "street_name": "Street Name"}}
 
+# "12 Ash Road", "12a Ash Road", "12-14 High Street" -> "Ash Road".
+# The council's street search matches street names only and returns no results
+# at all when a house number is included.
+_LEADING_HOUSE_NUMBER = re.compile(r"^\s*\d+[A-Za-z]?\s*(?:[-/,]\s*\d*[A-Za-z]?\s*)?")
+
+# Trailing "(TOWN)" as offered by this source's own suggestions, so a value
+# taken from an ambiguity error can be handed straight back.
+_TRAILING_TOWN = re.compile(r"\s*\(([^)]*)\)\s*$")
+
+
+def _normalise(value: str) -> str:
+    """Upper-case and strip punctuation/extra spaces for comparison only."""
+    return re.sub(r"\s+", " ", re.sub(r"[^A-Z0-9 ]", " ", value.upper())).strip()
+
 
 class Source:
     def __init__(self, roadID=None, street_name=None):
         if roadID is None and street_name is None:
-            errors = []
-            if roadID is None:
-                errors.append("roadID")
-            if street_name is None:
-                errors.append("street_name")
             raise SourceArgumentExceptionMultiple(
-                errors,
+                ["roadID", "street_name"],
                 "Either roadID or street_name is required to fetch waste collection schedule.",
             )
 
         self._roadID = roadID if roadID is not None else self._get_road_id(street_name)
         self._street_name = street_name
 
-    def _get_road_id(self, street_name):
+    def _search(self, searchterm):
+        """Return [(town, street_label, road_id)] for one search term."""
         session = requests.Session()
-        search_url = API_URLS["find_road"]
-
-        payload = {"searchterm": street_name}
-
-        response = session.post(search_url, data=payload, timeout=10)
+        response = session.post(
+            API_URLS["find_road"], data={"searchterm": searchterm}, timeout=10
+        )
         response.raise_for_status()
 
         soup = BeautifulSoup(response.text, "html.parser")
 
-        for link in soup.find_all("a", href=True):
-            href = link["href"]
-            if "roadID=" in href:
-                params = href.split("?")[-1].split("&")
-                for p in params:
-                    if p.startswith("roadID="):
-                        road_id = p.split("=")[1]
-                        return road_id
+        # Results are grouped per town:
+        #   <div class="flex-item-town"><h3>BENFLEET</h3>
+        #     <ol><li><a href="...roadID=4907">HIGH STREET</a></li>...
+        # The town is the only thing distinguishing two identically named
+        # streets (HIGH STREET exists in both Benfleet and Canvey Island), so it
+        # has to be carried alongside the label rather than discarded.
+        candidates = []
+        for group in soup.find_all("div", class_="flex-item-town"):
+            heading = group.find("h3")
+            town = heading.text.strip() if heading else ""
+            for link in group.find_all("a", href=True):
+                match = re.search(r"roadID=(\d+)", link["href"])
+                if match:
+                    candidates.append((town, link.text.strip(), match.group(1)))
+        return candidates
 
-        raise SourceArgumentNotFound(
+    @staticmethod
+    def _display(town, street_label):
+        """How a candidate is offered back to the user."""
+        return f"{street_label} ({town})" if town else street_label
+
+    @staticmethod
+    def _match_tiers(town, street_label):
+        """The names this candidate answers to, most specific first.
+
+        Tried in order so that a more exact reading wins before a looser one:
+
+        0. Town-qualified, the way this source suggests it. The only form that
+           separates two streets of the same name in different towns.
+        1. The label exactly as the council writes it.
+        2. The label without the council's district suffix, which is how a
+           resident names the street: "GIFFORD ROAD", not
+           "GIFFORD ROAD - SOUTH BENFLEET".
+
+        The ordering matters. "Ash Road" is both the full name of a street in
+        Canvey Island and the un-suffixed form of "ASH ROAD - HADLEIGH" in
+        Benfleet; tier 1 settles it on the one actually called Ash Road rather
+        than declaring the borough ambiguous.
+        """
+        return [
+            _normalise(Source._display(town, street_label)),
+            _normalise(street_label),
+            _normalise(street_label.split(" - ")[0]),
+        ]
+
+    @staticmethod
+    def _search_terms(street_name):
+        """Search terms to try, most specific first.
+
+        The council's search matches bare street names and returns nothing at
+        all for anything else — not for a house number in front, not for the
+        town-qualified form this source suggests, and not even for the
+        council's own "STREET - DISTRICT" label. So the term is progressively
+        simplified until the register recognises it, while the original value
+        is kept for matching.
+        """
+        terms = []
+
+        def add(term):
+            term = term.strip()
+            if term and term not in terms:
+                terms.append(term)
+
+        add(street_name)
+        without_number = _LEADING_HOUSE_NUMBER.sub("", street_name, count=1)
+        add(without_number)
+        without_town = _TRAILING_TOWN.sub("", without_number)
+        add(without_town)
+        add(without_town.split(" - ")[0])
+        return terms
+
+    def _get_road_id(self, street_name):
+        terms = self._search_terms(street_name)
+
+        candidates = []
+        for term in terms:
+            candidates = self._search(term)
+            if candidates:
+                break
+
+        # Match on the most specific form that identifies something, so a
+        # town-qualified value picks one of several same-named streets while a
+        # bare one still resolves.
+        matches = []
+        for term in terms:
+            wanted = _normalise(term)
+            for tier in range(3):
+                matches = [
+                    c
+                    for c in candidates
+                    if self._match_tiers(c[0], c[1])[tier] == wanted
+                ]
+                if matches:
+                    break
+            if matches:
+                break
+
+        if len(matches) == 1:
+            return matches[0][2]
+
+        # More than one street answers to this name, and they are on different
+        # collection rounds. Returning any one of them is a coin toss, so ask.
+        if len(matches) > 1:
+            raise SourceArgAmbiguousWithSuggestions(
+                "street_name",
+                street_name,
+                [self._display(town, label) for town, label, _ in matches],
+            )
+
+        raise SourceArgumentNotFoundWithSuggestions(
             "street_name",
             street_name,
-            f"Could not find a matching roadID for street name '{street_name}'.\nPlease check that the street name is correct and try again. If the problem persists, the council may have changed their website structure which would require an update to this integration.",
+            [self._display(town, label) for town, label, _ in candidates],
         )
 
     def fetch(self):
@@ -104,6 +227,7 @@ class Source:
         soup = BeautifulSoup(response.text, "html.parser")
 
         entries = []
+        now = datetime.now()
 
         # Find all tables or calendar container blocks on the page
         calendar_tables = soup.find_all("table", class_="calendar")
@@ -127,9 +251,18 @@ class Source:
             month_name = month_match.group(1)
             month = datetime.strptime(month_name.capitalize(), "%B").month
 
-            # Extract the year, defaulting to current year if missing
+            # The council's headers carry the month but no year ("August",
+            # "September"), so the year has to be inferred. The page shows the
+            # current month and the next one, which means that in December the
+            # second table is January of the *following* year — dating it to the
+            # current one put those collections eleven months in the past.
             year_match = re.search(r"\b(\d{4})\b", header_text)
-            year = int(year_match.group(1)) if year_match else datetime.now().year
+            if year_match:
+                year = int(year_match.group(1))
+            elif month < now.month - 6:
+                year = now.year + 1
+            else:
+                year = now.year
 
             # 2. Now scope your search for days ONLY inside this specific month's table
             day_elements = table.select(".pink, .normal")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/castlepoint_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/castlepoint_gov_uk.py
@@ -132,20 +132,26 @@ class Source:
 
         0. Town-qualified, the way this source suggests it. The only form that
            separates two streets of the same name in different towns.
-        1. The label exactly as the council writes it.
-        2. The label without the council's district suffix, which is how a
+        1. Town-qualified but without the district suffix, e.g.
+           "ASH ROAD (BENFLEET)" for "ASH ROAD - HADLEIGH" in Benfleet. The
+           bracketed town is what the parameter description tells people to add,
+           so it has to win over an un-qualified match on a different town.
+        2. The label exactly as the council writes it.
+        3. The label without the council's district suffix, which is how a
            resident names the street: "GIFFORD ROAD", not
            "GIFFORD ROAD - SOUTH BENFLEET".
 
         The ordering matters. "Ash Road" is both the full name of a street in
         Canvey Island and the un-suffixed form of "ASH ROAD - HADLEIGH" in
-        Benfleet; tier 1 settles it on the one actually called Ash Road rather
+        Benfleet; tier 2 settles it on the one actually called Ash Road rather
         than declaring the borough ambiguous.
         """
+        bare_label = street_label.split(" - ")[0]
         return [
             _normalise(Source._display(town, street_label)),
+            _normalise(Source._display(town, bare_label)),
             _normalise(street_label),
-            _normalise(street_label.split(" - ")[0]),
+            _normalise(bare_label),
         ]
 
     @staticmethod
@@ -189,7 +195,7 @@ class Source:
         matches = []
         for term in terms:
             wanted = _normalise(term)
-            for tier in range(3):
+            for tier in range(len(self._match_tiers("", ""))):
                 matches = [
                     c
                     for c in candidates

--- a/doc/source/castlepoint_gov_uk.md
+++ b/doc/source/castlepoint_gov_uk.md
@@ -26,7 +26,26 @@ waste_collection_schedule:
 
 Either `roadID` or `street_name` is required.
 
+A leading house number is accepted and ignored, so `12 Ash Road` resolves the
+same as `Ash Road`.
+
+Some street names occur more than once in the borough — there is a High Street in
+both Benfleet and Canvey Island, on different collection rounds. When that
+happens the configuration fails with the list of matching streets, each qualified
+by its town, and any one of those values can be used verbatim:
+
+```yaml
+street_name: "HIGH STREET (CANVEY ISLAND)"
+```
+
 To find your `roadID`, go to the [Castle Point my street page](https://apps.castlepoint.gov.uk/cpapps/index.cfm?fa=myStreet&f=homepage1), either enter your street name in the search box or select the first letter of your street, click on the street name, and look for the `roadID` in the URL.
+
+## Note for users outside the UK
+
+`apps.castlepoint.gov.uk` sits behind a firewall that only accepts connections
+from UK IP addresses; from anywhere else the connection is dropped without a
+reply. A Home Assistant instance hosted outside the UK (including on a
+non-UK cloud region or VPN exit) will see this source time out.
 
 ## Example
 


### PR DESCRIPTION
## Problem

`_get_road_id` returns the **first** `roadID=` link on the search results page, whatever it happens to be. Several street names occur more than once in the borough, on different collection rounds, so residents of the other one silently get another street's schedule.

Live results today:

```
searchterm=High Street  -> 3 results
    BENFLEET      / HIGH STREET            / 4907
    BENFLEET      / HIGH STREET - HADLEIGH / 4909
    CANVEY ISLAND / HIGH STREET            / 4908

searchterm=Ash Road    -> 2 results
    BENFLEET      / ASH ROAD - HADLEIGH    / 4481
    CANVEY ISLAND / ASH ROAD               / 4480
```

**The existing `Ash Road` TEST_CASE is one of these**, and the two are genuinely different rounds — fetched through the live site just now:

| `street_name` | roadID | next black sack | next pink sack |
|---|---|---|---|
| `Ash Road` (before this PR) | 4481 | 28 Aug | 5 Sep |
| `Ash Road` (after this PR) | 4480 | 1 Sep | 7 Sep |

So Canvey Island's Ash Road residents have been getting Benfleet's dates, and the test case passed throughout because it only ever checked that *some* dates came back.

Two smaller problems in the same path:

- The council's search matches bare street names and returns **nothing at all** for anything else — including a leading house number. `12 Ash Road`, which is what a resident naturally types, found no street whatsoever. (It also rejects the council's own `ASH ROAD - HADLEIGH` label.)
- A failed lookup raised bare `SourceArgumentNotFound`, so the config flow had no candidates to offer even when the search had returned some.

And one unrelated latent bug found while verifying the calendar parse:

- The month headers carry a month but no year (`August`, `September`), and the year fell back to `datetime.now().year` unconditionally. The page shows the current month *and the next*, so in December the second table is January of the following year — every collection in it was dated eleven months into the past.

## Change

Results are grouped per town in the markup (`div.flex-item-town` > `h3`), which is the only thing separating two streets of the same name. The town is now kept alongside the label, and candidates are matched in tiers:

0. town-qualified form, `HIGH STREET (CANVEY ISLAND)`
1. the council's exact label, `ASH ROAD`
2. the label without its district suffix, `GIFFORD ROAD` from `GIFFORD ROAD - SOUTH BENFLEET`

The tier order is what keeps `Ash Road` deterministic: it is both the full name of a Canvey Island street and the un-suffixed form of Benfleet's `ASH ROAD - HADLEIGH`, and tier 1 settles it on the one actually called Ash Road instead of declaring it ambiguous.

Where tiers cannot separate the candidates — `High Street` matches two byte-identical `HIGH STREET` labels — it now raises `SourceArgAmbiguousWithSuggestions` listing `HIGH STREET (BENFLEET)` and `HIGH STREET (CANVEY ISLAND)`. **Those suggested values are accepted verbatim as `street_name`**, so the config flow round-trips.

The search term is progressively simplified (house number, then town suffix, then district suffix) until the register recognises it, while the original value is kept for matching. `roadID` is untouched and still bypasses the search entirely.

## Behaviour change worth flagging

Anyone configured with `street_name: Ash Road` moves from roadID 4481 to 4480. The previous answer was positional, not chosen. Benfleet's street stays reachable as `ASH ROAD - HADLEIGH` or by `roadID: 4481`. I think that is the right way round, but happy to reverse the tie-break if you disagree.

## Verification

Everything below was run against the live site. Note that `apps.castlepoint.gov.uk` sits behind a firewall that only accepts UK IP addresses and drops everything else without a reply, so this source cannot be tested from outside the UK — I used a UK vantage point, and have added a note about it to the doc page since it also affects non-UK Home Assistant instances.

- Search-results and calendar HTML captured live, and the parser exercised against those pages: exact-label vs suffix-stripped tie-break, house-number stripping, suggestion round-trip, ambiguity, and the December→January year rollover.
- Parsed dates for `GIFFORD ROAD` (4802) cross-checked against the council's own calendar page — all nine entries, including the Thu 3 Sep slip for the bank-holiday week commencing 31 August.
- All TEST_CASES resolve live, `roadID` included.
- `python -m pytest tests/test_source_components.py` — 35 passed.
- `ruff check` / `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
