### PR TITLE
Fix Gosnells: migrate to OpenCities MyArea platform

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gosnells_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gosnells_wa_gov_au.py
@@ -112,9 +112,8 @@ def _parse_date(next_service: str, note: str, today: date) -> date | None:
     """Return the start date of a service's next collection."""
     match = _PRECISE_RE.search(next_service)
     if match:
-        day, month, year = (int(g) for g in match.groups())
         try:
-            return date(year, month, day)
+            return date(int(match.group(3)), int(match.group(2)), int(match.group(1)))
         except ValueError:
             return None
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gosnells_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gosnells_wa_gov_au.py
@@ -1,8 +1,12 @@
-from datetime import datetime
+import re
+from datetime import date, datetime
 
-import requests
-from dateutil.rrule import DAILY, FR, MO, SA, SU, TH, TU, WE, rrule
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
 
 TITLE = "City of Gosnells"
 DESCRIPTION = "Source for City of Gosnells, Western Australia."
@@ -13,78 +17,175 @@ TEST_CASES = {
     "Test_003": {"address": "35 Prince Street GOSNELLS 6110"},
     "Test_004 (space character test)": {"address": "4A Turley Court LANGFORD 6147"},
 }
-HEADERS = {"user-agent": "Mozilla/5.0", "accept": "application/json"}
-ICON_MAP = {
-    "rubbish": Icons.GENERAL_WASTE,
-    "recycling": Icons.RECYCLING,
-    "green": Icons.ORGANIC,
-    "junk": Icons.ELECTRONICS,
+
+PAGE_URL = "https://www.gosnells.wa.gov.au/City-Services/Waste-and-Recycling/Find-your-waste-collection-dates"
+
+HEADERS = {
+    "user-agent": "Mozilla/5.0",
+    # Without an explicit Accept header the search endpoint returns XML
+    # instead of JSON.
+    "accept": "application/json, text/javascript, */*; q=0.01",
+    "x-requested-with": "XMLHttpRequest",
+    "referer": PAGE_URL,
 }
-DAYS = {
-    "MONDAY": MO,
-    "TUESDAY": TU,
-    "WEDNESDAY": WE,
-    "THURSDAY": TH,
-    "FRIDAY": FR,
-    "SATURDAY": SA,
-    "SUNDAY": SU,
+
+# Council service name (the h3 in the widget) mapped to the collection type
+# reported to Home Assistant. The names on the right preserve the types this
+# source emitted before the council moved to the OpenCities MyArea platform,
+# so existing dashboards and automations keep working.
+TYPE_MAP = {
+    "general waste": "Rubbish",
+    "recycling": "Recycling",
+    "green waste": "Green",
+    "bulk junk": "Junk",
+}
+
+ICON_MAP = {
+    "Rubbish": Icons.GENERAL_WASTE,
+    "Recycling": Icons.RECYCLING,
+    "Green": Icons.ORGANIC,
+    "Junk": Icons.ELECTRONICS,
+}
+
+MONTHS = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
 }
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
-    "en": "Use the [City of Gosnells](https://www.gosnells.wa.gov.au/Your_property/Rubbish_and_recycling/Find_your_waste_collection_dates) website and search for your collection schedule. Use your address as it is displayed on the search results page.",
+    "en": f"Use the [City of Gosnells]({PAGE_URL}) website and search for your collection schedule. Use your address as it is displayed on the search results page.",
 }
-PARAM_DESCRIPTIONS = {  # Optional dict to describe the arguments, will be shown in the GUI configuration below the respective input field
+PARAM_DESCRIPTIONS = {
     "en": {
         "address": "Your street name and house number as it appears on the City of Gosnells website",
     },
 }
-PARAM_TRANSLATIONS = {  # Optional dict to translate the arguments, will be shown in the GUI configuration form as placeholder text
+PARAM_TRANSLATIONS = {
     "en": {
         "address": "Your street name and house number as it appears on the City of Gosnells website"
     },
 }
 
+_CONFIG = OpenCitiesConfig(
+    domain="https://www.gosnells.wa.gov.au",
+    argument_name="address",
+    headers=HEADERS,
+    # The council sits behind Akamai, which rejects the TLS handshake plain
+    # requests/urllib3 produces and answers 403 before the request reaches
+    # the application.
+    use_curl_cffi=True,
+)
+
+# "Mon 7/9/2026"
+_PRECISE_RE = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{4})")
+# "5th Oct - 13th Oct."
+_APPROX_RE = re.compile(r"(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]{3,})", re.IGNORECASE)
+_YEAR_RE = re.compile(r"(20\d{2})")
+
+
+def _candidate_years(note: str, today: date) -> list[int]:
+    """Years the note could be referring to.
+
+    A note naming one year ("Verge Collection 2026") is taken at its word, even
+    if that collection has already been and gone: verge collection weeks move
+    from year to year, so rolling a past date forward would invent a date the
+    council has not published. Only a note naming a span ("Verge Collection
+    2026-2027") or naming no year at all leaves a real choice to make.
+    """
+    years = [int(y) for y in _YEAR_RE.findall(note)]
+    if not years:
+        years = [today.year, today.year + 1]
+    return sorted(set(years))
+
+
+def _parse_date(next_service: str, note: str, today: date) -> date | None:
+    """Return the start date of a service's next collection."""
+    match = _PRECISE_RE.search(next_service)
+    if match:
+        day, month, year = (int(g) for g in match.groups())
+        try:
+            return date(year, month, day)
+        except ValueError:
+            return None
+
+    # Verge collections give an approximate window instead, e.g.
+    # "5th Oct - 13th Oct." The year appears only in the note ("Verge
+    # Collection 2026-2027"), so try each year the note names and take the
+    # first occurrence that has not already passed.
+    match = _APPROX_RE.search(next_service)
+    if not match:
+        return None
+    day = int(match.group(1))
+    month = MONTHS.get(match.group(2)[:3].lower())
+    if month is None:
+        return None
+
+    candidates = []
+    for year in _candidate_years(note, today):
+        try:
+            candidates.append(date(year, month, day))
+        except ValueError:
+            continue
+    future = [d for d in candidates if d >= today]
+    if future:
+        return min(future)
+    return max(candidates) if candidates else None
+
 
 class Source:
-    def __init__(self, address):
+    def __init__(self, address: str):
         self._address = address
+        self._client = OpenCitiesClient(_CONFIG)
+        self._geolocation_id: str | None = None
 
-    def fetch(self):
-        s = requests.Session()
+    def fetch(self) -> list[Collection]:
+        # Gosnells reports its verge collections as an approximate window
+        # ("5th Oct - 13th Oct.") whose year lives in the block's "note" div,
+        # which the shared client's parser doesn't return, so parse the raw
+        # HTML locally.
+        if self._geolocation_id is None:
+            self._geolocation_id = self._client.resolve_geolocation_id(self._address)
+        html = self._client.get_waste_services_html(self._geolocation_id)
+        soup = BeautifulSoup(html, "html.parser")
 
-        # get property id
-        data = {"query": self._address}
-        r = s.post(
-            "https://t1.gosnells.wa.gov.au/API/waste/v8/address",
-            headers=HEADERS,
-            data=data,
-        ).json()
-        property_id = r["results"][0]["property_no"]
+        today = datetime.now().date()
+        entries: list[Collection] = []
+        for block in soup.find_all("div", attrs={"class": "waste-services-result"}):
+            title = block.find("h3")
+            next_service = block.find("div", attrs={"class": "next-service"})
+            if title is None or next_service is None:
+                continue
 
-        # get schedule
-        r = s.get(
-            f"https://t1.gosnells.wa.gov.au/API/waste/v8/propertyNum/{property_id}",
-            headers=HEADERS,
-        ).json()
+            note = block.find("div", attrs={"class": "note"})
+            note_text = note.get_text(" ", strip=True) if note else ""
 
-        entries = []
-        for item in r["results"][0]:
-            for waste_type in ICON_MAP:
-                if waste_type in item and "status" not in item:
-                    if waste_type == "rubbish":
-                        # generate date from collection day
-                        today = datetime.now()
-                        day = DAYS[r["results"][0][item].strip()]
-                        dt = (rrule(DAILY, byweekday=day, dtstart=today)[0]).date()
-                    else:
-                        # use collection date provided
-                        dt = datetime.strptime(r["results"][0][item], "%Y-%m-%d").date()
-                    entries.append(
-                        Collection(
-                            date=dt,
-                            t=waste_type.capitalize(),
-                            icon=ICON_MAP.get(waste_type),
-                        )
-                    )
+            collection_date = _parse_date(
+                next_service.get_text(" ", strip=True), note_text, today
+            )
+            if collection_date is None:
+                continue
+
+            # "Green Waste 1" and "Green Waste 2" are the two verge collections.
+            name = title.get_text(" ", strip=True)
+            key = re.sub(r"\s*\d+$", "", name).strip().lower()
+            waste_type = TYPE_MAP.get(key, name)
+
+            entries.append(
+                Collection(
+                    date=collection_date,
+                    t=waste_type,
+                    icon=ICON_MAP.get(waste_type),
+                )
+            )
 
         return entries

--- a/doc/source/gosnells_wa_gov_au.md
+++ b/doc/source/gosnells_wa_gov_au.md
@@ -17,6 +17,8 @@ waste_collection_schedule:
 **address**
 *(string) (required)*
 
+Your street address as it appears on the City of Gosnells website, e.g. `15 Mackay Crescent GOSNELLS 6110`.
+
 ## Example
 
 ```yaml

--- a/doc/source/gosnells_wa_gov_au.md
+++ b/doc/source/gosnells_wa_gov_au.md
@@ -1,6 +1,6 @@
 # City of Gosnells
 
-Support for schedules provided by the [City of Gosnells](https://www.gosnells.wa.gov.au/Your_property/Rubbish_and_recycling/Find_your_waste_collection_dates), Western Australia.
+Support for schedules provided by the [City of Gosnells](https://www.gosnells.wa.gov.au/City-Services/Waste-and-Recycling/Find-your-waste-collection-dates), Western Australia.
 
 ## Configuration via configuration.yaml
 
@@ -22,11 +22,11 @@ waste_collection_schedule:
 ```yaml
 waste_collection_schedule:
   sources:
-    - name: gosnells_w_gov_au
+    - name: gosnells_wa_gov_au
       args:
         address: "15 Mackay Crescent GOSNELLS 6110"
 ```
 
 ## How to get the source arguments
 
-Use the [City of Gosnells](https://www.gosnells.wa.gov.au/Your_property/Rubbish_and_recycling/Find_your_waste_collection_dates) website and search for your collection schedule. Use your address as it is displayed on the search results page.
+Use the [City of Gosnells](https://www.gosnells.wa.gov.au/City-Services/Waste-and-Recycling/Find-your-waste-collection-dates) website and search for your collection schedule. Use your address as it is displayed on the search results page.


### PR DESCRIPTION
## Summary

Fixes #7132
Fixes #7162

The City of Gosnells retired the `t1.gosnells.wa.gov.au/API/waste/v8` endpoints.
Every path under them now returns a 502 HTML error page after a ~4.3s backend
timeout, which is the `JSONDecodeError: Expecting value: line 1 column 1` reported
in both issues. Versions v9 and above return 404, so there is no newer revision of
the old API to point at.

The council's collection-dates page now runs on OpenCities (Granicus) MyArea, so
this rewrites the source as a shim over the existing `OpenCitiesClient`:

    GET /api/v1/myarea/search?keywords=<address>   -> geolocation id
    GET /ocapi/Public/myarea/wasteservices?geolocationid=<id>

Two deployment quirks, both already covered by `OpenCitiesConfig` and both shared
with the neighbouring `cambridge_wa_gov_au` source:

- The site is behind Akamai, which rejects the TLS handshake requests/urllib3
  produces and answers 403 before the request reaches the application
  (`use_curl_cffi=True`).
- The search endpoint content-negotiates to XML without an explicit `Accept`
  header.

Dates are parsed locally via `get_waste_services_html` rather than by the shared
parser, because Gosnells reports its three verge collections as an approximate
window ("5th Oct - 13th Oct.") whose year appears only in the block's `note` div.
A note naming a single year is taken literally even when that date has passed:
verge weeks move from year to year, so rolling one forward would invent a date the
council has not published.

Collection types keep the names this source emitted before the migration (Rubbish,
Recycling, Green, Junk), so existing dashboards and automations are unaffected.

`doc/source/gosnells_wa_gov_au.md` is also corrected: it still linked the pre-2025
URL, and its example named a source that does not exist (`gosnells_w_gov_au`).

### test_sources.py output

```
Testing source gosnells_wa_gov_au ...
  found 5 entries for Test_001
    2026-08-31 : Rubbish     2026-09-07 : Recycling   2026-10-05 : Junk
    2026-11-09 : Green       2027-05-17 : Green
  found 5 entries for Test_002
    2026-08-31 : Rubbish     2026-09-07 : Recycling   2026-10-26 : Junk
    2026-11-30 : Green       2027-06-07 : Green
  found 5 entries for Test_003
    2026-09-01 : Rubbish     2026-09-01 : Recycling   2026-09-28 : Junk
    2026-11-02 : Green       2027-05-10 : Green
  found 5 entries for Test_004 (space character test)
    2026-08-27 : Rubbish     2026-09-03 : Recycling   2027-02-01 : Junk
    2026-08-17 : Green       2027-03-22 : Green
```

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes — 35 passed
- [x] `ruff check --fix` and `ruff format` run on changed source files — `All checks passed`, `1 file already formatted`
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge) — diff is 2 files: the source and its doc page. `source_metadata.json` carries the same stale URL but is deliberately left alone per AGENTS.md
- [x] `doc/source/<name>.md` created for new sources — not a new source; the existing page is updated in this PR
- [x] TEST_CASES use real, publicly accessible addresses (not my own) — unchanged from the existing source, not touched by this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
