### PR TITLE
fix(mohu_bp_hu): accept old and new OctoberCMS partial keys

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mohu_bp_hu.py
@@ -48,6 +48,15 @@ ICON_MAP = {
 }
 
 
+def _get_partial_html(data: dict, *keys: str) -> str:
+    """Return the first matching OctoberCMS partial HTML payload."""
+    for key in keys:
+        value = data.get(key)
+        if value is not None:
+            return value
+    raise KeyError(keys[0])
+
+
 class Source:
     def __init__(self, district, street, house_number, verify=True):
         self._district = district
@@ -70,8 +79,10 @@ class Source:
             verify=self._verify,
         )
         r.raise_for_status()
+        data = json.loads(r.text)
         soup = BeautifulSoup(
-            json.loads(r.text)[".publicPlaces"], features="html.parser"
+            _get_partial_html(data, ".publicPlaces", "ajax/publicPlaces"),
+            features="html.parser",
         )
 
         if soup.find("div", attrs={"class": "alert"}) is not None:
@@ -98,8 +109,10 @@ class Source:
             raise SourceArgumentNotFoundWithSuggestions(
                 "street", self._street, available_streets
             ) from e
+        data = json.loads(r.text)
         soup = BeautifulSoup(
-            json.loads(r.text)[".houseNumbers"], features="html.parser"
+            _get_partial_html(data, ".houseNumbers", "ajax/houseNumbers"),
+            features="html.parser",
         )
 
         if (
@@ -127,7 +140,11 @@ class Source:
             verify=self._verify,
         )
         r.raise_for_status()
-        soup = BeautifulSoup(json.loads(r.text)[".results"], features="html.parser")
+        data = json.loads(r.text)
+        soup = BeautifulSoup(
+            _get_partial_html(data, ".results", "ajax/calSearchResults"),
+            features="html.parser",
+        )
 
         if soup.find("div", attrs={"class": "alert"}) is not None:
             raise SourceArgumentNotFoundWithSuggestions(


### PR DESCRIPTION
## Summary

MOHU Budapest changed the JSON keys in its OctoberCMS AJAX responses:

- `ajax/publicPlaces` → `.publicPlaces`
- `ajax/houseNumbers` → `.houseNumbers`
- `ajax/calSearchResults` → `.results`

#7160 already updated the source for the new keys, but released versions (e.g. v2.32.0) still ship the old parser and fail with `KeyError: 'ajax/publicPlaces'`.

This PR adds a small helper that accepts **both** key formats (new first, old as fallback), so the source keeps working across API transitions and for users still on older releases until the next tag is published.

Tested live against district `1039`, street `Királyok útja`, house number `122`.

Fixes #7069 #7114

## Type of change

- [x] Bug fix / source fix

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes (not run locally — no pytest in environment)
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff