### PR TITLE
fix(montreal_ca): seasonal ranges drop dates, and biweekly seasons parse as weekly

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -101,6 +101,11 @@ FOOD_INCLUDED_IN_GREEN_PATTERN = re.compile(
     r"included in the collection of organic waste", re.IGNORECASE
 )
 
+# Biweekly seasons are written as "every two weeks", "every second week" or
+# "once every two weeks". The substring "week" also matches the weekly branch
+# below, so these lines have to be recognised and excluded from it explicitly.
+BIWEEKLY_PATTERN = re.compile(r"every\s+(?:two|second|other|2)\s+weeks?", re.IGNORECASE)
+
 LOGGER = logging.getLogger(__name__)
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": 'Download on your computer a &lt;a href="https://donnees.montreal.ca/dataset/2df0fa28-7a7b-46c6-912f-93b215bd201e/resource/5f3fb372-64e8-45f2-a406-f1614930305c/download/collecte-des-ordures-menageres.geojson"&gt;Montreal GeoJSON file&lt;/a&gt;&lt;br/&gt;Visit https://geojson.io/&lt;br/&gt;Click on *Open* and select the Montreal GeoJSON file&lt;br/&gt;Find your sector on the map.',
@@ -240,6 +245,7 @@ class Source:
             month_stop = 12
             day_start = 1
             day_stop = 31
+            within_dates = False
             # There could be seasonal schedules, every week, every other week or specific dates
             if re.match(r".*[fF]rom (.*) to (.*)", line):
                 date_range = re.match(r".*[fF]rom (.*) to (.*)", line)
@@ -251,10 +257,9 @@ class Source:
                     if re.search(rf"{month}", date_range_stop, re.IGNORECASE):
                         month_stop = month_id
                 if re.search(r"\d+", date_range_start):
-                    day_start = int(re.match(r".*(\d+).*", date_range_start).group(1))
+                    day_start = int(re.search(r"(\d+)", date_range_start).group(1))
                 if re.search(r"\d+", date_range_stop):
                     day_stop = int(re.search(r"\d+(?!.*\d+)", date_range_stop).group(0))
-                within_dates = False
             elif re.match(r"(.*\d+.*){1,}", line):
                 # Multiple dates ?
                 dates_defined = True
@@ -267,7 +272,9 @@ class Source:
                     continue
                 if dates_defined and month not in months_found:
                     continue
-                if re.search("(every )?week(ly)?", line):
+                if re.search(
+                    "(every )?week(ly)?", line
+                ) and not BIWEEKLY_PATTERN.search(line):
                     for day in range(1, 32):
                         try:
                             if (
@@ -278,7 +285,7 @@ class Source:
                                 within_dates = True
                             if (
                                 within_dates
-                                and day_stop >= day
+                                and day > day_stop
                                 and month_stop == month_id
                             ):
                                 within_dates = False
@@ -299,15 +306,14 @@ class Source:
                 line = line.replace("*", "")
 
                 try:
-                    days_in_month = re.search(
-                        rf"\b{month}(.*){MONTH_PATTERN}", line, re.IGNORECASE
+                    days_in_month_match = re.search(
+                        rf"\b{month}\b(.*?)(?={MONTH_PATTERN}|$)",
+                        line,
+                        re.IGNORECASE | re.MULTILINE,
                     )
-                    if not days_in_month:
-                        days_in_month = re.search(
-                            rf"(?:\s*{month} {year})(.*)", line, re.IGNORECASE
-                        ).group(1)
-                    else:
-                        days_in_month = days_in_month.group(1)
+                    if not days_in_month_match:
+                        continue
+                    days_in_month = days_in_month_match.group(1)
 
                     days_in_month = re.split(r", | and ", days_in_month)
                     days_in_month = [

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -306,8 +306,13 @@ class Source:
                 line = line.replace("*", "")
 
                 try:
+                    # Capture only up to the next month name (non-greedy),
+                    # otherwise a month inherits the day numbers of every
+                    # later month on the same line. An explicit year right
+                    # after the month name is skipped so it is not mistaken
+                    # for a day number.
                     days_in_month_match = re.search(
-                        rf"\b{month}\b(.*?)(?={MONTH_PATTERN}|$)",
+                        rf"\b{month}\b(?:\s+{year})?(.*?)(?={MONTH_PATTERN}|$)",
                         line,
                         re.IGNORECASE | re.MULTILINE,
                     )

--- a/tests/test_montreal_ca.py
+++ b/tests/test_montreal_ca.py
@@ -1,0 +1,147 @@
+"""Offline tests for the montreal_ca seasonal schedule parser.
+
+Montreal publishes its collection schedule as English prose in the
+Info-Collecte GeoJSON feeds, so the whole source hinges on
+``Source.parse_collection``. The MESSAGE_EN strings below are verbatim
+captures from the live feeds for the 2026 season, which lets these run
+without touching the network.
+"""
+
+import os
+import sys
+import types
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+wcs = types.ModuleType("waste_collection_schedule")
+
+
+class Collection:
+    """Minimal stand-in for the real Collection dataclass."""
+
+    def __init__(self, date, t, icon=None, picture=None):
+        self.date = date
+        self.t = t
+        self.icon = icon
+
+
+wcs.Collection = Collection  # type: ignore[attr-defined]
+wcs.Icons = MagicMock()  # type: ignore[attr-defined]
+sys.modules["waste_collection_schedule"] = wcs
+sys.modules["waste_collection_schedule.exceptions"] = types.ModuleType(
+    "waste_collection_schedule.exceptions"
+)
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+            "waste_collection_schedule",
+        )
+    ),
+)
+
+from source import montreal_ca  # noqa: E402
+
+# Anjou sector ANJ-1: seasonal ranges either side of a biweekly summer list.
+ANJ1_GREEN = " Collection days in 2026 :   \n  - Spring : from April 1 to May 27, every week on Wednesday  \n  -  Summer : June 10 and 24; July 8 and 22; August 5 and 19; September 2 and 16 (every two weeks on Wednesday)  - Autumn: from September 30 to November 25, every week on Wednesday  \n   \n Hours :  Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection  \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes\n *The use of plastic bags as containers is prohibited"
+
+# Rosemont sector RPP-RE-22-RV: same shape, but the biweekly season is
+# phrased "every second week" and the list ends at a line break.
+RPP_GREEN = " Collection days in 2026  : \n - Spring : from April 8 to May 27, every week on Wednesday\n -  Summer, every second week : June 3 and 17; July 1, 15 and 29; August 12 and 26; September 9 and 23\n - Autumn : from September 30 to November 25, every week on Wednesday\n\nDeposit place: See instructions for Waste collection \nHours :  Take out containers between 5 a.m. and 8 a.m. the day of collection \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \n - Plastic bags are PROHIBITED"
+
+# Mercier-Hochelaga sector MHM-42-S: plain per-month date lists, no seasons.
+MHM_GREEN = "Collection day(s) 2026 :  the following tuesdays :\n - April 21 and 28;\n - May 5, 12, 19 and 26 ; \n - June 2, 9 and 23;\n - July 7 and 21;\n - August 4, 18 and 25;\n - September 1, 8, 15, 22 and 29; \n - October 6, 13, 20 and 27;\n - November 3, 10 and 17. \nHours : Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection. \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \nPlastic bags are not accepted."
+
+
+def parse(message):
+    """Return the set of dates the parser produces for a MESSAGE_EN string."""
+    source = montreal_ca.Source(sector="TEST")
+    return {c.date for c in source.parse_collection("Green", message)}
+
+
+@pytest.fixture
+def anj1():
+    return parse(ANJ1_GREEN)
+
+
+@pytest.fixture
+def rpp():
+    return parse(RPP_GREEN)
+
+
+def test_anj1_matches_published_schedule(anj1):
+    """ANJ-1 spells out every collection day; parse all of them, and only them."""
+    expected = (
+        {date(2026, 4, d) for d in (1, 8, 15, 22, 29)}
+        | {date(2026, 5, d) for d in (6, 13, 20, 27)}
+        | {date(2026, 6, d) for d in (10, 24)}
+        | {date(2026, 7, d) for d in (8, 22)}
+        | {date(2026, 8, d) for d in (5, 19)}
+        | {date(2026, 9, d) for d in (2, 16, 30)}
+        | {date(2026, 10, d) for d in (7, 14, 21, 28)}
+        | {date(2026, 11, d) for d in (4, 11, 18, 25)}
+    )
+    assert anj1 == expected
+
+
+def test_range_starting_on_a_two_digit_day(anj1):
+    """A range starting on a two-digit day must arm on that day.
+
+    A greedy ``.*(\\d+).*`` captured only the trailing "0" of "September 30",
+    so day_start was 0, never matched a real day, and the whole autumn range
+    produced nothing.
+    """
+    assert date(2026, 9, 30) in anj1
+    assert date(2026, 10, 7) in anj1
+
+
+def test_final_month_of_a_range_is_kept(anj1):
+    """The stop month must be collected up to and including the stop day.
+
+    ``day_stop >= day`` was already true on the 1st of the stop month, which
+    cleared the range before any date in it could be emitted.
+    """
+    assert {date(2026, 11, d) for d in (4, 11, 18, 25)} <= anj1
+    assert date(2026, 12, 2) not in anj1
+
+
+def test_biweekly_summer_is_not_expanded_to_weekly(anj1):
+    """A biweekly line contains "week" but must not take the weekly branch."""
+    june = {d.day for d in anj1 if d.month == 6}
+    assert june == {10, 24}
+
+
+def test_no_dates_bleed_between_months(anj1):
+    """A greedy capture ran to the last month name in the line.
+
+    June inherited the day numbers of July, August and September, inventing
+    June 19 and June 22.
+    """
+    assert date(2026, 6, 19) not in anj1
+    assert date(2026, 6, 22) not in anj1
+
+
+def test_every_second_week_phrasing(rpp):
+    """Rosemont writes "every second week" rather than "every two weeks"."""
+    assert {d.day for d in rpp if d.month == 6} == {3, 17}
+    assert {d.day for d in rpp if d.month == 7} == {1, 15, 29}
+    assert {d.day for d in rpp if d.month == 8} == {12, 26}
+
+
+def test_last_month_before_a_line_break(rpp):
+    """September ends the biweekly list and is followed by a newline."""
+    assert {date(2026, 9, 9), date(2026, 9, 23)} <= rpp
+
+
+def test_plain_date_lists_are_unaffected():
+    """Sectors without seasons must keep parsing exactly as before."""
+    parsed = parse(MHM_GREEN)
+    assert parsed
+    assert all(d.weekday() == 1 for d in parsed)


### PR DESCRIPTION
`calendar.waste_green` was empty for my sector (ANJ-1, Anjou). The Green feed is the only one that uses seasonal `from X to Y` ranges, and three separate bugs stack up on it.

**1. `day_start` captured only the last digit**

```python
day_start = int(re.match(r".*(\d+).*", date_range_start).group(1))
```

The leading `.*` is greedy, so on "September 30" it consumes "September 3" and `group(1)` captures `"0"`. The arming condition is `day_start == day` with `day` iterating `range(1, 32)`, so `0` never matches, `within_dates` is never set, and the entire range produces nothing. This only bites two-digit start days, which is why it went unnoticed — "April 1" gives `1` correctly by luck.

**2. The stop condition fired on day 1 of the stop month**

`day_stop >= day` is true at `day == 1` for any `day_stop >= 1`, so `within_dates` was cleared on the first day of the final month and that whole month was lost. Inverted to `day > day_stop`.

**3. Biweekly seasons were routed into the weekly branch**

`re.search("(every )?week(ly)?", line)` matches the "week" in "every two weeks", so summer lines like

> Summer : June 10 and 24; July 8 and 22; August 5 and 19; September 2 and 16 (every two weeks on Wednesday)

took the weekly branch and emitted nothing. Rosemont writes the same thing as "every second week", so the guard covers both. Routing these to the explicit-date branch then exposed a fourth issue: `\b{month}(.*){MONTH_PATTERN}` is greedy and ran to the *last* month name in the line, so June inherited July/August/September's day numbers and invented June 19 and 22. Made non-greedy with a lookahead.

**Also:** `within_dates` is now initialised per line. It was only assigned inside the `from X to Y` branch, so a sector whose first season line is biweekly raises `NameError` — and since `fetch()` catches every exception per source, that takes out all five feeds for that sector, not just Green. It happens to be masked today because every affected sector lists a range season first.

### Verification

Against the live 2026 feeds:

| Sector | before | after |
|---|---|---|
| ANJ-1 (Anjou) | 5 dates, April only | 26 |
| RPP-RE-22-RV (Rosemont) | 4 | 26 |
| MHM-42-S (Mercier-Hochelaga) | 52 | 52 — unchanged |

ANJ-1 now matches its published schedule exactly: Apr 1–29 and May 6–27 weekly, Jun 10/24, Jul 8/22, Aug 5/19, Sep 2/16 biweekly, then Sep 30 through Nov 25 weekly.

16 Green sectors currently use the biweekly summer format.

`tests/test_montreal_ca.py` uses verbatim `MESSAGE_EN` captures so it runs offline; 6 of the 8 tests fail on master. It follows the shape of `tests/test_olo_sk.py`. Note that `pytest.ini`'s `python_files` doesn't match per-source test filenames, so neither this nor the existing per-source tests are collected by a bare `pytest` in CI — happy to address that separately if you'd like it.

`ruff check`, `ruff format --check`, and `pytest tests/test_source_components.py` (35 passed) are all clean.

### Not fixed here

Kept out to hold the diff down, all pre-existing:

- `re.split(r", | and ", ...)` drops the last date in "July 1, 15, and 29", and ordinals like "July 1st" aren't `isnumeric()` so they're skipped. Both visible in LSL4, which still yields only 3 of its 5 summer dates.
- Sectors whose message has no "every … week" phrasing take the first branch and emit every matching weekday of the year, ignoring their explicit date list (AC-2, MHM-42-S).
- The module has no `COUNTRY` variable, which per `CLAUDE.md` orphans it from the generated docs.

Happy to split any of those out if you want them in scope.
