### PR TITLE
fix(schweinfurt_de): update API_URL to new city website structure

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/schweinfurt_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/schweinfurt_de.py
@@ -18,7 +18,7 @@ TEST_CASES = {
 
 _LOGGER = logging.getLogger(__name__)
 
-API_URL = "https://www.schweinfurt.de/leben-freizeit/umwelt/abfallwirtschaft/4427.Aktuelle-Abfuhrtermine-und-Muellkalender.html"
+API_URL = "https://www.schweinfurt.de/umweltverkehr/abfall--entsorgung/mllkalender/14894.Aktuelle-Abfuhrtermine-und-Muellkalender.html"
 
 # Titles (or title fragments) that are announcements rather than an actual
 # collection/drop-off event, e.g. "Wertstoffhof geschlossen" (recycling

--- a/doc/source/schweinfurt_de.md
+++ b/doc/source/schweinfurt_de.md
@@ -1,6 +1,6 @@
 # Abfallwirtschaft Stadt Schweinfurt
 
-Support for schedules provided by [Schweinfurt](https://www.schweinfurt.de/leben-freizeit/umwelt/abfallwirtschaft/4427.Aktuelle-Abfuhrtermine-und-Muellkalender.html), Germany.
+Support for schedules provided by [Schweinfurt](https://www.schweinfurt.de/umweltverkehr/abfall--entsorgung/mllkalender/14894.Aktuelle-Abfuhrtermine-und-Muellkalender.html), Germany.
 
 ## Configuration via configuration.yaml
 
@@ -45,7 +45,7 @@ waste_collection_schedule:
 
 ## How to get the source arguments
 
-1. Go to your calendar at [Schweinfurt - Abfallkalender](https://www.schweinfurt.de/leben-freizeit/umwelt/abfallwirtschaft/4427.Aktuelle-Abfuhrtermine-und-Muellkalender.html)
+1. Go to your calendar at [Schweinfurt - Abfallkalender](https://www.schweinfurt.de/umweltverkehr/abfall--entsorgung/mllkalender/14894.Aktuelle-Abfuhrtermine-und-Muellkalender.html)
 2. Enter your street and housenumber
 3. Copy the exact values from the textboxes street in the source configuration.
 


### PR DESCRIPTION
## Summary
Fixes #7245 — the `schweinfurt_de` source was failing with a 404 error
because the City of Schweinfurt restructured their website. The old
waste-calendar URL:

`https://www.schweinfurt.de/leben-freizeit/umwelt/abfallwirtschaft/4427.Aktuelle-Abfuhrtermine-und-Muellkalender.html`

has been replaced with:

`https://www.schweinfurt.de/umweltverkehr/abfall--entsorgung/mllkalender/14894.Aktuelle-Abfuhrtermine-und-Muellkalender.html`

The new page serves the identical street-selection form and the same
`evList` JSON API (same query parameters, same response shape), so no
other code changes were required.

## Changes
- Updated `API_URL` in `schweinfurt_de.py`
- Updated the two documentation links in `doc/source/schweinfurt_de.md`

## Testing
- Live-tested all 4 `TEST_CASES` via `test_sources.py -s schweinfurt_de -l` — all pass and return real upcoming collection dates.
- `python -m pytest tests/test_source_components.py -q` — 35 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)