### PR TITLE
fix(borlange_energi_se): handle "Tömning idag" / "imorgon"

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/borlange_energi_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/borlange_energi_se.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import requests
 from waste_collection_schedule import Collection, Icons
@@ -44,14 +44,33 @@ ICON_MAP = {
 def parse_swedish_date(text: str) -> datetime:
     """Extract date from Swedish text.
 
-    Handles formats like 'Nästa tömning sker torsdag den 15 januari'.
+    Handles formats like 'Nästa tömning sker torsdag den 15 januari', as well
+    as the relative wording the API uses on the day of a collection ('Tömning
+    idag') and the day before it ('Tömning imorgon'). Both the joined and
+    separated spellings are accepted.
     """
-    match = re.search(r"(\d{1,2})\s+([a-zåäö]+)", text.lower())
+    lowered = text.lower()
+
+    # Expected API values on and just before a collection day, not malformed
+    # data, so they must not raise. Anchored on word boundaries so weekday
+    # names ending in "dag" are unaffected.
+    midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    if re.search(r"\bi\s?dag\b", lowered):
+        return midnight
+    if re.search(r"\bi\s?morgon\b", lowered):
+        return midnight + timedelta(days=1)
+
+    match = re.search(r"(\d{1,2})\s+([a-zåäö]+)", lowered)
     if not match:
         raise ValueError(f"Unrecognized date format: {text}")
 
     day = int(match.group(1))
     month_name = match.group(2)
+    if month_name not in MONTHS:
+        # The regex only requires a number followed by a word, so input such as
+        # "om 3 dagar" reaches here. Raise ValueError like the branch above
+        # instead of letting a KeyError escape.
+        raise ValueError(f"Unrecognized month name in date: {text}")
     month = MONTHS[month_name]
 
     year = datetime.now().year

--- a/tests/test_borlange_energi_se.py
+++ b/tests/test_borlange_energi_se.py
@@ -1,0 +1,84 @@
+"""Tests for the borlange_energi_se date parser.
+
+Borlänge Energi's API replaces the usual dated string with relative wording on
+the day of a collection ("Tömning idag") and the day before ("Tömning
+imorgon"). Those used to reach the date regex, match nothing and raise
+ValueError, which failed the whole fetch on every polling interval.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule.source.borlange_energi_se import (
+    parse_swedish_date,
+)
+
+
+def _midnight():
+    return datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+@pytest.mark.parametrize("text", ["Tömning idag", "Tömning i dag", "IDAG"])
+def test_today_is_parsed(text):
+    assert parse_swedish_date(text) == _midnight()
+
+
+@pytest.mark.parametrize("text", ["Tömning imorgon", "Tömning i morgon", "IMORGON"])
+def test_tomorrow_is_parsed(text):
+    assert parse_swedish_date(text) == _midnight() + timedelta(days=1)
+
+
+@pytest.mark.parametrize(
+    "weekday", ["måndag", "tisdag", "onsdag", "torsdag", "fredag", "lördag", "söndag"]
+)
+def test_weekdays_ending_in_dag_are_not_treated_as_relative(weekday):
+    """The relative match is anchored on word boundaries, so a weekday name
+    must still fall through to the dated branch."""
+    result = parse_swedish_date(f"Nästa tömning sker {weekday} den 15 januari")
+    assert (result.month, result.day) == (1, 15)
+
+
+def test_dated_form_still_parses():
+    result = parse_swedish_date("Nästa tömning sker torsdag den 15 januari")
+    assert (result.month, result.day) == (1, 15)
+
+
+def test_past_date_rolls_to_next_year():
+    now = datetime.now()
+    result = parse_swedish_date("tömning den 1 januari")
+    assert result.year == (
+        now.year if now.month == 1 and now.day == 1 else now.year + 1
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "om 3 dagar",  # number followed by a word that is not a month
+        "5 veckor",
+        "ingen tömning planerad",  # no number at all
+    ],
+)
+def test_unparseable_text_raises_value_error(text):
+    """A non-month word after the number used to raise KeyError, which callers
+    do not expect; it should be a ValueError like the no-match case."""
+    with pytest.raises(ValueError):
+        parse_swedish_date(text)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #7238

## Problem

Borlänge Energi's API swaps the usual dated string for relative wording on the day of a collection (`Tömning idag`) and the day before it (`Tömning imorgon`). `parse_swedish_date()` only matched `<number> <month>`, so those values reached:

```python
raise ValueError(f"Unrecognized date format: {text}")
```

That fails the whole fetch for the address, and keeps failing on every polling interval for as long as the API returns the relative wording — so it breaks precisely on the day the schedule matters most.

## Fix

These are expected API values, not malformed data, so they're resolved before the date regex runs:

```python
if re.search(r"\bi\s?dag\b", lowered):
    return midnight
if re.search(r"\bi\s?morgon\b", lowered):
    return midnight + timedelta(days=1)
```

Both spellings are accepted (`idag` / `i dag`, `imorgon` / `i morgon`), and the match is anchored on word boundaries so the seven Swedish weekday names ending in `dag` still fall through to the dated branch — I tested each one explicitly, since that was the obvious way to get this wrong.

Also raises `ValueError` rather than letting a `KeyError` escape when the regex matches a number followed by a non-month word:

```python
if month_name not in MONTHS:
    raise ValueError(f"Unrecognized month name in date: {text}")
```

The regex only requires a digit followed by any word, so text like `om 3 dagar` produced `MONTHS["dagar"]` → `KeyError`, which a caller of a function documented to raise `ValueError` wouldn't be catching.

## Verification

Added `tests/test_borlange_energi_se.py` — 18 cases covering both relative forms, all seven weekday names, the unchanged dated path, the year rollover, and the `ValueError` cases.

```
tests/test_borlange_energi_se.py     18 passed
tests/test_source_components.py      35 passed
ruff check / ruff format             clean
```

I also confirmed the new tests fail against the parser as it stands today — the four relative-form cases raise `ValueError` — so they genuinely cover the reported bug rather than just passing.

No generated files touched; the diff is the one source module plus the new test.