### PR TITLE
Enhance condition for update-docs job

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   update-docs:
-    if: github.actor != 'github-actions[bot]'
+    if: >
+      github.repository == 'mampfes/hacs_waste_collection_schedule' &&
+      github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Refine the condition for the update-docs job to ensure it only runs for the specified repository, preventing unnecessary executions by other repositories.

