### PR TITLE
fix(borlange_energi_se): correct icon mappings

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/borlange_energi_se.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/borlange_energi_se.py
@@ -32,7 +32,7 @@ PORTLET_ID_PATTERN = re.compile(
 )
 PAGE_ID_PATTERN = re.compile(r"/webapp-resource/([^/\"']+)/")
 
-DEFAULT_ICON = "mdi:trash-can"
+DEFAULT_ICON = Icons.GENERAL_WASTE
 MONTHS = {
     "januari": 1,
     "februari": 2,
@@ -52,7 +52,7 @@ ICON_MAP = {
     "Matavfall": Icons.BIO_KITCHEN,
     "Restavfall": Icons.GENERAL_WASTE,
     "Pappersförpackningar": Icons.PAPER,
-    "Plastförpackningar": Icons.GLASS,
+    "Plastförpackningar": Icons.PLASTIC_PACKAGING,
 }
 
 


### PR DESCRIPTION
## Description
Fixes two icon issues in `borlange_energi_se.py`:

1. `ICON_MAP["Plastförpackningar"]` (Swedish for "plastic packaging") was
   incorrectly mapped to `Icons.GLASS`. Changed to `Icons.PLASTIC_PACKAGING`.
2. `DEFAULT_ICON` was a raw `"mdi:trash-can"` string instead of using the
   canonical `Icons` enum, per project convention. Changed to
   `Icons.GENERAL_WASTE`.

Discovered while reviewing PR #7248.

## Testing
- `ruff check --fix` / `ruff format`: clean
- `python -m pytest tests/test_source_components.py -q`: 35 passed
- Live test against `TEST_CASES` currently returns HTTP 404 from the
  provider's endpoint for both test addresses — this appears to be an
  unrelated, pre-existing issue with the live endpoint (unaffected by
  this change, which only touches icon constants, not the fetch logic).

Fixes #7250

🤖 Generated with [Claude Code](https://claude.com/claude-code)