### PR TITLE
fix(montreal_ca): fetch via curl_cffi, and add COUNTRY

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -2,7 +2,7 @@ import logging
 import re
 from datetime import datetime
 
-import requests
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 # Currently, Montreal does not offer an iCal/Webcal subscription method.
@@ -13,6 +13,7 @@ from waste_collection_schedule import Collection, Icons  # type: ignore[attr-def
 TITLE = "Montreal (QC)"
 DESCRIPTION = "Source script for montreal.ca/info-collectes"
 URL = "https://montreal.ca/info-collectes"
+COUNTRY = "ca"
 TEST_CASES = {
     "Lasalle": {"sector": "LSL4"},
     "Mercier-Hochelaga": {
@@ -362,7 +363,7 @@ class Source:
         if source_type == "Green" and self._green_features is not None:
             features = self._green_features
         else:
-            r = requests.get(url, timeout=60)
+            r = requests.get(url, timeout=60, impersonate="chrome")
             r.raise_for_status()
 
             schedule = r.json()


### PR DESCRIPTION
Follow-up to #7243, taking the `curl_cffi` item from your review.

### What changed

Three lines: `from curl_cffi import requests`, `impersonate="chrome"` on the single `requests.get` call, and `COUNTRY = "ca"`.

`curl_cffi` is already in `requirements.txt`. Only `r.raise_for_status()` and `r.json()` are called on the response, and both exist on its `Response`.

### On the 403 — I could not reproduce it, and I don't think it's Cloudflare

I'd rather give you the evidence than let the commit imply more than I can show.

This source did return 403 on all five feeds twice in the past week: an outage from roughly 21 to 27 August, and again on 28 August at 18:12Z. Both cleared on their own. But I can't trigger it now.

Run inside the Home Assistant Core container rather than a shell alongside it, so the interpreter and library versions are exactly those the integration uses — `sys.prefix=/usr/local`, `requests 2.34.2`, `curl_cffi 0.16.1` — on a residential connection:

```python
# docker exec -i homeassistant python3 /config/tools/montreal_feed_probe.py
#
# Issues the same five requests Source.fetch() does: same URLs, same 60s
# timeout, sequential, redirects followed (donnees.montreal.ca 302s to a
# per-request signed Google Cloud Storage URL).
import requests
from curl_cffi import requests as cffi

BASE = (
    "https://donnees.montreal.ca/dataset/"
    "2df0fa28-7a7b-46c6-912f-93b215bd201e/resource/"
)
FEEDS = {
    "Waste": BASE
    + "5f3fb372-64e8-45f2-a406-f1614930305c/download/collecte-des-ordures-menageres.geojson",
    "Recycling": BASE
    + "d02dac7d-a114-4113-8e52-266001447591/download/collecte-des-matieres-recyclables.geojson",
    "Green": BASE
    + "d0882022-c74d-4fe2-813d-1aa37f6427c9/download/collecte-des-residus-verts-incluant-feuilles-mortes.geojson",
    "Food": BASE
    + "61e8c7e6-9bf1-45d9-8ebe-d7c0d50cfdbb/download/collecte-des-residus-alimentaires.geojson",
    "Bulky": BASE
    + "2345d55a-5325-488c-b4fc-a885fae458e2/download/collecte-des-residus-de-construction-de-renovation-et-de-demolition-crd-et-encombrants.geojson",
}
BROWSER_UA = {
    "User-Agent": (
        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
    )
}


def probe(label, get):
    results = {}
    for name, url in FEEDS.items():
        try:
            results[name] = get(url).status_code
        except Exception as exc:
            results[name] = type(exc).__name__
    print(f"{label:28s} {results}")


probe("requests, default UA", lambda u: requests.get(u, timeout=60))
probe("requests, browser UA", lambda u: requests.get(u, timeout=60, headers=BROWSER_UA))
probe("curl_cffi, chrome", lambda u: cffi.get(u, timeout=60, impersonate="chrome"))
```

```
requests, default UA         {'Waste': 200, 'Recycling': 200, 'Green': 200, 'Food': 200, 'Bulky': 200}
requests, browser UA         {'Waste': 200, 'Recycling': 200, 'Green': 200, 'Food': 200, 'Bulky': 200}
curl_cffi, chrome            {'Waste': 200, 'Recycling': 200, 'Green': 200, 'Food': 200, 'Bulky': 200}
```

So this hardens the transport against a failure I've observed but can't currently reproduce, rather than fixing one that reproduces on demand. Still worth doing on your recommendation and as the project convention — I'd just rather the commit not overstate it.

One correction, in case it matters elsewhere: the edge doesn't look like Cloudflare. `donnees.montreal.ca` answers with

```
server: istio-envoy
via: ...
x-envoy-upstream-service-time: ...
```

and no `cf-*` headers at all. The download URL then 302s to Google Cloud Storage (`server: UploadServer`), which mints a fresh signed URL per request with a 7-day expiry. An Envoy mesh can fingerprint or rate-limit just as effectively, so your remedy stands — only the attribution changes.

### Failure mode worth noting either way

`fetch()` catches per source, so whatever the cause, a total outage degrades to an empty calendar with every entity still reporting `available` and nothing logged above WARNING. That's how the August outage ran six days undetected on my instance before I noticed the green bin hadn't gone out.

### Verification

`ruff check` and `ruff format --check` clean. `pytest tests/test_source_components.py` — 35 passed, which is what validates the new `COUNTRY` against the allowlist. The parser is untouched, so the fixtures added in #7243 are unaffected.
