### PR TITLE
fix(montreal_ca): keep the last date in an Oxford-comma day list

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -321,7 +321,12 @@ class Source:
                         continue
                     days_in_month = days_in_month_match.group(1)
 
-                    days_in_month = re.split(r", | and ", days_in_month)
+                    # Treat an Oxford comma as one separator. Splitting on
+                    # ", " first leaves "and 29" as a token in "1, 15, and
+                    # 29", and the day is then dropped as non-numeric.
+                    days_in_month = re.split(
+                        r",\s*and\s+|,\s*|\s+and\s+", days_in_month
+                    )
                     days_in_month = [
                         part.lstrip().split(" ")[0] for part in days_in_month
                     ]

--- a/tests/test_montreal_ca.py
+++ b/tests/test_montreal_ca.py
@@ -56,6 +56,14 @@ ANJ1_GREEN = " Collection days in 2026 :   \n  - Spring : from April 1 to May 27
 # phrased "every second week" and the list ends at a line break.
 RPP_GREEN = " Collection days in 2026  : \n - Spring : from April 8 to May 27, every week on Wednesday\n -  Summer, every second week : June 3 and 17; July 1, 15 and 29; August 12 and 26; September 9 and 23\n - Autumn : from September 30 to November 25, every week on Wednesday\n\nDeposit place: See instructions for Waste collection \nHours :  Take out containers between 5 a.m. and 8 a.m. the day of collection \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \n - Plastic bags are PROHIBITED"
 
+# Lasalle sector LSL4: biweekly summer dates written with an Oxford comma,
+# and a leading day carrying an ordinal suffix.
+LSL4_GREEN = "Collection day(s) in 2026 :  Every Wednesday from April 15, 2026 to December 2, 2026.\n* Exception: During the months of July and August, collections take place once every two weeks :\n - July 1st, 15, and 29;\n - August 12 and 26. \nHours : Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \nPlastic bags are not accepted."
+
+# Villeray sector VSMPE-2a: an ordinal appearing inside a sentence that
+# denies a collection on that date.
+VSMPE2A_WASTE = "Collection day(s) :  Thursday\nHours :  Take out containers between 8 p.m. the evening before and 7 a.m. the day of collection\n\n\n  Important  - Starting September 24, household garbage will be collected every other week in your area. This means there will be a collection on September 24, but there will be no collection on October 1st, and so on.\n\n\n\n  No changes are planned for the collection of recyclable materials, food scraps, bulky items, or construction, renovation and demolition debris.\n\nFor more information, please visit montreal.ca\n\n"
+
 # Mercier-Hochelaga sector MHM-42-S: plain per-month date lists, no seasons.
 MHM_GREEN = "Collection day(s) 2026 :  the following tuesdays :\n - April 21 and 28;\n - May 5, 12, 19 and 26 ; \n - June 2, 9 and 23;\n - July 7 and 21;\n - August 4, 18 and 25;\n - September 1, 8, 15, 22 and 29; \n - October 6, 13, 20 and 27;\n - November 3, 10 and 17. \nHours : Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection. \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \nPlastic bags are not accepted."
 
@@ -145,3 +153,32 @@ def test_plain_date_lists_are_unaffected():
     parsed = parse(MHM_GREEN)
     assert parsed
     assert all(d.weekday() == 1 for d in parsed)
+
+
+def test_oxford_comma_keeps_the_final_date():
+    """The 29 in "July 1st, 15, and 29" must survive.
+
+    Splitting on ", " before " and " leaves "and 29" as a token, whose
+    first word is "and" -- not numeric, so the date was dropped.
+    """
+    parsed = parse(LSL4_GREEN)
+    assert date(2026, 7, 29) in parsed
+    assert {date(2026, 7, 15), date(2026, 8, 12), date(2026, 8, 26)} <= parsed
+
+
+def test_ordinal_day_numbers_are_deliberately_not_parsed():
+    """ "July 1st" is a real collection, but parsing ordinals is unsafe.
+
+    The same token shape appears in prose denying a collection -- see
+    test_a_denied_date_is_not_emitted -- and in "1st and 3rd Wednesday of
+    the month", where it is an ordinal week rather than a day. Telling
+    those apart needs more than tokenising, so the day is knowingly left
+    on the floor rather than risk inventing collections.
+    """
+    assert date(2026, 7, 1) not in parse(LSL4_GREEN)
+
+
+def test_a_denied_date_is_not_emitted():
+    """ "no collection on October 1st" must not produce a collection."""
+    assert date(2026, 10, 1) not in parse(VSMPE2A_WASTE)
+    assert date(2026, 9, 24) in parse(VSMPE2A_WASTE)


### PR DESCRIPTION
Third of the follow-ups from #7243. Small one.

### The bug

LSL4 (Lasalle, an existing `TEST_CASE`) publishes:

> July 1st, 15, and 29; August 12 and 26.

and yields only **July 15, August 12, August 26**.

`re.split(r", | and ", ...)` tries `", "` first, so `"15, and 29"` becomes `"15"` and `"and 29"`. The next line takes each token's first word, `"and"`, which fails `isnumeric()`, and July 29 is dropped. Splitting on `", and "` as a single separator recovers it.

### What I deliberately did not fix

The same message contains `July 1st`, which is also dropped, because `"1st"` isn't `isnumeric()`. That looks like the obvious companion fix. It isn't safe.

The identical token shape shows up in two other places in this dataset:

- **VSMPE-2a** (Waste): *"there will be a collection on September 24, but there will be **no collection on October 1st**, and so on."*
- **AC-1** (Bulky): *"**1st and 3rd** Wednesday of the month"*, an ordinal week rather than a day.

49 of the 93 affected sectors are Bulky, mostly that second shape.

I implemented ordinal support and measured it:

| Sector | master | Oxford only | Oxford + ordinal |
|---|---|---|---|
| Green/LSL4 | 3 | **4** (+Jul 29) | 5 (+Jul 1) |
| Waste/VSMPE-2a | 1 | 1 | **2 (+Oct 1)** |

It recovers one real date and invents one that the message explicitly denies. A phantom collection is worse than a missing one: it puts bins on the curb on a day with no pickup, and it would quietly satisfy any staleness check watching for gaps. So ordinals stay out, and `test_ordinal_day_numbers_are_deliberately_not_parsed` pins that with the reasoning, so it isn't "fixed" later by someone who only sees LSL4.

Doing it properly needs the parser to recognise negation and nth-weekday rules, which is structural rather than tokenising. That needs more thought before I would propose a solution, so it stays out of scope here and this PR takes the clean net gain instead.

### Verification

Of the 507 sector messages across all five feeds, 93 contain a construct this change could touch (Oxford comma, ordinal, tight comma, or multi-space "and"). Comparing master against this branch on the affected sectors:

```
sector                  master  oxford   delta
------------------------------------------------------
Green/LSL4                   3       4    +2026-07-29
Bulky/AC-1                   0       0
Bulky/LSL1                   0       0
Bulky/RPP-1-CRD             52      52
Food/RPP-RE-22-RA           52      52
Green/ANJ-1                 26      26
Green/RPP-RE-22-RV          26      26
Green/SLE-1                 52      52
Waste/RPP-OM-1              53      53
Waste/SLR-1                 52      52
Waste/VSMPE-2a               1       1
```

One sector gains a real date, no sector loses one.

Three tests added to `tests/test_montreal_ca.py`; one of them fails on master, which is the one that should. `ruff check` and `ruff format --check` clean; `pytest tests/test_source_components.py` 35 passed, `tests/test_montreal_ca.py` 11 passed.

On your `pytest.ini` point from #7243: I can reproduce it. Running the two files in one invocation gives `ModuleNotFoundError: No module named 'waste_collection_schedule.source'; 'waste_collection_schedule' is not a package`, from the per-source stub leaking into `test_source_components.py`. Run separately they're both green. Not touched here.

### Known gaps, not addressed here

Recording these so they are visible, not proposing them as follow-ups to this PR.

`header` is popped off before parsing and only mined for a year, so anything stated before the first `-` is never read. LSL4's `"Every Wednesday from April 15, 2026 to December 2, 2026"` lives there, so the sector keeps only its summer exception dates and loses the rest of the season. Bulky sectors AC-1 and LSL1 lose their moving-period collections the same way, and since their regular schedule is written as "1st and 3rd Wednesday of the month" they currently produce no dates at all.

Both are larger than a tokenising change and neither is a regression from this PR. This one stays narrow so the gain is unambiguous.
