### PR TITLE
Backport #7259: Update URLs to remove 'www' prefix on Environment First

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/environmentfirst_co_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/environmentfirst_co_uk.py
@@ -43,7 +43,7 @@ class Source:
 
         if self._uprn:
             # GET request returns schedule for matching uprn
-            r = s.get(f"https://www.environmentfirst.co.uk/house.php?uprn={self._uprn}")
+            r = s.get(f"https://environmentfirst.co.uk/house.php?uprn={self._uprn}")
             responseContent = r.text
 
         elif self._post_code and self._number:
@@ -54,7 +54,7 @@ class Source:
                 "street": "",
                 "postcode": self._post_code,
             }
-            r = s.post("https://www.environmentfirst.co.uk/results.php", data=payload)
+            r = s.post("https://environmentfirst.co.uk/results.php", data=payload)
             responseContent = r.text
 
         elif self._post_code and self._name:
@@ -65,7 +65,7 @@ class Source:
                 "street": "",
                 "postcode": self._post_code,
             }
-            r = s.post("https://www.environmentfirst.co.uk/results.php", data=payload)
+            r = s.post("https://environmentfirst.co.uk/results.php", data=payload)
             responseContent = r.text
 
             # Loop through postcode address list to find house name and uprn
@@ -77,7 +77,7 @@ class Source:
                         self._uprn = str.split(item.get("href"), "=")[1]
 
             # GET request returns schedule for matching uprn
-            r = s.get(f"https://www.environmentfirst.co.uk/house.php?uprn={self._uprn}")
+            r = s.get(f"https://environmentfirst.co.uk/house.php?uprn={self._uprn}")
             responseContent = r.text
 
         else:

--- a/doc/source/environmentfirst_co_uk.md
+++ b/doc/source/environmentfirst_co_uk.md
@@ -1,6 +1,6 @@
 # Environment First
 
-Consolidated support for schedules provided by [Eastbourne Borough Council](https://www.lewes-eastbourne.gov.uk/bins-waste-and-recycling/) and [Lewes District Council](https://www.lewes-eastbourne.gov.uk/bins-waste-and-recycling/).
+Consolidated support for schedules provided by [Eastbourne Borough Council](https://lewes-eastbourne.gov.uk/bins-waste-and-recycling/) and [Lewes District Council](https://lewes-eastbourne.gov.uk/bins-waste-and-recycling/).
 
 ## Configuration via configuration.yaml
 
@@ -73,4 +73,4 @@ waste_collection_schedule:
 
 An easy way to find your Unique Property Reference Number (UPRN) is by going to <https://www.findmyaddress.co.uk/> and entering in your address details.
 
-Otherwise you can inspect the web requests on the [Environment First](https://www.environmentfirst.co.uk/) having searched using your address details. Your UPRN is the collection of digits at the end of the URL, for example: `https://www.environmentfirst.co.uk/house.php?uprn=100060091178`
+Otherwise you can inspect the web requests on the [Environment First](https://environmentfirst.co.uk/) having searched using your address details. Your UPRN is the collection of digits at the end of the URL, for example: `https://environmentfirst.co.uk/house.php?uprn=100060091178`

--- a/doc/source/walsall_gov_uk.md
+++ b/doc/source/walsall_gov_uk.md
@@ -33,4 +33,4 @@ waste_collection_schedule:
 
 An easy way to find your Unique Property Reference Number (UPRN) is by going to <https://www.findmyaddress.co.uk/> and entering in your address details.
 
-Otherwise you can inspect the web requests on [Walsall Council](https://www.environmentfirst.co.uk/) having searched for and selected your address details. Your UPRN is the collection of digits at the end of the URL, for example: `https://cag.walsall.gov.uk/BinCollections/GetBins?uprn=100071103746`
+Otherwise you can inspect the web requests on [Walsall Council](https://cag.walsall.gov.uk/BinCollections/) having searched for and selected your address details. Your UPRN is the collection of digits at the end of the URL, for example: `https://cag.walsall.gov.uk/BinCollections/GetBins?uprn=100071103746`


### PR DESCRIPTION
## Summary

Backports #7259 to `release/3.0.0`. Clean cherry-pick (`57b81b85`) — the source file and docs are untouched by the v3 refactor, no conflicts.

Original PR fixed environmentfirst.co.uk requests/docs that used the `www.` subdomain, which no longer resolves (see #7219).

## Type of change

- [x] Bug fix / source fix (backport)

## Checklist

- [x] Clean cherry-pick, no manual resolution needed
- [x] `python -m pytest tests/test_source_components.py -q` passes (35 passed)
- [x] No generated files in diff