### PR TITLE
Add East Hampshire District Council source + UPRN lookup (#7244, #7258) (port to v3)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/easthants_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/easthants_gov_uk.py
@@ -12,6 +12,7 @@ from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFound,
     SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequired,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,6 +24,8 @@ COUNTRY = "uk"
 SOURCE_CODEOWNERS = ["@alexcroox"]
 
 _SCHEDULE_URL = f"{URL}/bin-collections/find-your-bin-calendar"
+_ADDRESS_URL = "https://maps.easthants.gov.uk/easthampshire.aspx"
+_HEADERS = {"User-Agent": "waste-collection-schedule/easthants_gov_uk"}
 _MONTHS = {
     "JAN": 1,
     "FEB": 2,
@@ -46,36 +49,44 @@ _GARDEN_CALENDAR_LINK_RE = re.compile(r"^G(\d+)\b", re.IGNORECASE)
 # calendars use RGB, while the garden calendars use CMYK.
 _RUBBISH_COLOUR = (0.248, 0.646, 0.209)
 _RECYCLING_COLOUR = (0.391, 0.389, 0.387)
+_HARD_TO_REACH_RECYCLING_COLOUR = (0.438, 0.437, 0.434)
+_GLASS_COLOUR = (0.0, 0.46, 0.748)
 _GARDEN_COLOUR = (0.6, 0.71, 1.0, 0.3)
 _SUSPENDED_COLOUR = (0.31, 0.98, 0.0, 0.0)
 _COLOUR_TOLERANCE = 0.02
 
 _TYPE_MAP = {
-    "rubbish": "Rubbish",
-    "recycling": "Recycling and glass",
-    "garden": "Garden waste",
+    "rubbish": ("Rubbish",),
+    "recycling": ("Recycling",),
+    "glass": ("Glass",),
+    "garden": ("Garden waste",),
 }
 ICON_MAP = {
     "Rubbish": Icons.GENERAL_WASTE,
-    "Recycling and glass": Icons.RECYCLING,
+    "Recycling": Icons.RECYCLING,
+    "Glass": Icons.GLASS,
     "Garden waste": Icons.GARDEN,
 }
 
 PARAM_DESCRIPTIONS = {
     "en": {
+        "uprn": (
+            "The property's Unique Property Reference Number (UPRN). When set, "
+            "the council automatically supplies its bin and garden calendars."
+        ),
         "calendar_number": (
-            "The bin calendar number assigned to your address, shown on your "
-            "existing calendar or on the council's bin calendar map."
+            "Optional manual bin calendar number, used when no UPRN is provided."
         ),
         "garden_calendar_number": (
-            "Optional garden waste calendar number (the numeric part of G1-G10) "
-            "for subscribed households."
+            "Optional manual garden waste calendar number (the numeric part of "
+            "G1-G10), used when no UPRN is provided."
         ),
     },
 }
 
 PARAM_TRANSLATIONS = {
     "en": {
+        "uprn": "Unique Property Reference Number (UPRN)",
         "calendar_number": "Calendar number",
         "garden_calendar_number": "Garden waste calendar number",
     },
@@ -84,13 +95,14 @@ PARAM_TRANSLATIONS = {
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": (
         "Open https://www.easthants.gov.uk/bin-collections/find-your-bin-calendar. "
-        "Use the map near the bottom of the page to find your address, then enter "
-        "the displayed calendar number. If you subscribe to garden waste, also "
-        "enter the numeric part of your G1-G10 garden calendar number."
+        "Use the map near the bottom of the page to find your address and its "
+        "Unique Property Ref, then enter that as the UPRN. Alternatively, enter "
+        "the displayed calendar numbers manually."
     ),
 }
 
 TEST_CASES = {
+    "UPRN lookup": {"uprn": 1710041123},
     "Calendar 16 with garden waste G1": {
         "calendar_number": 16,
         "garden_calendar_number": 1,
@@ -110,7 +122,7 @@ def _colour_matches(
 ) -> bool:
     return bool(
         actual
-        and len(actual) >= len(expected)
+        and len(actual) == len(expected)
         and all(
             abs(actual[index] - expected[index]) <= _COLOUR_TOLERANCE
             for index in range(len(expected))
@@ -137,6 +149,44 @@ def _calendar_links(html: str) -> tuple[dict[int, str], dict[int, str]]:
             )
 
     return links, garden_links
+
+
+def _secure_calendar_url(href: str) -> str:
+    url = urljoin(_ADDRESS_URL, href)
+    if url.startswith("http://maps.easthants.gov.uk/"):
+        return "https://" + url.removeprefix("http://")
+    return url
+
+
+def _uprn_calendar_urls(html: str, uprn: str) -> dict[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+    panel = soup.find(
+        "div", attrs={"aria-label": re.compile("waste and recycling", re.IGNORECASE)}
+    )
+    if panel is None:
+        raise SourceArgumentNotFound(
+            "uprn", uprn, "no East Hampshire address was found."
+        )
+
+    urls: dict[str, str] = {}
+    for heading in panel.find_all("h4"):
+        section = heading.find_parent("div", class_="atPanelContent")
+        if section is None or (link := section.find("a", href=True)) is None:
+            continue
+
+        title = heading.get_text(" ", strip=True).casefold()
+        if "garden" in title:
+            urls["garden"] = _secure_calendar_url(str(link["href"]))
+        elif "bin calendar" in title:
+            urls["bins"] = _secure_calendar_url(str(link["href"]))
+
+    if "bins" not in urls:
+        raise SourceArgumentNotFound(
+            "uprn",
+            uprn,
+            "the council did not provide a bin calendar for this property.",
+        )
+    return urls
 
 
 def _collection_rectangles(page, reader: PdfReader) -> list[tuple]:
@@ -171,8 +221,12 @@ def _collection_rectangles(page, reader: PdfReader) -> list[tuple]:
         elif operator == b"re" and len(operands) == 4:
             if _colour_matches(fill_colour, _RUBBISH_COLOUR):
                 type_key = "rubbish"
-            elif _colour_matches(fill_colour, _RECYCLING_COLOUR):
+            elif _colour_matches(fill_colour, _RECYCLING_COLOUR) or _colour_matches(
+                fill_colour, _HARD_TO_REACH_RECYCLING_COLOUR
+            ):
                 type_key = "recycling"
+            elif _colour_matches(fill_colour, _GLASS_COLOUR):
+                type_key = "glass"
             elif _colour_matches(fill_colour, _GARDEN_COLOUR):
                 type_key = "garden"
             elif _colour_matches(fill_colour, _SUSPENDED_COLOUR):
@@ -216,6 +270,12 @@ def _type_at_position(
     return None
 
 
+def _waste_types(type_key: str, separate_glass: bool) -> tuple[str, ...]:
+    if type_key == "recycling" and not separate_glass:
+        return (*_TYPE_MAP[type_key], "Glass")
+    return _TYPE_MAP[type_key]
+
+
 def _normalise_heading_year(
     printed_year: int, month: int, previous: tuple[int, int] | None
 ) -> int:
@@ -239,6 +299,7 @@ def _normalise_heading_year(
 
 def _parse_page(page, reader: PdfReader) -> list[Collection]:
     rectangles = _collection_rectangles(page, reader)
+    separate_glass = any(type_key == "glass" for *_, type_key in rectangles)
     fragments: list[tuple[str, float, float]] = []
 
     def collect_text(text, _cm, tm, _font, _font_size):
@@ -278,9 +339,9 @@ def _parse_page(page, reader: PdfReader) -> list[Collection]:
         if type_key == "suspended":
             continue
 
-        waste_type = _TYPE_MAP[type_key]
-        collections.append(
+        collections.extend(
             Collection(collection_date, waste_type, icon=ICON_MAP[waste_type])
+            for waste_type in _waste_types(type_key, separate_glass)
         )
 
     if unmatched_dates:
@@ -313,10 +374,25 @@ def _validate_calendar_number(argument: str, value: int) -> int:
     return calendar_number
 
 
+def _validate_uprn(value: str | int) -> str:
+    uprn = str(value).strip()
+    if not uprn.isdigit():
+        raise SourceArgumentNotFound("uprn", value)
+    return uprn
+
+
 class Source:
-    def __init__(self, calendar_number: int, garden_calendar_number: int | None = None):
-        self._calendar_number = _validate_calendar_number(
-            "calendar_number", calendar_number
+    def __init__(
+        self,
+        uprn: str | int | None = None,
+        calendar_number: int | None = None,
+        garden_calendar_number: int | None = None,
+    ):
+        self._uprn = None if uprn is None else _validate_uprn(uprn)
+        self._calendar_number = (
+            None
+            if calendar_number is None
+            else _validate_calendar_number("calendar_number", calendar_number)
         )
         self._garden_calendar_number = (
             None
@@ -325,6 +401,10 @@ class Source:
                 "garden_calendar_number", garden_calendar_number
             )
         )
+        if self._uprn is None and self._calendar_number is None:
+            raise SourceArgumentRequired(
+                "uprn", "provide a UPRN or a manual calendar number."
+            )
 
     @staticmethod
     def _fetch_calendar(
@@ -342,38 +422,60 @@ class Source:
 
     def fetch(self) -> list[Collection]:
         session = requests.Session()
-        page_response = session.get(_SCHEDULE_URL, timeout=30)
-        page_response.raise_for_status()
+        session.headers.update(_HEADERS)
 
-        links, garden_links = _calendar_links(page_response.text)
-        if self._calendar_number not in links:
-            raise SourceArgumentNotFoundWithSuggestions(
-                "calendar_number", self._calendar_number, sorted(links)
+        if self._uprn is not None:
+            address_response = session.get(
+                _ADDRESS_URL,
+                params={"action": "SetAddress", "UniqueId": self._uprn},
+                timeout=30,
             )
+            address_response.raise_for_status()
+            urls = _uprn_calendar_urls(address_response.text, self._uprn)
+            collections = self._fetch_calendar(
+                session, urls["bins"], f"for UPRN {self._uprn}"
+            )
+            if "garden" in urls:
+                collections.extend(
+                    self._fetch_calendar(
+                        session, urls["garden"], f"garden for UPRN {self._uprn}"
+                    )
+                )
+            source_name = f"UPRN {self._uprn}"
+        else:
+            page_response = session.get(_SCHEDULE_URL, timeout=30)
+            page_response.raise_for_status()
 
-        collections = self._fetch_calendar(
-            session, links[self._calendar_number], str(self._calendar_number)
-        )
-
-        if self._garden_calendar_number is not None:
-            if self._garden_calendar_number not in garden_links:
+            links, garden_links = _calendar_links(page_response.text)
+            if self._calendar_number not in links:
                 raise SourceArgumentNotFoundWithSuggestions(
-                    "garden_calendar_number",
-                    self._garden_calendar_number,
-                    sorted(garden_links),
+                    "calendar_number", self._calendar_number, sorted(links)
                 )
-            collections.extend(
-                self._fetch_calendar(
-                    session,
-                    garden_links[self._garden_calendar_number],
-                    f"G{self._garden_calendar_number}",
-                )
+
+            collections = self._fetch_calendar(
+                session, links[self._calendar_number], str(self._calendar_number)
             )
+
+            if self._garden_calendar_number is not None:
+                if self._garden_calendar_number not in garden_links:
+                    raise SourceArgumentNotFoundWithSuggestions(
+                        "garden_calendar_number",
+                        self._garden_calendar_number,
+                        sorted(garden_links),
+                    )
+                collections.extend(
+                    self._fetch_calendar(
+                        session,
+                        garden_links[self._garden_calendar_number],
+                        f"G{self._garden_calendar_number}",
+                    )
+                )
+            source_name = f"calendar {self._calendar_number}"
 
         collections.sort(key=lambda item: (item.date, item.type))
         _LOGGER.debug(
-            "Found %d collections for East Hampshire calendar %d",
+            "Found %d collections for East Hampshire %s",
             len(collections),
-            self._calendar_number,
+            source_name,
         )
         return collections

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/easthants_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/easthants_gov_uk.py
@@ -1,0 +1,379 @@
+import logging
+import re
+from datetime import date
+from io import BytesIO
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from pypdf import PdfReader
+from pypdf.generic import ContentStream
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+TITLE = "East Hampshire District Council"
+DESCRIPTION = "Waste collection schedules for East Hampshire District Council."
+URL = "https://www.easthants.gov.uk"
+COUNTRY = "uk"
+SOURCE_CODEOWNERS = ["@alexcroox"]
+
+_SCHEDULE_URL = f"{URL}/bin-collections/find-your-bin-calendar"
+_MONTHS = {
+    "JAN": 1,
+    "FEB": 2,
+    "MAR": 3,
+    "APR": 4,
+    "MAY": 5,
+    "JUN": 6,
+    "JUL": 7,
+    "AUG": 8,
+    "SEP": 9,
+    "OCT": 10,
+    "NOV": 11,
+    "DEC": 12,
+}
+_MONTH_RE = re.compile(r"^(" + "|".join(_MONTHS) + r")\s+(20\d{2})$")
+_DATE_RE = re.compile(r"^(?:MON|TUE|WED|THU|FRI|SAT|SUN)\s+(\d{1,2})$")
+_CALENDAR_LINK_RE = re.compile(r"^Calendar\s+(\d+)\b", re.IGNORECASE)
+_GARDEN_CALENDAR_LINK_RE = re.compile(r"^G(\d+)\b", re.IGNORECASE)
+
+# Fill colours used for collection rows in the council PDFs. The main bin
+# calendars use RGB, while the garden calendars use CMYK.
+_RUBBISH_COLOUR = (0.248, 0.646, 0.209)
+_RECYCLING_COLOUR = (0.391, 0.389, 0.387)
+_GARDEN_COLOUR = (0.6, 0.71, 1.0, 0.3)
+_SUSPENDED_COLOUR = (0.31, 0.98, 0.0, 0.0)
+_COLOUR_TOLERANCE = 0.02
+
+_TYPE_MAP = {
+    "rubbish": "Rubbish",
+    "recycling": "Recycling and glass",
+    "garden": "Garden waste",
+}
+ICON_MAP = {
+    "Rubbish": Icons.GENERAL_WASTE,
+    "Recycling and glass": Icons.RECYCLING,
+    "Garden waste": Icons.GARDEN,
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "calendar_number": (
+            "The bin calendar number assigned to your address, shown on your "
+            "existing calendar or on the council's bin calendar map."
+        ),
+        "garden_calendar_number": (
+            "Optional garden waste calendar number (the numeric part of G1-G10) "
+            "for subscribed households."
+        ),
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "calendar_number": "Calendar number",
+        "garden_calendar_number": "Garden waste calendar number",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Open https://www.easthants.gov.uk/bin-collections/find-your-bin-calendar. "
+        "Use the map near the bottom of the page to find your address, then enter "
+        "the displayed calendar number. If you subscribe to garden waste, also "
+        "enter the numeric part of your G1-G10 garden calendar number."
+    ),
+}
+
+TEST_CASES = {
+    "Calendar 16 with garden waste G1": {
+        "calendar_number": 16,
+        "garden_calendar_number": 1,
+    },
+    "Calendar 1 without garden waste": {
+        "calendar_number": 1,
+    },
+    "Calendar 20 with garden waste G10": {
+        "calendar_number": 20,
+        "garden_calendar_number": 10,
+    },
+}
+
+
+def _colour_matches(
+    actual: tuple[float, ...] | None, expected: tuple[float, ...]
+) -> bool:
+    return bool(
+        actual
+        and len(actual) >= len(expected)
+        and all(
+            abs(actual[index] - expected[index]) <= _COLOUR_TOLERANCE
+            for index in range(len(expected))
+        )
+    )
+
+
+def _calendar_links(html: str) -> tuple[dict[int, str], dict[int, str]]:
+    soup = BeautifulSoup(html, "html.parser")
+    links: dict[int, str] = {}
+    garden_links: dict[int, str] = {}
+
+    for anchor in soup.find_all("a", href=True):
+        label = " ".join(anchor.stripped_strings)
+        match = _CALENDAR_LINK_RE.match(label)
+        if match:
+            links[int(match.group(1))] = urljoin(_SCHEDULE_URL, str(anchor["href"]))
+            continue
+
+        garden_match = _GARDEN_CALENDAR_LINK_RE.match(label)
+        if garden_match:
+            garden_links[int(garden_match.group(1))] = urljoin(
+                _SCHEDULE_URL, str(anchor["href"])
+            )
+
+    return links, garden_links
+
+
+def _collection_rectangles(page, reader: PdfReader) -> list[tuple]:
+    """Return collection-type rectangles as (x0, y0, x1, y1, type_key)."""
+    rectangles: list[tuple] = []
+    fill_colour: tuple[float, ...] | None = None
+    colour_stack: list[tuple[float, ...] | None] = []
+
+    content = ContentStream(page.get_contents(), reader)
+    for operands, operator in content.operations:
+        if operator == b"q":
+            colour_stack.append(fill_colour)
+        elif operator == b"Q":
+            fill_colour = colour_stack.pop() if colour_stack else None
+        elif operator in (b"rg", b"scn") and len(operands) >= 3:
+            try:
+                fill_colour = tuple(float(value) for value in operands[:3])
+            except (TypeError, ValueError):
+                fill_colour = None
+        elif operator == b"k" and len(operands) >= 4:
+            try:
+                fill_colour = tuple(float(value) for value in operands[:4])
+            except (TypeError, ValueError):
+                fill_colour = None
+        elif operator == b"g" and operands:
+            try:
+                grey = float(operands[0])
+            except (TypeError, ValueError):
+                fill_colour = None
+            else:
+                fill_colour = (grey, grey, grey)
+        elif operator == b"re" and len(operands) == 4:
+            if _colour_matches(fill_colour, _RUBBISH_COLOUR):
+                type_key = "rubbish"
+            elif _colour_matches(fill_colour, _RECYCLING_COLOUR):
+                type_key = "recycling"
+            elif _colour_matches(fill_colour, _GARDEN_COLOUR):
+                type_key = "garden"
+            elif _colour_matches(fill_colour, _SUSPENDED_COLOUR):
+                type_key = "suspended"
+            else:
+                continue
+
+            try:
+                x, y, width, height = (float(value) for value in operands)
+            except (TypeError, ValueError):
+                continue
+
+            # Date cells are 53-71pt wide. On bank-holiday rows the date part is
+            # orange, but the adjacent 16-17pt icon cell retains the collection
+            # colour. Ignore smaller icon artwork and large legends.
+            if not (10 <= abs(width) <= 75 and 10 <= abs(height) <= 16):
+                continue
+
+            rectangles.append(
+                (
+                    min(x, x + width),
+                    min(y, y + height),
+                    max(x, x + width),
+                    max(y, y + height),
+                    type_key,
+                )
+            )
+
+    return rectangles
+
+
+def _type_at_position(
+    rectangles: list[tuple], text_x: float, text_y: float
+) -> str | None:
+    # Each calendar column is roughly 83pt wide. Looking no more than 70pt to
+    # the right includes the bank-holiday icon cell without reaching the next
+    # calendar column.
+    for x0, y0, x1, y1, type_key in rectangles:
+        if y0 - 1 <= text_y <= y1 + 1 and x1 >= text_x - 5 and x0 <= text_x + 70:
+            return type_key
+    return None
+
+
+def _normalise_heading_year(
+    printed_year: int, month: int, previous: tuple[int, int] | None
+) -> int:
+    """Correct an inconsistent printed year using the month sequence."""
+    if previous is None:
+        return printed_year
+
+    previous_year, previous_month = previous
+    expected_year = previous_year + int(month < previous_month)
+    if printed_year != expected_year:
+        _LOGGER.warning(
+            "Calendar PDF labels month %d as %d; using %d based on the "
+            "surrounding months",
+            month,
+            printed_year,
+            expected_year,
+        )
+        return expected_year
+    return printed_year
+
+
+def _parse_page(page, reader: PdfReader) -> list[Collection]:
+    rectangles = _collection_rectangles(page, reader)
+    fragments: list[tuple[str, float, float]] = []
+
+    def collect_text(text, _cm, tm, _font, _font_size):
+        cleaned = " ".join(text.split()).upper()
+        if cleaned:
+            fragments.append((cleaned, float(tm[4]), float(tm[5])))
+
+    page.extract_text(visitor_text=collect_text)
+
+    current_month_by_column: dict[float, tuple[int, int]] = {}
+    collections: list[Collection] = []
+    unmatched_dates: list[str] = []
+
+    for text, text_x, text_y in fragments:
+        column = round(text_x, 1)
+        if month_match := _MONTH_RE.fullmatch(text):
+            month = _MONTHS[month_match.group(1)]
+            printed_year = int(month_match.group(2))
+            current_month_by_column[column] = (
+                _normalise_heading_year(
+                    printed_year, month, current_month_by_column.get(column)
+                ),
+                month,
+            )
+            continue
+
+        date_match = _DATE_RE.fullmatch(text)
+        if not date_match or column not in current_month_by_column:
+            continue
+
+        year, month = current_month_by_column[column]
+        collection_date = date(year, month, int(date_match.group(1)))
+        type_key = _type_at_position(rectangles, text_x, text_y)
+        if type_key is None:
+            unmatched_dates.append(collection_date.isoformat())
+            continue
+        if type_key == "suspended":
+            continue
+
+        waste_type = _TYPE_MAP[type_key]
+        collections.append(
+            Collection(collection_date, waste_type, icon=ICON_MAP[waste_type])
+        )
+
+    if unmatched_dates:
+        raise ValueError(
+            "Could not determine collection types for PDF dates: "
+            + ", ".join(unmatched_dates)
+        )
+
+    return collections
+
+
+def _parse_pdf(content: bytes) -> list[Collection]:
+    reader = PdfReader(BytesIO(content))
+    collections: list[Collection] = []
+    for page in reader.pages:
+        collections.extend(_parse_page(page, reader))
+
+    unique = {(item.date, item.type): item for item in collections}
+    return sorted(unique.values(), key=lambda item: (item.date, item.type))
+
+
+def _validate_calendar_number(argument: str, value: int) -> int:
+    try:
+        calendar_number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise SourceArgumentNotFound(argument, value) from exc
+
+    if calendar_number < 1:
+        raise SourceArgumentNotFound(argument, value)
+    return calendar_number
+
+
+class Source:
+    def __init__(self, calendar_number: int, garden_calendar_number: int | None = None):
+        self._calendar_number = _validate_calendar_number(
+            "calendar_number", calendar_number
+        )
+        self._garden_calendar_number = (
+            None
+            if garden_calendar_number is None
+            else _validate_calendar_number(
+                "garden_calendar_number", garden_calendar_number
+            )
+        )
+
+    @staticmethod
+    def _fetch_calendar(
+        session: requests.Session, url: str, calendar_name: str
+    ) -> list[Collection]:
+        pdf_response = session.get(url, timeout=60)
+        pdf_response.raise_for_status()
+        collections = _parse_pdf(pdf_response.content)
+        if not collections:
+            raise ValueError(
+                f"No collection dates found in East Hampshire calendar "
+                f"{calendar_name}. The PDF format may have changed."
+            )
+        return collections
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        page_response = session.get(_SCHEDULE_URL, timeout=30)
+        page_response.raise_for_status()
+
+        links, garden_links = _calendar_links(page_response.text)
+        if self._calendar_number not in links:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "calendar_number", self._calendar_number, sorted(links)
+            )
+
+        collections = self._fetch_calendar(
+            session, links[self._calendar_number], str(self._calendar_number)
+        )
+
+        if self._garden_calendar_number is not None:
+            if self._garden_calendar_number not in garden_links:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "garden_calendar_number",
+                    self._garden_calendar_number,
+                    sorted(garden_links),
+                )
+            collections.extend(
+                self._fetch_calendar(
+                    session,
+                    garden_links[self._garden_calendar_number],
+                    f"G{self._garden_calendar_number}",
+                )
+            )
+
+        collections.sort(key=lambda item: (item.date, item.type))
+        _LOGGER.debug(
+            "Found %d collections for East Hampshire calendar %d",
+            len(collections),
+            self._calendar_number,
+        )
+        return collections

--- a/doc/source/easthants_gov_uk.md
+++ b/doc/source/easthants_gov_uk.md
@@ -1,0 +1,28 @@
+# East Hampshire District Council
+
+Support for schedules provided by [East Hampshire District Council](https://www.easthants.gov.uk/bin-collections/find-your-bin-calendar), serving East Hampshire, UK.
+
+The council publishes numbered calendars for rubbish (green bin), recycling (black bin), glass box, and subscribed garden waste collections. The source automatically follows the current PDFs linked for the selected calendar numbers.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: easthants_gov_uk
+      args:
+        calendar_number: 16
+        garden_calendar_number: 1
+```
+
+### Configuration Variables
+
+**calendar_number**
+*(Integer) (required)* The bin calendar number assigned to your address.
+
+**garden_calendar_number**
+*(Integer) (optional)* The numeric part of the G1-G10 garden waste calendar number assigned to subscribed households. For example, enter `1` for calendar G1.
+
+## How to find your calendar number
+
+Open the council's [Find your bin calendar](https://www.easthants.gov.uk/bin-collections/find-your-bin-calendar) page. If you do not already know your calendar numbers, use the map near the bottom of the page to find your address. Garden waste subscribers should also enter the numeric part of their G1-G10 garden waste calendar number.

--- a/doc/source/easthants_gov_uk.md
+++ b/doc/source/easthants_gov_uk.md
@@ -2,9 +2,21 @@
 
 Support for schedules provided by [East Hampshire District Council](https://www.easthants.gov.uk/bin-collections/find-your-bin-calendar), serving East Hampshire, UK.
 
-The council publishes numbered calendars for rubbish (green bin), recycling (black bin), glass box, and subscribed garden waste collections. The source automatically follows the current PDFs linked for the selected calendar numbers.
+The source can look up a property's current calendars from its UPRN. This automatically includes subscribed garden waste when the council lists a garden calendar for the property. Manual calendar numbers remain available as a fallback.
 
 ## Configuration via configuration.yaml
+
+### Recommended: UPRN lookup
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: easthants_gov_uk
+      args:
+        uprn: 1710041123
+```
+
+### Manual calendar numbers
 
 ```yaml
 waste_collection_schedule:
@@ -17,12 +29,22 @@ waste_collection_schedule:
 
 ### Configuration Variables
 
+**uprn**
+*(String or integer) (optional)* The property's Unique Property Reference Number. When supplied, this takes precedence over manual calendar numbers and automatically follows the bin and garden calendar links assigned by the council.
+
 **calendar_number**
-*(Integer) (required)* The bin calendar number assigned to your address.
+*(Integer) (optional)* The bin calendar number assigned to your address. Required when `uprn` is not supplied.
 
 **garden_calendar_number**
-*(Integer) (optional)* The numeric part of the G1-G10 garden waste calendar number assigned to subscribed households. For example, enter `1` for calendar G1.
+*(Integer) (optional)* The numeric part of the G1-G10 garden waste calendar number assigned to subscribed households. For example, enter `1` for calendar G1. This is only needed with manual calendar-number configuration.
 
-## How to find your calendar number
+## How to find the configuration values
 
-Open the council's [Find your bin calendar](https://www.easthants.gov.uk/bin-collections/find-your-bin-calendar) page. If you do not already know your calendar numbers, use the map near the bottom of the page to find your address. Garden waste subscribers should also enter the numeric part of their G1-G10 garden waste calendar number.
+Open the council's [Find your bin calendar](https://www.easthants.gov.uk/bin-collections/find-your-bin-calendar) page and use the map near the bottom to select your address. The map displays its **Unique Property Ref**, bin calendar, and any garden waste calendar.
+
+## Returned waste types
+
+- Rubbish
+- Recycling
+- Glass
+- Garden waste, when the property has a garden waste calendar or one is configured manually

--- a/tests/test_easthants_gov_uk.py
+++ b/tests/test_easthants_gov_uk.py
@@ -1,0 +1,103 @@
+"""Unit tests for the East Hampshire District Council source.
+
+Run explicitly because pytest.ini only auto-discovers the source-contract tests:
+
+    pytest tests/test_easthants_gov_uk.py
+"""
+
+import os
+import sys
+from datetime import date
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule import Collection
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentRequired,
+)
+from waste_collection_schedule.source import easthants_gov_uk
+
+UPRN_PAGE = """
+<div role="region" aria-label="Waste and Recycling">
+  <div class="atPanelContent"><h4>Bin Calendar</h4><a href="http://maps.easthants.gov.uk/calendars/H1.pdf">H1</a></div>
+  <div class="atPanelContent"><h4>Garden Waste Calendar</h4><a href="/calendars/G5.pdf">G5</a></div>
+</div>
+"""
+
+
+def test_uprn_calendar_urls_extracts_and_secures_links():
+    assert easthants_gov_uk._uprn_calendar_urls(UPRN_PAGE, "1710041123") == {
+        "bins": "https://maps.easthants.gov.uk/calendars/H1.pdf",
+        "garden": "https://maps.easthants.gov.uk/calendars/G5.pdf",
+    }
+
+
+def test_uprn_calendar_urls_rejects_unknown_property():
+    with pytest.raises(SourceArgumentNotFound):
+        easthants_gov_uk._uprn_calendar_urls("<html></html>", "invalid")
+
+
+def test_colour_matches_requires_the_same_colour_space():
+    assert easthants_gov_uk._colour_matches((0.1, 0.2, 0.3), (0.1, 0.2, 0.3))
+    assert not easthants_gov_uk._colour_matches((0.1, 0.2, 0.3, 0.4), (0.1, 0.2, 0.3))
+
+
+def test_waste_types_splits_combined_recycling_and_glass():
+    assert easthants_gov_uk._waste_types("recycling", separate_glass=False) == (
+        "Recycling",
+        "Glass",
+    )
+    assert easthants_gov_uk._waste_types("recycling", separate_glass=True) == (
+        "Recycling",
+    )
+    assert easthants_gov_uk._waste_types("glass", separate_glass=True) == ("Glass",)
+
+
+def test_source_requires_uprn_or_calendar_number():
+    with pytest.raises(SourceArgumentRequired):
+        easthants_gov_uk.Source()
+
+
+@patch.object(easthants_gov_uk.Source, "_fetch_calendar")
+@patch.object(easthants_gov_uk.requests, "Session")
+def test_fetch_uses_calendars_assigned_to_uprn(session_factory, fetch_calendar):
+    session = session_factory.return_value
+    session.get.return_value = Mock(text=UPRN_PAGE)
+    fetch_calendar.side_effect = [
+        [Collection(date(2026, 9, 1), "Rubbish")],
+        [Collection(date(2026, 9, 2), "Garden waste")],
+    ]
+
+    collections = easthants_gov_uk.Source(uprn=1710041123).fetch()
+
+    session.get.assert_called_once_with(
+        easthants_gov_uk._ADDRESS_URL,
+        params={"action": "SetAddress", "UniqueId": "1710041123"},
+        timeout=30,
+    )
+    assert fetch_calendar.call_args_list == [
+        call(
+            session,
+            "https://maps.easthants.gov.uk/calendars/H1.pdf",
+            "for UPRN 1710041123",
+        ),
+        call(
+            session,
+            "https://maps.easthants.gov.uk/calendars/G5.pdf",
+            "garden for UPRN 1710041123",
+        ),
+    ]
+    assert [item.type for item in collections] == ["Rubbish", "Garden waste"]


### PR DESCRIPTION
Port of #7244 and #7258 to `release/3.0.0`.

#7258 is a follow-up enhancement to the `easthants_gov_uk.py` source added in #7244; that base commit had not yet been ported, so both are included here in order (the file didn't exist on `release/3.0.0` prior to this PR). No v3-specific adaptation needed — the source is still in pre-v3 module style, same as most of the source tree.

Verified: `ruff check`/`format`, `pytest tests/test_source_components.py tests/test_easthants_gov_uk.py` (41 passed).
