### PR TITLE
Add support for additional waste types to lisburn_castlereagh source (#7059) (port to v3)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/lisburn_castlereagh_gov_uk.py
@@ -20,19 +20,23 @@ TEST_CASES = {
     "Test_001": {"postcode": "BT28 1AG", "house_number": "19A"},
     "Test_002": {"postcode": "BT26 6AB", "house_number": "31"},
     "Test_003": {"postcode": "BT26 6AB", "house_number": 15},
-    "Test_004": {"property_id": "DYYSm8Ls8XxGi3Nq"},
-    "Test_005": {"property_id": "ZJat6DWG1Lp95xp1"},
+    "Test_004": {"property_id": "RTTKBJY77wmTr5wP"},
+    "Test_005": {"property_id": "6opWbT5hi9odCQ2u"},
 }
 
 API_URL = "https://lisburn.isl-fusion.com"
 ICON_MAP = {
     "ResidualBin": Icons.GENERAL_WASTE,
     "RecycleBin": Icons.RECYCLING,
-    "BrownBin": Icons.BIO_KITCHEN,
+    "WheelieBox": Icons.RECYCLING,
+    "BrownBin": Icons.GARDEN,
+    "FoodWaste": Icons.BIO_KITCHEN,
 }
 NICE_NAMES = {
     "ResidualBin": "Refuse",
     "RecycleBin": "Recycling",
+    "WheelieBox": "Wheelie Box",
+    "FoodWaste": "Food Waste",
     "BrownBin": "Garden",
 }
 
@@ -115,11 +119,12 @@ class Source:
             collection_date = datetime.strptime(collection["date"], "%Y-%m-%d").date()
 
             for bin in collection["collections"].values():
+                bin_type = bin["name"]
                 entries.append(
                     Collection(
                         date=collection_date,
-                        t=NICE_NAMES.get(bin["name"]),
-                        icon=ICON_MAP.get(bin["name"]),
+                        t=NICE_NAMES.get(bin_type, bin_type),
+                        icon=ICON_MAP.get(bin_type),
                     )
                 )
 

--- a/doc/source/lisburn_castlereagh_gov_uk.md
+++ b/doc/source/lisburn_castlereagh_gov_uk.md
@@ -21,16 +21,16 @@ waste_collection_schedule:
     sources:
         - name: lisburn_castlereagh_gov_uk
           args:
-            post_code: "BT28 1AG"
+            postcode: "BT28 1AG"
             house_number: "19A"
 ```
 
 ### Configuration Variables
 
 **property_id**  
-*(string) (required if post_code not provided)*
+*(string) (required if postcode not provided)*
 
-**post_code**  
+**postcode**  
 *(string) (required if property_id not provided)*
 
 **house_number**  
@@ -43,7 +43,7 @@ waste_collection_schedule:
     sources:
     - name: lisburn_castlereagh_gov_uk
       args:
-        property_id: "DYYSm8Ls8XxGi3Nq"
+        property_id: "RTTKBJY77wmTr5wP"
 ```
 
 ## How to get the property_id argument
@@ -51,6 +51,6 @@ waste_collection_schedule:
 The property_id can be found in the URL when looking up your
 bin collection days at [Lisburn and Castlereagh bin collection days](https://lisburn.isl-fusion.com).
 
-## Why property_id over post_code and house_number?
+## Why property_id over postcode and house_number?
 
 The code has to do a search by post code and house number then look up the bin collection time using property ID


### PR DESCRIPTION
Port of #7059 to `release/3.0.0`.

Clean cherry-pick, both touched files already exist on `release/3.0.0`. No adaptation needed.

Verified: `ruff check`/`format`, `pytest tests/test_source_components.py` (35 passed).
