### PR TITLE
fix(montreal_ca): seasonal-schedule parser fix chain (#7256) (port to v3)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -321,7 +321,12 @@ class Source:
                         continue
                     days_in_month = days_in_month_match.group(1)
 
-                    days_in_month = re.split(r", | and ", days_in_month)
+                    # Treat an Oxford comma as one separator. Splitting on
+                    # ", " first leaves "and 29" as a token in "1, 15, and
+                    # 29", and the day is then dropped as non-numeric.
+                    days_in_month = re.split(
+                        r",\s*and\s+|,\s*|\s+and\s+", days_in_month
+                    )
                     days_in_month = [
                         part.lstrip().split(" ")[0] for part in days_in_month
                     ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -101,6 +101,11 @@ FOOD_INCLUDED_IN_GREEN_PATTERN = re.compile(
     r"included in the collection of organic waste", re.IGNORECASE
 )
 
+# Biweekly seasons are written as "every two weeks", "every second week" or
+# "once every two weeks". The substring "week" also matches the weekly branch
+# below, so these lines have to be recognised and excluded from it explicitly.
+BIWEEKLY_PATTERN = re.compile(r"every\s+(?:two|second|other|2)\s+weeks?", re.IGNORECASE)
+
 LOGGER = logging.getLogger(__name__)
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": 'Download on your computer a &lt;a href="https://donnees.montreal.ca/dataset/2df0fa28-7a7b-46c6-912f-93b215bd201e/resource/5f3fb372-64e8-45f2-a406-f1614930305c/download/collecte-des-ordures-menageres.geojson"&gt;Montreal GeoJSON file&lt;/a&gt;&lt;br/&gt;Visit https://geojson.io/&lt;br/&gt;Click on *Open* and select the Montreal GeoJSON file&lt;br/&gt;Find your sector on the map.',
@@ -240,6 +245,7 @@ class Source:
             month_stop = 12
             day_start = 1
             day_stop = 31
+            within_dates = False
             # There could be seasonal schedules, every week, every other week or specific dates
             if re.match(r".*[fF]rom (.*) to (.*)", line):
                 date_range = re.match(r".*[fF]rom (.*) to (.*)", line)
@@ -251,10 +257,9 @@ class Source:
                     if re.search(rf"{month}", date_range_stop, re.IGNORECASE):
                         month_stop = month_id
                 if re.search(r"\d+", date_range_start):
-                    day_start = int(re.match(r".*(\d+).*", date_range_start).group(1))
+                    day_start = int(re.search(r"(\d+)", date_range_start).group(1))
                 if re.search(r"\d+", date_range_stop):
                     day_stop = int(re.search(r"\d+(?!.*\d+)", date_range_stop).group(0))
-                within_dates = False
             elif re.match(r"(.*\d+.*){1,}", line):
                 # Multiple dates ?
                 dates_defined = True
@@ -267,7 +272,9 @@ class Source:
                     continue
                 if dates_defined and month not in months_found:
                     continue
-                if re.search("(every )?week(ly)?", line):
+                if re.search(
+                    "(every )?week(ly)?", line
+                ) and not BIWEEKLY_PATTERN.search(line):
                     for day in range(1, 32):
                         try:
                             if (
@@ -278,7 +285,7 @@ class Source:
                                 within_dates = True
                             if (
                                 within_dates
-                                and day_stop >= day
+                                and day > day_stop
                                 and month_stop == month_id
                             ):
                                 within_dates = False
@@ -299,15 +306,14 @@ class Source:
                 line = line.replace("*", "")
 
                 try:
-                    days_in_month = re.search(
-                        rf"\b{month}(.*){MONTH_PATTERN}", line, re.IGNORECASE
+                    days_in_month_match = re.search(
+                        rf"\b{month}\b(.*?)(?={MONTH_PATTERN}|$)",
+                        line,
+                        re.IGNORECASE | re.MULTILINE,
                     )
-                    if not days_in_month:
-                        days_in_month = re.search(
-                            rf"(?:\s*{month} {year})(.*)", line, re.IGNORECASE
-                        ).group(1)
-                    else:
-                        days_in_month = days_in_month.group(1)
+                    if not days_in_month_match:
+                        continue
+                    days_in_month = days_in_month_match.group(1)
 
                     days_in_month = re.split(r", | and ", days_in_month)
                     days_in_month = [

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -2,7 +2,7 @@ import logging
 import re
 from datetime import datetime
 
-import requests
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 # Currently, Montreal does not offer an iCal/Webcal subscription method.
@@ -13,6 +13,7 @@ from waste_collection_schedule import Collection, Icons  # type: ignore[attr-def
 TITLE = "Montreal (QC)"
 DESCRIPTION = "Source script for montreal.ca/info-collectes"
 URL = "https://montreal.ca/info-collectes"
+COUNTRY = "ca"
 TEST_CASES = {
     "Lasalle": {"sector": "LSL4"},
     "Mercier-Hochelaga": {
@@ -373,7 +374,7 @@ class Source:
         if source_type == "Green" and self._green_features is not None:
             features = self._green_features
         else:
-            r = requests.get(url, timeout=60)
+            r = requests.get(url, timeout=60, impersonate="chrome")
             r.raise_for_status()
 
             schedule = r.json()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -306,8 +306,13 @@ class Source:
                 line = line.replace("*", "")
 
                 try:
+                    # Capture only up to the next month name (non-greedy),
+                    # otherwise a month inherits the day numbers of every
+                    # later month on the same line. An explicit year right
+                    # after the month name is skipped so it is not mistaken
+                    # for a day number.
                     days_in_month_match = re.search(
-                        rf"\b{month}\b(.*?)(?={MONTH_PATTERN}|$)",
+                        rf"\b{month}\b(?:\s+{year})?(.*?)(?={MONTH_PATTERN}|$)",
                         line,
                         re.IGNORECASE | re.MULTILINE,
                     )

--- a/tests/test_montreal_ca.py
+++ b/tests/test_montreal_ca.py
@@ -1,0 +1,147 @@
+"""Offline tests for the montreal_ca seasonal schedule parser.
+
+Montreal publishes its collection schedule as English prose in the
+Info-Collecte GeoJSON feeds, so the whole source hinges on
+``Source.parse_collection``. The MESSAGE_EN strings below are verbatim
+captures from the live feeds for the 2026 season, which lets these run
+without touching the network.
+"""
+
+import os
+import sys
+import types
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+wcs = types.ModuleType("waste_collection_schedule")
+
+
+class Collection:
+    """Minimal stand-in for the real Collection dataclass."""
+
+    def __init__(self, date, t, icon=None, picture=None):
+        self.date = date
+        self.t = t
+        self.icon = icon
+
+
+wcs.Collection = Collection  # type: ignore[attr-defined]
+wcs.Icons = MagicMock()  # type: ignore[attr-defined]
+sys.modules["waste_collection_schedule"] = wcs
+sys.modules["waste_collection_schedule.exceptions"] = types.ModuleType(
+    "waste_collection_schedule.exceptions"
+)
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+            "waste_collection_schedule",
+        )
+    ),
+)
+
+from source import montreal_ca  # noqa: E402
+
+# Anjou sector ANJ-1: seasonal ranges either side of a biweekly summer list.
+ANJ1_GREEN = " Collection days in 2026 :   \n  - Spring : from April 1 to May 27, every week on Wednesday  \n  -  Summer : June 10 and 24; July 8 and 22; August 5 and 19; September 2 and 16 (every two weeks on Wednesday)  - Autumn: from September 30 to November 25, every week on Wednesday  \n   \n Hours :  Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection  \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes\n *The use of plastic bags as containers is prohibited"
+
+# Rosemont sector RPP-RE-22-RV: same shape, but the biweekly season is
+# phrased "every second week" and the list ends at a line break.
+RPP_GREEN = " Collection days in 2026  : \n - Spring : from April 8 to May 27, every week on Wednesday\n -  Summer, every second week : June 3 and 17; July 1, 15 and 29; August 12 and 26; September 9 and 23\n - Autumn : from September 30 to November 25, every week on Wednesday\n\nDeposit place: See instructions for Waste collection \nHours :  Take out containers between 5 a.m. and 8 a.m. the day of collection \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \n - Plastic bags are PROHIBITED"
+
+# Mercier-Hochelaga sector MHM-42-S: plain per-month date lists, no seasons.
+MHM_GREEN = "Collection day(s) 2026 :  the following tuesdays :\n - April 21 and 28;\n - May 5, 12, 19 and 26 ; \n - June 2, 9 and 23;\n - July 7 and 21;\n - August 4, 18 and 25;\n - September 1, 8, 15, 22 and 29; \n - October 6, 13, 20 and 27;\n - November 3, 10 and 17. \nHours : Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection. \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \nPlastic bags are not accepted."
+
+
+def parse(message):
+    """Return the set of dates the parser produces for a MESSAGE_EN string."""
+    source = montreal_ca.Source(sector="TEST")
+    return {c.date for c in source.parse_collection("Green", message)}
+
+
+@pytest.fixture
+def anj1():
+    return parse(ANJ1_GREEN)
+
+
+@pytest.fixture
+def rpp():
+    return parse(RPP_GREEN)
+
+
+def test_anj1_matches_published_schedule(anj1):
+    """ANJ-1 spells out every collection day; parse all of them, and only them."""
+    expected = (
+        {date(2026, 4, d) for d in (1, 8, 15, 22, 29)}
+        | {date(2026, 5, d) for d in (6, 13, 20, 27)}
+        | {date(2026, 6, d) for d in (10, 24)}
+        | {date(2026, 7, d) for d in (8, 22)}
+        | {date(2026, 8, d) for d in (5, 19)}
+        | {date(2026, 9, d) for d in (2, 16, 30)}
+        | {date(2026, 10, d) for d in (7, 14, 21, 28)}
+        | {date(2026, 11, d) for d in (4, 11, 18, 25)}
+    )
+    assert anj1 == expected
+
+
+def test_range_starting_on_a_two_digit_day(anj1):
+    """A range starting on a two-digit day must arm on that day.
+
+    A greedy ``.*(\\d+).*`` captured only the trailing "0" of "September 30",
+    so day_start was 0, never matched a real day, and the whole autumn range
+    produced nothing.
+    """
+    assert date(2026, 9, 30) in anj1
+    assert date(2026, 10, 7) in anj1
+
+
+def test_final_month_of_a_range_is_kept(anj1):
+    """The stop month must be collected up to and including the stop day.
+
+    ``day_stop >= day`` was already true on the 1st of the stop month, which
+    cleared the range before any date in it could be emitted.
+    """
+    assert {date(2026, 11, d) for d in (4, 11, 18, 25)} <= anj1
+    assert date(2026, 12, 2) not in anj1
+
+
+def test_biweekly_summer_is_not_expanded_to_weekly(anj1):
+    """A biweekly line contains "week" but must not take the weekly branch."""
+    june = {d.day for d in anj1 if d.month == 6}
+    assert june == {10, 24}
+
+
+def test_no_dates_bleed_between_months(anj1):
+    """A greedy capture ran to the last month name in the line.
+
+    June inherited the day numbers of July, August and September, inventing
+    June 19 and June 22.
+    """
+    assert date(2026, 6, 19) not in anj1
+    assert date(2026, 6, 22) not in anj1
+
+
+def test_every_second_week_phrasing(rpp):
+    """Rosemont writes "every second week" rather than "every two weeks"."""
+    assert {d.day for d in rpp if d.month == 6} == {3, 17}
+    assert {d.day for d in rpp if d.month == 7} == {1, 15, 29}
+    assert {d.day for d in rpp if d.month == 8} == {12, 26}
+
+
+def test_last_month_before_a_line_break(rpp):
+    """September ends the biweekly list and is followed by a newline."""
+    assert {date(2026, 9, 9), date(2026, 9, 23)} <= rpp
+
+
+def test_plain_date_lists_are_unaffected():
+    """Sectors without seasons must keep parsing exactly as before."""
+    parsed = parse(MHM_GREEN)
+    assert parsed
+    assert all(d.weekday() == 1 for d in parsed)

--- a/tests/test_montreal_ca.py
+++ b/tests/test_montreal_ca.py
@@ -56,6 +56,14 @@ ANJ1_GREEN = " Collection days in 2026 :   \n  - Spring : from April 1 to May 27
 # phrased "every second week" and the list ends at a line break.
 RPP_GREEN = " Collection days in 2026  : \n - Spring : from April 8 to May 27, every week on Wednesday\n -  Summer, every second week : June 3 and 17; July 1, 15 and 29; August 12 and 26; September 9 and 23\n - Autumn : from September 30 to November 25, every week on Wednesday\n\nDeposit place: See instructions for Waste collection \nHours :  Take out containers between 5 a.m. and 8 a.m. the day of collection \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \n - Plastic bags are PROHIBITED"
 
+# Lasalle sector LSL4: biweekly summer dates written with an Oxford comma,
+# and a leading day carrying an ordinal suffix.
+LSL4_GREEN = "Collection day(s) in 2026 :  Every Wednesday from April 15, 2026 to December 2, 2026.\n* Exception: During the months of July and August, collections take place once every two weeks :\n - July 1st, 15, and 29;\n - August 12 and 26. \nHours : Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \nPlastic bags are not accepted."
+
+# Villeray sector VSMPE-2a: an ordinal appearing inside a sentence that
+# denies a collection on that date.
+VSMPE2A_WASTE = "Collection day(s) :  Thursday\nHours :  Take out containers between 8 p.m. the evening before and 7 a.m. the day of collection\n\n\n  Important  - Starting September 24, household garbage will be collected every other week in your area. This means there will be a collection on September 24, but there will be no collection on October 1st, and so on.\n\n\n\n  No changes are planned for the collection of recyclable materials, food scraps, bulky items, or construction, renovation and demolition debris.\n\nFor more information, please visit montreal.ca\n\n"
+
 # Mercier-Hochelaga sector MHM-42-S: plain per-month date lists, no seasons.
 MHM_GREEN = "Collection day(s) 2026 :  the following tuesdays :\n - April 21 and 28;\n - May 5, 12, 19 and 26 ; \n - June 2, 9 and 23;\n - July 7 and 21;\n - August 4, 18 and 25;\n - September 1, 8, 15, 22 and 29; \n - October 6, 13, 20 and 27;\n - November 3, 10 and 17. \nHours : Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection. \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \nPlastic bags are not accepted."
 
@@ -145,3 +153,32 @@ def test_plain_date_lists_are_unaffected():
     parsed = parse(MHM_GREEN)
     assert parsed
     assert all(d.weekday() == 1 for d in parsed)
+
+
+def test_oxford_comma_keeps_the_final_date():
+    """The 29 in "July 1st, 15, and 29" must survive.
+
+    Splitting on ", " before " and " leaves "and 29" as a token, whose
+    first word is "and" -- not numeric, so the date was dropped.
+    """
+    parsed = parse(LSL4_GREEN)
+    assert date(2026, 7, 29) in parsed
+    assert {date(2026, 7, 15), date(2026, 8, 12), date(2026, 8, 26)} <= parsed
+
+
+def test_ordinal_day_numbers_are_deliberately_not_parsed():
+    """ "July 1st" is a real collection, but parsing ordinals is unsafe.
+
+    The same token shape appears in prose denying a collection -- see
+    test_a_denied_date_is_not_emitted -- and in "1st and 3rd Wednesday of
+    the month", where it is an ordinal week rather than a day. Telling
+    those apart needs more than tokenising, so the day is knowingly left
+    on the floor rather than risk inventing collections.
+    """
+    assert date(2026, 7, 1) not in parse(LSL4_GREEN)
+
+
+def test_a_denied_date_is_not_emitted():
+    """ "no collection on October 1st" must not produce a collection."""
+    assert date(2026, 10, 1) not in parse(VSMPE2A_WASTE)
+    assert date(2026, 9, 24) in parse(VSMPE2A_WASTE)

--- a/tests/test_montreal_ca.py
+++ b/tests/test_montreal_ca.py
@@ -29,25 +29,40 @@ class Collection:
 
 wcs.Collection = Collection  # type: ignore[attr-defined]
 wcs.Icons = MagicMock()  # type: ignore[attr-defined]
+
+# Stub the real package just long enough to import the module under test in
+# isolation, then put sys.path/sys.modules back — otherwise this stub leaks
+# into every test file collected afterwards and shadows the real package.
+_prev_wcs = sys.modules.get("waste_collection_schedule")
+_prev_wcs_exceptions = sys.modules.get("waste_collection_schedule.exceptions")
+_source_dir = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "custom_components",
+        "waste_collection_schedule",
+        "waste_collection_schedule",
+    )
+)
+
 sys.modules["waste_collection_schedule"] = wcs
 sys.modules["waste_collection_schedule.exceptions"] = types.ModuleType(
     "waste_collection_schedule.exceptions"
 )
+sys.path.insert(0, _source_dir)
 
-sys.path.insert(
-    0,
-    os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "custom_components",
-            "waste_collection_schedule",
-            "waste_collection_schedule",
-        )
-    ),
-)
-
-from source import montreal_ca  # noqa: E402
+try:
+    from source import montreal_ca
+finally:
+    sys.path.remove(_source_dir)
+    if _prev_wcs is not None:
+        sys.modules["waste_collection_schedule"] = _prev_wcs
+    else:
+        del sys.modules["waste_collection_schedule"]
+    if _prev_wcs_exceptions is not None:
+        sys.modules["waste_collection_schedule.exceptions"] = _prev_wcs_exceptions
+    else:
+        del sys.modules["waste_collection_schedule.exceptions"]
 
 # Anjou sector ANJ-1: seasonal ranges either side of a biweekly summer list.
 ANJ1_GREEN = " Collection days in 2026 :   \n  - Spring : from April 1 to May 27, every week on Wednesday  \n  -  Summer : June 10 and 24; July 8 and 22; August 5 and 19; September 2 and 16 (every two weeks on Wednesday)  - Autumn: from September 30 to November 25, every week on Wednesday  \n   \n Hours :  Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection  \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes\n *The use of plastic bags as containers is prohibited"


### PR DESCRIPTION
Port of the montreal_ca fix chain to `release/3.0.0`: seasonal-range/biweekly parsing fixes, an explicit-year edge case, curl_cffi + COUNTRY, and finally #7256's Oxford-comma day-list fix.

`tests/test_montreal_ca.py` didn't exist yet on `release/3.0.0` (introduced partway through this chain on master), so all four related commits are included together in dependency order.

**Also fixed here:** `test_montreal_ca.py` stubs `sys.modules["waste_collection_schedule"]` to import `montreal_ca` in isolation but never restored it, leaking the stub into every test file pytest collects afterwards. Harmless-looking on master's smaller suite, but it corrupts `release/3.0.0`'s much larger one (breaks `test_source_components.py` and dozens of others with `ImportError`/`AttributeError` when run in the same session). Restored `sys.path`/`sys.modules` after the import instead of leaving it patched. Flagging separately that `master`'s `tests/test_olo_sk.py` has the identical pattern — not touched here since it's out of scope for this port.

Verified: `ruff check`/`format`, `pytest tests/test_source_components.py tests/test_montreal_ca.py` in both file orders (46 passed each way).
