### PR TITLE
fix(montreal_ca): do not expand a whole year of weekdays over an explicit date list

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/montreal_ca.py
@@ -107,6 +107,31 @@ FOOD_INCLUDED_IN_GREEN_PATTERN = re.compile(
 # below, so these lines have to be recognised and excluded from it explicitly.
 BIWEEKLY_PATTERN = re.compile(r"every\s+(?:two|second|other|2)\s+weeks?", re.IGNORECASE)
 
+# A sector that enumerates collection days across several months has
+# published a schedule, not prose that happens to mention a date. Such a
+# message must not take the whole-year weekday expansion, which would
+# invent a collection on every remaining weekday of the year.
+#
+# Counted over the hyphen-delimited body only, because that is what the
+# date parser actually reads. A message whose dates sit ahead of the first
+# hyphen would otherwise be handed to a parser that cannot see them, and
+# would yield nothing at all.
+EXPLICIT_DATE_LIST_MIN_MONTHS = 4
+MONTH_WITH_DAY_PATTERN = re.compile(
+    rf"\b({'|'.join(MONTHS)})\s+\d{{1,2}}\b", re.IGNORECASE
+)
+
+
+def enumerates_dates_across_months(schedule_message):
+    """Whether the parsed body lists days in several distinct months."""
+    months = {
+        match.group(1).lower()
+        for line in schedule_message.split("-")[1:]
+        for match in MONTH_WITH_DAY_PATTERN.finditer(line)
+    }
+    return len(months) >= EXPLICIT_DATE_LIST_MIN_MONTHS
+
+
 LOGGER = logging.getLogger(__name__)
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": 'Download on your computer a &lt;a href="https://donnees.montreal.ca/dataset/2df0fa28-7a7b-46c6-912f-93b215bd201e/resource/5f3fb372-64e8-45f2-a406-f1614930305c/download/collecte-des-ordures-menageres.geojson"&gt;Montreal GeoJSON file&lt;/a&gt;&lt;br/&gt;Visit https://geojson.io/&lt;br/&gt;Click on *Open* and select the Montreal GeoJSON file&lt;br/&gt;Find your sector on the map.',
@@ -211,7 +236,7 @@ class Source:
         # These happens weekly
         if not re.search(
             r"(?:every\s+(?:.*)week|of the month)", schedule_message, re.IGNORECASE
-        ):
+        ) and not enumerates_dates_across_months(schedule_message):
             # Iterate through each month and day, and handle the "out of range" error
             for month in range(1, 13):
                 for day in range(1, 32):
@@ -327,14 +352,26 @@ class Source:
                     days_in_month = re.split(
                         r",\s*and\s+|,\s*|\s+and\s+", days_in_month
                     )
-                    days_in_month = [
-                        part.lstrip().split(" ")[0] for part in days_in_month
-                    ]
-
-                    # Converting the extracted strings to integers
-                    days_numbers = [
-                        int(num) for num in days_in_month if num.isnumeric()
-                    ]
+                    # A day list is a contiguous run of bare numbers.
+                    # A token that carries words after its number is the
+                    # end of the list: on sectors that continue in prose
+                    # on the same line, reading on takes the clock times
+                    # in "between 7 p.m. and 7 a.m." for days of the
+                    # month. Leading non-numeric tokens are skipped
+                    # rather than ending the list, because it can open
+                    # with an ordinal ("July 1st, 15, and 29") that is
+                    # not parsed as a day but must not discard the rest.
+                    days_numbers = []
+                    for part in days_in_month:
+                        token = part.strip()
+                        day_match = re.match(r"(\d{1,2})\b", token)
+                        if not day_match:
+                            if days_numbers:
+                                break
+                            continue
+                        days_numbers.append(int(day_match.group(1)))
+                        if token != day_match.group(1):
+                            break
 
                     for day in days_numbers:
                         date = datetime(year, MONTHS[month], day)

--- a/tests/test_montreal_ca.py
+++ b/tests/test_montreal_ca.py
@@ -64,6 +64,18 @@ LSL4_GREEN = "Collection day(s) in 2026 :  Every Wednesday from April 15, 2026 t
 # denies a collection on that date.
 VSMPE2A_WASTE = "Collection day(s) :  Thursday\nHours :  Take out containers between 8 p.m. the evening before and 7 a.m. the day of collection\n\n\n  Important  - Starting September 24, household garbage will be collected every other week in your area. This means there will be a collection on September 24, but there will be no collection on October 1st, and so on.\n\n\n\n  No changes are planned for the collection of recyclable materials, food scraps, bulky items, or construction, renovation and demolition debris.\n\nFor more information, please visit montreal.ca\n\n"
 
+# Ahuntsic sector AC-2: an explicit list of collection days, one bulleted
+# line per month, with no "every ... week" phrasing anywhere.
+AC2_GREEN = "Collection day(s) in 2026 :  Thursday\n - April 9, 16, 23 and 30;\n - May 7, 14, 21 and 28;\n - June 4, 11, 18 and 25;\n - July 9 and 23;\n - August 6 and 20;\n - September 3, 10, 17 and 24;\n - October 1, 8, 15, 22 and 29;\n - November 5, 12, 19 and 26.\nHours :  Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection \nContainers accepted :\n - paper bag weighing no more than 25 kg when full.\nPlastic bags are not accepted."
+
+# Saint-Leonard sector SLE-1: the same shape, but written on one line, so
+# the final month's list runs straight into prose containing clock times.
+SLE1_GREEN = "Collection day(s) in 2026 :  Wednesday  - April 22 and 29;  - May 6, 13, 20 and 27;  - June 3, 10, 17 and 24;  - July 8, 15, 22 and 29; - August 5, 12, 19 and 26;  - September 2, 9, 16, 23 and 30;  - October 7, 14, 21  and 28;  - November 4, 11 and 18. Hours :  Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection Containers accepted :  - Reusable rigid containers  - Paper bags - Cardboard boxes\n"
+
+# Montreal-Nord sector MTN-1: an explicit list too, but it contains no
+# hyphen at all, so the date parser would see nothing.
+MTN1_GREEN = "Collection day(s) in 2026 :  Friday April 10, 17 et 24;\nMay 1, 8, 15, 22 et 29; \nJune 5 et 19; \nJuly 3, 17 et 31; \nAugust 7 et 21; \nSeptember 4 et 18; \nOctober 2, 9, 16, 23 et 30; \nNovember 6, 13, 20 et 27. \n\nHours :  Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection"
+
 # Mercier-Hochelaga sector MHM-42-S: plain per-month date lists, no seasons.
 MHM_GREEN = "Collection day(s) 2026 :  the following tuesdays :\n - April 21 and 28;\n - May 5, 12, 19 and 26 ; \n - June 2, 9 and 23;\n - July 7 and 21;\n - August 4, 18 and 25;\n - September 1, 8, 15, 22 and 29; \n - October 6, 13, 20 and 27;\n - November 3, 10 and 17. \nHours : Take out containers between 7 p.m. the evening before and 7 a.m. the day of collection. \nContainers accepted : \n - Reusable rigid containers \n - Paper bags \n - Cardboard boxes \nPlastic bags are not accepted."
 
@@ -182,3 +194,50 @@ def test_a_denied_date_is_not_emitted():
     """ "no collection on October 1st" must not produce a collection."""
     assert date(2026, 10, 1) not in parse(VSMPE2A_WASTE)
     assert date(2026, 9, 24) in parse(VSMPE2A_WASTE)
+
+
+def test_explicit_date_list_is_not_expanded_to_the_whole_year():
+    """AC-2 lists its collection days, so only those may be emitted.
+
+    Without "every ... week" or "of the month" the message used to take
+    the whole-year weekday branch, which returned all 53 Thursdays of
+    2026 and ignored the list entirely. January to March and December
+    have no green collection at all.
+    """
+    parsed = parse(AC2_GREEN)
+    expected = (
+        {date(2026, 4, d) for d in (9, 16, 23, 30)}
+        | {date(2026, 5, d) for d in (7, 14, 21, 28)}
+        | {date(2026, 6, d) for d in (4, 11, 18, 25)}
+        | {date(2026, 7, d) for d in (9, 23)}
+        | {date(2026, 8, d) for d in (6, 20)}
+        | {date(2026, 9, d) for d in (3, 10, 17, 24)}
+        | {date(2026, 10, d) for d in (1, 8, 15, 22, 29)}
+        | {date(2026, 11, d) for d in (5, 12, 19, 26)}
+    )
+    assert parsed == expected
+
+
+def test_day_list_stops_where_prose_begins():
+    """SLE-1 continues in prose on the same line as its last month.
+
+    "November 4, 11 and 18. Hours : ... between 7 p.m. ... and 7 a.m."
+    must not contribute a November 7, which is a Saturday and not a
+    collection day.
+    """
+    parsed = parse(SLE1_GREEN)
+    assert {d.day for d in parsed if d.month == 11} == {4, 11, 18}
+    assert date(2026, 11, 7) not in parsed
+
+
+def test_reroute_requires_dates_the_parser_can_reach():
+    """MTN-1 lists days but has no hyphen, so the parser cannot see them.
+
+    Rerouting on the strength of the raw message would hand it to a
+    parser that reads only the hyphen-delimited body, and it would
+    produce nothing at all. Better to leave it on the existing branch
+    than to trade wrong dates for no dates.
+    """
+    parsed = parse(MTN1_GREEN)
+    assert len(parsed) > 40
+    assert all(d.weekday() == 4 for d in parsed)


### PR DESCRIPTION
Last of the follow-ups from #7243, and the one with real user impact.

### The bug

`parse_collection` opens with:

```python
if not re.search(r"(?:every\s+(?:.*)week|of the month)", schedule_message, re.IGNORECASE):
    # emit every matching weekday of the whole calendar year
    return entries
```

A message that states its schedule as a plain list of dates matches neither phrase, so it takes that branch and its list is never read.

28 Green sectors publish exactly that shape. AC-2 lists 29 Thursdays from April to November:

> Collection day(s) in 2026 : Thursday
> - April 9, 16, 23 and 30;
> - May 7, 14, 21 and 28;
> ...

and produces **all 53 Thursdays of 2026**, including January through March and December, when there is no green collection at all.

This is the opposite failure to #7243 and #7256. Those dropped dates. This one invents them, which is worse: the calendar asks for bins on days with no pickup, and any staleness check looking for gaps is quietly satisfied.

### The fix

Route the message to the date parser when its body enumerates days across four or more distinct months.

Two details that needed measuring rather than guessing.

**Counted over the hyphen-delimited body, not the whole message.** The date parser reads only what follows the first hyphen, since `header` is popped. MTN-1 to MTN-4 and OUT-RV list their days *ahead* of any hyphen, so rerouting on the raw text would hand them to a parser that cannot see them, turning 52 wrong dates into none. Counting the body leaves them alone.

**Threshold of four.** Across all 507 sector messages, distinct months per body distributes as:

| months in body | sectors |
|---|---|
| 0 | 388 |
| 1 | 4 |
| 2 | 2 |
| 8 | 23 |
| 9 | 5 |

Nothing sits between 2 and 8, so any threshold in that range selects the same 28 sectors. The number is not a tuning knob. Prose that merely mentions a date, such as *"Since May 2, 2024, food waste collection has been deployed..."*, lands in the low band and is untouched.

### A second fault this exposed

SLE-1 writes its whole schedule on one line, so the last month runs into prose:

> - November 4, 11 and 18. Hours : Take out containers between 7 p.m. the evening before and 7 a.m. ...

Rerouting it produced a **November 7**, a Saturday, read out of the clock times. The first-word-per-token approach hid this: `"18 Hours : Take out ... before"` yields `"18"`, and the following token starts `"7 am the day of collection"`.

A day list is now read as a contiguous run of bare numbers, ending at the first token that carries words after its number. Leading non-numeric tokens are skipped rather than ending the list, so `"July 1st, 15, and 29"` still yields 15 and 29 exactly as it does today.

### Verification

Against the live feeds, one shape per family. Every rerouted sector was checked date by date against its published list, not just by count.

```
sector        before  after   result
---------------------------------------------------------------
Green/AC-2        53     29    matches published list exactly
Green/MHM-42-S    52     26    matches published list exactly
Green/SO-1        52     25    matches published list exactly
Green/SLE-1       52     30    matches published list exactly
Green/VRD-1       52     25    published 26, missing August 31st

Green/MTN-1       52     52    unchanged, dates precede any hyphen
Green/OUT-RV      52     52    unchanged, same reason
Waste/AC-1        52     52    unchanged, prose date only
Waste/SLR-1       52     52    unchanged, two months in body
Green/ANJ-1       26     26    unchanged, seasonal path untouched
Green/RPP-RE-22-RV 26     26   unchanged
Green/LSL4         4      4    unchanged
```

The 28 rerouted sectors are five shape families: AC-1..4, SO-1..4 and SO-5-R1..R4, MHM-41 through MHM-44, SLE-1..4, VRD-1..5. Members of a family differ only in weekday and day numbers, and one of each is verified above.

VRD-1's August 31st is the ordinal case deliberately left unparsed in #7256. Unchanged here.

Three tests added. Two fail on master; the third is a guard that passes on both, which is the point of it. `ruff check` and `ruff format --check` clean, `tests/test_montreal_ca.py` 14 passed, `tests/test_source_components.py` 35 passed.

### Still not addressed

`Green/CD-E-*` and `Green/CD-R-*` say "Wednesday **from April 22 to November 25**", a range with no "every ... week" phrasing, so they also take the whole-year branch and over-emit. That would require routing to the range parser rather than the list parser, and deserves its own measurement. Not touched here.
