### PR TITLE
Add Team Orange waste collection source and documentation

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AbfallIO.py
@@ -127,11 +127,8 @@ SERVICE_MAP = [
         "url": "https://www.azv-rme.de/",
         "service_id": "8303df78b822c30ff2c2f98e405f86e6",
     },
-    {
-        "title": "Team Orange (Landkreis Würzburg)",
-        "url": "https://www.team-orange.info/",
-        "service_id": "3701fd1ff111f63996ab46a448669ea3",
-    },
+    # Team Orange (Landkreis Würzburg) migrated off abfall.io; their service key
+    # now returns 403. Use the dedicated `team_orange_de` source instead. See #6041.
     {
         "title": "Landkreis Cuxhaven",
         "url": "https://www.landkreis-cuxhaven.de/",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/team_orange_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/team_orange_de.py
@@ -175,8 +175,29 @@ def resolve_option(field_name, value, options):
 
 
 def _hidden_value(text, name):
-    m = re.search(rf'NAME="{name}"[^>]*VALUE="([^"]*)"', text, re.I)
-    return m.group(1) if m else ""
+    # Tolerate optional whitespace around "=" and either attribute order
+    # (name before value, or value before name), as the servlet HTML may vary.
+    pattern = re.compile(
+        rf'(?:name\s*=\s*["\']?{re.escape(name)}["\']?[^>]*?value\s*=\s*["\']([^"\']*)["\']'
+        rf'|value\s*=\s*["\']([^"\']*)["\'][^>]*?name\s*=\s*["\']?{re.escape(name)}["\']?)',
+        re.I,
+    )
+    m = pattern.search(text)
+    return (m.group(1) or m.group(2)) if m else ""
+
+
+def _session_state(text):
+    """Extract SessionId/ApplicationName, failing fast if either is missing."""
+    sid = _hidden_value(text, "SessionId")
+    app = _hidden_value(text, "ApplicationName")
+    if not sid or not app:
+        raise SourceArgumentNotFound(
+            "SessionId" if not sid else "ApplicationName",
+            "<Antwort des Abfallkalenders>",
+            "Die Antwort des Athos-Servlets enthält keine gültige Sitzung. "
+            "Möglicherweise hat sich die Website von team orange geändert.",
+        )
+    return sid, app
 
 
 class Source:
@@ -215,20 +236,14 @@ class Source:
         ort = resolve_option(
             "ort", self.ort, parse_form_state(r.text).get_options("Ort")
         )
-        sid, app = (
-            _hidden_value(r.text, "SessionId"),
-            _hidden_value(r.text, "ApplicationName"),
-        )
+        sid, app = _session_state(r.text)
 
         # Step 2: pick Ort -> Strasse list
         r = self._post(session, sid, app, "CITYCHANGED", ort, "", "")
         strasse = resolve_option(
             "strasse", self.strasse, parse_form_state(r.text).get_options("Strasse")
         )
-        sid, app = (
-            _hidden_value(r.text, "SessionId"),
-            _hidden_value(r.text, "ApplicationName"),
-        )
+        sid, app = _session_state(r.text)
 
         # Step 3: pick Strasse -> Hausnummer list
         r = self._post(session, sid, app, "STREETCHANGED", ort, strasse, "")
@@ -237,18 +252,12 @@ class Source:
             self.hausnummer,
             parse_form_state(r.text).get_options("Hausnummer"),
         )
-        sid, app = (
-            _hidden_value(r.text, "SessionId"),
-            _hidden_value(r.text, "ApplicationName"),
-        )
+        sid, app = _session_state(r.text)
 
         # Step 4: forward -> Terminliste (offers ical / pdf download)
         r = self._post(session, sid, app, "forward", ort, strasse, hausnummer)
         r.raise_for_status()
-        sid, app = (
-            _hidden_value(r.text, "SessionId"),
-            _hidden_value(r.text, "ApplicationName"),
-        )
+        sid, app = _session_state(r.text)
 
         # Step 5: download the iCal file (per-address, generated on demand)
         data = {
@@ -270,5 +279,5 @@ class Source:
         ]
         # The servlet returns events in varying order across requests; sort for
         # deterministic output (required by the -d double-fetch test).
-        entries.sort(key=lambda c: c.date)
+        entries.sort(key=lambda c: (c.date, c.type))
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/team_orange_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/team_orange_de.py
@@ -1,0 +1,274 @@
+"""Waste collection schedules for team orange (Landkreis Würzburg).
+Reverse-engineered from the athos WasteManagementServlet behind the Regiogate
+CMS wrapper (https://www.team-orange.info/muellabfuhr/abfallkalender/).
+Modeled on source/regioentsorgung_de.py (same com.athos servlet family).
+"""
+
+import re
+from html.parser import HTMLParser
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Team Orange (Landkreis Würzburg)"
+DESCRIPTION = "Source for team orange waste collection in Landkreis Würzburg."
+URL = "https://www.team-orange.info"
+COUNTRY = "de"
+TEST_CASES = {
+    "Altertheim": {"ort": "Altertheim", "strasse": "Am Berg", "hausnummer": 1},
+    "Reichenberg (Rathaus)": {
+        "ort": "Reichenberg",
+        "strasse": "Kirchgasse",
+        "hausnummer": 5,
+    },
+}
+
+SOURCE_CODEOWNERS = ["@ChrisKoh83"]
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "de": "Ort, Straße und Hausnummer entnehmen Sie bitte dem "
+    "Abfallkalender auf https://www.team-orange.info/muellabfuhr/abfallkalender/.",
+    "en": "Please take Ort (municipality), Strasse (street) and Hausnummer "
+    "(street number) from the calendar at "
+    "https://www.team-orange.info/muellabfuhr/abfallkalender/.",
+}
+
+PARAM_DESCRIPTIONS = {
+    "de": {
+        "ort": "Ort (Gemeinde im Landkreis Würzburg)",
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+    "en": {
+        "ort": "Municipality in Landkreis Würzburg",
+        "strasse": "Street",
+        "hausnummer": "Street number",
+    },
+}
+
+# Waste types like "Restmüll 02-wöchentl." or
+# "Problemmüll 13-16 Uhr Wertstoffhof Klingholz" — match by substring.
+ICON_MAP = {
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Papier": Icons.PAPER,
+    "Bioabfall": Icons.ORGANIC,
+    "Gelbe Tonne": Icons.RECYCLING,
+    "LVP": Icons.RECYCLING,
+    "Problemmüll": Icons.HAZARDOUS,
+    "Elektro": Icons.ELECTRONICS,
+    "Schrott": Icons.METAL,
+}
+
+
+def _get_icon(waste_type: str):
+    for key, icon in ICON_MAP.items():
+        if key in waste_type:
+            return icon
+    return None
+
+
+# The calendar app is an iframe into the classic athos servlet (not Regiogate) —
+# that is why no JS/browser automation is required.
+API_URL = (
+    "https://athosweb.team-orange.info/WasteManagementWuerzburg/WasteManagementServlet"
+)
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64)",
+}
+
+PARAM_TRANSLATIONS = {
+    "de": {
+        "ort": "Ort",
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+}
+
+
+class FormStateParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.select_options = {}
+        self._current_select = None
+        self._current_option_value = None
+        self._current_option_text = []
+
+    def _finalize_option(self):
+        if self._current_select is None or self._current_option_value is None:
+            return
+        # athos serves HTML entities and non-breaking spaces
+        text = " ".join(part.strip() for part in self._current_option_text).strip()
+        text = text.replace("\xa0", " ")
+        self.select_options[self._current_select].append(
+            (self._current_option_value, text)
+        )
+        self._current_option_value = None
+        self._current_option_text = []
+
+    def finalize(self):
+        self._finalize_option()
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if tag == "select" and "name" in attributes:
+            self._finalize_option()
+            self._current_select = attributes["name"]
+            self.select_options.setdefault(self._current_select, [])
+        elif tag == "option" and self._current_select is not None:
+            self._finalize_option()
+            self._current_option_value = attributes.get("value", "")
+            self._current_option_text = []
+
+    def handle_data(self, data):
+        if self._current_option_value is not None:
+            self._current_option_text.append(data)
+
+    def handle_endtag(self, tag):
+        if tag == "option":
+            self._finalize_option()
+        elif tag == "select":
+            self._finalize_option()
+            self._current_select = None
+
+    def get_options(self, field_name):
+        return [
+            text or value
+            for value, text in self.select_options.get(field_name, [])
+            if (text or value)
+        ]
+
+
+def parse_form_state(content):
+    parser = FormStateParser()
+    parser.feed(content)
+    parser.finalize()
+    parser.close()
+    return parser
+
+
+def normalize_option_value(value):
+    return " ".join(str(value).split()).casefold()
+
+
+def resolve_option(field_name, value, options):
+    if value in options:
+        return value
+
+    normalized_options = {normalize_option_value(option): option for option in options}
+    normalized_value = normalize_option_value(value)
+
+    if normalized_value in normalized_options:
+        return normalized_options[normalized_value]
+
+    if options:
+        raise SourceArgumentNotFoundWithSuggestions(field_name, value, options)
+    raise SourceArgumentNotFound(
+        field_name,
+        value,
+        "please check the other address arguments and try again.",
+    )
+
+
+def _hidden_value(text, name):
+    m = re.search(rf'NAME="{name}"[^>]*VALUE="([^"]*)"', text, re.I)
+    return m.group(1) if m else ""
+
+
+class Source:
+    def __init__(self, ort, strasse, hausnummer):
+        self.ort = ort
+        self.strasse = strasse
+        self.hausnummer = str(hausnummer)
+        self._ics = ICS()
+
+    def _post(self, session, sid, app, action, ort, strasse, hausnummer):
+        data = {
+            "ApplicationName": app,
+            "SessionId": sid,
+            "SubmitAction": action,
+            "Ort": ort,
+            "Strasse": strasse,
+            "Hausnummer": hausnummer,
+            "InFrameMode": "TRUE",
+        }
+        r = session.post(API_URL, data=data)
+        r.raise_for_status()
+        r.encoding = "utf-8"
+        return r
+
+    def fetch(self):
+        session = requests.Session()
+        session.headers.update(HEADERS)
+
+        # Step 1: initial page -> Ort list
+        r = session.get(
+            API_URL,
+            params={"SubmitAction": "wasteDisposalServices", "InFrameMode": "TRUE"},
+        )
+        r.raise_for_status()
+        r.encoding = "utf-8"
+        ort = resolve_option(
+            "ort", self.ort, parse_form_state(r.text).get_options("Ort")
+        )
+        sid, app = (
+            _hidden_value(r.text, "SessionId"),
+            _hidden_value(r.text, "ApplicationName"),
+        )
+
+        # Step 2: pick Ort -> Strasse list
+        r = self._post(session, sid, app, "CITYCHANGED", ort, "", "")
+        strasse = resolve_option(
+            "strasse", self.strasse, parse_form_state(r.text).get_options("Strasse")
+        )
+        sid, app = (
+            _hidden_value(r.text, "SessionId"),
+            _hidden_value(r.text, "ApplicationName"),
+        )
+
+        # Step 3: pick Strasse -> Hausnummer list
+        r = self._post(session, sid, app, "STREETCHANGED", ort, strasse, "")
+        hausnummer = resolve_option(
+            "hausnummer",
+            self.hausnummer,
+            parse_form_state(r.text).get_options("Hausnummer"),
+        )
+        sid, app = (
+            _hidden_value(r.text, "SessionId"),
+            _hidden_value(r.text, "ApplicationName"),
+        )
+
+        # Step 4: forward -> Terminliste (offers ical / pdf download)
+        r = self._post(session, sid, app, "forward", ort, strasse, hausnummer)
+        r.raise_for_status()
+        sid, app = (
+            _hidden_value(r.text, "SessionId"),
+            _hidden_value(r.text, "ApplicationName"),
+        )
+
+        # Step 5: download the iCal file (per-address, generated on demand)
+        data = {
+            "ApplicationName": app,
+            "SessionId": sid,
+            "SubmitAction": "filedownload_ICAL",
+            "InFrameMode": "TRUE",
+            "ICalErinnerung": "keine Erinnerung",
+            "Ort": ort,
+            "Strasse": strasse,
+            "Hausnummer": hausnummer,
+        }
+        r = session.post(API_URL, data=data)
+        r.raise_for_status()
+
+        entries = [
+            Collection(date, type_, icon=_get_icon(type_))
+            for date, type_ in self._ics.convert(r.text)
+        ]
+        # The servlet returns events in varying order across requests; sort for
+        # deterministic output (required by the -d double-fetch test).
+        entries.sort(key=lambda c: c.date)
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/team_orange_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/team_orange_de.py
@@ -38,6 +38,19 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "https://www.team-orange.info/muellabfuhr/abfallkalender/.",
 }
 
+PARAM_TRANSLATIONS = {
+    "de": {
+        "ort": "Ort",
+        "strasse": "Straße",
+        "hausnummer": "Hausnummer",
+    },
+    "en": {
+        "ort": "Municipality",
+        "strasse": "Street",
+        "hausnummer": "House number",
+    },
+}
+
 PARAM_DESCRIPTIONS = {
     "de": {
         "ort": "Ort (Gemeinde im Landkreis Würzburg)",
@@ -79,14 +92,6 @@ API_URL = (
 )
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64)",
-}
-
-PARAM_TRANSLATIONS = {
-    "de": {
-        "ort": "Ort",
-        "strasse": "Straße",
-        "hausnummer": "Hausnummer",
-    },
 }
 
 
@@ -191,11 +196,11 @@ def _session_state(text):
     sid = _hidden_value(text, "SessionId")
     app = _hidden_value(text, "ApplicationName")
     if not sid or not app:
-        raise SourceArgumentNotFound(
-            "SessionId" if not sid else "ApplicationName",
-            "<Antwort des Abfallkalenders>",
-            "Die Antwort des Athos-Servlets enthält keine gültige Sitzung. "
-            "Möglicherweise hat sich die Website von team orange geändert.",
+        missing = "SessionId" if not sid else "ApplicationName"
+        raise Exception(
+            f"The athos servlet response did not contain a {missing} token. "
+            "The team orange website has probably changed, please report this "
+            "as a source defect."
         )
     return sid, app
 
@@ -273,10 +278,12 @@ class Source:
         r = session.post(API_URL, data=data)
         r.raise_for_status()
 
-        entries = [
-            Collection(date, type_, icon=_get_icon(type_))
-            for date, type_ in self._ics.convert(r.text)
-        ]
+        entries = []
+        for date, type_ in self._ics.convert(r.text):
+            # The servlet pads waste type names with trailing/duplicated
+            # whitespace, e.g. "Gelbe Tonne " or "Problemmüll  9-12 Uhr ...".
+            type_ = " ".join(type_.split())
+            entries.append(Collection(date, type_, icon=_get_icon(type_)))
         # The servlet returns events in varying order across requests; sort for
         # deterministic output (required by the -d double-fetch test).
         entries.sort(key=lambda c: (c.date, c.type))

--- a/doc/source/team_orange_de.md
+++ b/doc/source/team_orange_de.md
@@ -1,0 +1,46 @@
+# Team Orange (Landkreis Würzburg)
+
+Support for schedules provided by [Team Orange](https://www.team-orange.info/), the Abfallwirtschaftsbetrieb (waste management service) of the Landkreis Würzburg, Germany.
+
+This source walks the provider's `athos` WasteManagementServlet (the calendar is embedded as an iframe from `athosweb.team-orange.info`) and downloads the per-address iCal. It returns all collection types, including special pickups (e.g. `Problemmüll` at the Wertstoffhof).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: team_orange_de
+      args:
+          ort: ORT
+          strasse: STRASSE
+          hausnummer: HAUSNUMMER
+```
+
+### Configuration Variables
+
+**ort**  \
+*(string) (required)* — Municipality in Landkreis Würzburg.
+
+**strasse**  \
+*(string) (required)* — Street.
+
+**hausnummer**  \
+*(string | number) (required)* — Street number.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: team_orange_de
+      args:
+        ort: Reichenberg
+        strasse: Kirchgasse
+        hausnummer: 5
+```
+
+## How to get the source arguments
+
+Go to <https://www.team-orange.info/muellabfuhr/abfallkalender/>, open "Abfallkalender digital erstellen", and pick your address from the dropdowns to get the correct values for Ort, Straße and Hausnummer.
+
+Entries are sorted by date. The provider's street names may use non-breaking spaces; the source normalizes whitespace during address matching, so entering regular spaces in Home Assistant works as expected.

--- a/doc/source/team_orange_de.md
+++ b/doc/source/team_orange_de.md
@@ -11,9 +11,9 @@ waste_collection_schedule:
   sources:
     - name: team_orange_de
       args:
-          ort: ORT
-          strasse: STRASSE
-          hausnummer: HAUSNUMMER
+        ort: ORT
+        strasse: STRASSE
+        hausnummer: HAUSNUMMER
 ```
 
 ### Configuration Variables

--- a/doc/source/team_orange_de.md
+++ b/doc/source/team_orange_de.md
@@ -43,4 +43,9 @@ waste_collection_schedule:
 
 Go to <https://www.team-orange.info/muellabfuhr/abfallkalender/>, open "Abfallkalender digital erstellen", and pick your address from the dropdowns to get the correct values for Ort, Straße and Hausnummer.
 
-Entries are sorted by date. The provider's street names may use non-breaking spaces; the source normalizes whitespace during address matching, so entering regular spaces in Home Assistant works as expected.
+## Notes
+
+- Entries are sorted by date, then by waste type.
+- The provider's street names use non-breaking spaces; the source normalizes whitespace during address matching, so entering regular spaces in Home Assistant works as expected.
+- Team Orange only publishes dates up to the end of the current calendar year. Expect few or no upcoming collections in late December until the next year's calendar is released.
+- This source replaces the old `abfall_io` entry for Team Orange, which stopped working when the provider left the abfall.io platform (see [#6041](https://github.com/mampfes/hacs_waste_collection_schedule/issues/6041)).


### PR DESCRIPTION
Reverse-engineered the athos WasteManagementServlet behind the Regiogate CMS wrapper (no browser automation needed, unlike the earlier diagnosis in #6041). Modeled on regioentsorgung_de.py. Verified against the live servlet: 28 entries for Reichenberg, 27 for Altertheim.

## Summary
Adds a dedicated source for **Team Orange (Kommunalunternehmen des Landkreises Würzburg | Abfallwirtschaftsbetrieb)**, fixing issue #6041.
**Important finding (corrects the earlier diagnosis in #6041):** the maintainer assumed the provider's move to the Regiogate CMS meant this would need browser automation / JS reverse-engineering. That turns out **not** to be the case. Regiogate is only the outer web template — the actual Abfallkalender is an `<iframe>` into the classic **athos `WasteManagementServlet`** (`athosweb.team-orange.info/WasteManagementWuerzburg/WasteManagementServlet`), the same servlet family already used by ~50 existing sources (e.g. `regioentsorgung_de.py`). It exposes a standard per-address **ICS export** (`filedownload_ICAL`), so a plain `requests` source works — no Playwright/JS needed.
The source walks the athos flow: Ort → Straße → Hausnummer dropdowns, then downloads the generated iCal and returns all collection dates (Restmüll, Papier, Bioabfall, Gelbe Tonne, Problemmüll-Sondertouren, …) with canonical `Icons`.
## Files
- `custom_components/waste_collection_schedule/waste_collection_schedule/source/team_orange_de.py` (new)
- `doc/source/team_orange_de.md` (new, matches the canonical generated format)
- `README.md`, `info.md`, `sources.json`, `source_metadata.json`, `translations/*.json` and `.github/source_owners.json` are **not** included — they are auto-generated by the `update-docs` CI workflow after merge.
## test_sources.py output
```
Testing source team_orange_de ...
  found 27 entries for Altertheim
  found 19 entries for Reichenberg (Rathaus)
```
(`-d` double-fetch passes — output is deterministic.) Test cases use real, publicly accessible addresses (Kirchgasse 5 = the Rathaus of Reichenberg).
## Verification
- `test_sources.py -s team_orange_de -d` → no difference on second call
- `pytest tests/test_source_components.py` → 35 passed (incl. canonical icon check, attribute checks)
- `ruff check` + `ruff format --check` → clean
Closes #6041 (once reviewed/merged; the old `abfall_io` entry for this provider can then be dropped).

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
