### PR TITLE
[BSR_DE] Update instruction for downloading calendar

### DIFF
--- a/doc/source/bsr_de.md
+++ b/doc/source/bsr_de.md
@@ -47,7 +47,7 @@ It will then query the BSR for the `schedule_id`.
 1. Go to https://www.bsr.de/abfuhrkalender.
 1. Enter your street (Straße) and house number (Hausnummer) in the form at the lower part of the page (you might get a list where you have to select your postal code).
 1. Now you should see a calendar with pickup dates.
-1. Click on the 3 dots in a circle that is directly above the calender on the right.
+1. Click on the "Downloads" button that is directly above the calendar on the right.
 1. A popup opens (you can download either a PDF or a ICS document, but there's no need to do it).
 1. When you hover with your mouse over one of the two links you will see the link at the very bottom of the window.
 1. Part of this link is a 24 digit number - this is your `sched_id`.


### PR DESCRIPTION
BSR have updated their customer portal. It seems that everything is still working except obtaining the sched_id via the UI.

I just checked - the python program still works.

## Summary

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
