### PR TITLE
Fix Newham date parsing, add food waste collections, and fail loudly on bad property IDs

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
@@ -5,6 +5,7 @@ import requests
 import urllib3
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "London Borough of Newham"
 DESCRIPTION = "Source for newham.gov.uk services for London Borough of Newham, UK."
@@ -24,8 +25,10 @@ ICON_MAP = {
 API_URL = "https://bincollection.newham.gov.uk/Details/Index/{property}"
 
 # "Next<nbsp>Tuesday<nbsp>01/09/2026" - the day name is optional, the date is
-# always dd/mm/yyyy.
-NEXT_DATE = re.compile(r"Next\D*(\d{2}/\d{2}/\d{4})")
+# always dd/mm/yyyy. Allow at most one word between "Next" and the date, and
+# never "Previous", so that a card with an empty "Next" cannot match the
+# "Previous" date that follows it.
+NEXT_DATE = re.compile(r"Next\s*(?:(?!Previous)[A-Za-z]+\s*)?(\d{2}/\d{2}/\d{4})")
 
 # The server presents only its leaf certificate, so the chain cannot be verified.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -40,6 +43,25 @@ class Source:
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, features="html.parser")
+
+        # An unknown (but well formed) property ID still returns HTTP 200 with a
+        # fully rendered page; only the address card is left empty. Without this
+        # check every collection card is skipped and fetch() returns [] silently.
+        # Key the lookup on the header text, not on card order: every collection
+        # card carries the "card" class too, so a positional lookup would read a
+        # collection card (and pass) if the page were ever reordered.
+        address = None
+        for card in soup.find_all("div", class_="card"):
+            header = card.find("div", {"class": "card-header"})
+            if header is not None and "address" in header.get_text(strip=True).lower():
+                address = card.find("p", {"class": "card-text"})
+                break
+        if address is None or not address.get_text(strip=True):
+            raise SourceArgumentNotFound(
+                "property",
+                self._property,
+                "this property ID does not exist on bincollection.newham.gov.uk.",
+            )
 
         entries = []
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
@@ -1,6 +1,9 @@
+import re
+from datetime import datetime
+
 import requests
+import urllib3
 from bs4 import BeautifulSoup
-from dateutil import parser as dateparser
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 
 TITLE = "London Borough of Newham"
@@ -14,8 +17,18 @@ TEST_CASES = {
 
 ICON_MAP = {
     "DOMESTIC": Icons.GENERAL_WASTE,
-    "RECYCLING": Icons.GLASS,
+    "RECYCLING": Icons.RECYCLING,
+    "FOOD WASTE": Icons.BIO_KITCHEN,
 }
+
+API_URL = "https://bincollection.newham.gov.uk/Details/Index/{property}"
+
+# "Next<nbsp>Tuesday<nbsp>01/09/2026" - the day name is optional, the date is
+# always dd/mm/yyyy.
+NEXT_DATE = re.compile(r"Next\D*(\d{2}/\d{2}/\d{4})")
+
+# The server presents only its leaf certificate, so the chain cannot be verified.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class Source:
@@ -23,51 +36,42 @@ class Source:
         self._property = str(property).zfill(12)
 
     def fetch(self):
-        s = requests.Session()
-        r = s.get(
-            f"https://bincollection.newham.gov.uk/Details/Index/{self._property}",
-            verify=False,
-        )
+        r = requests.get(API_URL.format(property=self._property), verify=False)
+        r.raise_for_status()
 
-        # Make a BS4 object
         soup = BeautifulSoup(r.text, features="html.parser")
-        soup.prettify()
 
-        # Form an array for the bins
         entries = []
 
-        # Find section with bins in
-        sections = soup.find_all("div", {"class": "card h-100"})
-
-        # there may also be a recycling one too
-        sections_recycling = soup.find_all(
-            "div", {"class": "card h-100 card-recycling"}
-        )
-        if len(sections_recycling) > 0:
-            sections.append(sections_recycling[0])
-
-        # For each bin section, get the text and the list elements
-        for item in sections:
-            header = item.find("div", {"class": "card-header"})
-            bin_type_element = header.find_next("b")
+        # Each collection type is its own card; the type is in bold in the card
+        # header ("Your <b>Domestic</b> Collection Day"). Cards without a bold
+        # header (e.g. green and garden waste) carry no schedule.
+        for card in soup.find_all("div", class_="card"):
+            header = card.find("div", {"class": "card-header"})
+            if header is None:
+                continue
+            bin_type_element = header.find("b")
             if bin_type_element is None:
                 continue
-            bin_type = bin_type_element.text
-            array_expected_types = ["Domestic", "Recycling"]
-            if bin_type not in array_expected_types:
+            bin_type = bin_type_element.get_text(strip=True)
+            # ICON_MAP doubles as the allowlist of collection types: a type
+            # Newham adds later is skipped until it is given an icon here.
+            if bin_type.upper() not in ICON_MAP:
                 continue
-            date_string = (
-                item.find_next("p", {"class": "card-text"})
-                .find_next("mark")
-                .next_sibling.strip()
-            )
-            next_collection = dateparser.parse(date_string).date()
+
+            body = card.find("p", {"class": "card-text"})
+            if body is None:
+                continue
+            match = NEXT_DATE.search(body.get_text())
+            if match is None:
+                # The card is rendered even when no collection is scheduled.
+                continue
 
             entries.append(
                 Collection(
-                    date=next_collection,
+                    date=datetime.strptime(match.group(1), "%d/%m/%Y").date(),
                     t=bin_type,
-                    icon=ICON_MAP.get(bin_type.split(" ")[0].upper()),
+                    icon=ICON_MAP.get(bin_type.upper()),
                 )
             )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/newham_gov_uk.py
@@ -39,7 +39,9 @@ class Source:
         self._property = str(property).zfill(12)
 
     def fetch(self):
-        r = requests.get(API_URL.format(property=self._property), verify=False)
+        r = requests.get(
+            API_URL.format(property=self._property), verify=False, timeout=30
+        )
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, features="html.parser")

--- a/doc/source/newham_gov_uk.md
+++ b/doc/source/newham_gov_uk.md
@@ -22,7 +22,7 @@ Unique number the London Borough of Newham uses to identify your property.
 
 #### How to find your `PROPERTY_ID`
 
-Searach for your waste collection schedule at (https://bincollection.newham.gov.uk/). Your `PROPERTY_ID` is the set of numbers at the end of the url when your schedule is being displayed.
+Search for your waste collection schedule at <https://bincollection.newham.gov.uk/>. Your `PROPERTY_ID` is the set of numbers at the end of the url when your schedule is being displayed.
 
 For example: https://bincollection.newham.gov.uk/Details/Index/000046029438
 

--- a/tests/test_newham_gov_uk.py
+++ b/tests/test_newham_gov_uk.py
@@ -1,0 +1,203 @@
+"""Tests for the newham_gov_uk source.
+
+Newham's bin collection site is HTML only, and three of its behaviours have
+caused silent breakage:
+
+* dates are rendered ``dd/mm/yyyy``, which a month-first parser reads as a
+  different (and plausible looking) date;
+* an unknown property ID returns HTTP 200 with a fully rendered page, so only
+  the empty address card distinguishes it from a real address;
+* a card can render an empty "Next" while still showing a "Previous" date
+  below it.
+
+The markup in the fixtures below is copied from live responses.
+
+This file is not auto-discovered by pytest: pytest.ini restricts python_files to
+test_source_components.py and test_fetch_retry.py. Run it explicitly:
+
+    pytest tests/test_newham_gov_uk.py -o python_files=test_newham_gov_uk.py -v
+"""
+
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(
+    str(Path(__file__).parents[1] / "custom_components" / "waste_collection_schedule")
+)
+
+from waste_collection_schedule import Icons
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.source import newham_gov_uk
+
+
+class Response:
+    def __init__(self, html: str):
+        self.text = html
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+ADDRESS_CARD = """
+<div class="card">
+  <div class="card-header">Your Address</div>
+  <p class="card-text"> <i class="fas fa-home fa-4x"></i>
+    5 <br/> ST GEORGES ROAD <br/> E7 8HU
+  </p>
+</div>
+"""
+
+EMPTY_ADDRESS_CARD = """
+<div class="card">
+  <div class="card-header">Your Address</div>
+  <p class="card-text"> <i class="fas fa-home fa-4x"></i> <br/> <br/> </p>
+</div>
+"""
+
+GARDEN_CARD = """
+<div class="card h-100">
+  <div class="card-header">Green and Garden Waste (only available from Mar to Oct)</div>
+  <p class="card-text"> <i class="fas fa-tree fa-4x"></i>We collect green and
+    garden waste from Newham residents.
+  </p>
+</div>
+"""
+
+
+def _collection_card(bin_type: str, extra_class: str, next_date: str, prev_date: str):
+    """Build a collection card; an empty next_date renders an empty <mark>."""
+    next_mark = (
+        f"<mark>Thursday</mark>\xa0{next_date}" if next_date else "<mark></mark>\xa0"
+    )
+    prev_mark = (
+        f"<mark>Wednesday</mark>\xa0{prev_date}" if prev_date else "<mark></mark>\xa0"
+    )
+    return f"""
+    <div class="card h-100 {extra_class}">
+      <div class="card-header">Your <b>{bin_type}</b> Collection Day</div>
+      <p class="card-text">
+        <b>Next\xa0</b>{next_mark}<br/>
+        <b>Previous\xa0</b>{prev_mark}<br/>
+      </p>
+    </div>
+    """
+
+
+def _page(*cards: str) -> str:
+    return f"<html><body>{''.join(cards)}</body></html>"
+
+
+FULL_SERVICE_PAGE = _page(
+    ADDRESS_CARD,
+    _collection_card("Domestic", "", "03/09/2026", "26/08/2026"),
+    _collection_card("Recycling", "card-recycling", "03/09/2026", "26/08/2026"),
+    _collection_card("Food Waste", "card-food", "03/09/2026", "26/08/2026"),
+    GARDEN_CARD,
+)
+
+NO_FOOD_SERVICE_PAGE = _page(
+    ADDRESS_CARD,
+    _collection_card("Domestic", "", "01/09/2026", "24/08/2026"),
+    _collection_card("Recycling", "card-recycling", "01/09/2026", "24/08/2026"),
+    _collection_card("Food Waste", "card-food", "", ""),
+    GARDEN_CARD,
+)
+
+# The shape that made "Next\\D*" match the previous collection: an empty "Next"
+# followed by a populated "Previous".
+STALE_FOOD_PAGE = _page(
+    ADDRESS_CARD,
+    _collection_card("Domestic", "", "03/09/2026", "26/08/2026"),
+    _collection_card("Food Waste", "card-food", "", "26/08/2026"),
+)
+
+UNKNOWN_PROPERTY_PAGE = _page(
+    EMPTY_ADDRESS_CARD,
+    """
+    <div class="card h-100">
+      <div class="card-header">Your <b>Domestic</b> Collection Day</div>
+      <p class="card-text">There are no domestic collection details available
+        for this address!</p>
+    </div>
+    """,
+    GARDEN_CARD,
+)
+
+
+def _fetch(html: str, property_id="000046250697"):
+    with patch.object(newham_gov_uk.requests, "get", return_value=Response(html)):
+        return newham_gov_uk.Source(property=property_id).fetch()
+
+
+def test_all_three_collection_types_are_returned():
+    entries = _fetch(FULL_SERVICE_PAGE)
+
+    assert [e.type for e in entries] == ["Domestic", "Recycling", "Food Waste"]
+
+
+def test_food_waste_uses_the_food_icon():
+    food = [e for e in _fetch(FULL_SERVICE_PAGE) if e.type == "Food Waste"]
+
+    assert len(food) == 1
+    assert food[0].icon == Icons.BIO_KITCHEN
+
+
+def test_dates_are_parsed_day_first():
+    """03/09/2026 is 3 September, not 9 March."""
+    entries = _fetch(FULL_SERVICE_PAGE)
+
+    assert {e.date for e in entries} == {date(2026, 9, 3)}
+
+
+def test_address_and_garden_cards_are_skipped():
+    assert len(_fetch(FULL_SERVICE_PAGE)) == 3
+
+
+def test_property_without_food_service_returns_other_types():
+    entries = _fetch(NO_FOOD_SERVICE_PAGE)
+
+    assert [e.type for e in entries] == ["Domestic", "Recycling"]
+    assert {e.date for e in entries} == {date(2026, 9, 1)}
+
+
+def test_empty_next_does_not_fall_through_to_previous():
+    entries = _fetch(STALE_FOOD_PAGE)
+
+    assert [e.type for e in entries] == ["Domestic"]
+    assert date(2026, 8, 26) not in {e.date for e in entries}
+
+
+def test_unknown_property_raises_rather_than_returning_nothing():
+    with pytest.raises(SourceArgumentNotFound) as excinfo:
+        _fetch(UNKNOWN_PROPERTY_PAGE, property_id="999999999999")
+
+    assert "property" in str(excinfo.value)
+
+
+def test_property_id_is_zero_padded():
+    assert newham_gov_uk.Source(property=46012509)._property == "000046012509"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (
+            "Next\xa0Thursday\xa003/09/2026 Previous\xa0Wednesday\xa026/08/2026",
+            "03/09/2026",
+        ),
+        ("Next 03/09/2026", "03/09/2026"),
+        ("Next  Previous  ", None),
+        ("Next  Previous Wednesday 26/08/2026", None),
+        # No day name before the previous date, so "Previous" is the only word
+        # between "Next" and a date. Rejected by the negative lookahead alone.
+        ("Next\xa0\xa0Previous\xa026/08/2026", None),
+    ],
+)
+def test_next_date_regex_boundaries(text, expected):
+    match = newham_gov_uk.NEXT_DATE.search(text)
+
+    assert (match.group(1) if match else None) == expected

--- a/tests/test_newham_gov_uk.py
+++ b/tests/test_newham_gov_uk.py
@@ -27,11 +27,11 @@ import pytest
 
 sys.path.append(
     str(Path(__file__).parents[1] / "custom_components" / "waste_collection_schedule")
-)
+)  # isort:skip
 
-from waste_collection_schedule import Icons
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
-from waste_collection_schedule.source import newham_gov_uk
+from waste_collection_schedule import Icons  # isort:skip
+from waste_collection_schedule.exceptions import SourceArgumentNotFound  # isort:skip
+from waste_collection_schedule.source import newham_gov_uk  # isort:skip
 
 
 class Response:


### PR DESCRIPTION
## Summary

### 1. Dates were parsed month-first

Newham recently changed date renders back to UK date format `dd/mm/yyyy`, but the source used `dateutil.parser`, which defaults to month-first. So `03/09/2026` was read as **9 March** instead of **3 September**. Every date with a day of 12 or lower was breaking.

Now parsed with an explicit `datetime.strptime(..., "%d/%m/%Y")`.

### 2. Include newly added "Food waste" collections

The card selectors were hardcoded to the classes `card h-100` and `card h-100 card-recycling`. Newham's food waste card is `card h-100 card-food`, so it was skipped entirely.

Replaced with a scan over every `card`, keyed on the bold bin type in the card header, so the food card is picked up and any future card shape keeps working.

Also switched the recycling icon from `Icons.GLASS` to `Icons.RECYCLING`.

### 3. An unknown property ID silently returned nothing

A well-formed but non-existent property ID returns **HTTP 200** with a fully rendered page — `raise_for_status()` passes, every collection card says "no details available", and `fetch()` returned `[]`. The user got an empty sensor and no explanation.

Only the address card is left blank in that case, so the check keys on that rather than on an empty result — a valid property can legitimately return fewer entries when it has no food waste service. Raises `SourceArgumentNotFound` so the HA UI names the argument at fault.

### 4. Test
Added `tests/test_newham_gov_uk.py` — offline, fixtures copied from live responses (including the non-breaking spaces and the empty `<mark>` a card renders when it has no next collection). Covers day-first parsing, the food card, a property without food waste service, and the unknown-ID path.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
