### PR TITLE
Add City of Roseville, CA to ReCollect sources

### DIFF
--- a/doc/ics/yaml/recollect.yaml
+++ b/doc/ics/yaml/recollect.yaml
@@ -203,6 +203,9 @@ extra_info:
   - title: City of Kamloops, BC
     url: https://www.kamloops.ca
     country: ca
+  - title: City of Roseville, CA
+    url: https://www.roseville.ca.gov/environmental_utilities/at_your_service/trash_recycling/index.php
+    country: us
 
 howto:
   en: |
@@ -261,6 +264,7 @@ howto:
     |City of Apopka, FL|USA|[apopka.gov](https://www.apopka.gov/319/Solid-Waste)|
     |City of Raleigh, NC|USA|[raleighnc.gov](https://raleighnc.gov/landfill-and-reuse/services/raleigh-reuse-web-tool-and-mobile-app)|
     |City of Kamloops, BC|Canada|[kamloops.ca](https://www.kamloops.ca/city-services/recycling-garbage-organics/residential-collection-schedule)|
+    |City of Roseville, CA|USA|[roseville.ca.gov](https://www.roseville.ca.gov/environmental_utilities/at_your_service/trash_recycling/index.php)|
 
     and probably a lot more.
 
@@ -322,4 +326,10 @@ test_cases:
     split_at: '\, (?:and )?|(?: and )'
   100 Sunset Crt, Kamloops, BC, Canada:
     url: https://recollect.a.ssl.fastly.net/api/places/CA6C8A4C-A85B-11E7-960A-90E7FC0D224B/services/671/events.en.ics
+    split_at: '\, (?:and )?|(?: and )'
+  2001 San Carlos Ci, Roseville, CA, USA:
+    url: https://recollect-us.global.ssl.fastly.net/api/places/9830F71C-52CB-11E5-8F53-2B4047A8A7C0/services/302/events.en-US.ics
+    split_at: '\, (?:and )?|(?: and )'
+  2001 Borealis Ci, Roseville, CA, USA:
+    url: https://recollect-us.global.ssl.fastly.net/api/places/9E105164-9E10-11EB-986B-69C776DC127A/services/302/events.en-US.ics
     split_at: '\, (?:and )?|(?: and )'


### PR DESCRIPTION
## Summary

Adds the City of Roseville, CA as a known-working deployment of the shared ReCollect ICS platform (`doc/ics/yaml/recollect.yaml`). No new source module needed — Roseville's public schedule lookup (roseville.ca.gov) is powered by the same ReCollect backend (`api.recollect.net`) already supported here.

- Added `extra_info` entry for City of Roseville, CA
- Added corresponding row to the `howto.en` table of known-working providers
- Added two test cases (public addresses discovered via ReCollect's own address-lookup API, not private residences) covering both weekday/A-B green-waste rotations Roseville uses

## How residents get their URL

Same flow as the other cities in this file: visit https://api.recollect.net/r/area/Roseville, enter your address, choose "Get a calendar" → "Add to Google Calendar", then strip the `client_id` query parameter from the resulting link.

## Test plan

- [x] `python -m pytest tests/test_source_components.py -q` — 35 passed
- [x] Both new test-case URLs verified live (HTTP 200, real upcoming collection dates fetched via `test_sources.py -y recollect -l`)
- [x] Confirmed `split_at: '\, (?:and )?|(?: and )'` correctly splits Roseville's combined "Green waste and trash & recycling bin" event text into separate collection types