### PR TITLE
Fix WM weekday holiday delay parsing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
@@ -64,8 +64,19 @@ _API_KEY_HOLIDAYS = "C2068E03CB6B73D4FEBA"  # holidays endpoint
 
 # Regexes for parsing holiday delay messages, e.g.:
 #   "Due to the Thanksgiving holiday, service on 11/24 will be on a 1 day delay."
-_HOLIDAY_DATE_RE = re.compile(r"\d{1,2}/\d{1,2}(?:/\d{2,4})?")
-_DELAY_RE = re.compile(r"(\d+)(?: day)? delay", re.IGNORECASE)
+#   "Labor Day is on Monday, September 7th. Weekday collections will
+#    experience a delay of one day."
+_HOLIDAY_DATE_RE = re.compile(
+    r"\d{1,2}/\d{1,2}(?:/\d{2,4})?|"
+    r"\b(?:January|February|March|April|May|June|July|August|September|"
+    r"October|November|December)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?",
+    re.IGNORECASE,
+)
+_DELAY_RE = re.compile(
+    r"(?:(\d+)(?: day)? delay|"
+    r"delay(?: of| by)?(?: up to)?\s+one(?: day)?)",
+    re.IGNORECASE,
+)
 
 # WM wasteStreamGroupCode values → canonical Icons enum
 ICON_MAP: dict[str, Icons] = {
@@ -156,12 +167,24 @@ def _parse_holiday_message(
     for m in _HOLIDAY_DATE_RE.finditer(message):
         raw = m.group()
         try:
-            if raw.count("/") == 2:
-                dt = datetime.datetime.strptime(raw, "%m/%d/%Y")
+            if "/" in raw:
+                has_year = raw.count("/") == 2
+                if has_year:
+                    dt = datetime.datetime.strptime(raw, "%m/%d/%Y")
+                else:
+                    dt = datetime.datetime.strptime(raw, "%m/%d").replace(
+                        year=today.year
+                    )
             else:
-                dt = datetime.datetime.strptime(raw, "%m/%d").replace(year=today.year)
-                if dt < today:
-                    dt = dt.replace(year=today.year + 1)
+                raw = re.sub(r"(\d)(?:st|nd|rd|th)\b", r"\1", raw)
+                has_year = "," in raw
+                date_format = "%B %d, %Y" if has_year else "%B %d"
+                dt = datetime.datetime.strptime(raw, date_format)
+                if not has_year:
+                    dt = dt.replace(year=today.year)
+
+            if not has_year and dt < today:
+                dt = dt.replace(year=today.year + 1)
         except ValueError:
             continue
         date_spans.append((dt, m.start(), m.end()))
@@ -171,8 +194,20 @@ def _parse_holiday_message(
         next_start = date_spans[i + 1][1] if i + 1 < len(date_spans) else len(message)
         segment = message[end:next_start]
         delay_match = _DELAY_RE.search(segment)
-        offset = int(delay_match.group(1)) if delay_match else 0
-        result[dt] = dt + datetime.timedelta(days=offset)
+        if not delay_match:
+            continue
+
+        offset = int(delay_match.group(1)) if delay_match.group(1) else 1
+
+        if "weekday collections" in segment.lower():
+            collection_date = dt
+            while collection_date.weekday() < 5:
+                result[collection_date] = collection_date + datetime.timedelta(
+                    days=offset
+                )
+                collection_date += datetime.timedelta(days=1)
+        else:
+            result[dt] = dt + datetime.timedelta(days=offset)
 
     return result
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
@@ -67,7 +67,7 @@ _API_KEY_HOLIDAYS = "C2068E03CB6B73D4FEBA"  # holidays endpoint
 #   "Labor Day is on Monday, September 7th. Weekday collections will
 #    experience a delay of one day."
 _HOLIDAY_DATE_RE = re.compile(
-    r"\d{1,2}/\d{1,2}(?:/\d{2,4})?|"
+    r"\d{1,2}/\d{1,2}(?:/(?:\d{4}|\d{2}))?|"
     r"\b(?:January|February|March|April|May|June|July|August|September|"
     r"October|November|December)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?",
     re.IGNORECASE,
@@ -161,7 +161,7 @@ def _parse_holiday_message(
       "Due to the Thanksgiving holiday, your service on 11/24 will be on
        a 1 day delay."
     """
-    today = datetime.datetime.today()
+    today = datetime.date.today()
     date_spans: list[tuple[datetime.datetime, int, int]] = []
 
     for m in _HOLIDAY_DATE_RE.finditer(message):
@@ -170,7 +170,8 @@ def _parse_holiday_message(
             if "/" in raw:
                 has_year = raw.count("/") == 2
                 if has_year:
-                    dt = datetime.datetime.strptime(raw, "%m/%d/%Y")
+                    year_format = "%y" if len(raw.rsplit("/", 1)[1]) == 2 else "%Y"
+                    dt = datetime.datetime.strptime(raw, f"%m/%d/{year_format}")
                 else:
                     dt = datetime.datetime.strptime(raw, "%m/%d").replace(
                         year=today.year
@@ -183,7 +184,7 @@ def _parse_holiday_message(
                 if not has_year:
                     dt = dt.replace(year=today.year)
 
-            if not has_year and dt < today:
+            if not has_year and dt.date() < today:
                 dt = dt.replace(year=today.year + 1)
         except ValueError:
             continue

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
@@ -72,9 +72,24 @@ _HOLIDAY_DATE_RE = re.compile(
     r"October|November|December)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?",
     re.IGNORECASE,
 )
+# Spelled-out delay lengths WM uses. Anything longer than a few days is always
+# written numerically, so a short table is enough.
+_NUMBER_WORDS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+}
+
+# Matches both orderings WM uses for the delay length:
+#   "...will be on a 1 day delay"      -> group "before"
+#   "...a delay of up to 2 days"       -> group "after"
+#   "...a delay of one day"            -> group "word"
 _DELAY_RE = re.compile(
-    r"(?:(\d+)(?: day)? delay|"
-    r"delay(?: of| by)?(?: up to)?\s+one(?: day)?)",
+    r"(?:(?P<before>\d+)(?: days?)? delay"
+    r"|delay(?: of| by)?(?: up to)?\s+"
+    r"(?:(?P<after>\d+)|(?P<word>" + "|".join(_NUMBER_WORDS) + r"))\b(?: days?)?)",
     re.IGNORECASE,
 )
 
@@ -152,6 +167,7 @@ def _guest_headers(api_key: str) -> dict[str, str]:
 
 def _parse_holiday_message(
     message: str,
+    today: datetime.date | None = None,
 ) -> dict[datetime.datetime, datetime.datetime]:
     """
     Parse a WM holiday text message into a mapping of
@@ -160,8 +176,12 @@ def _parse_holiday_message(
     WM returns human-readable strings such as:
       "Due to the Thanksgiving holiday, your service on 11/24 will be on
        a 1 day delay."
+
+    ``today`` is the reference date used to resolve messages that omit the
+    year; it defaults to the current date and exists so tests can pin it.
     """
-    today = datetime.date.today()
+    if today is None:
+        today = datetime.date.today()
     date_spans: list[tuple[datetime.datetime, int, int]] = []
 
     for m in _HOLIDAY_DATE_RE.finditer(message):
@@ -201,10 +221,23 @@ def _parse_holiday_message(
         if not delay_match:
             continue
 
-        offset = int(delay_match.group(1)) if delay_match.group(1) else 1
+        digits = delay_match.group("before") or delay_match.group("after")
+        if digits:
+            offset = int(digits)
+        else:
+            offset = _NUMBER_WORDS.get((delay_match.group("word") or "").lower(), 1)
 
         if "weekday collections" in segment.lower():
+            # WM observes a weekend holiday on the adjacent weekday: a Saturday
+            # holiday moves to the Friday before, a Sunday holiday to the Monday
+            # after. Anchor the window there, otherwise a weekend date would
+            # produce no shifts at all even though collections are affected.
             collection_date = dt
+            if collection_date.weekday() == 5:  # Saturday
+                collection_date -= datetime.timedelta(days=1)
+            elif collection_date.weekday() == 6:  # Sunday
+                collection_date += datetime.timedelta(days=1)
+
             while collection_date.weekday() < 5:
                 result[collection_date] = collection_date + datetime.timedelta(
                     days=offset

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py
@@ -184,7 +184,10 @@ def _parse_holiday_message(
                 if not has_year:
                     dt = dt.replace(year=today.year)
 
-            if not has_year and dt.date() < today:
+            # WM keeps holiday notices active through the delayed collection week.
+            # Do not roll a just-passed holiday into next year while its delay can
+            # still affect this week's pickups.
+            if not has_year and dt.date() + datetime.timedelta(days=6) < today:
                 dt = dt.replace(year=today.year + 1)
         except ValueError:
             continue

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -1172,3 +1172,42 @@ END:VCALENDAR
         ("2026-01-04", "Papier"),
         ("2026-01-05", "Restabfall"),
     ]
+
+
+def test_wm_com_parses_service_date_delay() -> None:
+    module = _get_module("wm_com")
+
+    result = module._parse_holiday_message(
+        "Due to the Thanksgiving holiday, your service on 11/24/2026 will be on "
+        "a 1 day delay.",
+    )
+
+    assert result == {
+        module.datetime.datetime(2026, 11, 24): module.datetime.datetime(2026, 11, 25)
+    }
+
+
+def test_wm_com_parses_weekday_collection_delays() -> None:
+    module = _get_module("wm_com")
+
+    labor_day = module._parse_holiday_message(
+        "Residential: Labor Day is on Monday, September 7th, 2026, and we will be "
+        "closed. Weekday collections will experience a delay of one day. "
+        "Commercial: Labor Day is on Monday, September 7th, 2026, and we will be "
+        "closed. Weekday collections may experience a delay of up to one day.",
+    )
+    assert labor_day == {
+        module.datetime.datetime(2026, 9, day): module.datetime.datetime(
+            2026, 9, day + 1
+        )
+        for day in range(7, 12)
+    }
+
+    thanksgiving = module._parse_holiday_message(
+        "Thanksgiving is on Thursday, November 26th, 2026. Weekday collections "
+        "will experience a delay of one day.",
+    )
+    assert thanksgiving == {
+        module.datetime.datetime(2026, 11, 26): module.datetime.datetime(2026, 11, 27),
+        module.datetime.datetime(2026, 11, 27): module.datetime.datetime(2026, 11, 28),
+    }

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -1186,6 +1186,39 @@ def test_wm_com_parses_service_date_delay() -> None:
         module.datetime.datetime(2026, 11, 24): module.datetime.datetime(2026, 11, 25)
     }
 
+    two_digit_year = module._parse_holiday_message(
+        "Due to the Thanksgiving holiday, your service on 11/24/26 will be on "
+        "a 1 day delay.",
+    )
+
+    assert two_digit_year == {
+        module.datetime.datetime(2026, 11, 24): module.datetime.datetime(2026, 11, 25)
+    }
+
+
+def test_wm_com_keeps_no_year_holiday_on_today() -> None:
+    from datetime import date
+
+    module = _get_module("wm_com")
+
+    class Today(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 9, 7)
+
+    with patch.object(module.datetime, "date", Today):
+        result = module._parse_holiday_message(
+            "Labor Day is on Monday, September 7th. Weekday collections will "
+            "experience a delay of one day.",
+        )
+
+    assert result == {
+        module.datetime.datetime(2026, 9, day): module.datetime.datetime(
+            2026, 9, day + 1
+        )
+        for day in range(7, 12)
+    }
+
 
 def test_wm_com_parses_weekday_collection_delays() -> None:
     module = _get_module("wm_com")

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -1220,6 +1220,30 @@ def test_wm_com_keeps_no_year_holiday_on_today() -> None:
     }
 
 
+def test_wm_com_keeps_recent_no_year_holiday_in_current_year() -> None:
+    from datetime import date
+
+    module = _get_module("wm_com")
+
+    class DayAfterLaborDay(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 9, 8)
+
+    with patch.object(module.datetime, "date", DayAfterLaborDay):
+        result = module._parse_holiday_message(
+            "Labor Day is on Monday, September 7th. Weekday collections will "
+            "experience a delay of one day.",
+        )
+
+    assert result == {
+        module.datetime.datetime(2026, 9, day): module.datetime.datetime(
+            2026, 9, day + 1
+        )
+        for day in range(7, 12)
+    }
+
+
 def test_wm_com_parses_weekday_collection_delays() -> None:
     module = _get_module("wm_com")
 

--- a/tests/test_source_components.py
+++ b/tests/test_source_components.py
@@ -1197,20 +1197,15 @@ def test_wm_com_parses_service_date_delay() -> None:
 
 
 def test_wm_com_keeps_no_year_holiday_on_today() -> None:
-    from datetime import date
+    from datetime import date as _date
 
     module = _get_module("wm_com")
 
-    class Today(date):
-        @classmethod
-        def today(cls):
-            return cls(2026, 9, 7)
-
-    with patch.object(module.datetime, "date", Today):
-        result = module._parse_holiday_message(
-            "Labor Day is on Monday, September 7th. Weekday collections will "
-            "experience a delay of one day.",
-        )
+    result = module._parse_holiday_message(
+        "Labor Day is on Monday, September 7th. Weekday collections will "
+        "experience a delay of one day.",
+        today=_date(2026, 9, 7),
+    )
 
     assert result == {
         module.datetime.datetime(2026, 9, day): module.datetime.datetime(
@@ -1221,26 +1216,42 @@ def test_wm_com_keeps_no_year_holiday_on_today() -> None:
 
 
 def test_wm_com_keeps_recent_no_year_holiday_in_current_year() -> None:
-    from datetime import date
+    from datetime import date as _date
 
     module = _get_module("wm_com")
 
-    class DayAfterLaborDay(date):
-        @classmethod
-        def today(cls):
-            return cls(2026, 9, 8)
-
-    with patch.object(module.datetime, "date", DayAfterLaborDay):
-        result = module._parse_holiday_message(
-            "Labor Day is on Monday, September 7th. Weekday collections will "
-            "experience a delay of one day.",
-        )
+    result = module._parse_holiday_message(
+        "Labor Day is on Monday, September 7th. Weekday collections will "
+        "experience a delay of one day.",
+        today=_date(2026, 9, 8),
+    )
 
     assert result == {
         module.datetime.datetime(2026, 9, day): module.datetime.datetime(
             2026, 9, day + 1
         )
         for day in range(7, 12)
+    }
+
+
+def test_wm_com_rolls_stale_no_year_holiday_into_next_year() -> None:
+    from datetime import date as _date
+
+    module = _get_module("wm_com")
+
+    # Once the delayed collection week has fully passed, a year-less notice
+    # refers to next year's occurrence rather than the one just gone.
+    result = module._parse_holiday_message(
+        "Labor Day is on Monday, September 7th. Weekday collections will "
+        "experience a delay of one day.",
+        today=_date(2026, 9, 20),
+    )
+
+    assert result == {
+        module.datetime.datetime(2027, 9, day): module.datetime.datetime(
+            2027, 9, day + 1
+        )
+        for day in range(7, 11)
     }
 
 
@@ -1268,3 +1279,69 @@ def test_wm_com_parses_weekday_collection_delays() -> None:
         module.datetime.datetime(2026, 11, 26): module.datetime.datetime(2026, 11, 27),
         module.datetime.datetime(2026, 11, 27): module.datetime.datetime(2026, 11, 28),
     }
+
+
+def test_wm_com_anchors_weekend_holiday_to_observed_weekday() -> None:
+    module = _get_module("wm_com")
+
+    # 2026-11-01 is a Sunday, observed on Monday the 2nd: the whole of that
+    # week's weekday collections shift.
+    sunday = module._parse_holiday_message(
+        "The holiday is on Sunday, November 1st, 2026. Weekday collections "
+        "will experience a delay of one day.",
+    )
+    assert sunday == {
+        module.datetime.datetime(2026, 11, day): module.datetime.datetime(
+            2026, 11, day + 1
+        )
+        for day in range(2, 7)
+    }
+
+    # 2026-11-07 is a Saturday, observed on Friday the 6th: only that Friday
+    # is left in the week, so it is the only collection that shifts.
+    saturday = module._parse_holiday_message(
+        "The holiday is on Saturday, November 7th, 2026. Weekday collections "
+        "will experience a delay of one day.",
+    )
+    assert saturday == {
+        module.datetime.datetime(2026, 11, 6): module.datetime.datetime(2026, 11, 7)
+    }
+
+
+def test_wm_com_parses_delay_length_after_the_word_delay() -> None:
+    module = _get_module("wm_com")
+
+    numeric_after = module._parse_holiday_message(
+        "Due to the holiday, your service on 11/24/2026 will be on a delay of 2 days.",
+    )
+    assert numeric_after == {
+        module.datetime.datetime(2026, 11, 24): module.datetime.datetime(2026, 11, 26)
+    }
+
+    spelled_out = module._parse_holiday_message(
+        "Due to the holiday, your service on 11/24/2026 will experience a "
+        "delay of two days.",
+    )
+    assert spelled_out == numeric_after
+
+    up_to = module._parse_holiday_message(
+        "Due to the holiday, your service on 11/24/2026 may be on a delay of "
+        "up to 3 days.",
+    )
+    assert up_to == {
+        module.datetime.datetime(2026, 11, 24): module.datetime.datetime(2026, 11, 27)
+    }
+
+    # The original "<n> day delay" ordering must keep working.
+    numeric_before = module._parse_holiday_message(
+        "Due to the holiday, your service on 11/24/2026 will be on a 2 day delay.",
+    )
+    assert numeric_before == numeric_after
+
+    # A notice with no delay length at all still yields no adjustment.
+    assert (
+        module._parse_holiday_message(
+            "Due to the holiday, your service on 11/24/2026 may be affected.",
+        )
+        == {}
+    )


### PR DESCRIPTION
## Summary

- parse WM holiday dates in both numeric and named-month formats
- recognize WM's service-specific and generic weekday delay wording
- apply generic weekday delays from the holiday through Friday while preserving existing exact-date behavior
- add regression coverage for the existing numeric format, Labor Day, and Thanksgiving

Fixes #7288

## Testing

- `ruff check custom_components/waste_collection_schedule/waste_collection_schedule/source/wm_com.py tests/test_source_components.py`
- `python -m pytest tests -q` — 41 passed
- live `Source.fetch()` against the affected WM schedule returned `2026-09-10` instead of the unadjusted `2026-09-09`