### PR TITLE
Add source: Entsorgung + Recycling Stadt Bern (ERB), Switzerland

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
@@ -1,0 +1,186 @@
+import hashlib
+import re
+from datetime import date, datetime
+
+import requests
+from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Entsorgung + Recycling Stadt Bern"
+DESCRIPTION = "Source for waste collection in the city of Bern, Switzerland."
+URL = "https://www.bern.ch/themen/umwelt-natur-und-energie/abfall-und-recycling"
+COUNTRY = "ch"
+SOURCE_CODEOWNERS = ["@sbaerlocher"]
+
+TEST_CASES = {
+    "Bundesplatz 1 (Bundeshaus)": {"strasse": "Bundesplatz", "hnr": 1},
+    "Helvetiaplatz 5 (Historisches Museum)": {"strasse": "Helvetiaplatz", "hnr": 5},
+    "Waisenhausplatz 30 (Polizeiwache)": {"strasse": "Waisenhausplatz", "hnr": 30},
+    "Key only (Bundesplatz 1)": {"key": "DC46354136EE5531B312A864FA2C4604"},
+}
+
+API_URL = "https://bernentsorgung.glue.ch/erb/web"
+SEARCH_URL = f"{API_URL}/searchAddress"
+ICAL_URL = f"{API_URL}/ical"
+
+ICON_MAP = {
+    "Hauskehricht": Icons.GENERAL_WASTE,
+    "Altpapiersammlung": Icons.PAPER,
+    # Bern collects kitchen and garden organics together in one "Grünabfuhr".
+    "Gruenabfuhr": Icons.ORGANIC,
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "de": (
+        "Strasse und Hausnummer wie auf "
+        "https://bernentsorgung.glue.ch/erb/web/index angeben, z. B. "
+        "Strasse 'Bundesplatz' und Hausnummer '1'. Hausnummern mit "
+        "Zusatz werden als '3a' angegeben. Alternativ kann der "
+        "Schlüssel aus dem iKalender-Link (…/ical?key=…) direkt im Feld "
+        "'key' eingetragen werden."
+    ),
+    "en": (
+        "Enter street and house number as shown on "
+        "https://bernentsorgung.glue.ch/erb/web/index, e.g. street "
+        "'Bundesplatz' and house number '1'. House numbers with a suffix "
+        "are written as '3a'. Alternatively, paste the key from the "
+        "iCalendar link (…/ical?key=…) directly into the 'key' field."
+    ),
+}
+
+PARAM_DESCRIPTIONS = {
+    "de": {
+        "strasse": "Strassenname, z. B. 'Bundesplatz'.",
+        "hnr": "Hausnummer, z. B. '1' oder '3a'.",
+        "key": "Optional: Schlüssel aus dem iKalender-Link, ersetzt Strasse und Hausnummer.",
+    },
+    "en": {
+        "strasse": "Street name, e.g. 'Bundesplatz'.",
+        "hnr": "House number, e.g. '1' or '3a'.",
+        "key": "Optional: key from the iCalendar link, replaces street and house number.",
+    },
+}
+
+PARAM_TRANSLATIONS = {
+    "de": {
+        "strasse": "Strasse",
+        "hnr": "Hausnummer",
+        "key": "Schlüssel (optional)",
+    },
+    "en": {
+        "strasse": "Street",
+        "hnr": "House number",
+        "key": "Key (optional)",
+    },
+}
+
+
+class Source:
+    def __init__(
+        self,
+        strasse: str | None = None,
+        hnr: str | int | None = None,
+        key: str | None = None,
+    ):
+        self._strasse = strasse.strip() if isinstance(strasse, str) else strasse
+        self._hnr = str(hnr).strip() if hnr is not None else None
+        self._key = key.strip().upper() if isinstance(key, str) else key
+        self._ics = ICS()
+
+        if not self._key and not (self._strasse and self._hnr):
+            raise SourceArgumentNotFound(
+                "strasse",
+                self._strasse,
+                "Either 'key' or both 'strasse' and 'hnr' must be provided.",
+            )
+
+    def _search_key(self, strasse: str, hnr: str, session: requests.Session) -> str:
+        """Resolve street + house number to the calendar key via the official
+        address search, falling back to the documented MD5 derivation."""
+        try:
+            r = session.get(SEARCH_URL, params={"query": strasse}, timeout=30)
+            r.raise_for_status()
+            addresses = r.json()
+        except (requests.RequestException, ValueError):
+            addresses = []
+
+        for address in addresses:
+            if address.get("number", "").lower() == hnr.lower():
+                return address["key"]
+
+        if addresses:
+            # The street exists but the house number does not.
+            raise SourceArgumentNotFoundWithSuggestions(
+                "hnr",
+                hnr,
+                sorted({a.get("number", "") for a in addresses}),
+            )
+
+        # Address search returned nothing (unknown street, or endpoint changed).
+        # Fall back to the key derivation: MD5 of street + number, no separator.
+        return hashlib.md5(f"{strasse}{hnr}".encode()).hexdigest().upper()
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        # __init__ guarantees either a key or both strasse and hnr.
+        if self._key:
+            key = self._key
+        else:
+            key = self._search_key(str(self._strasse), str(self._hnr), session)
+
+        r = session.get(ICAL_URL, params={"key": key}, timeout=30)
+        if r.status_code != 200 or "BEGIN:VCALENDAR" not in r.text:
+            # The service answers an unknown key with HTTP 500.
+            if self._key:
+                raise SourceArgumentNotFound(
+                    "key", self._key, "The service does not know this key."
+                )
+            raise SourceArgumentNotFound(
+                "strasse",
+                f"{self._strasse} {self._hnr}",
+                "The service does not know this address.",
+            )
+        r.encoding = "utf-8"
+
+        # The feed carries empty "EXDATE:" lines, which icalendar reports as a
+        # broken property. Dropping them keeps the multi-value EXDATE lines
+        # (the public-holiday exclusions) intact.
+        ics_data = re.sub(r"^EXDATE:\s*\r?\n", "", r.text, flags=re.MULTILINE)
+
+        # The feed bounds each RRULE with UNTIL=<Dec 31>T230000Z. That instant is
+        # 00:00 local time on Jan 1, and because the events are all-day, the
+        # recurrence yields one phantom collection on New Year's Day — a date the
+        # published calendar does not contain. Drop everything after the UNTIL
+        # date carried by this feed (read at runtime, no year is assumed) to
+        # remove that artifact. This is not a user-facing time-range filter: the
+        # source still returns every collection the provider publishes.
+        last_day = self._until_date(ics_data)
+
+        entries = []
+        for d, waste_type in self._ics.convert(ics_data):
+            if last_day and d > last_day:
+                continue
+            entries.append(
+                Collection(date=d, t=waste_type, icon=ICON_MAP.get(waste_type))
+            )
+
+        if not entries:
+            raise SourceArgumentNotFound(
+                "strasse",
+                f"{self._strasse or ''} {self._hnr or ''}".strip() or self._key,
+                "No collections returned for this address.",
+            )
+
+        return entries
+
+    @staticmethod
+    def _until_date(ics_data: str) -> date | None:
+        """Last calendar day covered by the feed, from the RRULE UNTIL value."""
+        matches = re.findall(r"UNTIL=(\d{8})T\d{6}Z", ics_data)
+        if not matches:
+            return None
+        return max(datetime.strptime(m, "%Y%m%d").date() for m in matches)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
@@ -30,7 +30,10 @@ ICAL_URL = f"{API_URL}/ical"
 ICON_MAP = {
     "Hauskehricht": Icons.GENERAL_WASTE,
     "Altpapiersammlung": Icons.PAPER,
-    # Bern collects kitchen and garden organics together in one "Grünabfuhr".
+    # Keys must match the feed's SUMMARY values verbatim. The feed spells this
+    # one without the umlaut ("Gruenabfuhr") even though the website shows
+    # "Grünabfuhr". ORGANIC is the right member because Bern collects kitchen
+    # and garden organics together.
     "Gruenabfuhr": Icons.ORGANIC,
 }
 
@@ -169,9 +172,17 @@ class Source:
             )
 
         if not entries:
+            # Report the argument the user actually configured, so the Home
+            # Assistant UI highlights the right field.
+            if self._key:
+                raise SourceArgumentNotFound(
+                    "key",
+                    self._key,
+                    "No collections returned for this key.",
+                )
             raise SourceArgumentNotFound(
                 "strasse",
-                f"{self._strasse or ''} {self._hnr or ''}".strip() or self._key,
+                f"{self._strasse} {self._hnr}",
                 "No collections returned for this address.",
             )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
@@ -103,9 +103,15 @@ class Source:
                 "Provide 'strasse' and 'hnr', or 'key' instead.",
             )
 
-    def _search_key(self, strasse: str, hnr: str, session: requests.Session) -> str:
+    def _search_key(
+        self, strasse: str, hnr: str, session: requests.Session
+    ) -> tuple[str, list[str]]:
         """Resolve street + house number to the calendar key via the official
-        address search, falling back to the documented MD5 derivation."""
+        address search, falling back to the documented MD5 derivation.
+
+        Returns the key plus the house numbers the search reported for the
+        street, which fetch() offers as suggestions if the key is rejected.
+        """
         try:
             r = session.get(SEARCH_URL, params={"query": strasse}, timeout=30)
             r.raise_for_status()
@@ -113,29 +119,39 @@ class Source:
         except (requests.RequestException, ValueError):
             addresses = []
 
-        for address in addresses:
-            if address.get("number", "").lower() == hnr.lower():
-                return address["key"]
+        # The endpoint is a typeahead: it matches street name prefixes and can
+        # return several streets at once, so keep only the requested street.
+        matches = [
+            a
+            for a in addresses
+            if isinstance(a, dict)
+            and str(a.get("street", "")).lower() == strasse.lower()
+        ]
 
-        if addresses:
-            # The street exists but the house number does not.
-            raise SourceArgumentNotFoundWithSuggestions(
-                "hnr",
-                hnr,
-                sorted({a.get("number", "") for a in addresses}),
-            )
+        for address in matches:
+            if str(address.get("number", "")).lower() == hnr.lower() and address.get(
+                "key"
+            ):
+                return str(address["key"]), []
 
-        # Address search returned nothing (unknown street, or endpoint changed).
-        # Fall back to the key derivation: MD5 of street + number, no separator.
-        return hashlib.md5(f"{strasse}{hnr}".encode()).hexdigest().upper()
+        # The house number is not in the response — but the typeahead caps its
+        # result list at 20 entries, so on longer streets that says nothing
+        # about whether the address exists. Derive the key instead of giving up
+        # here: MD5 of street + number, no separator. fetch() reports the
+        # numbers found below only if the service also rejects that key.
+        key = hashlib.md5(f"{strasse}{hnr}".encode()).hexdigest().upper()
+        return key, sorted({str(a.get("number", "")) for a in matches})
 
     def fetch(self) -> list[Collection]:
         session = requests.Session()
         # __init__ guarantees either a key or both strasse and hnr.
+        suggestions: list[str] = []
         if self._key:
             key = self._key
         else:
-            key = self._search_key(str(self._strasse), str(self._hnr), session)
+            key, suggestions = self._search_key(
+                str(self._strasse), str(self._hnr), session
+            )
 
         r = session.get(ICAL_URL, params={"key": key}, timeout=30)
         if r.status_code != 200 or "BEGIN:VCALENDAR" not in r.text:
@@ -143,6 +159,11 @@ class Source:
             if self._key:
                 raise SourceArgumentNotFound(
                     "key", self._key, "The service does not know this key."
+                )
+            if suggestions:
+                # The street is known, so the house number is the wrong part.
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "hnr", str(self._hnr), suggestions
                 )
             raise SourceArgumentNotFound(
                 "strasse",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/bern_ch.py
@@ -7,6 +7,7 @@ from waste_collection_schedule import Collection, Icons
 from waste_collection_schedule.exceptions import (
     SourceArgumentNotFound,
     SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequired,
 )
 from waste_collection_schedule.service.ICS import ICS
 
@@ -95,10 +96,11 @@ class Source:
         self._ics = ICS()
 
         if not self._key and not (self._strasse and self._hnr):
-            raise SourceArgumentNotFound(
-                "strasse",
-                self._strasse,
-                "Either 'key' or both 'strasse' and 'hnr' must be provided.",
+            # Point at the field the user actually left empty.
+            missing = "strasse" if not self._strasse else "hnr"
+            raise SourceArgumentRequired(
+                missing,
+                "Provide 'strasse' and 'hnr', or 'key' instead.",
             )
 
     def _search_key(self, strasse: str, hnr: str, session: requests.Session) -> str:

--- a/doc/source/bern_ch.md
+++ b/doc/source/bern_ch.md
@@ -1,0 +1,82 @@
+# Entsorgung + Recycling Stadt Bern
+
+Support for schedules provided by [Entsorgung + Recycling Stadt Bern (ERB)](https://www.bern.ch/themen/umwelt-natur-und-energie/abfall-und-recycling), serving the city of Bern, Switzerland.
+
+Collections are read from the city's public iCalendar feed and cover Hauskehricht (household waste), Grünabfuhr (organic waste, kitchen and garden combined) and Altpapiersammlung (paper).
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: bern_ch
+      args:
+        strasse: STRASSE
+        hnr: HNR
+        key: KEY  # optional
+```
+
+### Configuration Variables
+
+**strasse**
+*(string) (required if `key` is not set)*
+
+Street name exactly as listed on the [ERB collection-dates page](https://bernentsorgung.glue.ch/erb/web/index), e.g. `Bundesplatz`. Spaces and umlauts are kept as shown; multi-word names are usually hyphenated (e.g. `Von-Werdt-Passage`).
+
+**hnr**
+*(string or integer) (required if `key` is not set)*
+
+House number, e.g. `1`. Numbers with a letter suffix are written without a space, e.g. `3a`. The suffix is matched case-insensitively, so `3a` and `3A` both work.
+
+**key**
+*(string) (optional)*
+
+The address key from your personal iCalendar link. If set, `strasse` and `hnr` are ignored and the key is used directly.
+
+This is an escape hatch: the source normally derives the key itself, but if ERB ever changes how the key is built, you can paste the key from your own link and keep working without waiting for a new release.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: bern_ch
+      args:
+        strasse: Bundesplatz
+        hnr: 1
+```
+
+Using the key directly instead:
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: bern_ch
+      args:
+        key: DC46354136EE5531B312A864FA2C4604
+```
+
+## How to get the source arguments
+
+Open the [ERB collection-dates page](https://bernentsorgung.glue.ch/erb/web/index) and start typing your street into the search field. Pick your address from the suggestion list — that is the exact spelling to use for `strasse` and `hnr`.
+
+If the address search does not find your street, or you would rather pin the address permanently, use the `key` argument instead:
+
+1. Search for your address on the page above.
+2. Click **Import iKalender**.
+3. Copy the `key` parameter out of the resulting link:
+
+   ```text
+   https://bernentsorgung.glue.ch/erb/web/ical?key=DC46354136EE5531B312A864FA2C4604
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   ```
+
+4. Use that value as the `key` argument.
+
+## Notes
+
+The feed covers the current calendar year only, so the number of returned collections shrinks as the year goes on. ERB publishes the next year's dates in December.
+
+Public holidays are already excluded by the service and are therefore not reported as collection days.
+
+The number of collections differs by address: collection weekdays vary by district, and Altpapiersammlung is weekly in some streets and fortnightly in others.


### PR DESCRIPTION
## Summary

Adds `bern_ch.py` plus `doc/source/bern_ch.md`, covering the city of Bern's three collection types: Hauskehricht, Grünabfuhr and Altpapiersammlung. Data comes from the city's public iCalendar feed.

Closes #3727

Note on #3727: that issue carries the `data: PDF` label, but the city also publishes an iCalendar feed (the reporter linked it themselves). This source uses the feed, not the PDF — the label can be dropped. The issue asks for all three zones; zones need no configuration here, since the address lookup resolves them internally. The reporter's example address (Morgenstrasse, zone B) resolves correctly.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)

---


## Data source

ERB publishes a public iCalendar feed:

    https://bernentsorgung.glue.ch/erb/web/ical?key=<KEY>

Plain GET, no auth, no cookie, no session. Three recurring VEVENTs with an RRULE bounded by `UNTIL=<end of current year>`, plus EXDATE lines for public holidays. Parsed with the existing `service/ICS.py` — no changes to shared code.

## Key derivation

The key is the uppercase MD5 of the street name concatenated directly with the house number, UTF-8 encoded, no separator, no ZIP, no salt:

    key = MD5(street + number).hexdigest().upper()
    MD5("Bundesplatz1") = DC46354136EE5531B312A864FA2C4604

Rather than hashing user input blindly, the source resolves the address through the site's own typeahead endpoint:

    GET /erb/web/searchAddress?query=<street>

which returns the canonical street spelling, the house number and the key itself. The returned keys match the MD5 derivation exactly for every address checked, including suffixed numbers and streets with spaces.

The lookup runs first because raw hashing only succeeds on byte-perfect input: `bundesplatz1`, `Bundesplatz 1` and `Helvetiaplatz3A` all return HTTP 500 and would fall through to the lookup anyway. Hashing first would therefore be slower for mistyped input and identical otherwise, and a wrong-cased number would produce a valid-looking key whose 500 is indistinguishable from an unknown address — losing the suggestion list. MD5 remains the fallback when the lookup returns nothing.

## Edge cases verified against the live service

- **House-number suffix:** no space, lowercase, e.g. `Helvetiaplatz3a`. The hash is case-sensitive — `MD5(...3a)` returns HTTP 200 and matches the server's key, `MD5(...3A)` returns HTTP 500. The lookup compares case-insensitively, so users may enter either form.
- **Multi-word streets:** the space is preserved verbatim. `MD5("Alter Aargauerstalden2b")` matches the server's key. Bern has no "Alte Bernstrasse"; multi-word names are usually hyphenated (`Von-Werdt-Passage`).
- **Unknown key:** HTTP 500 — not 404, not an empty VCALENDAR. Surfaced as `SourceArgumentNotFound`.
- **Unknown house number on a known street:** raises `SourceArgumentNotFoundWithSuggestions` listing the known numbers.

## Feed quirks handled in the source

Both handled locally so `service/ICS.py` stays untouched — a fix there would affect ~600 other sources and belongs in its own PR:

1. Empty `EXDATE:` lines on two of the three events, which icalendar reports as a broken property. Stripped before parsing. The multi-value `EXDATE;VALUE=DATE:...,...,...` line parses correctly as-is, so holiday exclusions do come through — verified that 2026-11-23 and 2026-12-25 are absent from the results.

2. RRULE `UNTIL` is given in UTC (`<Dec 31>T230000Z`) while the events are all-day, so that instant is 00:00 local on Jan 1 and the recurrence yields a phantom collection on New Year's Day — confirmed against the published calendar as not a collection day. Entries past the feed's own `UNTIL` date are dropped. The bound is read from the fetched feed at runtime (no year assumed); this removes a parsing artifact and is not a user-facing time-range filter.

## Arguments

- `strasse` — street name, e.g. `Bundesplatz`
- `hnr` — house number, e.g. `1` or `3a`
- `key` — optional; accepts the key from the iKalender link directly and skips address resolution. An escape hatch: if ERB changes the hashing scheme or retires the lookup, users can paste their own link and keep working without waiting for a release.

`HOW_TO_GET_ARGUMENTS_DESCRIPTION`, `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` are provided in de and en.

## Test cases

Public buildings only, no private residences:

    Bundesplatz 1        (Bundeshaus)          104 entries
    Helvetiaplatz 5      (Historisches Museum)  62 entries
    Waisenhausplatz 30   (Polizeiwache)        104 entries
    key only             (Bundesplatz 1)       104 entries

The fourth case exercises the key fallback and returns the same result as the street/number path for the same address. Helvetiaplatz 5 legitimately returns fewer entries — its Hauskehricht runs `BYDAY=MO,TH` rather than `MO,TU,TH,FR`, and its Altpapiersammlung is `INTERVAL=2` (fortnightly). All three collection types are present.

Dates cross-checked against bernentsorgung.glue.ch for the same address, including the holiday exclusions. `test_sources.py` passes with `-d` (`fetch()` does not mutate the Source object). pytest: 39 passed. `pre-commit run --all-files`: all hooks pass.
