### PR TITLE
fix(eastdevon_gov_uk): resolve postcode + address to a UPRN

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdevon_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastdevon_gov_uk.py
@@ -1,4 +1,5 @@
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentRequired
 from waste_collection_schedule.service.uk_cloud9_apps import Cloud9Client
 
 TITLE = "East Devon District Council"
@@ -8,18 +9,24 @@ COUNTRY = "uk"
 TEST_CASES = {
     "Test_001": {"uprn": "010000246114"},
     "Test_002": {"uprn": 10000272679},
+    "Test_003": {"postcode": "EX8 2AN", "address": "1 Dagmar Road"},
+    "Test_004": {"postcode": "EX5 2AB", "address": "1 Blackhorse Cottages"},
 }
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
-    "en": "You can find your UPRN by visiting [Find My Address](https://www.findmyaddress.co.uk) and entering your address details, or from the UPRN query parameter on the East Devon bin collection page."
+    "en": "Either give your UPRN, or give your postcode together with your address. You can find your UPRN by visiting [Find My Address](https://www.findmyaddress.co.uk) and entering your address details, or from the UPRN query parameter on the East Devon bin collection page."
 }
 PARAM_TRANSLATIONS = {
     "en": {
         "uprn": "Unique Property Reference Number (UPRN)",
+        "postcode": "Postcode",
+        "address": "Address",
     }
 }
 PARAM_DESCRIPTIONS = {
     "en": {
         "uprn": "Unique Property Reference Number (UPRN)",
+        "postcode": "Postcode, e.g. EX8 2AN. Use together with address instead of a UPRN.",
+        "address": "House name or number and street, e.g. 1 Dagmar Road. Use together with postcode instead of a UPRN.",
     }
 }
 ICON_MAP = {
@@ -34,9 +41,32 @@ SOURCE_CODEOWNERS = ["@SimonRice"]
 
 
 class Source:
-    def __init__(self, uprn: str | int):
+    def __init__(
+        self,
+        uprn: str | int | None = None,
+        postcode: str | None = None,
+        address: str | None = None,
+    ):
         self._client = Cloud9Client("eastdevon", icon_keywords=ICON_MAP)
-        self._uprn = str(uprn).zfill(12)
+        # Existing configurations pass a bare UPRN, which this API wants
+        # zero-padded to 12 digits. Keep the padding so they keep working.
+        self._uprn = str(uprn).zfill(12) if uprn else None
+        self._postcode = postcode
+        self._address = address
 
     def fetch(self) -> list[Collection]:
-        return self._client.fetch_by_uprn(self._uprn)
+        if self._uprn:
+            return self._client.fetch_by_uprn(self._uprn)
+        if not self._postcode:
+            raise SourceArgumentRequired(
+                "uprn", "Provide a UPRN, or a postcode together with an address"
+            )
+        return self._client.fetch_by_address(
+            postcode=self._postcode,
+            address_string=self._address or "",
+            # The client's suggestions are whole addresses and it reports the
+            # address it was given as the offending value, so they belong to
+            # the address argument: picking one has to refine `address`, not
+            # overwrite the postcode with a full address.
+            argument_name="address",
+        )

--- a/doc/source/eastdevon_gov_uk.md
+++ b/doc/source/eastdevon_gov_uk.md
@@ -14,13 +14,33 @@ waste_collection_schedule:
         uprn: UNIQUE_PROPERTY_REFERENCE_NUMBER
 ```
 
+or
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: eastdevon_gov_uk
+      args:
+        postcode: POSTCODE
+        address: ADDRESS
+```
+
 ### Configuration Variables
 
 **uprn**
-*(string) (required)*
+*(string) (optional)*
 
+**postcode**
+*(string) (optional)*
+
+**address**
+*(string) (optional)*
+
+Provide either `uprn`, or `postcode` together with `address`.
 
 ## Examples
+
+Using a UPRN:
 
 ```yaml
 waste_collection_schedule:
@@ -29,6 +49,20 @@ waste_collection_schedule:
       args:
         uprn: "010000246114"
 ```
+
+Using a postcode and address:
+
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: eastdevon_gov_uk
+      args:
+        postcode: "EX8 2AN"
+        address: "1 Dagmar Road"
+```
+
+If the address does not uniquely identify a property, the integration reports
+the matching addresses so you can copy an exact one.
 
 ## How to find your UPRN
 


### PR DESCRIPTION
## Summary

`eastdevon_gov_uk` uses the shared `uk_cloud9_apps.Cloud9Client`, which already
exposes `fetch_by_address`, but the source only ever wired up `fetch_by_uprn`.
That made a 12-digit UPRN the only way to configure it.

This accepts `postcode` + `address` as an alternative, mirroring `arun_gov_uk`
and `southend_gov_uk`, which use the same client and already offer both forms.

## Why

I run a public bin-day lookup that uses this source. Over 2026-08-26 to
2026-09-01, 94 of 101 completed East Devon lookups returned an **empty
schedule**: a UPRN that a person guesses or mistypes resolves to no collection
data rather than to an error, so there is no useful feedback. Offering the
address path removes the guessing.

## Compatibility

- Existing `uprn` configurations are unchanged, including the 12-digit zero
  padding (`str(uprn).zfill(12)`).
- All three arguments are optional; `uprn` wins when supplied. Passing neither
  `uprn` nor `postcode` raises `SourceArgumentRequired`.
- An ambiguous address surfaces the client's existing
  `SourceArgAmbiguousWithSuggestions`, so the user gets a candidate list.

## Tests

`TEST_CASES` keeps both existing UPRN cases and adds two address cases:

```
Test_001 {"uprn": "010000246114"}                                -> 3 collections
Test_002 {"uprn": 10000272679}                                   -> 4 collections
Test_003 {"postcode": "EX8 2AN", "address": "1 Dagmar Road"}     -> 4 collections
Test_004 {"postcode": "EX5 2AB", "address": "1 Blackhorse Cottages"} -> 3 collections
```

All four pass against the live API.
