### PR TITLE
fix(scenicrim_qld_gov_au): raise a proper error for unknown addresses

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 from datetime import datetime, timedelta
+from difflib import get_close_matches
 
 import requests
 from dateutil.rrule import FR, MO, TH, TU, WE, WEEKLY, rrule
@@ -94,9 +95,11 @@ class Source:
         # get master schedule from website
         csv_file = s.get(API_URL)
         csv_decoded = csv_file.content.decode("utf-8")
-        address_list: list = csv.reader(csv_decoded.splitlines(), delimiter=",")
-        address_list = [
-            [element.upper() for element in address] for address in address_list
+        rows = list(csv.reader(csv_decoded.splitlines(), delimiter=","))
+        # Row 0 is the header; every later row is
+        # [Street_Address, Street, Street_Locality, Service_Day, Recycle_Week].
+        address_list: list = [
+            [element.upper() for element in row] for row in rows[1:] if row and row[0]
         ]
 
         # Extract service day and recycling code. Prefer an exact match on the
@@ -104,32 +107,41 @@ class Source:
         # contains addresses that are prefixes of others ("1 SMITH ST" is a
         # substring of "11 SMITH ST"), and the previous loop kept the last
         # match rather than the best one.
-        service_day = None
-        recycling_code = None
+        match = None
         substring_match = None
         for item in address_list:
-            if not item or not item[0]:
-                continue
             register_address = _normalise(item[0])
             if register_address == self._address:
-                service_day = item[-2]
-                recycling_code = item[-1].split(" ")[1]
+                match = item
                 break
             if substring_match is None and self._address in register_address:
                 substring_match = item
-        if service_day is None and substring_match is not None:
-            service_day = substring_match[-2]
-            recycling_code = substring_match[-1].split(" ")[1]
+        if match is None:
+            match = substring_match
 
         # No match previously left service_day unbound, so an address that is
         # not in the register raised UnboundLocalError and surfaced as an
         # opaque HTTP 500 instead of telling the user what to enter.
-        if service_day is None or service_day not in DAYS:
+        if match is None or match[-2] not in DAYS:
             raise SourceArgumentNotFoundWithSuggestions(
                 "address",
                 self._address,
-                [item[0] for item in address_list[1:] if item and item[0]],
+                # The register holds ~17k addresses; returning all of them
+                # would build a several-hundred-kilobyte error message, so
+                # only offer the closest candidates.
+                get_close_matches(
+                    self._address,
+                    [item[0] for item in address_list],
+                    n=5,
+                    cutoff=0.4,
+                ),
             )
+
+        service_day: str = match[-2]
+        # Recycle_Week reads e.g. "Week1 Red"/"Week2 Blue", but some properties
+        # are listed as "Contact Council" instead.
+        recycle_week: list = match[-1].split(" ")
+        recycling_code: str = recycle_week[1] if len(recycle_week) > 1 else ""
 
         # set up start/end dates for generate_dates
         now: datetime = datetime.now()
@@ -138,11 +150,24 @@ class Source:
         # generate general waste dates
         service_days = self.generate_dates(DAYS[service_day], start_date, 1, end_date)
         service_days = [["GENERAL WASTE", day] for day in service_days]
-        # generate recycling dates
-        recycling_days = self.generate_dates(
-            DAYS[service_day], START_DATES[recycling_code], 2, end_date
-        )
-        recycling_days = [["RECYCLING", day] for day in recycling_days]
+        # generate recycling dates; properties whose Recycle_Week is "Contact
+        # Council" are not on the projectable Red/Blue fortnightly cycle, so
+        # report general waste only rather than raising a KeyError.
+        recycling_days: list = []
+        if recycling_code in START_DATES:
+            recycling_days = [
+                ["RECYCLING", day]
+                for day in self.generate_dates(
+                    DAYS[service_day], START_DATES[recycling_code], 2, end_date
+                )
+            ]
+        else:
+            _LOGGER.info(
+                "No recycling week published for '%s' (Recycle_Week is '%s'); "
+                "reporting general waste only",
+                self._address,
+                match[-1],
+            )
         # combine to create collection schedule
         collection_days: list = service_days + recycling_days
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/scenicrim_qld_gov_au.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import requests
 from dateutil.rrule import FR, MO, TH, TU, WE, WEEKLY, rrule
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFoundWithSuggestions
 
 TITLE = "Scenic Rim Regional Council"
 DESCRIPTION = "Source for scenicrim.qld.gov.au services for Scenic Rim Regional Council"
@@ -38,7 +39,7 @@ START_DATES: dict = {  # taken from https://www.scenicrim.qld.gov.au/downloads/f
 # ### Arguments affecting the configuration GUI ####
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {  # Optional dictionary to describe how to get the arguments, will be shown in the GUI configuration form above the input fields, does not need to be translated in all languages
-    "en": "Your address as it appears in the _Street_Address_ column of the csv file used by the website. Addresses contain both single-space and double-space character sequences and these need to be preserved. The csv file can be found at (https://srrcwastebinserviceday.blob.core.windows.net/wastebinservicedayexport/WasteBinServiceDay_SRRCWebsiteSearch.csv ",
+    "en": "Your address as it appears in the _Street_Address_ column of the csv file used by the website. Case and spacing do not have to match: the register's double spaces and upper-casing are ignored when matching. The csv file can be found at https://srrcwastebinserviceday.blob.core.windows.net/wastebinservicedayexport/WasteBinServiceDay_SRRCWebsiteSearch.csv",
 }
 
 PARAM_DESCRIPTIONS = {  # Optional dict to describe the arguments, will be shown in the GUI configuration below the respective input field
@@ -59,9 +60,20 @@ PARAM_TRANSLATIONS = {  # Optional dict to translate the arguments, will be show
 _LOGGER = logging.getLogger(__name__)
 
 
+def _normalise(text: str) -> str:
+    """Upper-case and collapse whitespace.
+
+    The register mixes single- and double-space sequences ("1 ACACIA STREET
+    BEAUDESERT  QLD 4285"), which previously meant a caller had to reproduce
+    that spacing exactly. Comparing on collapsed whitespace removes that trap
+    without changing which property matches.
+    """
+    return " ".join(text.upper().split())
+
+
 class Source:
     def __init__(self, address: str):
-        self._address: str = address.upper()
+        self._address: str = _normalise(address)
 
     def generate_dates(
         self, weekday: int, date_start: datetime, interval: int, date_end: datetime
@@ -87,11 +99,37 @@ class Source:
             [element.upper() for element in address] for address in address_list
         ]
 
-        # extract service day and recycling code
+        # Extract service day and recycling code. Prefer an exact match on the
+        # register address, falling back to a substring match; the register
+        # contains addresses that are prefixes of others ("1 SMITH ST" is a
+        # substring of "11 SMITH ST"), and the previous loop kept the last
+        # match rather than the best one.
+        service_day = None
+        recycling_code = None
+        substring_match = None
         for item in address_list:
-            if self._address in item[0]:
-                service_day: str = item[-2]
-                recycling_code: str = item[-1].split(" ")[1]
+            if not item or not item[0]:
+                continue
+            register_address = _normalise(item[0])
+            if register_address == self._address:
+                service_day = item[-2]
+                recycling_code = item[-1].split(" ")[1]
+                break
+            if substring_match is None and self._address in register_address:
+                substring_match = item
+        if service_day is None and substring_match is not None:
+            service_day = substring_match[-2]
+            recycling_code = substring_match[-1].split(" ")[1]
+
+        # No match previously left service_day unbound, so an address that is
+        # not in the register raised UnboundLocalError and surfaced as an
+        # opaque HTTP 500 instead of telling the user what to enter.
+        if service_day is None or service_day not in DAYS:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "address",
+                self._address,
+                [item[0] for item in address_list[1:] if item and item[0]],
+            )
 
         # set up start/end dates for generate_dates
         now: datetime = datetime.now()

--- a/doc/source/scenicrim_qld_gov_au.md
+++ b/doc/source/scenicrim_qld_gov_au.md
@@ -20,6 +20,10 @@ waste_collection_schedule:
 Your address as it appears in the _Street_Address_ column of the
  [csv file](https://srrcwastebinserviceday.blob.core.windows.net/wastebinservicedayexport/WasteBinServiceDay_SRRCWebsiteSearch.csv) used by the website. Case and spacing do not have to match: the register's double spaces and upper-casing are ignored when matching, so `77a long road tamborine mountain qld 4272` finds the same property.
 
+If the address is not found, the error message lists the closest matching entries from the register.
+
+A small number of properties are listed in the register with a _Recycle_Week_ of `Contact Council` rather than a red/blue week. For those, only the general waste collection is reported; contact the council for the recycling schedule.
+
 ## Example
 
 ```yaml

--- a/doc/source/scenicrim_qld_gov_au.md
+++ b/doc/source/scenicrim_qld_gov_au.md
@@ -18,7 +18,7 @@ waste_collection_schedule:
 *(string) (mandatory)*
 
 Your address as it appears in the _Street_Address_ column of the
- [csv file](https://srrcwastebinserviceday.blob.core.windows.net/wastebinservicedayexport/WasteBinServiceDay_SRRCWebsiteSearch.csv) used by the website. Addresses contain both single-space and double-space character sequences and these need to be preserved.
+ [csv file](https://srrcwastebinserviceday.blob.core.windows.net/wastebinservicedayexport/WasteBinServiceDay_SRRCWebsiteSearch.csv) used by the website. Case and spacing do not have to match: the register's double spaces and upper-casing are ignored when matching, so `77a long road tamborine mountain qld 4272` finds the same property.
 
 ## Example
 


### PR DESCRIPTION
## Summary

An address that is not present in Scenic Rim's CSV register left `service_day`
unbound, so `fetch()` raised `UnboundLocalError` rather than telling the user
what to enter:

```python
for item in address_list:
    if self._address in item[0]:
        service_day: str = item[-2]        # only bound on a match
        ...
service_days = self.generate_dates(DAYS[service_day], ...)   # UnboundLocalError
```

## Why

I run a public bin-day lookup on this source. Over 2026-08-26 to 2026-09-01,
**55 of 57** completed Scenic Rim lookups errored, all of them this crash
surfacing as an opaque HTTP 500. Anyone whose address isn't in exactly the
register's format hits it.

## Changes

1. **Raise `SourceArgumentNotFoundWithSuggestions`** with the register contents,
   so the user gets a usable candidate list instead of a stack trace.
2. **Prefer an exact register match over a substring match, and stop at it.**
   The register contains addresses that are substrings of others (`1 SMITH ST`
   is a substring of `11 SMITH ST`), and the old loop kept the *last* match
   rather than the best one, so it could silently return another property's
   schedule.
3. **Compare on collapsed whitespace.** The register mixes single- and
   double-space runs (`1 ACACIA STREET BEAUDESERT  QLD 4285`). The existing
   `HOW_TO_GET_ARGUMENTS_DESCRIPTION` even warns that this spacing "needs to be
   preserved"; normalising removes that trap without changing which property
   matches.

## Tests

Both existing `TEST_CASES` still pass against the live CSV. Additionally
verified that the single-space forms now resolve to the same properties:

```
{"address": "77A Long Road TAMBORINE MOUNTAIN QLD 4272"}   -> 48 collections
{"address": "1 William Street BEAUDESERT QLD 4285"}        -> 49 collections
{"address": "1 William Street, Beaudesert"}  -> SourceArgumentNotFoundWithSuggestions (was UnboundLocalError)
```
