### PR TITLE
fix(fairfieldcity_nsw_gov_au): resolve street against the council autocomplete

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fairfieldcity_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fairfieldcity_nsw_gov_au.py
@@ -1,20 +1,34 @@
+import re
 from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
-from waste_collection_schedule.exceptions import SourceArgumentNotFound
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+)
 
 TITLE = "Fairfield City Council"
 DESCRIPTION = "Source for Fairfield City Council bin collection, NSW, Australia."
 URL = "https://kerbside.fairfieldcity.nsw.gov.au/kerbside/"
 COUNTRY = "au"
 TEST_CASES = {
-    "1 Dawson ST, FAIRFIELD HEIGHTS": {
+    "1 Dawson Street, FAIRFIELD HEIGHTS": {
+        "street_number": "1",
+        "street_and_suburb": "Dawson Street, FAIRFIELD HEIGHTS",
+    },
+    "12 Zadro Avenue, BOSSLEY PARK": {
+        "street_number": "12",
+        "street_and_suburb": "Zadro Avenue, BOSSLEY PARK",
+    },
+    # Abbreviated street types: what the council's autocomplete used to emit,
+    # and therefore what most existing configurations still contain.
+    "1 Dawson ST, FAIRFIELD HEIGHTS (abbreviated)": {
         "street_number": "1",
         "street_and_suburb": "Dawson ST, FAIRFIELD HEIGHTS",
     },
-    "12 Zadro AVE, BOSSLEY PARK": {
+    "12 Zadro AVE, BOSSLEY PARK (abbreviated)": {
         "street_number": "12",
         "street_and_suburb": "Zadro AVE, BOSSLEY PARK",
     },
@@ -54,6 +68,54 @@ ICON_MAP = {
 }
 
 API_URL = "https://kerbside.fairfieldcity.nsw.gov.au/kerbside/"
+# The council's own autocomplete list. The form only answers for a value taken
+# verbatim from it, and the list was switched from abbreviated street types
+# ("Dawson ST") to spelled-out ones ("Dawson Street"), which silently broke
+# every previously valid saved value.
+AUTOCOMPLETE_URL = f"{API_URL}fcc-autocomplete.js"
+AUTOCOMPLETE_ARRAY = "arrAddressStreetAndSuburb"
+
+# Street-type abbreviations seen in the old list and in what people type.
+STREET_TYPES = {
+    "AV": "AVENUE",
+    "AVE": "AVENUE",
+    "BVD": "BOULEVARD",
+    "CCT": "CIRCUIT",
+    "CH": "CHASE",
+    "CL": "CLOSE",
+    "CR": "CRESCENT",
+    "CRES": "CRESCENT",
+    "CT": "COURT",
+    "DR": "DRIVE",
+    "ESP": "ESPLANADE",
+    "GDNS": "GARDENS",
+    "GR": "GROVE",
+    "GRV": "GROVE",
+    "HWY": "HIGHWAY",
+    "LN": "LANE",
+    "LP": "LOOP",
+    "PDE": "PARADE",
+    "PKWY": "PARKWAY",
+    "PL": "PLACE",
+    "RD": "ROAD",
+    "RSE": "RISE",
+    "SQ": "SQUARE",
+    "ST": "STREET",
+    "TCE": "TERRACE",
+    "WY": "WAY",
+}
+
+
+def _canonical(value: str) -> str:
+    """Upper-case words only, single-spaced, street types spelled out.
+
+    Comparing on this lets a stored "Dawson ST, FAIRFIELD HEIGHTS" match the
+    list's current "Dawson Street, FAIRFIELD HEIGHTS", and vice versa.
+    Punctuation and repeated spaces are dropped rather than preserved, so a
+    missing comma or a doubled space is not the thing that fails a lookup.
+    """
+    words = re.findall(r"\w+", value.upper())
+    return " ".join(STREET_TYPES.get(w, w) for w in words)
 
 
 class Source:
@@ -61,12 +123,45 @@ class Source:
         self._street_number = str(street_number).strip()
         self._street_and_suburb = street_and_suburb.strip()
 
+    def _known_streets(self, session: requests.Session) -> list[str]:
+        try:
+            response = session.get(AUTOCOMPLETE_URL, timeout=30)
+            response.raise_for_status()
+        except requests.RequestException:
+            # The list is a convenience, not the lookup itself. A timeout, a
+            # refused connection or a 5xx must not stop the POST that would
+            # otherwise have worked, so treat it as "no list" and fall back.
+            return []
+        match = re.search(
+            AUTOCOMPLETE_ARRAY + r"\s*=\s*\[(.*?)\]", response.text, re.DOTALL
+        )
+        if not match:
+            return []
+        return re.findall(r'"([^"]+)"', match.group(1))
+
+    def _resolve_street_and_suburb(self, session: requests.Session) -> str:
+        streets = self._known_streets(session)
+        if not streets:
+            # Autocomplete unavailable or restructured; send what we were given
+            # rather than refusing outright.
+            return self._street_and_suburb
+        wanted = _canonical(self._street_and_suburb)
+        for street in streets:
+            if _canonical(street) == wanted:
+                return street
+        raise SourceArgumentNotFoundWithSuggestions(
+            "street_and_suburb", self._street_and_suburb, streets
+        )
+
     def fetch(self) -> list[Collection]:
-        response = requests.post(
+        session = requests.Session()
+        street_and_suburb = self._resolve_street_and_suburb(session)
+
+        response = session.post(
             API_URL,
             data={
                 "myStreetNumber": self._street_number,
-                "myStreetAndSuburb": self._street_and_suburb,
+                "myStreetAndSuburb": street_and_suburb,
             },
             timeout=30,
         )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/fairfieldcity_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/fairfieldcity_nsw_gov_au.py
@@ -38,9 +38,10 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": (
         "Visit https://kerbside.fairfieldcity.nsw.gov.au/kerbside/ and start typing "
         "your street name and suburb into the 'Street name & Suburb' field. "
-        "Use the autocomplete suggestion (e.g. 'Dawson ST, FAIRFIELD HEIGHTS') "
+        "Use the autocomplete suggestion (e.g. 'Dawson Street, FAIRFIELD HEIGHTS') "
         "as the value for street_and_suburb, and enter just your street number "
-        "for street_number."
+        "for street_number. Abbreviated street types from older configurations "
+        "(e.g. 'Dawson ST, FAIRFIELD HEIGHTS') are still accepted."
     )
 }
 
@@ -56,7 +57,8 @@ PARAM_DESCRIPTIONS = {
         "street_number": "Your street number (e.g. 1, 7A, 7/10).",
         "street_and_suburb": (
             "Street name and suburb as shown in the autocomplete list "
-            "(e.g. 'Dawson ST, FAIRFIELD HEIGHTS')."
+            "(e.g. 'Dawson Street, FAIRFIELD HEIGHTS'). Abbreviated street "
+            "types such as 'Dawson ST, FAIRFIELD HEIGHTS' also work."
         ),
     }
 }

--- a/doc/source/fairfieldcity_nsw_gov_au.md
+++ b/doc/source/fairfieldcity_nsw_gov_au.md
@@ -23,7 +23,9 @@ Your street number (e.g. `1`, `7A`, `7/10`).
 **street_and_suburb**
 *(string) (required)*
 
-Your street name and suburb exactly as it appears in the autocomplete list on the council's kerbside lookup page (e.g. `Dawson ST, FAIRFIELD HEIGHTS`).
+Your street name and suburb as it appears in the autocomplete list on the council's kerbside lookup page (e.g. `Dawson Street, FAIRFIELD HEIGHTS`).
+
+The council switched its autocomplete from abbreviated street types (`Dawson ST`) to spelled-out ones (`Dawson Street`). Both spellings are accepted, so existing configurations keep working.
 
 ## Example
 
@@ -33,12 +35,12 @@ waste_collection_schedule:
     - name: fairfieldcity_nsw_gov_au
       args:
         street_number: "1"
-        street_and_suburb: "Dawson ST, FAIRFIELD HEIGHTS"
+        street_and_suburb: "Dawson Street, FAIRFIELD HEIGHTS"
 ```
 
 ## How to get the source arguments
 
 1. Visit the [Fairfield City Council kerbside lookup](https://kerbside.fairfieldcity.nsw.gov.au/kerbside/).
 2. Start typing your street name into the **Street name & Suburb** field and select your street from the autocomplete list.
-3. Use the selected autocomplete value (e.g. `Dawson ST, FAIRFIELD HEIGHTS`) as `street_and_suburb`.
+3. Use the selected autocomplete value (e.g. `Dawson Street, FAIRFIELD HEIGHTS`) as `street_and_suburb`.
 4. Enter your house or unit number as `street_number`.


### PR DESCRIPTION
## Summary

Fairfield City Council changed its street autocomplete list from abbreviated
street types (`Dawson ST, FAIRFIELD HEIGHTS`) to spelled-out ones
(`Dawson Street, FAIRFIELD HEIGHTS`). The kerbside form only returns results
for a value taken verbatim from that list, so every previously valid
configuration silently stopped resolving.

**Both existing `TEST_CASES` fail on master:**

```
1 Dawson ST, FAIRFIELD HEIGHTS  -> SourceArgumentNotFound
12 Zadro AVE, BOSSLEY PARK      -> SourceArgumentNotFound
```

## Why

I run a public bin-day lookup on this source. Over 2026-08-26 to 2026-09-01,
**70 of 70** completed Fairfield lookups failed — a 0% success rate — because
the stored abbreviated values no longer exist in the council's list.

## Changes

- Resolve `street_and_suburb` against the council's own live list
  (`fcc-autocomplete.js`, `arrAddressStreetAndSuburb`) and POST the exact
  entry it holds.
- Compare on upper-cased, whitespace-collapsed text with street-type
  abbreviations expanded (`ST`→`STREET`, `AVE`→`AVENUE`, …), so both the old
  and the new spelling resolve. Existing configurations keep working, and so
  will values copied from the current autocomplete.
- Unknown streets raise `SourceArgumentNotFoundWithSuggestions` with the list,
  rather than a bare not-found.
- If the autocomplete is unavailable or restructured, fall back to sending the
  value as given rather than refusing outright.

## Tests

`TEST_CASES` now covers both spellings for the same two properties, so a future
switch in either direction is caught. All four pass against the live site:

```
{"street_number": "1",  "street_and_suburb": "Dawson Street, FAIRFIELD HEIGHTS"} -> 3
{"street_number": "12", "street_and_suburb": "Zadro Avenue, BOSSLEY PARK"}       -> 3
{"street_number": "1",  "street_and_suburb": "Dawson ST, FAIRFIELD HEIGHTS"}     -> 3
{"street_number": "12", "street_and_suburb": "Zadro AVE, BOSSLEY PARK"}          -> 3
```
