### PR TITLE
feat: add source for the community of Ismaning, Germany

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
@@ -18,6 +18,8 @@ DESCRIPTION = (
 URL = "https://ismaning.de/umwelt-energie/abfall/abfallkalender/"
 COUNTRY = "de"
 
+SOURCE_CODEOWNERS = ["@Kufi089"]
+
 AJAX_URL = "https://ismaning.de/wp-admin/admin-ajax.php"
 HEADERS = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120 Safari/537.36",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
@@ -1,0 +1,154 @@
+import re
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import requests
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFound,
+    SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequiredWithSuggestions,
+)
+from waste_collection_schedule.service.ICS import ICS
+
+TITLE = "Gemeinde Ismaning – Abfallkalender"
+DESCRIPTION = (
+    "Source for the waste collection schedule of the community Ismaning, Germany."
+)
+URL = "https://ismaning.de/umwelt-energie/abfall/abfallkalender/"
+COUNTRY = "de"
+
+AJAX_URL = "https://ismaning.de/wp-admin/admin-ajax.php"
+HEADERS = {
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120 Safari/537.36",
+    "x-requested-with": "XMLHttpRequest",
+    "referer": "https://ismaning.de/umwelt-energie/abfall/abfallkalender/",
+}
+
+ICON_MAP = {
+    "Restmüll": Icons.GENERAL_WASTE,
+    "Biotonne": Icons.BIO_KITCHEN,
+    "Papiertonne": Icons.PAPER,
+    "Gelber Sack": Icons.PLASTIC_PACKAGING,
+    "Giftmobil": Icons.HAZARDOUS,
+    "Giftmobil-Samstag": Icons.HAZARDOUS,
+    "Giftmobil-Fischerhäuser": Icons.HAZARDOUS,
+    "Christbaumabholung": Icons.CHRISTMAS_TREE,
+    "Rama-Dama": Icons.BULKY,
+}
+
+TEST_CASES = {
+    "Am Englischen Garten (ohne Hausnummer)": {"street": "Am Englischen Garten"},
+    "Bahnhofstraße 5 (mit Hausnummer)": {"street": "Bahnhofstraße", "street_nr": "5"},
+}
+
+PARAM_TRANSLATIONS = {
+    "de": {
+        "street": "Straße",
+        "street_nr": "Hausnummer",
+    },
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "de": (
+        "Geben Sie Ihre Straße ein. Wenn die Straße eine Hausnummer benötigt, wird "
+        "diese im nächsten Schritt als Auswahl abgefragt."
+    ),
+}
+
+
+class Source:
+    def __init__(self, street: str = "", street_nr: str = "") -> None:
+        self._session = requests.Session()
+        self._session.headers.update(HEADERS)
+        self._ics = ICS()
+        self._year = datetime.now(ZoneInfo("Europe/Berlin")).year
+
+        self._street = self._resolve_street(street)
+        street_type = self._ajax(
+            action="iap_get_first_at_frontend", street=self._street, year=self._year
+        ).strip()
+
+        self._street_nr: str | None = None
+        if street_type == "2":
+            gebiet = self._street_gebietsnummer
+            numbers = self._house_numbers(self._street, gebiet)
+            street_nr = street_nr.strip()
+            if not street_nr:
+                raise SourceArgumentRequiredWithSuggestions(
+                    "street_nr",
+                    "Diese Straße benötigt eine Hausnummer.",
+                    numbers,
+                )
+            if street_nr not in numbers:
+                raise SourceArgumentNotFoundWithSuggestions(
+                    "street_nr", street_nr, numbers
+                )
+            self._street_nr = street_nr
+        # street_type == "1": no house number needed (street_nr is ignored).
+
+    def fetch(self) -> list[Collection]:
+        params = {"street": self._street, "year": self._year}
+        if self._street_nr is not None:
+            params["hnr"] = self._street_nr
+
+        ics_url = self._ajax(action="ics_non_notification_generation", **params).strip()
+        if not ics_url.startswith("http"):
+            raise SourceArgumentNotFound(
+                "street",
+                self._street,
+                "Der Server konnte für diese Auswahl keinen Abfahrtskalender "
+                "erstellen.",
+            )
+
+        response = self._session.get(ics_url, timeout=30)
+        response.raise_for_status()
+        # Ismaning does not send a charset header; requests defaults to
+        # ISO-8859-1 which mangles the German summaries. The ICS is UTF-8.
+        dates = self._ics.convert(response.content.decode("utf-8"))
+
+        return [
+            Collection(date, waste_type.strip(), icon=ICON_MAP.get(waste_type.strip()))
+            for date, waste_type in dates
+        ]
+
+    def _ajax(self, **params) -> str:
+        response = self._session.post(AJAX_URL, data=params, timeout=30)
+        response.raise_for_status()
+        return response.text
+
+    def _resolve_street(self, street: str) -> str:
+        street = street.strip()
+        streets = self._streets()
+        if not streets:
+            raise SourceArgumentNotFound(
+                "street", street, "Es wurden keine Straßen gefunden."
+            )
+        if not street:
+            raise SourceArgumentRequiredWithSuggestions(
+                "street", "Bitte wählen Sie Ihre Straße.", [n for _, n in streets]
+            )
+
+        target = street.casefold()
+        for gebiet, name in streets:
+            if name.strip().casefold() == target:
+                self._street_gebietsnummer = gebiet
+                return name.strip()
+
+        raise SourceArgumentNotFoundWithSuggestions(
+            "street", street, [n.strip() for _, n in streets]
+        )
+
+    def _streets(self) -> list[tuple[str, str]]:
+        html = self._ajax(action="get_streets", year=self._year)
+        return re.findall(r'<option data-gebietsnummer="(\d+)">([^<]+)</option>', html)
+
+    def _house_numbers(self, street: str, gebiet: str) -> list[str]:
+        html = self._ajax(
+            action="iap_get_erg_by_second",
+            street=street,
+            year=self._year,
+            gebietsnummer=gebiet,
+        )
+        options = re.findall(r"<option[^>]*>([^<]+)</option>", html)
+        return [o.strip() for o in options if o.strip() and o.strip() != "Bitte wählen"]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
@@ -36,7 +36,8 @@ ICON_MAP = {
     "Giftmobil-Samstag": Icons.HAZARDOUS,
     "Giftmobil-Fischerhäuser": Icons.HAZARDOUS,
     "Christbaumabholung": Icons.CHRISTMAS_TREE,
-    "Rama-Dama": Icons.BULKY,
+    # Community-wide volunteer litter-picking day, not a bulky waste collection.
+    "Rama-Dama": Icons.EVENT,
 }
 
 TEST_CASES = {
@@ -45,13 +46,38 @@ TEST_CASES = {
 }
 
 PARAM_TRANSLATIONS = {
+    "en": {
+        "street": "Street",
+        "street_nr": "House number",
+    },
     "de": {
         "street": "Straße",
         "street_nr": "Hausnummer",
     },
 }
 
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "street": "Name of your street as listed in the Ismaning waste calendar.",
+        "street_nr": (
+            "Only needed for streets that are split into house-number ranges; "
+            "leave empty otherwise."
+        ),
+    },
+    "de": {
+        "street": "Name Ihrer Straße wie im Ismaninger Abfallkalender aufgeführt.",
+        "street_nr": (
+            "Nur für Straßen erforderlich, die in Hausnummernbereiche unterteilt "
+            "sind; ansonsten leer lassen."
+        ),
+    },
+}
+
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Enter your street. If the street requires a house number, it is offered "
+        "as a selection in the next step."
+    ),
     "de": (
         "Geben Sie Ihre Straße ein. Wenn die Straße eine Hausnummer benötigt, wird "
         "diese im nächsten Schritt als Auswahl abgefragt."
@@ -65,6 +91,7 @@ class Source:
         self._session.headers.update(HEADERS)
         self._ics = ICS()
 
+        self._street_gebietsnummer: str = ""
         self._street = self._resolve_street(street)
         street_type = self._ajax(
             action="iap_get_first_at_frontend", street=self._street, year=self._year
@@ -105,8 +132,7 @@ class Source:
             raise SourceArgumentNotFound(
                 "street",
                 self._street,
-                "Der Server konnte für diese Auswahl keinen Abfahrtskalender "
-                "erstellen.",
+                "Der Server konnte für diese Auswahl keinen Abfallkalender erstellen.",
             )
 
         response = self._session.get(ics_url, timeout=30)

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ismaning_de.py
@@ -64,7 +64,6 @@ class Source:
         self._session = requests.Session()
         self._session.headers.update(HEADERS)
         self._ics = ICS()
-        self._year = datetime.now(ZoneInfo("Europe/Berlin")).year
 
         self._street = self._resolve_street(street)
         street_type = self._ajax(
@@ -88,6 +87,13 @@ class Source:
                 )
             self._street_nr = street_nr
         # street_type == "1": no house number needed (street_nr is ignored).
+
+    @property
+    def _year(self) -> int:
+        # Recomputed on every access. Home Assistant reuses the same Source
+        # instance across refreshes, so caching the year in __init__ would
+        # keep requesting the previous year's calendar after a year rollover.
+        return datetime.now(ZoneInfo("Europe/Berlin")).year
 
     def fetch(self) -> list[Collection]:
         params = {"street": self._street, "year": self._year}

--- a/doc/source/ismaning_de.md
+++ b/doc/source/ismaning_de.md
@@ -1,0 +1,40 @@
+# Gemeinde Ismaning – Abfallkalender
+
+Support for the waste collection schedule of the community (Gemeinde) Ismaning, Germany.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ismaning_de
+      args:
+        street: Am Englischen Garten
+```
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ismaning_de
+      args:
+        street: Bahnhofstraße
+        street_nr: "5"
+```
+
+### Configuration Variables
+
+**street**  
+*(string) (required)* Name of the street as listed in the Ismaning waste calendar.
+
+**street_nr**  
+*(string) (optional)* House number. Only required for streets that
+the Ismaning waste calendar splits into house-number ranges; for other
+streets leave it empty. When a value is missing for a street that needs
+one, the Home Assistant config flow shows a dropdown of the valid numbers.
+
+## How to get the source arguments
+
+Open the [Abfallkalender](https://ismaning.de/umwelt-energie/abfall/abfallkalender/)
+and select your street. If a house-number selection appears, note the
+number for your address and provide it as `street_nr`; otherwise leave
+`street_nr` empty.


### PR DESCRIPTION
## Summary

Adds a new source for the waste collection schedule of the community of Ismaning, Germany (official site ismaning.de).

The source resolves the selected street via the community's ajax endpoint. For streets that the community splits into house-number ranges (type 2), it also resolves and validates the house number, raising suggestion-based errors (config-flow dropdowns) when a value is missing or invalid. It then requests the ICS calendar for the matching selection and parses the collection dates into typed entries using the canonical icon catalogue.

Both flows are covered: streets without a house number and streets with one.

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] python -m pytest tests/test_source_components.py -q passes
- [x] ruff check --fix and ruff format run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] doc/source/<name>.md created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
