### PR TITLE
fix(melton, ballina, hornsby): pass Akamai's bot check with curl_cffi

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -114,6 +114,21 @@ class OpenCitiesConfig:
     "ambiguous" failure.
     """
 
+    strict_single_result: bool = False
+    """
+    Only meaningful with ``strict_address_matching``. By default a lone search
+    result is trusted even under strict matching, on the assumption that one
+    hit means the API was confident. A few deployments' search is loose enough
+    to answer an unrelated query with exactly one wrong hit -- lakemac returns
+    the single result "2 Lake Ridge Lane, MURRAYS BEACH" for the query
+    "2 Wallarah Rd" -- and there strict matching needs to apply to a single
+    result too, so the caller is offered it as a suggestion to confirm rather
+    than silently handed another property's bins. Left off by default because
+    for most councils the lone hit is right and merely formatted differently
+    from what the user typed (a missing state abbreviation or postcode), which
+    would otherwise turn a correct resolution into a hard failure.
+    """
+
     require_date_precise: bool = False
     """
     If True, only wasteservices blocks additionally carrying a
@@ -167,12 +182,12 @@ class OpenCitiesClient:
             self._geolocation_id = self.resolve_geolocation_id(address)
 
         try:
-            return self.fetch_by_geolocation_id(self._geolocation_id)  # type: ignore[arg-type]
+            return self.fetch_by_geolocation_id(self._geolocation_id, address)  # type: ignore[arg-type]
         except SourceArgumentNotFound:
             if not used_cache:
                 raise
             self._geolocation_id = self.resolve_geolocation_id(address)
-            return self.fetch_by_geolocation_id(self._geolocation_id)
+            return self.fetch_by_geolocation_id(self._geolocation_id, address)
 
     def resolve_geolocation_id(self, address: str) -> str:
         if self._cfg.warm_up_before == "search":
@@ -180,11 +195,15 @@ class OpenCitiesClient:
         items = self._search(address)
         return self._select_address(address, items)
 
-    def fetch_by_geolocation_id(self, geolocation_id: str) -> list[Collection]:
-        html = self.get_waste_services_html(geolocation_id)
+    def fetch_by_geolocation_id(
+        self, geolocation_id: str, address: str | None = None
+    ) -> list[Collection]:
+        html = self.get_waste_services_html(geolocation_id, address)
         return self._parse_wasteservices_html(html)
 
-    def get_waste_services_html(self, geolocation_id: str) -> str:
+    def get_waste_services_html(
+        self, geolocation_id: str, address: str | None = None
+    ) -> str:
         """Return the raw wasteservices HTML fragment for a geolocation id.
 
         Exposed alongside :meth:`fetch_by_geolocation_id` for the rare
@@ -205,7 +224,17 @@ class OpenCitiesClient:
         )
         data = response.json()
         if not data.get("success", True) or not data.get("responseContent"):
-            raise SourceArgumentNotFound(self._cfg.argument_name, geolocation_id)
+            # The address resolved, but the council holds no waste service for
+            # that property (vacant land, a commercial lot, a newly titled block
+            # not yet on a run). Report the address the visitor gave rather than
+            # the internal geolocation GUID, which reads as nonsense to them.
+            raise SourceArgumentNotFound(
+                self._cfg.argument_name,
+                address if address is not None else geolocation_id,
+                "The council lists no waste collection service for this "
+                "property. Check the address, or contact the council if it "
+                "should have a collection.",
+            )
         return data["responseContent"]
 
     # ---- internals ------------------------------------------------------
@@ -264,7 +293,9 @@ class OpenCitiesClient:
     def _select_address(self, address: str, items: list[dict[str, Any]]) -> str:
         if not items:
             raise SourceArgumentNotFound(self._cfg.argument_name, address)
-        if len(items) == 1 or not self._cfg.strict_address_matching:
+        if not self._cfg.strict_address_matching:
+            return items[0]["Id"]
+        if len(items) == 1 and not self._cfg.strict_single_result:
             return items[0]["Id"]
 
         normalized = address.lower().replace(" ", "")

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ballina_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ballina_nsw_gov_au.py
@@ -14,19 +14,19 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     )
 }
 TEST_CASES = {
-    "1 Grant St, Ballina NSW 2478": {"address": "1 Grant St, Ballina NSW 2478"}
+    "1/49 Grant Street BALLINA": {"address": "1/49 Grant Street BALLINA"},
+    "2/7 Hartigan St CUMBALUM": {"address": "2/7 Hartigan St CUMBALUM"},
 }
 
 PAGE_LINK = "/$8a878053-5e29-431d-896b-8c79ce08799f$/Residents/Waste-and-Recycling/Bin-Collection-Day"
 
+# Ballina sits behind Akamai, which fingerprints the TLS handshake as well as
+# the headers. Announcing Chrome in the User-Agent over a plain `requests`
+# handshake is the worst of both worlds and is served a 403 "Access Denied"
+# page; curl_cffi's Chrome impersonation makes the two agree and passes.
 HEADERS = {
     "accept": "application/json, text/javascript, */*; q=0.01",
     "referer": URL,
-    "user-agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/146.0.0.0 Safari/537.36"
-    ),
     "x-requested-with": "XMLHttpRequest",
 }
 
@@ -41,9 +41,16 @@ ICON_MAP = {
 _CONFIG = OpenCitiesConfig(
     domain="https://www.ballina.nsw.gov.au",
     search_fuzzy=True,
-    max_results=1,
+    # Ballina's fuzzy search ranks poorly: "1 Grant St, Ballina NSW 2478"
+    # comes back with "2/7 Hartigan St CUMBALUM" first and the Grant Street
+    # properties behind it. Capping at one result therefore guaranteed the
+    # wrong property, so take the whole list and disambiguate it here.
     page_link=PAGE_LINK,
     headers=HEADERS,
+    use_curl_cffi=True,
+    search_response_format="json_then_xml",
+    strict_address_matching=True,
+    strict_single_result=True,
     icon_keywords=ICON_MAP,
 )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/hornsby_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/hornsby_nsw_gov_au.py
@@ -5,12 +5,12 @@ import json
 import logging
 import re
 import urllib.parse
-import urllib.request
 from html.parser import HTMLParser
 from io import BytesIO
 from statistics import median
 from typing import Any
 
+from curl_cffi import requests as curl_cffi_requests
 from pdfminer.high_level import extract_pages
 from pdfminer.layout import (
     LTChar,
@@ -75,22 +75,24 @@ _FORTNIGHTLY_COUNT = 26
 _WEEKLY_COUNT = 26
 
 
+# Hornsby sits behind Akamai, which fingerprints the TLS handshake as well as
+# the headers. urllib announcing a browser User-Agent over a Python handshake
+# was served a 403 for every request; curl_cffi's Chrome impersonation makes
+# the handshake match what the User-Agent claims and passes.
+_HEADERS = {
+    "Accept": "application/json, */*",
+    "Referer": "https://www.hornsby.nsw.gov.au/",
+    "X-Requested-With": "XMLHttpRequest",
+}
+
+
 def _http_get(url: str, timeout_s: float = 25.0) -> bytes:
     """Perform an HTTP GET request and return the response body."""
-    req = urllib.request.Request(
-        url,
-        headers={
-            "User-Agent": (
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
-            ),
-            "Accept": "application/json, */*",
-            "Referer": "https://www.hornsby.nsw.gov.au/",
-            "X-Requested-With": "XMLHttpRequest",
-        },
-        method="GET",
+    response = curl_cffi_requests.get(
+        url, headers=_HEADERS, impersonate="chrome", timeout=timeout_s
     )
-    with urllib.request.urlopen(req, timeout=timeout_s) as resp:
-        return resp.read()
+    response.raise_for_status()
+    return response.content
 
 
 def _parse_geolocation_id(response_bytes: bytes) -> str:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/melton_vic_gov_au.py
@@ -8,10 +8,10 @@ TITLE = "Melton City Council"
 DESCRIPTION = "Source for Melton City Council rubbish collection."
 URL = "https://www.melton.vic.gov.au"
 TEST_CASES = {
-    "Tuesday A": {"street_address": "23 PILBARA AVENUE BURNSIDE 3023"},
-    "Tuesday B": {"street_address": "29 COROWA CRESCENT BURNSIDE 3023"},
-    "Wednesday A": {"street_address": "2 ASPIRE BOULEVARD FRASER RISE 3336"},
-    "Wednesday B": {"street_address": "17 KEYNES CIRCUIT FRASER RISE 3336"},
+    "Melton": {"street_address": "1 HIGH STREET MELTON 3337"},
+    "Melton South": {"street_address": "3 BRIDGE ROAD MELTON SOUTH 3338"},
+    "Fraser Rise": {"street_address": "20 ASPIRE BOULEVARD FRASER RISE 3336"},
+    "Cobblebank": {"street_address": "2-26 FERRIS ROAD COBBLEBANK 3338"},
 }
 
 ICON_MAP = {
@@ -20,12 +20,22 @@ ICON_MAP = {
     "Recycling": Icons.RECYCLING,
 }
 
-HEADERS = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "}
+# Melton sits behind Akamai, which scores the TLS/HTTP fingerprint as well as
+# the headers: plain `requests` is served a 403 "Access Denied" page for every
+# request, including the warm-up. curl_cffi's Chrome impersonation passes.
+# The Accept header is what keeps the search endpoint answering JSON -- without
+# it, content negotiation hands back the legacy XML shape instead.
+HEADERS = {
+    "accept": "application/json, text/javascript, */*; q=0.01",
+    "x-requested-with": "XMLHttpRequest",
+}
 
 _CONFIG = OpenCitiesConfig(
     domain="https://www.melton.vic.gov.au",
     argument_name="street_address",
     headers=HEADERS,
+    use_curl_cffi=True,
+    search_response_format="json_then_xml",
     warm_up_url="https://www.melton.vic.gov.au/My-Area",
     icon_keywords=ICON_MAP,
 )


### PR DESCRIPTION
All three councils sit behind Akamai, which scores the TLS/HTTP fingerprint as well as the headers. Each one announced a browser in the User-Agent while handshaking as Python, and was served a 403 "Access Denied" page for every request, the OpenCities warm-up included.

Switching them to curl_cffi's Chrome impersonation makes the handshake agree with the User-Agent and all three answer normally again.

- **Melton** and **Ballina** already had `use_curl_cffi` available on `OpenCitiesConfig`.
- **Hornsby** predates that shared client and calls the same two endpoints over `urllib`, so its `_http_get` moves across directly.
- Both OpenCities configs also take `search_response_format="json_then_xml"`, since content negotiation hands curl_cffi the legacy XML shape unless an explicit JSON `Accept` header wins.

### Ballina address matching

Ballina also capped its fuzzy search at a single result, and that search ranks poorly: the documented test address `1 Grant St, Ballina NSW 2478` comes back with an unrelated Cumbalum property *ahead of* the Grant Street ones, so the cap guaranteed another property's bins:

```
searchfuzzy "1 Grant St, Ballina NSW 2478"
 -> ['2/7 Hartigan St CUMBALUM', '1/49 Grant Street BALLINA', '1/33 Grant Street BALLINA', ...]
```

Now it takes the whole list and disambiguates it with the strict matching lakemac already uses, offering the candidates when that is not conclusive. Its test cases move to two addresses that exist in the council's own register (the old one does not).

### Melton test cases

All four pointed at properties the council no longer holds a waste service for; the `wasteservices` call answers `success: false` for them while neighbouring properties are fine. Replaced with live ones across four suburbs.

### Shared client error message

`OpenCitiesClient` reported the internal geolocation GUID as the value to go and check whenever a property has no waste service:

> We could not find values for the argument 'street_address' with the value '523630c4-462d-4f77-a9e9-6f6481555720'

It now reports the address the visitor actually gave, and says what the council is telling us.

### Testing

All test cases pass for all three sources against the live councils.