### PR TITLE
fix(calderdale_gov_uk): say when the council's own finder is down

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/calderdale_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/calderdale_gov_uk.py
@@ -46,6 +46,18 @@ class Source:
         response = requests.post(API_URL, data=data)
         response.raise_for_status()
 
+        # Calderdale redirects the finder to a notice page while it is down for
+        # maintenance, and to new.calderdale.gov.uk since the site move. Landing
+        # anywhere but the finder means there is nothing to parse, and saying so
+        # beats blaming a UPRN that is very probably correct.
+        if not response.url.startswith(API_URL):
+            raise ValueError(
+                "Calderdale's collection day finder is not answering at the "
+                f"moment (it redirected to {response.url}). This is the "
+                "council's own service being unavailable, not a problem with "
+                "your address; please try again later."
+            )
+
         # Parse HTML response
         soup = BeautifulSoup(response.text, "html.parser")
 


### PR DESCRIPTION
Calderdale has taken its collection day finder offline for system updates, and `collectiondayfinder.jsp` now redirects to a notice page on `new.calderdale.gov.uk`:

> The collection day finder will not be available until early September while we carry out system updates.

The POST still returns 200, so the parser finds no table and falls through to:

> Could not find collection information for the provided UPRN and postcode combination. Please verify both values are correct.

which sends every visitor off to re-check an address that was right all along. Both of the source's own test cases currently produce this.

This detects the redirect away from the finder and says plainly that it is the council's service that is unavailable, so the outage reads as an outage rather than as a bad UPRN.

Note the redirect also lands on `new.calderdale.gov.uk`, so `API_URL` will likely need revisiting once the finder is back; that is left alone here since the replacement form is not up yet to check against.