### PR TITLE
fix(darebin_vic_gov_au): resolve the address, and stop crashing on no match

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
@@ -2,6 +2,10 @@ from datetime import timedelta
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgAmbiguousWithSuggestions,
+    SourceArgumentNotFound,
+)
 from waste_collection_schedule.service.ArcGis import (
     epoch_ms_to_date,
     get_next_n_dates,
@@ -18,8 +22,51 @@ TEST_CASES = {
     "23 EDWARDES STREET RESERVOIR 3073": {
         "property_location": "23 EDWARDES STREET RESERVOIR 3073"
     },
+    # The shapes people type. The register holds none of them verbatim.
+    "Comma separated with state": {
+        "property_location": "266 Gower Street, Preston VIC 3072"
+    },
+    "Abbreviated street type": {"property_location": "266 Gower St Preston"},
 }
 API_URL = "https://services-ap1.arcgis.com/1WJBRkF3v1EEG5gz/arcgis/rest/services/Waste_Collection_Date3/FeatureServer/0/query"
+_ARG = "property_location"
+
+# EZI_ADDRESS is the Vicmap address string: upper case, no commas, street type
+# spelled out, suburb then postcode ("266 GOWER STREET PRESTON 3072"). The
+# query below is a prefix LIKE against it, so a comma, a "VIC", or an
+# abbreviated street type matches nothing at all -- which is most of what
+# visitors actually type.
+_STREET_TYPES = {
+    "AV": "AVENUE",
+    "AVE": "AVENUE",
+    "BVD": "BOULEVARD",
+    "BLVD": "BOULEVARD",
+    "CCT": "CIRCUIT",
+    "CL": "CLOSE",
+    "CR": "CRESCENT",
+    "CRES": "CRESCENT",
+    "CT": "COURT",
+    "DR": "DRIVE",
+    "ESP": "ESPLANADE",
+    "GDNS": "GARDENS",
+    "GR": "GROVE",
+    "GRV": "GROVE",
+    "HWY": "HIGHWAY",
+    "LN": "LANE",
+    "PDE": "PARADE",
+    "PL": "PLACE",
+    "RD": "ROAD",
+    "SQ": "SQUARE",
+    "ST": "STREET",
+    "TCE": "TERRACE",
+    "WY": "WAY",
+}
+_STATES = {"VIC", "VICTORIA"}
+
+# Enough to show the visitor which property they meant, without pulling the
+# whole municipality back when someone searches for a bare street name.
+_MAX_SUGGESTIONS = 10
+
 WEEKDAY_MAP = {
     "Monday": 0,
     "Tuesday": 1,
@@ -31,35 +78,103 @@ WEEKDAY_MAP = {
 }
 
 
+def _normalise(value: str) -> str:
+    """Upper case, drop commas and collapse whitespace."""
+    return " ".join(value.upper().replace(",", " ").split())
+
+
+def _register_form(value: str) -> str:
+    """What the visitor typed, written the way EZI_ADDRESS holds it."""
+    words = [_STREET_TYPES.get(word, word) for word in _normalise(value).split()]
+    while words and words[-1] in _STATES:
+        words.pop()
+    return " ".join(words)
+
+
+def _prefixes(value: str) -> list[str]:
+    """Progressively shorter prefixes of the address, longest first.
+
+    EZI_ADDRESS ends with the suburb and postcode, and a visitor who gets
+    either of those slightly wrong (or omits them) would otherwise match
+    nothing. Shortening the prefix recovers the match; the caller still has to
+    decide what to do when more than one property comes back.
+    """
+    address = _register_form(value)
+    words = address.split()
+    candidates = [address]
+    # Trailing postcode, then the suburb one word at a time, never past the
+    # street number and street name.
+    if words and words[-1].isdigit() and len(words[-1]) == 4:
+        words = words[:-1]
+        candidates.append(" ".join(words))
+    while len(words) > 2:
+        words = words[:-1]
+        candidates.append(" ".join(words))
+    return list(dict.fromkeys(c for c in candidates if c))
+
+
 class Source:
     def __init__(self, property_location: str):
         self.property_location = property_location
 
+    def _query(self, where: str, out_fields: str, **extra) -> list[dict]:
+        params = {"where": where, "outFields": out_fields, "f": "json", **extra}
+        r = requests.get(API_URL, params=params)
+        r.raise_for_status()
+        return r.json().get("features") or []
+
+    def _resolve_object_id(self) -> int:
+        wanted = _register_form(self.property_location)
+        for prefix in _prefixes(self.property_location):
+            # ArcGIS `where` is SQL-ish, so a quote in the address (O'Hea
+            # Street) would otherwise end the literal early.
+            escaped = prefix.replace("'", "''")
+            features = self._query(
+                f"UPPER(EZI_ADDRESS) LIKE '{escaped}%'",
+                "EZI_ADDRESS,OBJECTID",
+                resultRecordCount=_MAX_SUGGESTIONS + 1,
+            )
+            if not features:
+                continue
+
+            exact = [
+                f
+                for f in features
+                if _normalise(f["attributes"]["EZI_ADDRESS"]) == wanted
+            ]
+            if len(exact) == 1:
+                return exact[0]["attributes"]["OBJECTID"]
+            if len(features) == 1:
+                return features[0]["attributes"]["OBJECTID"]
+
+            raise SourceArgAmbiguousWithSuggestions(
+                _ARG,
+                self.property_location,
+                [f["attributes"]["EZI_ADDRESS"] for f in features[:_MAX_SUGGESTIONS]],
+            )
+
+        raise SourceArgumentNotFound(
+            _ARG,
+            self.property_location,
+            "Darebin holds addresses as street number, street name, suburb and "
+            "postcode, for example '266 Gower Street PRESTON 3072'.",
+        )
+
     def fetch(self) -> list[Collection]:
-        params = {
-            "where": f"EZI_ADDRESS LIKE '{self.property_location}%'",
-            "outFields": "EZI_ADDRESS,OBJECTID",
-            "f": "json",
-        }
-        r = requests.get(API_URL, params=params)
-        r.raise_for_status()
+        object_id = self._resolve_object_id()
 
-        data = r.json()
-        features = data.get("features")
-        attributes = features[0]["attributes"]
-        object_id = attributes["OBJECTID"]
-
-        params = {
-            "f": "json",
-            "objectIds": object_id,
-            "outFields": "Collection_Day,Condition,EZI_ADDRESS,Green_Collection,Recycle_Collection,Street_Sweeping",
-        }
-
-        r = requests.get(API_URL, params=params)
-        r.raise_for_status()
-
-        data = r.json()
-        features = data.get("features")
+        features = self._query(
+            "1=1",
+            "Collection_Day,Condition,EZI_ADDRESS,Green_Collection,"
+            "Recycle_Collection,Street_Sweeping",
+            objectIds=object_id,
+        )
+        if not features:
+            raise SourceArgumentNotFound(
+                _ARG,
+                self.property_location,
+                "Darebin found the address but holds no collection details for it.",
+            )
         attributes = features[0]["attributes"]
 
         collection_day = attributes["Collection_Day"]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/darebin_vic_gov_au.py
@@ -31,6 +31,17 @@ TEST_CASES = {
 API_URL = "https://services-ap1.arcgis.com/1WJBRkF3v1EEG5gz/arcgis/rest/services/Waste_Collection_Date3/FeatureServer/0/query"
 _ARG = "property_location"
 
+PARAM_TRANSLATIONS = {
+    "en": {
+        "property_location": "Property location",
+    }
+}
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "property_location": "Address as held by the council's address register: street number, street name, suburb and postcode, for example '266 Gower Street PRESTON 3072'.",
+    }
+}
+
 # EZI_ADDRESS is the Vicmap address string: upper case, no commas, street type
 # spelled out, suburb then postcode ("266 GOWER STREET PRESTON 3072"). The
 # query below is a prefix LIKE against it, so a comma, a "VIC", or an

--- a/doc/source/darebin_vic_gov_au.md
+++ b/doc/source/darebin_vic_gov_au.md
@@ -30,4 +30,6 @@ waste_collection_schedule:
 
 ## How to get the source arguments
 
-Visit the [City of Darebin Find my bin collection day page](https://darebin.maps.arcgis.com/apps/instant/basic/index.html?appid=51d4de7339f84dd5a6d2790cb2081be2) page and search for your address.  The argument should exactly match the result shown for Address portion of the Property Information.
+Visit the [City of Darebin Find my bin collection day page](https://darebin.maps.arcgis.com/apps/instant/basic/index.html?appid=51d4de7339f84dd5a6d2790cb2081be2) page and search for your address. The safest value is the Address shown in the Property Information panel, for example `266 Gower Street PRESTON 3072`.
+
+Common variations are accepted as well: commas, a trailing `VIC`/`VICTORIA` and abbreviated street types (`St`, `Rd`, `Ave`, ...) are rewritten to the form the council's address register holds, and a missing or slightly wrong suburb/postcode is retried with a shorter prefix. If several properties match, the error message lists the matching addresses so you can copy the right one.


### PR DESCRIPTION
Two problems, both hit on ordinary input.

### The register form is not what people type

The query is a prefix `LIKE` against `EZI_ADDRESS`, the Vicmap address string: upper case, no commas, street type spelled out, suburb then postcode (`266 GOWER STREET PRESTON 3072`). A comma, an added "VIC", or an abbreviated street type therefore matches nothing:

```
"266 Gower Street PRESTON 3072"        4 collections   (the existing test case)
"266 Gower Street, Preston VIC 3072"   no match
"266 Gower St Preston"                 no match
```

The address is now rewritten into the register's own form (commas dropped, street type expanded, trailing state removed) and tried as progressively shorter prefixes, so a slightly-off suburb or a missing postcode still resolves.

### No match crashed

`features[0]` on an empty result set raised `list index out of range`, which tells the visitor nothing. Now:

- more than one candidate → `SourceArgAmbiguousWithSuggestions` listing the matching addresses;
- none → `SourceArgumentNotFound` explaining the format the council holds.

The second request (by `OBJECTID`) is guarded the same way.

### Quoting

Single quotes in the address are escaped. The `where` clause is SQL-ish, so `O'Hea Street` used to end the string literal early and take the whole query with it.

### Testing

Both existing test cases still pass, plus two new ones for the shapes that used to fail. All four pass against the live council.