### PR TITLE
fix(cbcity_nsw_gov_au): match the address on a normalised form

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cbcity_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cbcity_nsw_gov_au.py
@@ -27,10 +27,56 @@ ICON_MAP = {
 
 CACHE_DURATION = 30 * 24 * 60 * 60  # 30 days
 
+# fullAddress is held as "102 Crinan Street, Hurlstone Park 2193": comma before
+# the suburb, street type spelled out, postcode but no state. Matching on that
+# string verbatim meant a missing comma, an added "NSW" or an abbreviated
+# street type found nothing, so both sides are compared on the form below.
+STREET_TYPES = {
+    "AV": "AVENUE",
+    "AVE": "AVENUE",
+    "BVD": "BOULEVARD",
+    "BLVD": "BOULEVARD",
+    "CCT": "CIRCUIT",
+    "CL": "CLOSE",
+    "CR": "CRESCENT",
+    "CRES": "CRESCENT",
+    "CT": "COURT",
+    "DR": "DRIVE",
+    "ESP": "ESPLANADE",
+    "GDNS": "GARDENS",
+    "GR": "GROVE",
+    "GRV": "GROVE",
+    "HWY": "HIGHWAY",
+    "LN": "LANE",
+    "PDE": "PARADE",
+    "PKWY": "PARKWAY",
+    "PL": "PLACE",
+    "RD": "ROAD",
+    "RSE": "RISE",
+    "SQ": "SQUARE",
+    "ST": "STREET",
+    "TCE": "TERRACE",
+    "WY": "WAY",
+}
+_STATES = {"NSW", "NEW SOUTH WALES"}
+
+
+def _normalise(value: str) -> str:
+    """Compare-ready form: upper case, no commas or slashes, no state."""
+    text = value.upper().replace(",", " ").replace("/", " ")
+    words = [STREET_TYPES.get(word, word) for word in text.split()]
+    return " ".join(word for word in words if word not in _STATES)
+
+
 TEST_CASES = {
     "Tab 1 Zone A": {
         "address": "102 Crinan Street, Hurlstone Park 2193",
     },
+    # The shapes people type: no comma, an added state, an abbreviated
+    # street type. None of them matched before.
+    "No comma": {"address": "102 Crinan Street Hurlstone Park 2193"},
+    "With state": {"address": "102 Crinan Street, Hurlstone Park NSW 2193"},
+    "Abbreviated street type": {"address": "102 Crinan St Hurlstone Park"},
     "Tab 1 Zone B": {
         "address": "1 / 1 Aster Avenue, Punchbowl 2196",
     },
@@ -302,6 +348,7 @@ class Source:
 
     def __init__(self, address: str):
         self._address = address.strip().lower()
+        self._wanted = _normalise(address)
 
     @classmethod
     def _is_cache_valid(cls) -> bool:
@@ -364,10 +411,22 @@ class Source:
         for row in data:
             if row.get("fullAddress", "").lower() == self._address:
                 return row
+
+        # Compare on the normalised form, so a missing comma, an added state
+        # or an abbreviated street type still finds the property.
+        normalised = [(row, _normalise(row.get("fullAddress", ""))) for row in data]
+        exact = [row for row, full in normalised if full == self._wanted]
+        if len(exact) == 1:
+            return exact[0]
+        if exact:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "address",
+                self._address,
+                [row["fullAddress"] for row in exact[:10]],
+            )
+
         # Try partial match
-        partial = [
-            row for row in data if self._address in row.get("fullAddress", "").lower()
-        ]
+        partial = [row for row, full in normalised if self._wanted in full]
         if len(partial) == 1:
             return partial[0]
         if partial:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cbcity_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cbcity_nsw_gov_au.py
@@ -58,25 +58,24 @@ STREET_TYPES = {
     "TCE": "TERRACE",
     "WY": "WAY",
 }
-_STATES = {"NSW", "NEW SOUTH WALES"}
+_STATE = "NSW"
+_STATE_SPELLED_OUT = "NEW SOUTH WALES"
 
 
 def _normalise(value: str) -> str:
     """Compare-ready form: upper case, no commas or slashes, no state."""
     text = value.upper().replace(",", " ").replace("/", " ")
+    # Collapse the spelled-out state first: the filter below is word by word,
+    # so it can only drop the state once it is a single token.
+    text = " ".join(text.split()).replace(_STATE_SPELLED_OUT, _STATE)
     words = [STREET_TYPES.get(word, word) for word in text.split()]
-    return " ".join(word for word in words if word not in _STATES)
+    return " ".join(word for word in words if word != _STATE)
 
 
 TEST_CASES = {
     "Tab 1 Zone A": {
         "address": "102 Crinan Street, Hurlstone Park 2193",
     },
-    # The shapes people type: no comma, an added state, an abbreviated
-    # street type. None of them matched before.
-    "No comma": {"address": "102 Crinan Street Hurlstone Park 2193"},
-    "With state": {"address": "102 Crinan Street, Hurlstone Park NSW 2193"},
-    "Abbreviated street type": {"address": "102 Crinan St Hurlstone Park"},
     "Tab 1 Zone B": {
         "address": "1 / 1 Aster Avenue, Punchbowl 2196",
     },
@@ -101,6 +100,14 @@ TEST_CASES = {
     "Tab 6": {
         "address": "32 Kitchener Parade, Bankstown 2200",
     },
+    # The shapes people type: no comma, an added state (abbreviated or spelled
+    # out), an abbreviated street type. None of them matched before.
+    "Address without comma": {"address": "102 Crinan Street Hurlstone Park 2193"},
+    "Address with state": {"address": "102 Crinan Street, Hurlstone Park NSW 2193"},
+    "Address with state spelled out": {
+        "address": "102 Crinan Street, Hurlstone Park New South Wales 2193",
+    },
+    "Address with abbreviated street type": {"address": "102 Crinan St Hurlstone Park"},
 }
 
 WEEKDAY_MAP = {name: i for i, name in enumerate(calendar.day_name)}


### PR DESCRIPTION
`fullAddress` is held as `102 Crinan Street, Hurlstone Park 2193`: comma before the suburb, street type spelled out, postcode but no state. Matching against that string verbatim (or as a substring of it) meant three of the most ordinary things a person types found nothing at all:

```
"102 Crinan Street Hurlstone Park 2193"       no comma            -> no match
"102 Crinan Street, Hurlstone Park NSW 2193"  added state         -> no match
"102 Crinan St Hurlstone Park"                abbreviated type    -> no match
```

The whole street list is already downloaded, so both sides can simply be compared on a normalised form: upper case, commas and unit slashes dropped, street-type abbreviations expanded, state removed.

The verbatim check is kept ahead of it, and the partial-match and suggestion behaviour is unchanged apart from running on the normalised text too.

### Testing

All nine existing test cases still pass, plus three new ones for the shapes above, against the live data file.