### PR TITLE
fix(folkestone_hythe_gov_uk): report an unknown UPRN instead of crashing

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/folkestone_hythe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/folkestone_hythe_gov_uk.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "Folkestone and Hythe District Councol"
 DESCRIPTION = "Source for Folkestone and Hythe District Council, United Kingdom."
@@ -31,13 +32,27 @@ class Source:
         r.raise_for_status()
 
         soup = BeautifulSoup(r.text, "html.parser")
-        bin_tab = soup.findAll("div", {"id": "bincollections"})
-        waste_types = bin_tab[0].findAll("span", {"class": "bold"})
-        schedules = bin_tab[0].findAll("ul")
+        bin_tab = soup.find("div", {"id": "bincollections"})
+        if bin_tab is None:
+            # The page answers 200 with no collections panel at all for a UPRN
+            # the council does not hold. Subscripting the empty result set
+            # raised "list index out of range", which tells the visitor
+            # nothing about what to correct.
+            raise SourceArgumentNotFound(
+                "uprn",
+                self._uprn,
+                "Folkestone and Hythe returned no bin collections for this "
+                "UPRN. Check it against the council's own address search.",
+            )
+        waste_types = bin_tab.findAll("span", {"class": "bold"})
+        schedules = bin_tab.findAll("ul")
 
         entries = []
 
         for idx, item in enumerate(waste_types):
+            if idx >= len(schedules):
+                # A waste type listed with no dates beneath it.
+                continue
             for li in schedules[idx].findAll("li"):
                 entries.append(
                     Collection(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/folkestone_hythe_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/folkestone_hythe_gov_uk.py
@@ -35,14 +35,14 @@ class Source:
         bin_tab = soup.find("div", {"id": "bincollections"})
         if bin_tab is None:
             # The page answers 200 with no collections panel at all for a UPRN
-            # the council does not hold. Subscripting the empty result set
-            # raised "list index out of range", which tells the visitor
-            # nothing about what to correct.
+            # the council does not hold, so there is nothing to index into.
             raise SourceArgumentNotFound(
                 "uprn",
                 self._uprn,
-                "Folkestone and Hythe returned no bin collections for this "
-                "UPRN. Check it against the council's own address search.",
+                "Folkestone and Hythe returned no bin collections panel for "
+                "this UPRN. Check it against the council's own address "
+                "search; if the UPRN is correct there, the council has "
+                "probably changed its page layout - please open an issue.",
             )
         waste_types = bin_tab.findAll("span", {"class": "bold"})
         schedules = bin_tab.findAll("ul")


### PR DESCRIPTION
The council's page answers 200 with no `#bincollections` panel at all for a UPRN it does not hold, so `findAll("div", {"id": "bincollections"})[0]` raised `list index out of range` — which tells the visitor nothing about what to correct. Both of the source's own test UPRNs currently produce it.

This uses `find()` and says what happened when the panel is absent, and skips a waste type listed with no dates beneath it rather than indexing past the end of `schedules`.

**This does not restore the lookup for those two UPRNs.** `service.folkestone-hythe.gov.uk` is served to UK addresses only, and from outside the UK the connection is dropped, so whether the page changed shape or the test UPRNs went stale could not be established here. The error now says which of those it is rather than hiding it behind an IndexError — if a UK-based maintainer can check the two test UPRNs against the council's own address search, that would settle it and I am happy to follow up with the real fix.