### PR TITLE
fix(was_wolfsburg_de): handle new nested 'behaelter' response format

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/was_wolfsburg_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/was_wolfsburg_de.py
@@ -49,14 +49,25 @@ class Source:
         r.raise_for_status()
         answer = r.json()
 
-        for name, icon in ICON_MAP.items():
-            for a in answer[0][name]:
-                entries.append(
-                    Collection(
-                        date=datetime.strptime(a, "%Y-%m-%d").date(),
-                        t=name,
-                        icon=icon,
+        # As of early September 2026 the API wraps the collection dates in a
+        # "behaelter" (container) dict keyed by container size, instead of
+        # returning a flat list as the top-level element. See
+        # https://github.com/mampfes/hacs_waste_collection_schedule/issues/7076
+        if not isinstance(answer, dict) or not answer:
+            raise ValueError(f"No data found for '{self._street} {self._number}'")
+
+        entry = next(iter(answer.values()))
+        behaelter = entry.get("behaelter", {})
+
+        for container in behaelter.values():
+            for name, icon in ICON_MAP.items():
+                for date_str in container.get(name, {}):
+                    entries.append(
+                        Collection(
+                            date=datetime.strptime(date_str, "%Y-%m-%d").date(),
+                            t=name,
+                            icon=icon,
+                        )
                     )
-                )
 
         return entries


### PR DESCRIPTION
## Problem

The WAS Wolfsburg API (`abfuhrtermine.waswob.de`) changed its JSON response structure again in early September 2026, shortly after #7155 was merged (23.08.2026) to fix the previous format change. The API now returns collection dates nested under a per-address dict with a `behaelter` (container) key, keyed by container size:

```json
{
  "<Straße>_<Hausnummer>": {
    ...,
    "behaelter": {
      "<size>": {
        "Restabfall": ["2026-09-05", ...],
        "Bioabfall": [...],
        ...
      }
    }
  }
}
```

instead of the flat `answer[0][name]` structure the current code expects. This causes every fetch to raise `KeyError: 0`.

## Fix

Updated `fetch()` to read the new nested structure: take the first (only) address entry from the response dict, read its `behaelter` dict, and iterate collection dates per container/waste type from there.

## Testing

Reproduced the `KeyError: 0` against the live API with a real Wolfsburg address (Hilkeroder Weg), confirmed the new nested `behaelter` response shape via a direct API call, and verified the updated `fetch()` logic parses it correctly.

## Related

- Fixes #7076
- Continuation of the fix from #7155 — that PR correctly fixed the *previous* API change (moving off the old token/session-based scraper) but the API has since changed its response shape again.