### PR TITLE
Fix/issue 7306 gmina sroda slaska

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gmina_sroda_slaska_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gmina_sroda_slaska_pl.py
@@ -1,57 +1,90 @@
 import datetime
 
 import requests
-from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons
 
 TITLE = "Gmina Środa Śląska"
 DESCRIPTION = "Source for Gmina Środa Śląska, Poland"
-URL = "https://waste-collection.sciana.pro"
+URL = "https://srodowisko.srodaslaska.pl/gospodarka-odpadami/harmonogram-odbioru-odpadow-komunalnych/"
+SCHEDULE_URL = "https://www.com-d.pl/komunalne/harm/sroda-slaska"
+COUNTRY = "pl"
 TEST_CASES = {
-    "Ciechów": {"location_id": 3},
+    "Szczepanów": {"location": "szczepanow"},
 }
 
 ICON_MAP = {
-    "Zmieszane komunalne": Icons.GENERAL_WASTE,
-    "Tworzywa sztuczne": Icons.RECYCLING,
-    "Odpady kuchenne ulegające biodegradacji": Icons.BIO_KITCHEN,
-    "Papier": Icons.PAPER,
-    "Szkło": Icons.GLASS,
-    "Odpady wielkogabarytowe": Icons.BULKY,
+    "1xmc-odpady-szklo": Icons.GLASS,
+    "inne-odpady-rozne": Icons.TEXTILE,
+    "inne-odpady-zbiorki": Icons.BULKY,
+    "inne-odpady-papier": Icons.PAPER,
+    "t-odpady-biodegradowalne": Icons.ORGANIC,
+    "t-odpady-zmieszane": Icons.GENERAL_WASTE,
+    "tp-odpady-metaletworzywa": Icons.RECYCLING,
 }
 
-API_URL = "https://waste-collection.sciana.pro/api/v1/"
-API_URL_JSON = ".json"
-
-HOW_TO_GET_ARGUMENTS_DESCRIPTION = {  # Optional dictionary to describe how to get the arguments, will be shown in the GUI configuration form above the input fields, does not need to be translated in all languages
-    "en": "To get your LOCATION_ID go to https://waste-collection.sciana.pro and search for your address.",
+TYPE_MAP = {
+    "1xmc-odpady-szklo": "Szkło",
+    "inne-odpady-rozne": "Tekstylia i odzież",
+    "inne-odpady-zbiorki": "Odpady wielkogabarytowe",
+    "inne-odpady-papier": "Papier",
+    "t-odpady-biodegradowalne": "Odpady biodegradowalne",
+    "t-odpady-zmieszane": "Zmieszane odpady komunalne",
+    "tp-odpady-metaletworzywa": "Metale i tworzywa sztuczne",
 }
 
-PARAM_DESCRIPTIONS = {  # Optional dict to describe the arguments, will be shown in the GUI configuration below the respective input field
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": "Visit https://www.com-d.pl/komunalne/harm/sroda-slaska, select your locality or Środa Śląska district, and enter the final part of its URL.",
+}
+
+PARAM_DESCRIPTIONS = {
     "en": {
-        "location_id": "Unique location id (LOCATION_ID)",
+        "location": "Locality or district URL slug from the COM-D schedule page",
     },
 }
 
 
 class Source:
-    def __init__(self, location_id):
-        self._location_id = location_id
+    def __init__(self, location):
+        self._location = location
 
     def fetch(self):
-        api_response = requests.get(API_URL + str(self._location_id) + API_URL_JSON)
-
         entries = []
+        seen = set()
+        response = requests.get(f"{SCHEDULE_URL}/{self._location}", timeout=30)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
 
-        kinds = api_response.json()["data"]["garbage_kinds"]
+        schedule_table = next(
+            table
+            for table in soup.find_all("table")
+            if table.find("th", string="Frakcja")
+        )
+        category_urls = {
+            link["href"] for link in schedule_table.select('a[href*="/sroda-slaska/"]')
+        }
 
-        for k in kinds:
-            name = k["name"]
-            for d in k["disposals"]:
+        for category_url in category_urls:
+            category = category_url.rsplit("/", 1)[-1]
+            category_response = requests.get(
+                f"https://www.com-d.pl{category_url}", timeout=30
+            )
+            category_response.raise_for_status()
+            category_soup = BeautifulSoup(category_response.text, "html.parser")
+
+            for collection_day in category_soup.select("td.highlighted[data-date]"):
+                collection_date = datetime.datetime.strptime(
+                    collection_day["data-date"], "%Y-%m-%d"
+                ).date()
+                entry = (collection_date, category)
+                if entry in seen:
+                    continue
+                seen.add(entry)
                 entries.append(
                     Collection(
-                        date=datetime.datetime.strptime(d["date"], "%Y-%m-%d").date(),
-                        t=name.capitalize(),
-                        icon=ICON_MAP.get(name),
+                        date=collection_date,
+                        t=TYPE_MAP.get(category, category.capitalize()),
+                        icon=ICON_MAP.get(category),
                     )
                 )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/gmina_sroda_slaska_pl.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/gmina_sroda_slaska_pl.py
@@ -3,14 +3,23 @@ import datetime
 import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+    SourceArgumentRequired,
+)
 
 TITLE = "Gmina Środa Śląska"
 DESCRIPTION = "Source for Gmina Środa Śląska, Poland"
 URL = "https://srodowisko.srodaslaska.pl/gospodarka-odpadami/harmonogram-odbioru-odpadow-komunalnych/"
-SCHEDULE_URL = "https://www.com-d.pl/komunalne/harm/sroda-slaska"
 COUNTRY = "pl"
+
+BASE_URL = "https://www.com-d.pl"
+SCHEDULE_URL = f"{BASE_URL}/komunalne/harm/sroda-slaska"
+
 TEST_CASES = {
     "Szczepanów": {"location": "szczepanow"},
+    "Środa Śląska I rejon": {"location": "sroda-slaska-i-rejon"},
+    "Ciechów": {"location": "ciechow"},
 }
 
 ICON_MAP = {
@@ -37,38 +46,104 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": "Visit https://www.com-d.pl/komunalne/harm/sroda-slaska, select your locality or Środa Śląska district, and enter the final part of its URL.",
 }
 
-PARAM_DESCRIPTIONS = {
+PARAM_TRANSLATIONS = {
     "en": {
-        "location": "Locality or district URL slug from the COM-D schedule page",
+        "location": "Location",
+        "location_id": "Location ID (obsolete)",
+    },
+    "de": {
+        "location": "Ort",
+        "location_id": "Orts-ID (veraltet)",
     },
 }
 
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "location": "Locality or district URL slug from the COM-D schedule page",
+        "location_id": "No longer supported, use 'location' instead",
+    },
+    "de": {
+        "location": "URL-Kürzel des Ortes bzw. Stadtteils von der COM-D Abfuhrplan-Seite",
+        "location_id": "Wird nicht mehr unterstützt, bitte stattdessen 'location' verwenden",
+    },
+}
+
+HOW_TO_GET_LOCATION = (
+    f"open {SCHEDULE_URL}, select your locality or Środa Śląska district and use the "
+    "last part of its URL"
+)
+LEGACY_ARGUMENT_REASON = (
+    "the waste collection provider changed, so the old 'location_id' groups no longer "
+    f"exist; {HOW_TO_GET_LOCATION}"
+)
+
+
+def _get_locations(session: requests.Session) -> list[str]:
+    """Return all locality/district slugs published by COM-D."""
+    response = session.get(SCHEDULE_URL, timeout=30)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    return sorted(
+        {
+            link["href"].rsplit("/", 1)[-1]
+            for link in soup.find_all("a", href=True)
+            if "sroda-slaska/" in link["href"]
+        }
+    )
+
 
 class Source:
-    def __init__(self, location):
-        self._location = location
+    def __init__(
+        self, location: str | None = None, location_id: str | int | None = None
+    ):
+        # location_id was used by the previous provider. Its values grouped several
+        # localities together and cannot be mapped to a COM-D location automatically,
+        # so existing configurations get a helpful message instead of a TypeError.
+        if not location:
+            raise SourceArgumentRequired(
+                "location",
+                LEGACY_ARGUMENT_REASON
+                if location_id is not None
+                else HOW_TO_GET_LOCATION,
+            )
+        self._location: str = location
 
-    def fetch(self):
-        entries = []
-        seen = set()
-        response = requests.get(f"{SCHEDULE_URL}/{self._location}", timeout=30)
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+
+        response = session.get(f"{SCHEDULE_URL}/{self._location}", timeout=30)
+        if response.status_code == 404:
+            raise SourceArgumentNotFoundWithSuggestions(
+                "location", self._location, _get_locations(session)
+            )
         response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
 
         schedule_table = next(
-            table
-            for table in soup.find_all("table")
-            if table.find("th", string="Frakcja")
+            (
+                table
+                for table in soup.find_all("table")
+                if table.find("th", string="Frakcja")
+            ),
+            None,
         )
+        if schedule_table is None:
+            raise ValueError(
+                "Could not find a collection schedule for the location "
+                f"'{self._location}' at {SCHEDULE_URL}/{self._location}. "
+                "The website layout may have changed."
+            )
+
         category_urls = {
             link["href"] for link in schedule_table.select('a[href*="/sroda-slaska/"]')
         }
 
-        for category_url in category_urls:
+        entries: list[Collection] = []
+        seen = set()
+
+        for category_url in sorted(category_urls):
             category = category_url.rsplit("/", 1)[-1]
-            category_response = requests.get(
-                f"https://www.com-d.pl{category_url}", timeout=30
-            )
+            category_response = session.get(f"{BASE_URL}{category_url}", timeout=30)
             category_response.raise_for_status()
             category_soup = BeautifulSoup(category_response.text, "html.parser")
 

--- a/doc/source/gmina_sroda_slaska_pl.md
+++ b/doc/source/gmina_sroda_slaska_pl.md
@@ -2,9 +2,9 @@
 
 Waste collection for Gmina Środa Śląska.
 
-All data  based on source: [https://srodowisko.srodaslaska.pl/gospodarka-odpadami/harmonogram-odbioru-odpadow-komunalnych/](https://srodowisko.srodaslaska.pl/gospodarka-odpadami/harmonogram-odbioru-odpadow-komunalnych/).
+The [Gmina Środa Śląska schedule page](https://srodowisko.srodaslaska.pl/gospodarka-odpadami/harmonogram-odbioru-odpadow-komunalnych/) is the official source. It currently directs residents to the COM-D schedule service; the collection provider may change in the future.
 
-Support by [github issues](https://github.com/ksciana/waste_collection/issues).
+Support by [GitHub issues](https://github.com/mampfes/hacs_waste_collection_schedule/issues).
 
 ## Configuration via configuration.yaml
 ```yaml
@@ -12,12 +12,14 @@ waste_collection_schedule:
   sources:
     - name: gmina_sroda_slaska_pl
       args:
-        location_id: LOCATION_ID
+        location: LOCATION
 ```
+
+Existing `location_id` configurations cannot be migrated automatically because they identify groups of locations rather than a single COM-D schedule. Replace `location_id` with the location slug for your own locality or district.
 
 ### Configuration Variables
 
-**location_id**  
+**location**
 *(string) (required)*
 
 ## Example
@@ -27,18 +29,9 @@ waste_collection_schedule:
   sources:
     - name: gmina_sroda_slaska_pl
       args:
-        location_id: 3
+        location: szczepanow
 ```
 
 ## How to get the source arguments
 
-Replace `LOCATION_ID` with following `Id`:
-
-| Id | Location | Details |
-| --: | --- | --- |
-| 1 | Środa Śląska 1 |  DLA NIERUCHOMOŚCI JEDNORODZINNYCH: Cmentarna, Czereśniowa, Daszyńskiego, Górna, Gruszkowa, Jabłkowa, Kajakowa, Kilińskiego,Konstytucji 3 Maja,Korczaka, Łąkowa,Mleczarska, Morelowa, Parkowa,Partyzantów, Plac Solny, Plac Wolności, Spokojna, Stawowa,Strzelecka,Śliwkowa, Wąska, Wierzbowa,Winogronowa, Wrocławska, Zaciszna,0Baczyńskiego, Basztowa Al., Białoskornicza, Boya-Żeleńskiego,Brodatgeo H., Chwalimierska, Dojazdowa, Flamandzka, Floriańska, Jana ze Środy, Karnasa,Kopernika, Korwina, Kościuszki, Kościelna,  Księżnej Jadwigi, Księżycowa, Łanowa, Mickiewicza, Ogrodowa,Oławska, Piastów Śląskich, Przyszkolna, Rakoszycka, Różana, Skłodowskiej-Curie, skwer Zesłańców Sybiru, Słoneczna, Słowackiego, Szkolna, Śląska, Willowa, Winnicza,Wiśniowa, Żwirki i Wigury |
-| 2 | Ogrodnica,  Proszków | |
-| 3 | Bukówek, Cesarzowice, Chwalimierz, Ciechów, Ligotka, Michałów,  Pęczków,  Wrocisławice | |
-| 4 | Brodno, Jastrzębce, Kobylniki, Lipnica, Lisiny, Odyniec, Rzeczyca, Słup, Szczepanów, Zakrzów | |
-| 5 | Środa Śląska 2 |  DLA NIERUCHOMOŚCI JEDNORODZINNYCH: Bluszczowa, Bociania, Chabrowa, Dworcowa, Fiołkowa, Goździkowa,Irysowa, Jastrzębia, Konwaliowa, Krucza,Legnicka, Leśna, Makowa, Miłosza, Mostowa, Nasturcjowa, Ogrodnicka,Orla, Reymonta, Rumiankowa, Sokola, Spółdzielcza, Storczykowa,Świdnicka,  św. Andrzeja, trakt św. Jakuba, Targowa, Tulipanowa, Waniliowa, Wiejska, Wrzosowa, Żurawia,01 Maja, Akacjowa, Do Termatu, Dębowa, Działkowa, Hallera, Jarzębinowa,Jaśminowa, Jesionowa, Kasztanowa,Klonowa, Kolejowa, Lipnicka, Lipowa, Malczycka,Miła, Młynarska, Na Polance, Ogrody Zamkowe, Traugutta, Sikorskiego, Spacerowa, Stacyjna, Topolowa, Żytnia |
-| 6 | Gozdawa, Jugowiec Juszczyn, Komorniki, Kryniczno,Kulin, Przedmoście, Święte, Rakoszyce, Wojczyce | |
+Open the COM-D schedule linked from the [Gmina Środa Śląska schedule page](https://srodowisko.srodaslaska.pl/gospodarka-odpadami/harmonogram-odbioru-odpadow-komunalnych/), choose your locality or Środa Śląska district, and copy the last part of its URL. For example, use `szczepanow` for `https://www.com-d.pl/komunalne/harm/sroda-slaska/szczepanow`.

--- a/doc/source/gmina_sroda_slaska_pl.md
+++ b/doc/source/gmina_sroda_slaska_pl.md
@@ -19,8 +19,10 @@ Existing `location_id` configurations cannot be migrated automatically because t
 
 ### Configuration Variables
 
-**location**
+**location**  
 *(string) (required)*
+
+The URL slug of your locality or Środa Śląska district on the COM-D schedule page, for example `szczepanow`.
 
 ## Example
 


### PR DESCRIPTION
## Summary

Fixes #7306

Updates the Gmina Środa Śląska source after the waste-collection provider changed.

The source now retrieves the current public schedule from COM-D, which is linked by the official Gmina Środa Śląska schedule page. The integration metadata and documentation reference the municipality page as the authoritative source.

The legacy `location_id` represented groups of locations, while COM-D publishes schedules per locality or district. Users therefore need to replace `location_id` with their COM-D URL slug, for example `location: szczepanow`.

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [x] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources (not applicable; existing documentation updated)
- [x] TEST_CASES use real, publicly accessible addresses (not my own)