### PR TITLE
Update API URL for waste collection schedule

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/thurrock_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/thurrock_gov_uk.py
@@ -49,7 +49,7 @@ ICON_MAP = {
 STREETS_BASE_URL = (
     "https://www.thurrock.gov.uk/household-bin-collection-days/street-names"
 )
-API_URL = "https://www.thurrock.gov.uk/household-bin-collection-days/household-bin-collection-weeks"
+API_URL = "https://www.thurrock.gov.uk/bindays"
 
 # Matches both ASCII hyphen-minus (-) and Unicode en-dash (–) with optional surrounding whitespace.
 DATE_RANGE_RE = re.compile(r"\s*[-–—]\s*")


### PR DESCRIPTION
fix(thurrock_gov_uk): use up-to-date weeks table URL

## Summary
The Thurrock source was scraping the old weeks page:
`https://www.thurrock.gov.uk/household-bin-collection-days/household-bin-collection-weeks`

That page is currently stale (only contains weeks up to 24–28 August), so the source returns no upcoming collections and sensors show as unavailable.

The up-to-date schedule is available at:
`https://www.thurrock.gov.uk/bindays`

This PR changes `API_URL` to the working page.

Related to #7237

## Type of change
- [x] Bug fix / source fix

## Checklist
- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses