### PR TITLE
fix(eastlothian_gov_uk): update collection URL to www.eastlothian.gov.uk

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastlothian_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/eastlothian_gov_uk.py
@@ -36,7 +36,7 @@ ICON_MAP = {
     "food waste": Icons.BIO_KITCHEN,
 }
 
-BASE_URL = "https://collectiondates.eastlothian.gov.uk"
+BASE_URL = "https://www.eastlothian.gov.uk"
 SCHEDULE_URL = f"{BASE_URL}/waste-collection-schedule"
 
 


### PR DESCRIPTION
## Summary

Fixes the broken **East Lothian** (`eastlothian_gov_uk`) source. East Lothian Council has moved its waste collection schedule off the dedicated `collectiondates.eastlothian.gov.uk` subdomain back onto the main council domain.

The old host's DNS record now CNAMEs to `collectiondates.eastlothian-gov-uk.bbdclients.net`, which has no A record, so the host no longer resolves and every fetch fails.

The schedule is now served at `https://www.eastlothian.gov.uk/waste-collection-schedule` (linked from the council's `/bins-waste-and-recycling` page). It returns the **same** Drupal LocalGov `localgov_waste_collection_postcode_form` — identical `form_build_id`, `postcode`, `op=Find` and `uprn` fields the source already parses — so only `BASE_URL` needs to change. No scrape/parse logic changes.

```diff
-BASE_URL = "https://collectiondates.eastlothian.gov.uk"
+BASE_URL = "https://www.eastlothian.gov.uk"
```

`SCHEDULE_URL` and the ICS download path (`{BASE_URL}/waste-collection-schedule/download/{uprn}`) derive from `BASE_URL`, so they follow automatically.

## Testing

All three `TEST_CASES` pass against the new host — 89 entries each:

```
found 89 entries for EH21 8GU 4 Laing Loan, Wallyford
found 89 entries for EH41 4LN Peterhouse, Morham, Haddington
found 89 entries for 1 Colliers Row Wallyford
```

`ruff check` / `ruff format --check` clean.

Fixes #7314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
