### PR TITLE
#7309 Fix canterbury_gov_uk.py source

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/canterbury_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/canterbury_gov_uk.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from datetime import datetime
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/canterbury_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/canterbury_gov_uk.py
@@ -26,7 +26,7 @@ HEADERS = {
 
 API_URLS = {
     "address_search": "https://trsewmllv7.execute-api.eu-west-2.amazonaws.com/dev/address",
-    "collection": "https://zbr7r13ke2.execute-api.eu-west-2.amazonaws.com/Beta/get-bin-dates",
+    "collection": "https://n6ljrw455m.execute-api.eu-west-2.amazonaws.com/prod/get-bin-dates",
 }
 
 ICON_MAP = {

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/canterbury_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/canterbury_gov_uk.py
@@ -90,7 +90,7 @@ class Source:
         )
         r.raise_for_status()
 
-        collectionsRaw = json.loads(r.json()["dates"])
+        collectionsRaw = r.json()["dates"]
         collections = {
             "General": collectionsRaw["blackBinDay"],
             "Recycling": collectionsRaw["recyclingBinDay"],


### PR DESCRIPTION
## Summary

Fixes the UK Canterbury Govt source to use the new Production API rather than the non-functional Beta API. 

## Type of change

- [ ] New source
- [x] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
