### PR TITLE
fix(memotri_agglo_pau_fr): post address search to /recherche-adresse/

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/memotri_agglo_pau_fr.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/memotri_agglo_pau_fr.py
@@ -1,5 +1,6 @@
 import re
 from datetime import date, timedelta
+from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
@@ -29,6 +30,8 @@ COUNTRY = "fr"
 
 GEOCODER_URL = "https://api-adresse.data.gouv.fr/search/"
 BASE_URL = "https://memotri.agglo-pau.fr"
+# Fallback if the home page's form does not expose an action attribute.
+SEARCH_PATH = "/recherche-adresse/"
 
 TEST_CASES = {
     "Pau - Avenue Larribau": {
@@ -116,8 +119,8 @@ class Source:
             )
         return ban_id, label
 
-    def _get_csrf_token(self, session: curl_requests.Session) -> str:
-        """Get CSRF token from the home page."""
+    def _get_search_form(self, session: curl_requests.Session) -> tuple[str, str]:
+        """Get the address search form's target URL and CSRF token from the home page."""
         r = session.get(BASE_URL + "/", timeout=15)
         if r.status_code == 404:
             raise SourceArgumentException(
@@ -132,7 +135,12 @@ class Source:
                 "address",
                 "Unable to retrieve CSRF token from the website. The site may be temporarily unavailable.",
             )
-        return csrf_input["value"]
+
+        # Read the target from the form holding the token so a future change
+        # of the endpoint does not break this source.
+        form = csrf_input.find_parent("form")
+        action = (form.get("action") or "").strip() if form else ""
+        return urljoin(BASE_URL + "/", action or SEARCH_PATH), csrf_input["value"]
 
     def _parse_schedule(
         self, schedule_text: str
@@ -171,11 +179,11 @@ class Source:
 
         session = curl_requests.Session(impersonate="chrome131")
 
-        csrf_token = self._get_csrf_token(session)
+        search_url, csrf_token = self._get_search_form(session)
 
         # Submit form: select2 value format is 'banId&label'
         r = session.post(
-            BASE_URL + "/",
+            search_url,
             data={
                 "csrfmiddlewaretoken": csrf_token,
                 "select_adresse": f"{ban_id}&{label}",


### PR DESCRIPTION
### Problem

`memotri_agglo_pau_fr` currently fails with *"Unable to fetch waste collection data"*.

The provider moved its address-search form off the site root:

```html
<form action="/recherche-adresse/" method="post" ...>
```

The source still posted the form to `/`, which now answers **HTTP 405 Method Not Allowed**, so `fetch()` raised before any parsing happened.

### Fix

Instead of swapping one hardcoded URL for another, the POST target is now read from the `action` attribute of the form that carries the CSRF token, with `/recherche-adresse/` as the fallback. This same class of change has broken the source twice now, so reading the endpoint from the page means the next move of it does not need a code change.

Geocoding (`api-adresse.data.gouv.fr`) and the result markup are untouched — the BAN-based lookup and the `memotri` divs still parse exactly as before.

### Note on the geocoder

The site's own JS has also switched to `data.geopf.fr`. I tested following suit and deliberately did **not**: for the same addresses the new geocoder returns a different `banId` that memotri rejects (0 results vs. 3), and for addresses without an exact house-number match it returns features with no `banId` at all. Switching would have been a silent regression, so the geocoding step stays as it is.

### Verification

- Both `TEST_CASES` fetch live: **133 entries** each for *Pau - Avenue Larribau* and *Idron - Rue de l'Industrie*.
- `ruff check` / `ruff format` clean.
- `python -m pytest tests/test_source_components.py` → 35 passed.

No generated files touched; one source file changed (+13/−5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUcmjPxm2KroGxq9Dy8D8R
