### PR TITLE
Add Monthey (VS) to localcities_ch

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/localcities_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/localcities_ch.py
@@ -51,6 +51,10 @@ TEST_CASES = {
         "municipality": "beinwil-am-see",
         "municipality_id": "5313",
     },
+    "Monthey (zoneless)": {
+        "municipality": "monthey",
+        "municipality_id": "8085",
+    },
 }
 
 EXTRA_INFO = [
@@ -115,6 +119,15 @@ EXTRA_INFO = [
         "default_params": {
             "municipality": "beinwil-am-see",
             "municipality_id": "5313",
+        },
+    },
+    {
+        "title": "Monthey",
+        "url": "https://www.monthey.ch",
+        "country": "ch",
+        "default_params": {
+            "municipality": "monthey",
+            "municipality_id": "8085",
         },
     },
 ]

--- a/doc/source/localcities_ch.md
+++ b/doc/source/localcities_ch.md
@@ -27,9 +27,9 @@ The municipality name as it appears in the localcities.ch URL.
 The numeric ID from the localcities.ch URL.
 
 **zone**
-*(string) (required)*
+*(string) (optional)*
 
-Your collection zone or locality name, as shown on the calendar page.
+Your collection zone or locality name, as shown on the calendar page. Omit it for municipalities without zones.
 
 ## How to find your arguments
 
@@ -61,4 +61,15 @@ waste_collection_schedule:
         municipality: grenchen
         municipality_id: 3533
         zone: "Zone Ost"
+```
+
+### Monthey (no zones)
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: localcities_ch
+      args:
+        municipality: monthey
+        municipality_id: 8085
 ```


### PR DESCRIPTION
Adds **Monthey** (Valais, Switzerland) to the existing `localcities_ch` source.

**Provider**
Monthey publishes its paper/cardboard collection dates on localcities.ch: https://www.localcities.ch/de/entsorgung/monthey/8085. The official calendar on https://www.monthey.ch/dechets is an image-only PDF, and household waste goes into underground Molok containers without collection dates, so paper is the only dated door-to-door collection. The municipality has no zones.

**How to obtain the parameters**
From the localcities.ch URL: `municipality: monthey`, `municipality_id: 8085`. No `zone` argument.

**Changes**
- `source/localcities_ch.py`: Monthey entry in `EXTRA_INFO` and a `TEST_CASES` entry.
- `doc/source/localcities_ch.md`: Monthey example, and the `zone` argument is now documented as optional, which matches `PARAM_DESCRIPTIONS` and the existing zoneless test cases.

**Tests**
- `python test_sources.py -s localcities_ch`: all 9 cases return entries; Monthey returns 7 paper dates (17.09.2026 to 17.12.2026).
- `python -m pytest tests/`: 39 passed.
- `ruff check` and `ruff format`: clean.
