### PR TITLE
feat(shoalhaven_nsw_gov_au): accept a street address, not only a Geolocation ID

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -56,6 +56,14 @@ class OpenCitiesConfig:
     argument_name: str = "address"
     """Exact ``Source.__init__`` kwarg name, used in raised exceptions."""
 
+    direct_argument_name: str | None = None
+    """
+    ``Source.__init__`` kwarg holding a geolocation id given instead of an
+    address, for the sources that accept one. Exceptions raised on that path
+    name this argument, so the config flow marks the field the visitor
+    actually filled in rather than the empty address one.
+    """
+
     search_fuzzy: bool = False
     """Use ``/api/v1/myarea/searchfuzzy`` instead of ``/api/v1/myarea/search``."""
 
@@ -228,10 +236,19 @@ class OpenCitiesClient:
             # The address resolved, but the council holds no waste service for
             # that property (vacant land, a commercial lot, a newly titled block
             # not yet on a run). Report the address the visitor gave rather than
-            # the internal geolocation GUID, which reads as nonsense to them.
+            # the internal geolocation GUID, which reads as nonsense to them --
+            # unless the GUID is what they gave, in which case name that
+            # argument so the config flow flags the field they filled in.
+            if address is not None:
+                argument_name, value = self._cfg.argument_name, address
+            else:
+                argument_name = (
+                    self._cfg.direct_argument_name or self._cfg.argument_name
+                )
+                value = geolocation_id
             raise SourceArgumentNotFound(
-                self._cfg.argument_name,
-                address if address is not None else geolocation_id,
+                argument_name,
+                value,
                 "The council lists no waste collection service for this "
                 "property. Check the address, or contact the council if it "
                 "should have a collection.",

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/shoalhaven_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/shoalhaven_nsw_gov_au.py
@@ -1,4 +1,5 @@
 from waste_collection_schedule import Collection, Icons
+from waste_collection_schedule.exceptions import SourceArgumentExceptionMultiple
 from waste_collection_schedule.service.OpenCities import (
     OpenCitiesClient,
     OpenCitiesConfig,
@@ -8,6 +9,11 @@ TITLE = "Shoalhaven City Council"
 DESCRIPTION = "Source script for shoalhaven.nsw.gov.au"
 URL = "https://www.shoalhaven.nsw.gov.au/"
 TEST_CASES = {
+    "2 Cherry Plum Way, WORRIGEE": {"street_address": "2 Cherry Plum Way, WORRIGEE"},
+    "10 Station Street, NOWRA": {"street_address": "10 Station Street, NOWRA"},
+    "3 The Park Drive, SANCTUARY POINT": {
+        "street_address": "3 The Park Drive, SANCTUARY POINT"
+    },
     # Example Geolocation ID from the provided URL.
     "Elizabeth Dr, VINCENTIA": {
         "geolocation_id": "2ea7b0c7-b627-421d-8436-248b8da384b6"
@@ -27,7 +33,12 @@ ICON_MAP = {
 
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": """
-    To get your Geolocation ID:
+    Enter your street address as the council's own address search shows it,
+    e.g. "2 Cherry Plum Way, WORRIGEE". You can check it on the
+    <https://www.shoalhaven.nsw.gov.au/My-Area> page.
+
+    A Geolocation ID may be given instead of an address, and takes precedence
+    when both are set. To find it:
     1. Go to the Shoalhaven City Council 'My Area' page: <https://www.shoalhaven.nsw.gov.au/My-Area>
     2. Open Developer Tools in your browser by pressing F12 and go to the Network tab.
     3. Enter your address in the search bar and select it from the suggestions.
@@ -38,12 +49,14 @@ HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
 
 PARAM_DESCRIPTIONS = {
     "en": {
-        "geolocation_id": "Your unique Geolocation ID for the address (e.g., 2ea7b0c7-b627-421d-8436-248b8da384b6)",
+        "street_address": "Your street address, e.g. 2 Cherry Plum Way, WORRIGEE",
+        "geolocation_id": "Your unique Geolocation ID for the address (e.g., 2ea7b0c7-b627-421d-8436-248b8da384b6). Only needed if the address search cannot find your property.",
     }
 }
 
 PARAM_TRANSLATIONS = {
     "en": {
+        "street_address": "Street address",
         "geolocation_id": "Geolocation ID",
     },
 }
@@ -52,21 +65,49 @@ PARAM_TRANSLATIONS = {
 
 _CONFIG = OpenCitiesConfig(
     domain="https://www.shoalhaven.nsw.gov.au",
-    argument_name="geolocation_id",
+    # The address-only path is the one users take, so name that argument in
+    # the exceptions the client raises -- except when the visitor supplied the
+    # geolocation id instead, which is the argument to flag then.
+    argument_name="street_address",
+    direct_argument_name="geolocation_id",
     icon_keywords=ICON_MAP,
     require_date_precise=True,
+    # The council sits behind Akamai, which fingerprints the TLS handshake as
+    # well as the headers: the address search answers 403 to plain
+    # requests/urllib3 no matter what User-Agent it announces. curl_cffi's
+    # Chrome impersonation makes the handshake match the claim and passes.
+    use_curl_cffi=True,
+    # Without an explicit Accept header the search endpoint returns XML
+    # instead of JSON.
+    headers={"Accept": "application/json"},
 )
 
 
 class Source:
-    def __init__(self, geolocation_id: str):
+    def __init__(
+        self,
+        street_address: str | None = None,
+        geolocation_id: str | None = None,
+    ):
         """
-        Initialize the Source with the provided geolocation ID.
+        Initialize the Source with a street address or a geolocation ID.
 
-        :param geolocation_id: The unique ID for the address to fetch waste services for.
+        :param street_address: The address to look up, as the council's address
+            search shows it, e.g. "2 Cherry Plum Way, WORRIGEE".
+        :param geolocation_id: The unique ID for the address to fetch waste
+            services for, used in preference to ``street_address`` when given.
         """
+        if street_address is None and geolocation_id is None:
+            raise SourceArgumentExceptionMultiple(
+                ["street_address", "geolocation_id"],
+                "Either street_address or geolocation_id must have a value",
+            )
+
+        self._street_address = street_address
         self._geolocation_id = geolocation_id
         self._client = OpenCitiesClient(_CONFIG)
 
     def fetch(self) -> list[Collection]:
-        return self._client.fetch(geolocation_id=self._geolocation_id)
+        return self._client.fetch(
+            address=self._street_address, geolocation_id=self._geolocation_id
+        )

--- a/doc/source/shoalhaven_nsw_gov_au.md
+++ b/doc/source/shoalhaven_nsw_gov_au.md
@@ -1,40 +1,53 @@
 # Shoalhaven City Council
 
+Support for schedules provided by [Shoalhaven City Council](https://www.shoalhaven.nsw.gov.au/), NSW, Australia.
+
 ## Configuration via configuration.yaml
 
-To configure the Shoalhaven City Council waste collection source, add the following to your `configuration.yaml` file under the `waste_collection_schedule` integration:
-
-```
+```yaml
 waste_collection_schedule:
     sources:
     - name: shoalhaven_nsw_gov_au
       args:
-        geolocation_id: YOUR_GEOLOCATION_ID
-
+        street_address: STREET_ADDRESS
 ```
 
 ## Configuration Variables
 
-* **`geolocation_id`** (string) (required): Your unique Geolocation ID for the address. This is a long string of letters and numbers (e.g., `2ea7b0c7-b627-421d-8436-248b8da384b6`).
+**street_address**  
+*(string) (optional)* Your street address, as the council's own address search shows it.
 
-  **How to get your Geolocation ID:**
+**geolocation_id**  
+*(string) (optional)* The council's internal ID for your property. Only needed if the address search cannot find it; used in preference to `street_address` when both are given.
 
-  1. Go to the Shoalhaven City Council 'My Area' page: <https://www.shoalhaven.nsw.gov.au/My-Area>
-
-  2. Open Developer Tools in your browser by pressing F12 and go to the Network tab.
-
-  3. Enter your address in the search bar and select it from the suggestions.
-
-  4. Once your address information is displayed, look at the `wasteservices` URL in the Network tab.
-
-  5. Copy the long string of letters and numbers that follows `geolocationid=` (e.g., `2ea7b0c7-b627-421d-8436-248b8da384b6`). This is your Geolocation ID.
+One of `street_address` or `geolocation_id` is required.
 
 ## Example
 
-```
+```yaml
 waste_collection_schedule:
     sources:
     - name: shoalhaven_nsw_gov_au
       args:
-        geolocation_id: "1ce23c4a-633a-464f-ab56-6f1d2c0d929f"
+        street_address: "2 Cherry Plum Way, WORRIGEE"
+```
 
+```yaml
+waste_collection_schedule:
+    sources:
+    - name: shoalhaven_nsw_gov_au
+      args:
+        geolocation_id: "2ea7b0c7-b627-421d-8436-248b8da384b6"
+```
+
+## How to get the source argument
+
+Enter your address on the [My Area](https://www.shoalhaven.nsw.gov.au/My-Area) page and use it as the address search shows it, e.g. `2 Cherry Plum Way, WORRIGEE`.
+
+To find a Geolocation ID instead:
+
+1. Go to the Shoalhaven City Council [My Area](https://www.shoalhaven.nsw.gov.au/My-Area) page.
+2. Open Developer Tools in your browser by pressing F12 and go to the Network tab.
+3. Enter your address in the search bar and select it from the suggestions.
+4. Once your address information is displayed, look at the `wasteservices` URL in the Network tab.
+5. Copy the long string of letters and numbers that follows `geolocationid=` (e.g. `2ea7b0c7-b627-421d-8436-248b8da384b6`). This is your Geolocation ID.


### PR DESCRIPTION
`shoalhaven_nsw_gov_au` only takes `geolocation_id`, a GUID that has to be copied out of the council's internal `wasteservices` request in the browser's network tab. A Shoalhaven resident reported it after doing exactly that: the address was right, and the developer console was the only way through.

The council runs the same OpenCities/MyArea widget as the other sources on `service/OpenCities.py`, so the `/api/v1/myarea/search` endpoint the shared client already resolves addresses with is available here too. This is a config change rather than new scraping.

The search is forgiving about shape — `2 Cherry Plum Way`, `2 cherry plum way worrigee`, `2 Cherry Plum Wy Worrigee` and the same address with a state and postcode appended all resolve to the one property.

Two things were in the way:

- The **search** endpoint sits behind Akamai, which fingerprints the TLS handshake as well as the headers and answers `403 Access Denied` to plain requests/urllib3 whatever User-Agent it announces. `wasteservices` itself is unprotected, which is why the id-only path never hit this. Fixed with `use_curl_cffi=True`, as melton/ballina/hornsby already do.
- Without an explicit `Accept: application/json` the search returns XML — the same quirk already noted on banyule and cambridge.

`geolocation_id` keeps working and still takes precedence when both are given, so no existing configuration changes.

### Testing

All six TEST_CASES verified live (three addresses, three existing geolocation ids):

```
Testing source shoalhaven_nsw_gov_au ...
  found 2 entries for 2 Cherry Plum Way, WORRIGEE
  found 2 entries for 10 Station Street, NOWRA
  found 2 entries for 3 The Park Drive, SANCTUARY POINT
  found 2 entries for Elizabeth Dr, VINCENTIA
  found 2 entries for The Park Dr, SANCTUARY POINT
  found 2 entries for Station St, NOWRA
```

`pytest tests/test_source_components.py` passes (35 passed); `ruff check` and `ruff format --check` clean.