### PR TITLE
feat(OpenCities): carry each service's note through as the collection description

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/OpenCities.py
@@ -9,8 +9,9 @@ domain (the widget behind e.g. https://www.logan.qld.gov.au/MyLogan):
 - ``GET <domain>/ocapi/Public/myarea/wasteservices`` — given a
   ``geolocationid``, returns ``{"success": bool, "responseContent": "<html>"}``
   where the HTML is a series of ``<article>``/``div.waste-services-result``
-  blocks, each with an ``<h3>`` (waste type) and a ``.next-service`` element
-  (next collection date).
+  blocks, each with an ``<h3>`` (waste type), a ``.next-service`` element
+  (next collection date) and usually a ``.note`` element (the service's
+  cadence and kerbside instructions in prose).
 
 This module centralises that flow behind :class:`OpenCitiesClient` so
 per-council source files stay a thin ``OpenCitiesConfig`` + ``Source`` shim.
@@ -363,11 +364,22 @@ class OpenCitiesClient:
             if collection_date is None:
                 continue
 
+            # Most deployments state the service's cadence and kerbside
+            # instructions in a "note" div next to the date ("Collected
+            # fortnightly. Place bin on the kerb before the morning of
+            # collection."). The API returns only the ONE next date per
+            # service, so this sentence is the only place the cadence appears
+            # at all -- carry it through as the collection's description
+            # instead of dropping it.
+            note = block.select_one(".note")
+            description = note.get_text(" ", strip=True) if note else None
+
             entries.append(
                 Collection(
                     date=collection_date,
                     t=waste_type,
                     icon=self._resolve_icon(waste_type),
+                    description=description,
                 )
             )
         return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/willoughby_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/willoughby_nsw_gov_au.py
@@ -103,6 +103,10 @@ class Source:
                     date=entry.date,
                     t=waste_type,
                     icon=ICON_MAP.get(waste_type),
+                    # The council states each service's cadence here ("Same day
+                    # each week"), and it is the only place it appears -- the
+                    # widget gives one date per bin.
+                    description=entry.description,
                 )
             )
         return entries


### PR DESCRIPTION
The `wasteservices` widget answers with **one next date per service** and puts the service's cadence in prose beside it. The shared parser reads the `<h3>` and `.next-service` and drops the `.note`, so that sentence never reaches Home Assistant — even though it is the only statement of the cadence anywhere in the response.

Real note text, captured 2026-09-07:

| Council | Note |
|---|---|
| Shoalhaven | `Collected fortnightly. Place bin on the kerb before the morning of collection.` |
| Monash | `Collected fortnightly. Your next collection day is:` |
| Gold Coast | `Collected weekly Your next collection date:` |
| Whittlesea (Glass) | `Collected every four weeks Your next collection date is on:` |
| Maroondah | `Recyclables (blue lid) are collected every 2 weeks. Your next collection date is:` |
| Ballina | `Fortnightly collection in Urban and Rural areas. See below for your next landfill bin collection or` |
| Willoughby | `Same day each week Find out more about this service Your next service will be:` |

Passing it through as `description` puts it on the calendar event and the sensor attributes, where HA already renders descriptions, and lets a consumer that needs a recurrence rule read the interval from the council's own words rather than inferring "weekly" from a lone date.

Willoughby rebuilds its Collections to normalise the type names, so it takes one extra line to keep the description it now receives.

### Behaviour

No dates and no types change. Deployments with no `.note` div (Ryde, Logan) or a note that is just a label (Banyule: `Recycling`) behave exactly as before.

### Testing

Verified live against ballina, banyule, goldcoast, logan, maroondah, monash, ryde, shoalhaven, whittlesea and willoughby — same entry counts as before, descriptions present wherever the council writes a note. `pytest tests/test_source_components.py` passes (35 passed); `ruff check` and `ruff format --check` clean.