### PR TITLE
fix(casey_vic_gov_au): the council writes "Previous", so four bins came out as "iousGarbage"

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/casey_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/casey_vic_gov_au.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 
 import requests
@@ -71,10 +72,16 @@ PARAM_TRANSLATIONS = {
     },
 }
 
-# Collection date property name prefix / postfix
-_PREV_STRING = "Prev"
-_NEXT_STRING = "Next"
-_DATE_STRING = "Date"
+# Collection dates arrive as one property per bin and per direction, e.g.
+# "NextGarbageDate" and "PreviousRecycleDate". The bin name is whatever sits
+# between the two, so new bins need no mapping here -- Glass appeared that way.
+#
+# The council writes the backward-looking prefix as "Previous"; matching a bare
+# "Prev" and stripping it by substring turned "PreviousGarbageDate" into
+# "iousGarbage", which the app then showed as a bin of its own beside the real
+# "Garbage" -- eight bins, four of them nonsense. Anchoring the whole key also
+# keeps a bin whose own name contains "Date" or "Next" intact.
+_COLLECTION_DATE_KEY_RE = re.compile(r"^(?:Next|Prev(?:ious)?)(?P<name>.+)Date$")
 
 
 class Source:
@@ -140,17 +147,11 @@ class Source:
         entries = []
 
         for key, value in search_results["result"][0].items():
-            # properties come through like "NextGarbageDate", "NextRecycleDate" or "PrevGardenDate" etc
-            # extracting waste type name from the middle of "Next{x}Date" to support future waste types without direct mapping
-            if key.endswith(_DATE_STRING) and (
-                key.startswith((_NEXT_STRING, _PREV_STRING))
-            ):
-                name = (
-                    key.replace(_DATE_STRING, "")
-                    .replace(_NEXT_STRING, "")
-                    .replace(_PREV_STRING, "")
-                )
-
+            # properties come through like "NextGarbageDate" and
+            # "PreviousGardenDate"; the bin name is the middle
+            match = _COLLECTION_DATE_KEY_RE.match(key)
+            if match and value:
+                name = match.group("name")
                 date = datetime.strptime(value, "%Y-%m-%d").date()
                 icon = ICON_MAP[name] if name in ICON_MAP else None
                 entries.append(Collection(date=date, t=name, icon=icon))


### PR DESCRIPTION
The property record carries one date per bin per direction. The council now names the backward-looking ones `PreviousGarbageDate` where it used to write `PrevGarbageDate`, and the parser stripped the prefix by substring — matching a bare `Prev` and removing it from `PreviousGarbageDate` leaves `iousGarbage`.

So every address returned eight collections:

```
2026-09-14 : Garbage        2026-09-07 : iousGarbage
2026-09-14 : Recycle        2026-08-31 : iousRecycle
2026-09-21 : Garden         2026-09-07 : iousGarden
2026-11-16 : Glass          2026-08-24 : iousGlass
```

Live keys today: `NextGarbageDate`, `NextRecycleDate`, `NextGardenDate`, `NextGlassDate`, `PreviousGarbageDate`, `PreviousRecycleDate`, `PreviousGardenDate`, `PreviousGlassDate`.

Anchoring the whole key with one regex fixes the name and merges each pair back into one bin, so the two dates the record holds land on the same collection type. A bin whose own name contains `Next` or `Date` survives too, and an empty date value is skipped instead of raising on `strptime`.

### Testing

Both TEST_CASES verified live: four bins, two dates each (a week apart for Garbage, a fortnight for Recycle and Garden). `pytest tests/test_source_components.py` passes; `ruff check` and `ruff format --check` clean.
