### PR TITLE
fix(canadabay, cumberland, innerwest): match the waste-info register, and say when it does not

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/WasteInfo.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/WasteInfo.py
@@ -1,0 +1,83 @@
+"""Register matching for councils on the waste-info.com.au platform.
+
+Those councils expose the same v1 API: ``localities.json``, then
+``streets.json?locality=`` and ``properties.json?street=``, each answering with
+``{"name": ..., "id": ...}`` rows that a source has to match by name. The names
+are the council's own register wording, and matching them literally is what
+makes an ordinary address look unserviced:
+
+- case and spacing vary ("berala" and "Merrylands  Road" are what people type,
+  "Berala" and "Merrylands Road" is what the register holds);
+- a property row may carry a building name between the number and the street
+  ("4-12 five dock library Garfield Street Five Dock"), so the number, street
+  and suburb are all correct and the row still does not compare equal.
+
+Sources with their own richer matching (brisbane, impactapps, redland) are
+untouched; this is for the ones that compared raw strings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def norm(value: object) -> str:
+    """Register-comparable form: single-spaced and case-folded.
+
+    Only ``None`` is empty. Street numbers arrive as ``int`` as well as ``str``,
+    so ``0`` has to keep its own value rather than fall back to "".
+    """
+    if value is None:
+        return ""
+    return " ".join(str(value).split()).casefold()
+
+
+def same(a: object, b: object) -> bool:
+    """True when two register names differ only by case or spacing."""
+    return norm(a) == norm(b)
+
+
+def property_matches(
+    register_name: object, street_number: object, street_name: object, suburb: object
+) -> bool:
+    """True when a ``properties.json`` row is the address that was asked for.
+
+    Accepts the register's canonical ``"<number> <street> <suburb>"`` and the
+    same row with a building name inserted after the number. The number must
+    still match in full, so "4-12" does not answer for "1m/4-12".
+    """
+    name = norm(register_name)
+    if name == norm(f"{street_number} {street_name} {suburb}"):
+        return True
+    return name.startswith(norm(street_number) + " ") and name.endswith(
+        norm(f"{street_name} {suburb}")
+    )
+
+
+def street_number_suggestions(
+    register_names: Iterable[object], street_name: object
+) -> list[str]:
+    """The number (and building name) of every register row on that street.
+
+    Suggesting a street number only helps if the rows are found the same way
+    ``property_matches`` finds them, so the street is located on the case- and
+    spacing-insensitive form while the register's own wording is what gets
+    suggested. The last occurrence wins, because a building name can repeat the
+    street ("1 Garfield Street Cafe Garfield Street Five Dock").
+    """
+    wanted = norm(street_name).split()
+    if not wanted:
+        return []
+
+    suggestions = []
+    for register_name in register_names:
+        words = str(register_name if register_name is not None else "").split()
+        folded = [word.casefold() for word in words]
+        for start in range(len(folded) - len(wanted), -1, -1):
+            if folded[start : start + len(wanted)] != wanted:
+                continue
+            number = " ".join(words[:start])
+            if number:
+                suggestions.append(number)
+            break
+    return suggestions

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/canadabay_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/canadabay_nsw_gov_au.py
@@ -3,6 +3,14 @@ from datetime import date, timedelta
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.WasteInfo import (
+    property_matches,
+    same,
+    street_number_suggestions,
+)
 
 TITLE = "City of Canada Bay Council"
 DESCRIPTION = "Source for City of Canada Bay Council rubbish collection."
@@ -52,12 +60,14 @@ class Source:
 
         # Find the ID for our suburb
         for item in data["localities"]:
-            if item["name"] == self.suburb:
+            if same(item["name"], self.suburb):
                 suburb_id = item["id"]
                 break
 
         if suburb_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "suburb", self.suburb, [x["name"] for x in data["localities"]]
+            )
 
         # Retrieve the streets in our suburb
         r = requests.get(
@@ -69,12 +79,14 @@ class Source:
 
         # Find the ID for our street
         for item in data["streets"]:
-            if item["name"] == self.street_name:
+            if same(item["name"], self.street_name):
                 street_id = item["id"]
                 break
 
         if street_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street_name", self.street_name, [x["name"] for x in data["streets"]]
+            )
 
         # Retrieve the properties in our street
         r = requests.get(
@@ -86,12 +98,20 @@ class Source:
 
         # Find the ID for our property
         for item in data["properties"]:
-            if item["name"] == f"{self.street_number} {self.street_name} {self.suburb}":
+            if property_matches(
+                item["name"], self.street_number, self.street_name, self.suburb
+            ):
                 property_id = item["id"]
                 break
 
         if property_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street_number",
+                self.street_number,
+                street_number_suggestions(
+                    (x["name"] for x in data["properties"]), self.street_name
+                ),
+            )
 
         # Retrieve the upcoming collections for our property
         r = requests.get(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cumberland_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cumberland_nsw_gov_au.py
@@ -3,6 +3,14 @@ from datetime import date, timedelta
 
 import requests
 from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.WasteInfo import (
+    property_matches,
+    same,
+    street_number_suggestions,
+)
 
 TITLE = "Cumberland Council (NSW)"
 DESCRIPTION = "Source for Cumberland Council (NSW) rubbish collection."
@@ -51,12 +59,14 @@ class Source:
 
         # Find the ID for our suburb
         for item in data["localities"]:
-            if item["name"] == self.suburb:
+            if same(item["name"], self.suburb):
                 suburb_id = item["id"]
                 break
 
         if suburb_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "suburb", self.suburb, [x["name"] for x in data["localities"]]
+            )
 
         # Retrieve the streets in our suburb
         r = requests.get(
@@ -67,12 +77,14 @@ class Source:
 
         # Find the ID for our street
         for item in data["streets"]:
-            if item["name"] == self.street_name:
+            if same(item["name"], self.street_name):
                 street_id = item["id"]
                 break
 
         if street_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street_name", self.street_name, [x["name"] for x in data["streets"]]
+            )
 
         # Retrieve the properties in our street
         r = requests.get(
@@ -83,12 +95,20 @@ class Source:
 
         # Find the ID for our property
         for item in data["properties"]:
-            if item["name"] == f"{self.street_number} {self.street_name} {self.suburb}":
+            if property_matches(
+                item["name"], self.street_number, self.street_name, self.suburb
+            ):
                 property_id = item["id"]
                 break
 
         if property_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street_number",
+                self.street_number,
+                street_number_suggestions(
+                    (x["name"] for x in data["properties"]), self.street_name
+                ),
+            )
 
         # Retrieve the upcoming collections for our property
         r = requests.get(

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/innerwest_nsw_gov_au.py
@@ -3,6 +3,14 @@ from datetime import date, timedelta
 
 import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentNotFoundWithSuggestions,
+)
+from waste_collection_schedule.service.WasteInfo import (
+    property_matches,
+    same,
+    street_number_suggestions,
+)
 
 TITLE = "Inner West Council (NSW)"
 DESCRIPTION = "Source for Inner West Council (NSW) rubbish collection."
@@ -57,11 +65,13 @@ class Source:
         council_api = ""
 
         # Retrieve suburbs and council API
+        all_localities: list[str] = []
         for api in APIS:
             r = requests.get(f"{api}/localities.json", headers=HEADERS)
             data = json.loads(r.text)
+            all_localities += [x["name"] for x in data["localities"]]
             for item in data["localities"]:
-                if item["name"] == self.suburb:
+                if same(item["name"], self.suburb):
                     council_api = api
                     suburb_id = item["id"]
                     break
@@ -69,7 +79,11 @@ class Source:
                 break
 
         if suburb_id == 0:
-            return []
+            # The three councils are searched in turn, so the suggestion list is
+            # every locality across the ones reached, not just the last.
+            raise SourceArgumentNotFoundWithSuggestions(
+                "suburb", self.suburb, all_localities
+            )
 
         # Retrieve the streets in our suburb
         r = requests.get(
@@ -80,12 +94,14 @@ class Source:
 
         # Find the ID for our street
         for item in data["streets"]:
-            if item["name"] == self.street_name:
+            if same(item["name"], self.street_name):
                 street_id = item["id"]
                 break
 
         if street_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street_name", self.street_name, [x["name"] for x in data["streets"]]
+            )
 
         # Retrieve the properties in our street
         r = requests.get(
@@ -96,12 +112,20 @@ class Source:
 
         # Find the ID for our property
         for item in data["properties"]:
-            if item["name"] == f"{self.street_number} {self.street_name} {self.suburb}":
+            if property_matches(
+                item["name"], self.street_number, self.street_name, self.suburb
+            ):
                 property_id = item["id"]
                 break
 
         if property_id == 0:
-            return []
+            raise SourceArgumentNotFoundWithSuggestions(
+                "street_number",
+                self.street_number,
+                street_number_suggestions(
+                    (x["name"] for x in data["properties"]), self.street_name
+                ),
+            )
 
         # Retrieve the upcoming collections for our property
         r = requests.get(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_fetch_retry.py
+python_files = test_source_components.py test_fetch_retry.py test_waste_info.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_fetch_retry.py test_waste_info.py
+python_files = test_source_components.py test_fetch_retry.py test_ics_timezone.py

--- a/tests/test_waste_info.py
+++ b/tests/test_waste_info.py
@@ -1,0 +1,118 @@
+"""Tests for the shared waste-info.com.au register matching.
+
+The three sources using this (canadabay, cumberland, innerwest) can only be
+exercised against live council data, which moves. These lock down the rules the
+matcher promises: case and spacing are ignored, a building name may sit between
+the number and the street, and a number still has to match in full.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule.service.WasteInfo import (
+    norm,
+    property_matches,
+    same,
+    street_number_suggestions,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Merrylands  Road", "merrylands road"),
+        ("  Berala\n", "berala"),
+        (283, "283"),
+        (0, "0"),
+        (None, ""),
+    ],
+)
+def test_norm(value, expected):
+    assert norm(value) == expected
+
+
+def test_zero_is_not_empty():
+    # "0 Smith Street" is a real address; `value or ""` used to erase it.
+    assert not same(0, None)
+    assert same(0, "0")
+
+
+@pytest.mark.parametrize("suburb", ["Berala", "berala", "  BERALA "])
+def test_same_ignores_case_and_spacing(suburb):
+    assert same("Berala", suburb)
+
+
+def test_property_matches_canonical_row():
+    assert property_matches(
+        "76 Tennyson Road Mortlake", "76", "Tennyson Road", "Mortlake"
+    )
+
+
+def test_property_matches_ignores_case_and_spacing():
+    assert property_matches(
+        "76  tennyson road  MORTLAKE", "76", "Tennyson  Road", "mortlake"
+    )
+
+
+def test_property_matches_with_building_name():
+    assert property_matches(
+        "4-12 five dock library Garfield Street Five Dock",
+        "4-12",
+        "Garfield Street",
+        "Five Dock",
+    )
+
+
+def test_property_matches_requires_the_whole_number():
+    # "1m/4-12 ..." is a different property from "4-12 ...".
+    assert not property_matches(
+        "1m/4-12 Garfield Street Five Dock", "4-12", "Garfield Street", "Five Dock"
+    )
+
+
+def test_property_matches_requires_the_right_suburb():
+    assert not property_matches(
+        "76 Tennyson Road Mortlake", "76", "Tennyson Road", "Concord"
+    )
+
+
+def test_street_number_suggestions_keeps_register_wording():
+    rows = [
+        "76 Tennyson Road Mortlake",
+        "4-12 Five Dock Library Garfield Street Five Dock",
+        "1A Gipps Street Concord",
+    ]
+    assert street_number_suggestions(rows, "garfield  street") == [
+        "4-12 Five Dock Library"
+    ]
+
+
+def test_street_number_suggestions_uses_the_last_occurrence():
+    rows = ["1 Garfield Street Cafe Garfield Street Five Dock"]
+    assert street_number_suggestions(rows, "Garfield Street") == [
+        "1 Garfield Street Cafe"
+    ]
+
+
+def test_street_number_suggestions_skips_rows_with_no_number():
+    assert (
+        street_number_suggestions(["Garfield Street Five Dock"], "Garfield Street")
+        == []
+    )
+
+
+def test_street_number_suggestions_without_a_street():
+    assert street_number_suggestions(["76 Tennyson Road Mortlake"], "") == []


### PR DESCRIPTION
`canadabay_nsw_gov_au`, `cumberland_nsw_gov_au` and `innerwest_nsw_gov_au` share one copy of the waste-info.com.au flow: match a locality by name, then a street, then `"<number> <street> <suburb>"`. Each match compared the raw strings, and each failure `return []`, so an ordinary address came back as "no collections found" with nothing to act on.

**Case and spacing.** The register holds `Berala` and `Merrylands Road`; visitors type `berala` and `merrylands  road`. Comparing case-folded and single-spaced makes those the same address, which is what they are.

**A building name between the number and the street.** Canada Bay files the Five Dock library as:

```
'4-12 five dock library Garfield Street Five Dock'
'1m/4-12 Garfield Street Five Dock'
...
```

so for `4-12 / Garfield Street / Five Dock` the number, street and suburb are all correct and the row still does not compare equal. That address is this source's own TEST_CASE and had never resolved — the silent empty list made it look like a pass. The number must still match in full, so `4-12` does not answer for `1m/4-12`.

The three now raise `SourceArgumentNotFoundWithSuggestions` with what the register does hold at the depth that failed, as `brisbane_qld_gov_au`, `redland_qld_gov_au` and `impactapps_com_au` already do on the same platform. Inner West searches three councils in turn, so its locality suggestions are the union across the ones reached rather than whichever list happened to be last.

The shared matching lives in `service/WasteInfo.py`. Sources with their own richer matching are untouched.

### Testing

All three sources' TEST_CASES verified live — Five Dock Library resolves for the first time (106 entries). Lower-cased and upper-cased inputs resolve. An unknown suburb now lists the council's localities instead of returning nothing. `pytest tests/test_source_components.py` passes; `ruff check` and `ruff format --check` clean.
