### PR TITLE
fix(coventry, geelong): raise argument errors, not RuntimeError and Exception

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/coventry_gov_uk.py
@@ -5,6 +5,10 @@ from datetime import date, datetime
 import requests
 from bs4 import BeautifulSoup
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import (
+    SourceArgumentException,
+    SourceArgumentNotFound,
+)
 
 TITLE = "Coventry City Council"
 DESCRIPTION = "Source for waste collection services for Coventry City Council"
@@ -14,6 +18,9 @@ HEADERS = {"user-agent": "Mozilla/5.0"}
 API_URLS = {
     "search": "https://www.coventry.gov.uk/directory/search",
     "directory_record": "https://www.coventry.gov.uk",
+    # Where the council moved bin days to. This source cannot read it, so the
+    # only useful thing left to hand the user is the address of the service.
+    "my_account": "https://myaccount.coventry.gov.uk/service/find_my_bin_day",
 }
 TEST_CASES = {
     "Test_001": {
@@ -65,6 +72,18 @@ class Source:
             "search": "Search",
         }
         r = s.get(API_URLS["search"], headers=HEADERS, params=params, timeout=30)
+        if r.status_code == 404:
+            # The council retired the street directory this source searches;
+            # /directory/search now serves its "page not found" page, whose own
+            # navigation links carry the same CSS class the street results did.
+            # Without this check the site menu is offered as a list of streets.
+            raise SourceArgumentException(
+                "street",
+                "Coventry has retired the street directory this lookup uses "
+                f"({API_URLS['search']} now returns 404). Collection days have "
+                f"moved to {API_URLS['my_account']}, which this source does "
+                "not read yet.",
+            )
         soup: BeautifulSoup = BeautifulSoup(r.content, "html.parser")
         list_links: list = soup.find_all("a", {"class": "list__link"})
         directory_record: str | None = None
@@ -74,7 +93,14 @@ class Source:
                 break
 
         if directory_record is None:
-            raise RuntimeError(f"Street '{self._street}' not found")
+            # RuntimeError reached the caller as a server error, so an ordinary
+            # misspelling was reported as an outage.
+            raise SourceArgumentNotFound(
+                "street",
+                self._street,
+                "The council's street directory returned no match. Check the "
+                "spelling, and include the street type (Road, Drive).",
+            )
 
         # use directory record to get collection day
         r = s.get(
@@ -89,8 +115,11 @@ class Source:
                 break
 
         if schedule is None:
-            raise RuntimeError(
-                f"No bin collection calendar link found for '{self._street}'"
+            raise SourceArgumentNotFound(
+                "street",
+                self._street,
+                "The council's directory has this street but no bin collection "
+                "calendar for it.",
             )
 
         # Use the collection calendar link to get the current schedule.

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/geelongaustralia_com_au.py
@@ -3,6 +3,7 @@ import datetime
 import requests
 from bs4 import BeautifulSoup, Tag
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.exceptions import SourceArgumentNotFound
 
 TITLE = "City of Greater Geelong"
 DESCRIPTION = "Source City of Greater Geelong rubbish collection"
@@ -65,8 +66,15 @@ class Source:
         r.raise_for_status()
 
         if "We couldn't find a match for" in r.text:
-            raise Exception(
-                f"No collection calendars are available for the selected property. Make sure your address returns entries on the council website ({API_URL})."
+            # The council answered, and its answer is that this address is not
+            # in its register. Raising a bare Exception made that a server
+            # error to every caller; SourceArgumentNotFound names the argument
+            # at fault so it can be reported against the field.
+            raise SourceArgumentNotFound(
+                "address",
+                self._address,
+                "No collection calendars are available for this property. "
+                f"Check the address against the council's own search ({API_URL}).",
             )
 
         soup = BeautifulSoup(r.text, "html.parser")


### PR DESCRIPTION
Both sources reported an unresolvable address by raising an untyped exception (`RuntimeError`, bare `Exception`), which a consumer can only treat as a server fault. The information needed to put the message against the field was there all along.

**Coventry** additionally offered the wrong thing. The council retired the street directory this source searches — `/directory/search?directoryID=82` answers `404` — and the 404 page's own navigation carries the same `list__link` class the street results did, so the not-found path was ready to hand back candidate "streets" like:

```
['Skip to content', 'Skip to navigation', 'Menu', 'Adult social care and health', ... 'Pay for it']
```

The 404 is now detected and reported for what it is: the council has moved collection days to its My Account service, which this source does not read yet. A genuine no-match on a directory that *does* answer says so instead, without a suggestion list.

**Geelong**'s "We couldn't find a match for" means the property is not in the register, so it is a `SourceArgumentNotFound` on the address it was given, naming the council's own search as the place to check it.

### Testing

Verified live: Coventry reports the retired directory instead of raising `RuntimeError`; Geelong reports the unmatched address instead of raising `Exception`, and its TEST_CASES still resolve. `pytest tests/test_source_components.py` passes; `ruff check` and `ruff format --check` clean.
