### PR TITLE
Fix PUP Saubermacher schedule endpoint

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
@@ -33,10 +33,7 @@ PARAM_TRANSLATIONS = {
     }
 }
 
-BASE_URL = (
-    "https://www.pup-saubermacher.si/"
-    "index.php/domov/urnik-odvoza-odpadkov"
-)
+BASE_URL = "https://www.pup-saubermacher.si/index.php/domov/urnik-odvoza-odpadkov"
 
 
 class Source:
@@ -47,26 +44,26 @@ class Source:
         args = {
             "q": self._place_id,
         }
-    
+
         response = requests.get(BASE_URL, params=args)
         response.encoding = "utf-8"
         response.raise_for_status()
-    
+
         content = BeautifulSoup(response.text, "html.parser")
-    
+
         data = self.parse_to_obj(content)
-    
+
         if not data:
             raise SourceArgumentNotFound("place_id", self._place_id)
-    
+
         entries = []
-    
+
         for item in data:
             type_char = self.get_type(item["title"])
-    
+
             for date_info in item["dates"]:
                 date = self.get_date(date_info)
-    
+
                 if date is not None:
                     entries.append(
                         Collection(
@@ -75,33 +72,30 @@ class Source:
                             ICON_MAP[type_char],
                         )
                     )
-    
+
         return entries
 
     def parse_to_obj(self, content):
         data = []
-    
+
         waste_types = (
             "Mešana embalaža",
             "Mešani komunalni odpadki",
             "Biološki odpadki",
         )
-    
+
         for b_tag in content.find_all("b"):
             title = b_tag.get_text(strip=True)
-    
+
             if not title.startswith(waste_types):
                 continue
-    
+
             ul_tag = b_tag.find_next("ul")
-    
+
             if ul_tag:
-                dates = [
-                    li.get_text(strip=True)
-                    for li in ul_tag.find_all("li")
-                ]
+                dates = [li.get_text(strip=True) for li in ul_tag.find_all("li")]
                 data.append({"title": title, "dates": dates})
-    
+
         return data
 
     def get_type(self, title):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
@@ -87,27 +87,20 @@ class Source:
             "Biološki odpadki",
         )
     
-        for text_node in content.find_all(string=True):
-            title = text_node.strip()
+        for b_tag in content.find_all("b"):
+            title = b_tag.get_text(strip=True)
     
             if not title.startswith(waste_types):
                 continue
     
-            parent = text_node.parent
-            ul_tag = parent.find_next("ul")
+            ul_tag = b_tag.find_next("ul")
     
             if ul_tag:
                 dates = [
                     li.get_text(strip=True)
                     for li in ul_tag.find_all("li")
                 ]
-    
-                data.append(
-                    {
-                        "title": title,
-                        "dates": dates,
-                    }
-                )
+                data.append({"title": title, "dates": dates})
     
         return data
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
@@ -33,7 +33,10 @@ PARAM_TRANSLATIONS = {
     }
 }
 
-BASE_URL = "https://www.pup-saubermacher.si/php/dobi_tabelo.php"
+BASE_URL = (
+    "https://www.pup-saubermacher.si/"
+    "index.php/domov/urnik-odvoza-odpadkov"
+)
 
 
 class Source:
@@ -44,48 +47,68 @@ class Source:
         args = {
             "q": self._place_id,
         }
+    
         response = requests.get(BASE_URL, params=args)
         response.encoding = "utf-8"
         response.raise_for_status()
-
+    
         content = BeautifulSoup(response.text, "html.parser")
-
-        if response.text == "null" or not content.find_all("ul"):
-            raise SourceArgumentNotFound("place_id", self._place_id)
-
-        entries = []
+    
         data = self.parse_to_obj(content)
-
+    
+        if not data:
+            raise SourceArgumentNotFound("place_id", self._place_id)
+    
+        entries = []
+    
         for item in data:
             type_char = self.get_type(item["title"])
-
+    
             for date_info in item["dates"]:
                 date = self.get_date(date_info)
-
+    
                 if date is not None:
                     entries.append(
-                        Collection(date, BIN_TYPES[type_char], ICON_MAP[type_char])
+                        Collection(
+                            date,
+                            BIN_TYPES[type_char],
+                            ICON_MAP[type_char],
+                        )
                     )
-
+    
         return entries
 
     def parse_to_obj(self, content):
-        # Find all <b> tags and their following <ul> tags
-        b_tags = content.find_all("b")[2:]  # Skip the first two <b> tags
         data = []
-
-        for b_tag in b_tags:
-            title = b_tag.get_text()
-            ul_tag = b_tag.find_next_sibling("ul")
-
+    
+        waste_types = (
+            "Mešana embalaža",
+            "Mešani komunalni odpadki",
+            "Biološki odpadki",
+        )
+    
+        for text_node in content.find_all(string=True):
+            title = text_node.strip()
+    
+            if not title.startswith(waste_types):
+                continue
+    
+            parent = text_node.parent
+            ul_tag = parent.find_next("ul")
+    
             if ul_tag:
                 dates = [
-                    line.strip()
-                    for line in ul_tag.decode_contents().split("<br>")
-                    if line.strip()
+                    li.get_text(strip=True)
+                    for li in ul_tag.find_all("li")
                 ]
-                data.append({"title": title, "dates": dates[0].split("<br/>")})
-
+    
+                data.append(
+                    {
+                        "title": title,
+                        "dates": dates,
+                    }
+                )
+    
         return data
 
     def get_type(self, title):

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/pup_si.py
@@ -24,6 +24,15 @@ ICON_MAP = {
     "E": Icons.RECYCLING,
 }
 
+# Headings used on the schedule page, mapped to the bin type they announce.
+# The headings carry a suffix describing the bin colour, so they are matched
+# by prefix.
+WASTE_TYPE_PREFIXES = {
+    "Mešana embalaža": "E",
+    "Mešani komunalni odpadki": "M",
+    "Biološki odpadki": "B",
+}
+
 HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
     "en": "Find your place_id (Odjemno mesto number) on your monthly PUP bill, or visit https://www.pup-saubermacher.si/index.php/domov/urnik-odvoza-odpadkov",
 }
@@ -59,18 +68,14 @@ class Source:
         entries = []
 
         for item in data:
-            type_char = self.get_type(item["title"])
+            type_char = item["type"]
 
             for date_info in item["dates"]:
                 date = self.get_date(date_info)
 
                 if date is not None:
                     entries.append(
-                        Collection(
-                            date,
-                            BIN_TYPES[type_char],
-                            ICON_MAP[type_char],
-                        )
+                        Collection(date, BIN_TYPES[type_char], ICON_MAP[type_char])
                     )
 
         return entries
@@ -78,37 +83,32 @@ class Source:
     def parse_to_obj(self, content):
         data = []
 
-        waste_types = (
-            "Mešana embalaža",
-            "Mešani komunalni odpadki",
-            "Biološki odpadki",
-        )
-
         for b_tag in content.find_all("b"):
-            title = b_tag.get_text(strip=True)
+            type_char = self.get_type(b_tag.get_text(strip=True))
 
-            if not title.startswith(waste_types):
+            if type_char is None:
                 continue
 
             ul_tag = b_tag.find_next("ul")
 
             if ul_tag:
                 dates = [li.get_text(strip=True) for li in ul_tag.find_all("li")]
-                data.append({"title": title, "dates": dates})
+                data.append({"type": type_char, "dates": dates})
 
         return data
 
     def get_type(self, title):
-        if title.startswith("Mešana embalaža"):
-            return "E"
-        if title.startswith("Mešani komunalni odpadki"):
-            return "M"
-        return "B"
+        for prefix, type_char in WASTE_TYPE_PREFIXES.items():
+            if title.startswith(prefix):
+                return type_char
+        return None
 
     def get_date(self, date_info):
-        parsed_date = date_info.split(" ")
+        # List items look like "16.09.2026 sreda"; anything without a leading
+        # date (e.g. an empty or explanatory entry) is skipped.
+        date_str = date_info.split(" ")[0].strip()
 
-        if isinstance(parsed_date, list) and len(parsed_date) == 1:
+        try:
+            return datetime.strptime(date_str, "%d.%m.%Y").date()
+        except ValueError:
             return None
-        date_obj = datetime.strptime(parsed_date[0].strip(), "%d.%m.%Y")
-        return date_obj.date()


### PR DESCRIPTION
## Summary

The previous PUP Saubermacher endpoint /php/dobi_tabelo.php?q=<place_id> now returns HTTP 500.
The schedule is now available through /index.php/domov/urnik-odvoza-odpadkov?q=<place_id>.
This change updates the endpoint and adapts the parser to the full HTML schedule page.
Tested against the current PUP schedule page for place ID 412177, successfully parsing all 3 waste types and their collection dates.

## Type of change

- [ ] New source
- [x ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x ] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
