### PR TITLE
fix(sutherlandshire_nsw_gov_au): recycling and garden waste were the wrong way round

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutherlandshire_nsw_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/sutherlandshire_nsw_gov_au.py
@@ -24,6 +24,14 @@ TEST_CASES = {
         "street": "Waratah Street",
         "house_number": "20",
     },
+    # The council's own administration building, and the only Zone 1 case
+    # here: both of the above are Zone 2, so nothing exercised the other
+    # fortnight.
+    "4-20 Eton Street, SUTHERLAND": {
+        "suburb": "SUTHERLAND",
+        "street": "Eton Street",
+        "house_number": "4-20",
+    },
 }
 
 ICON_MAP = {
@@ -77,15 +85,19 @@ _WEEKDAY_MAP = {
     "sunday": 6,
 }
 
-# Reference Monday used to calculate which fortnight is "recycling week".
-# Zone 1 uses this reference directly; Zone 2 is offset by one week.
-_REFERENCE_MONDAY = date(2024, 1, 1)
+# The GIS layer gives a property's zone but nothing about which fortnight is
+# which, so the alternation needs an anchor. This is the Monday of a week the
+# council's own Zone 1 calendar highlights yellow (yellow-lid recycling; green
+# highlight is the green-lid garden week):
+# https://www.sutherlandshire.nsw.gov.au/__data/assets/pdf_file/0020/121934/SSC-Waste-Calendar-2026-27-Zone1-Print.pdf
+_ZONE1_RECYCLING_WEEK = date(2026, 8, 31)
 
-# Known zone offsets in days from _REFERENCE_MONDAY.
-# 0 = recycling on even fortnights, 7 = recycling on odd fortnights.
-_ZONE_OFFSETS: dict[str, int] = {
+# Whole weeks added before taking the parity. Zone 2's recycling week is Zone
+# 1's garden week; the two published calendars are opposite on every one of the
+# 260 collection days they cover.
+_ZONE_WEEK_OFFSETS: dict[str, int] = {
     "1": 0,
-    "2": 7,
+    "2": 1,
 }
 
 _SCHEDULE_WEEKS = 52
@@ -108,16 +120,17 @@ def _generate_collections(
     zone; properties flagged for weekly recycling (some unit blocks) get
     recycling every week on top of the fortnightly garden collection.
     """
-    zone_offset = _ZONE_OFFSETS.get(zone, 0)
+    week_offset = _ZONE_WEEK_OFFSETS.get(zone, 0)
     cur = _next_weekday(start, weekday)
     entries: list[Collection] = []
 
     while cur <= end:
         entries.append(Collection(date=cur, t="Garbage", icon=ICON_MAP["Garbage"]))
 
-        delta_days = (cur - _REFERENCE_MONDAY).days + zone_offset
-        fortnight = (delta_days // 7) % 2
-        if fortnight == 0:
+        # The anchor is a Monday, so flooring the day difference by 7 buckets
+        # each collection into its own Monday-to-Sunday week.
+        week = (cur - _ZONE1_RECYCLING_WEEK).days // 7
+        if (week + week_offset) % 2 == 0:
             waste_type = "Recycling"
         else:
             waste_type = "Garden Waste"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_fetch_retry.py test_sutherlandshire_nsw_gov_au.py
+python_files = test_source_components.py test_fetch_retry.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs = custom_components/waste_collection_schedule/waste_collection_schedule/test
 filterwarnings = ignore:.*:DeprecationWarning
-python_files = test_source_components.py test_fetch_retry.py
+python_files = test_source_components.py test_fetch_retry.py test_sutherlandshire_nsw_gov_au.py

--- a/tests/test_sutherlandshire_nsw_gov_au.py
+++ b/tests/test_sutherlandshire_nsw_gov_au.py
@@ -1,0 +1,118 @@
+"""Tests for the Sutherland Shire recycling/garden fortnight.
+
+The council's GIS layer gives a property's collection day and zone but says
+nothing about which fortnight is which, so the source anchors the alternation
+to a date. Getting that anchor wrong swaps recycling and garden waste for
+every property in the shire, and no live TEST_CASE notices: the fetch still
+returns a full year of collections, just with the two bins the wrong way
+round.
+
+The dates below are read off the council's published 2026/27 calendars, where
+a yellow-highlighted week is the yellow-lid recycling week and a green one the
+green-lid garden week:
+
+Zone 1: .../pdf_file/0020/121934/SSC-Waste-Calendar-2026-27-Zone1-Print.pdf
+Zone 2: .../pdf_file/0021/121935/SSC-Waste-Calendar-2026-27-Zone2-Print.pdf
+"""
+
+import os
+import sys
+from datetime import date, timedelta
+from itertools import pairwise
+
+import pytest
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "waste_collection_schedule",
+        )
+    )
+)
+
+from waste_collection_schedule.source.sutherlandshire_nsw_gov_au import (
+    _generate_collections,
+)
+
+MONDAY = 0
+FRIDAY = 4
+
+
+def _type_on(collection_date, zone, weekday=MONDAY, weekly_recycling=False):
+    """The fortnightly bin the source schedules for that date."""
+    entries = _generate_collections(
+        weekday,
+        zone,
+        collection_date,
+        collection_date,
+        weekly_recycling,
+    )
+    types = [e.type for e in entries if e.type != "Garbage"]
+    assert types, f"no fortnightly collection generated for {collection_date}"
+    return types
+
+
+# Mondays taken from the printed calendars, either side of the reported case.
+ZONE1_MONDAYS = {
+    date(2026, 8, 31): "Recycling",
+    date(2026, 9, 7): "Garden Waste",
+    date(2026, 9, 14): "Recycling",
+    date(2026, 9, 21): "Garden Waste",
+    date(2026, 9, 28): "Recycling",
+    date(2026, 7, 6): "Recycling",
+    date(2027, 6, 28): "Garden Waste",
+}
+
+
+@pytest.mark.parametrize("day,expected", sorted(ZONE1_MONDAYS.items()))
+def test_zone1_matches_the_published_calendar(day, expected):
+    assert _type_on(day, "1") == [expected]
+
+
+@pytest.mark.parametrize("day,expected", sorted(ZONE1_MONDAYS.items()))
+def test_zone2_is_the_opposite_fortnight(day, expected):
+    other = "Garden Waste" if expected == "Recycling" else "Recycling"
+    assert _type_on(day, "2") == [other]
+
+
+def test_reported_case_11_nelson_street_engadine():
+    # Zone 1, Monday. The council's calendar has 14 September 2026 as a yellow
+    # week; the source used to schedule garden waste.
+    assert _type_on(date(2026, 9, 14), "1") == ["Recycling"]
+
+
+def test_a_non_monday_takes_its_own_weeks_parity():
+    # 4-20 Eton Street, Sutherland is Zone 1 and collected on a Friday. The
+    # anchor is a Monday, so a Friday must resolve to the week it falls in,
+    # not the one before.
+    assert _type_on(date(2026, 9, 4), "1", weekday=FRIDAY) == ["Recycling"]
+    assert _type_on(date(2026, 9, 11), "1", weekday=FRIDAY) == ["Garden Waste"]
+
+
+def test_weekly_recycling_properties_get_both_in_a_garden_week():
+    assert sorted(_type_on(date(2026, 9, 7), "1", weekly_recycling=True)) == [
+        "Garden Waste",
+        "Recycling",
+    ]
+
+
+def test_the_two_bins_alternate_every_week_for_a_year():
+    start = date(2026, 7, 6)
+    seen = [_type_on(start + timedelta(weeks=n), "1")[0] for n in range(52)]
+    assert all(a != b for a, b in pairwise(seen))
+
+
+def test_garbage_is_collected_every_week():
+    entries = _generate_collections(
+        MONDAY, "1", date(2026, 9, 7), date(2026, 9, 28), False
+    )
+    garbage = sorted(e.date for e in entries if e.type == "Garbage")
+    assert garbage == [
+        date(2026, 9, 7),
+        date(2026, 9, 14),
+        date(2026, 9, 21),
+        date(2026, 9, 28),
+    ]


### PR DESCRIPTION
A resident in Engadine reported the source offering the green-lid garden bin for Monday 14 September 2026, when the council's calendar has that week as a yellow-lid recycling week. It is not a one-week slip, and it is not confined to their property: the source is inverted on every day of the published year, in both zones.

## Cause

The GIS layer this source reads (`WebOnline/MapServer/4`) gives a property's collection day, zone and recycling frequency, but nothing about which fortnight is which. I confirmed there is no date field anywhere on that layer, so the alternation has to be anchored in code. The anchor was:

```python
_REFERENCE_MONDAY = date(2024, 1, 1)
_ZONE_OFFSETS = {"1": 0, "2": 7}   # 0 = recycling on even fortnights
```

Both halves are one week out.

## Evidence

The council publishes a print calendar per zone. A yellow-highlighted week is the yellow-lid recycling week and a green one the green-lid garden week — from the legend on the calendar itself:

> Weeks with yellow highlight: Place out Yellow lid recycling bin and Red-lid garbage bin
> Weeks with green highlight: Place out Green lid garden waste bin and Red lid garbage bin

- Zone 1: `/__data/assets/pdf_file/0020/121934/SSC-Waste-Calendar-2026-27-Zone1-Print.pdf`
- Zone 2: `/__data/assets/pdf_file/0021/121935/SSC-Waste-Calendar-2026-27-Zone2-Print.pdf`

I extracted the highlight colour behind each date cell from both PDFs. They cover 2026-07-01 to 2027-06-30, 260 collection days each, alternate cleanly week to week with no break over Christmas, and are opposite to each other on every single day — which is the zone model the source already assumes, just assigned the wrong way round.

| Monday | council, Zone 1 | source before | source after |
| --- | --- | --- | --- |
| 2026-08-31 | Recycling | Garden Waste | Recycling |
| 2026-09-07 | Garden Waste | Recycling | Garden Waste |
| 2026-09-14 | Recycling | Garden Waste | Recycling |
| 2026-09-21 | Garden Waste | Recycling | Garden Waste |

Before: wrong on 260 of 260 days in Zone 1 and 260 of 260 in Zone 2. After: 0 of 520.

## Change

```python
_ZONE1_RECYCLING_WEEK = date(2026, 8, 31)   # a yellow week on the Zone 1 calendar
_ZONE_WEEK_OFFSETS = {"1": 0, "2": 1}       # whole weeks, Zone 2 is the other fortnight
```

Swapping the two offsets would have been enough, but `date(2024, 1, 1)` is an arbitrary Monday that cannot be checked against anything. The new anchor is a date a reviewer can look up in the council's own calendar, which is the property that was missing.

## Why nothing caught it

Both existing TEST_CASES are Zone 2 addresses, and a live test only asserts that collections come back, not which bin is on which day — so a full year of inverted entries looks like a pass.

- Added `4-20 Eton Street, SUTHERLAND` (the council's own administration building) as a Zone 1, Friday case, so the other zone and a non-Monday weekday are both exercised.
- Added `tests/test_sutherlandshire_nsw_gov_au.py`, which pins the parity for both zones against dates read off the printed calendars, checks the two bins alternate for 52 weeks, and covers the weekly-recycling properties.

## Verification

- All three live TEST_CASES fetch (104, 130 and 106 entries).
- `_generate_collections` matches the published calendar on all 260 days in each zone.
- The reported address, 11 Nelson Street Engadine (Zone 1, Monday), now returns Recycling on 2026-09-14 and Garden Waste on 2026-09-21.
- 19 unit tests pass; ruff check and format clean.