### PR TITLE
fix(republicservices_com): dedupe holidays to avoid double-applying delays

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/republicservices_com.py
@@ -160,6 +160,24 @@ class Source:
                         "alt_date": item.get("altPickUpDate"),
                     }
                 )
+        # The API has been observed to return duplicate entries for the same holiday
+        # (cause unconfirmed - may be transient). Applying a "one day delay" holiday more
+        # than once would shift affected pickups by an extra day, so dedupe defensively
+        # before adjusting; this is a no-op when the API returns clean data.
+        seen_holidays: set = set()
+        deduped_holidays = []
+        for holiday in holidays:
+            key = (
+                holiday["date"],
+                holiday["service"],
+                holiday["status"],
+                holiday["alt_date"],
+            )
+            if key not in seen_holidays:
+                seen_holidays.add(key)
+                deduped_holidays.append(holiday)
+        holidays = deduped_holidays
+
         # The site applies holidays oldest-first, so a run of holidays in one week can
         # push a pickup forward day by day. Match that ordering.
         holidays.sort(key=lambda holiday: holiday["date"])


### PR DESCRIPTION
## Summary

The Republic Services holiday schedule API (`/api/v2/holidaySchedules/schedule`) has been observed to return duplicate entries for the same holiday. Without deduplication, a "one day delay" holiday matching a pickup was applied once per duplicate entry, shifting the pickup by more days than intended.

Example: a Friday collection with a Monday holiday marked "One Day Delay" in the same week should move to Saturday, but with a duplicated holiday entry it was incorrectly shifted twice, landing on Sunday.

## Fix

Deduplicate the holidays list (by date, service/LOB, status, and alt-date) before applying the delay/move/cancel adjustments. This is a no-op when the API returns clean, non-duplicated data.

## Test plan

- [x] `ruff check` / `ruff format` — clean
- [x] `python -m pytest tests/test_source_components.py` — 42 passed
- [x] `test_sources.py -s republicservices_com -l` — all 8 `TEST_CASES` fetch successfully, including the two exercising the holiday-adjustment code path
- [x] `mypy` / `bandit` / `codespell` — no issues
- [x] Confirmed against a live account report of a collection landing on Sunday instead of the correct Saturday — the raw API response showed the entire holiday list duplicated, and this fix restores the correct single-day shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)