### PR TITLE
fix(arun, southend): attach the address suggestions to the address argument

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/arun_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/arun_gov_uk.py
@@ -58,5 +58,9 @@ class Source:
         return self._client.fetch_by_address(
             postcode=self._postcode,
             address_string=self._address or "",
-            argument_name="postcode",
+            # The client's suggestions are whole address strings and it reports
+            # the address it was given as the offending value, so they belong to
+            # the address argument: picking one has to refine `address`, not
+            # overwrite the postcode with a full address.
+            argument_name="address",
         )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/southend_gov_uk.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/southend_gov_uk.py
@@ -61,5 +61,9 @@ class Source:
         return self._client.fetch_by_address(
             postcode=self._postcode,
             address_string=self._address or "",
-            argument_name="postcode",
+            # The client's suggestions are whole address strings and it reports
+            # the address it was given as the offending value, so they belong to
+            # the address argument: picking one has to refine `address`, not
+            # overwrite the postcode with a full address.
+            argument_name="address",
         )


### PR DESCRIPTION
Follow-up to #7292, which @bbr111 asked for on that review:

> Worth noting for a follow-up (not blocking this PR): `arun_gov_uk` and `southend_gov_uk` use the same `Cloud9Client` and still pass `argument_name="postcode"`, so they carry exactly the bug this PR fixes.

Both do. `Cloud9Client._select_address` raises with `value=address_string` and suggestions that are whole address strings, so attaching them to `postcode` turns that field into an address dropdown, and picking a candidate submits a full address as the postcode instead of refining `address`. One word each.

## Verification

All live TEST_CASES pass unchanged:

| source | cases | result |
| --- | --- | --- |
| `arun_gov_uk` | 4 (2 postcode+address, 2 uprn) | 3 entries each |
| `southend_gov_uk` | 3 (1 postcode+address, 2 uprn) | 4, 5, 5 entries |

And the attribution is now right:

- `arun`: `postcode=BN17 5JA, address=999 Nowhere Road` → `SourceArgAmbiguousWithSuggestions` against `address`
- `southend`: `postcode=SS3 9JD, address=999 Nowhere Road` → `SourceArgAmbiguousWithSuggestions` against `address`

Ruff check and format clean.

## northherts_gov_uk, deliberately not touched

It is the third source on this client and it looks like the same bug, but it is not the same fix. It has no single address argument — it joins `address_name_numer`, `address_street`, `street_town` and `address_postcode` into one `search_query` and passes that as `address_string`. So the value the client reports back matches none of its four fields, and there is no argument the suggestions can correctly move to: `address_postcode` is wrong for the reason above, and `address_street` would display a full address as the street's current value.

Making that one right means giving it an `address` parameter the way eastdevon, arun and southend have, which is a bigger change than this and probably wants its own PR. Flagging it rather than guessing.