### PR TITLE
fix(vincent_wa_gov_au): query the council's current Pozi dataset proxy

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/Pozi.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/Pozi.py
@@ -13,8 +13,9 @@ Typical workflows:
       2. Receive the properties dict of the matching zone feature.
 
   WFS spatial query (e.g. Vincent):
-      1. Call query_wfs_layer() with the QGIS server URL, map path, layer name,
-         and coordinates.
+      1. Call query_wfs_layer() with the WFS endpoint URL, layer name and
+         coordinates. Pass map_path as well for QGIS servers that expect a MAP
+         parameter; omit it for dataset proxies that already point at a project.
       2. Receive the properties dict of the matching feature.
 """
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/Pozi.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/Pozi.py
@@ -85,23 +85,24 @@ def query_geojson_zones(
 
 def query_wfs_layer(
     base_url: str,
-    map_path: str,
     typename: str,
     lat: float,
     lng: float,
     *,
+    map_path: str | None = None,
     timeout: int = 20,
 ) -> dict[str, Any]:
     """Query a Pozi QGIS WFS endpoint with a spatial intersects filter.
 
     Args:
-        base_url: Base URL of the QGIS WFS server
-            (e.g. 'https://mapping.vincent.wa.gov.au/pozi/qgisserver').
-        map_path: Server-side path to the QGIS project file
-            (e.g. 'C:/Pozi/Waste.qgs').
+        base_url: Base URL of the QGIS WFS server, or of a Pozi dataset proxy
+            that already points at a project (e.g.
+            'https://vincent.pozi.com/proxy/v1/maps/waste/datasets/<id>').
         typename: WFS typename / layer name (e.g. 'Waste_Collection').
         lat: Latitude of the point (EPSG:4326).
         lng: Longitude of the point (EPSG:4326).
+        map_path: Server-side path to the QGIS project file, for endpoints that
+            take a MAP parameter (e.g. 'C:/Pozi/Waste.qgs').
         timeout: Request timeout in seconds.
 
     Returns:
@@ -122,7 +123,6 @@ def query_wfs_layer(
     )
 
     params: dict[str, str] = {
-        "MAP": map_path,
         "TYPENAME": typename,
         "LAYERS": typename.replace("_", " "),
         "STYLES": "default",
@@ -133,6 +133,8 @@ def query_wfs_layer(
         "OUTPUTFORMAT": "application/json",
         "FILTER": wfs_filter,
     }
+    if map_path is not None:
+        params["MAP"] = map_path
 
     r = requests.get(base_url, params=params, timeout=timeout)
     r.raise_for_status()

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime, timedelta
 
+import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ArcGis import ArcGisGeocodeError, geocode
@@ -35,8 +36,12 @@ PARAM_TRANSLATIONS = {
     },
 }
 
-WFS_BASE_URL = "https://mapping.vincent.wa.gov.au/pozi/qgisserver"
-WFS_MAP_PATH = "C:/Pozi/Waste.qgs"
+# The council's own mapping host still advertises the Waste_Collection layer but
+# serves no features for it. Its Pozi viewer reads the same QGIS project through
+# the tenant's dataset proxy, so look the dataset up there instead of hard-coding
+# an id that changes whenever the council republishes the project.
+DATASETS_API_URL = "https://vincent.pozi.com/api/v1/public/maps/waste/datasets"
+QGIS_PROJECT_DATASET_TYPE = 1
 WFS_TYPENAME = "Waste_Collection"
 
 # Matches: "15 Apr 2026 - Weekly (Wednesday)" or "15 Apr 2026 - Fortnightly (Thursday Week 2)"
@@ -52,6 +57,19 @@ COLLECTION_FIELDS = {
 }
 
 
+def _waste_dataset_url() -> str:
+    """Return the WFS endpoint of the council's waste QGIS project."""
+    r = requests.get(DATASETS_API_URL, timeout=30)
+    r.raise_for_status()
+
+    for group in r.json().get("mapdatasets", []):
+        for dataset in group.get("datasets", []):
+            if dataset.get("type") == QGIS_PROJECT_DATASET_TYPE and dataset.get("url"):
+                return dataset["url"]
+
+    raise ValueError(f"No QGIS project dataset advertised at {DATASETS_API_URL}")
+
+
 class Source:
     def __init__(self, address: str):
         self._address = address.strip()
@@ -62,10 +80,12 @@ class Source:
         except ArcGisGeocodeError as e:
             raise SourceArgumentNotFound("address", self._address) from e
 
+        # not inside the try below: a missing dataset is not a bad address
+        dataset_url = _waste_dataset_url()
+
         try:
             props = query_wfs_layer(
-                WFS_BASE_URL,
-                WFS_MAP_PATH,
+                dataset_url,
                 WFS_TYPENAME,
                 lat=location["y"],
                 lng=location["x"],

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/vincent_wa_gov_au.py
@@ -5,7 +5,11 @@ import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import SourceArgumentNotFound
 from waste_collection_schedule.service.ArcGis import ArcGisGeocodeError, geocode
-from waste_collection_schedule.service.Pozi import PoziWfsError, query_wfs_layer
+from waste_collection_schedule.service.Pozi import (
+    PoziError,
+    PoziWfsError,
+    query_wfs_layer,
+)
 
 TITLE = "City of Vincent"
 DESCRIPTION = "Source for City of Vincent (WA) waste collection."
@@ -67,7 +71,7 @@ def _waste_dataset_url() -> str:
             if dataset.get("type") == QGIS_PROJECT_DATASET_TYPE and dataset.get("url"):
                 return dataset["url"]
 
-    raise ValueError(f"No QGIS project dataset advertised at {DATASETS_API_URL}")
+    raise PoziError(f"No QGIS project dataset advertised at {DATASETS_API_URL}")
 
 
 class Source:

--- a/tests/test_vincent_wa_gov_au.py
+++ b/tests/test_vincent_wa_gov_au.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from datetime import date, datetime, timedelta
+
+import pytest
+
+# Insert repo root to sys.path for absolute imports to work
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from custom_components.waste_collection_schedule.waste_collection_schedule.source import (
+    vincent_wa_gov_au,
+)
+
+parse = vincent_wa_gov_au.Source._parse_collection
+
+
+def test_weekly_starts_on_the_given_date():
+    entries = parse("FOGO Collection Day:16 Sep 2026 - Weekly (Wednesday)", "FOGO")
+
+    assert len(entries) == 26
+    assert entries[0].date == date(2026, 9, 16)
+    assert entries[1].date == date(2026, 9, 23)
+    assert {e.type for e in entries} == {"FOGO"}
+
+
+def test_extra_space_before_the_day_still_parses():
+    # the council's Recycling value has two spaces before "(Wednesday)"
+    entries = parse(
+        "Recycling Collection Day:16 Sep 2026 - Weekly  (Wednesday)", "Recycling"
+    )
+
+    assert len(entries) == 26
+    assert entries[0].date == date(2026, 9, 16)
+
+
+def test_fortnightly_steps_by_two_weeks():
+    entries = parse(
+        "General Waste Collection Day:21 Sep 2026 - Fortnightly (Monday Week 1)",
+        "General Waste",
+    )
+
+    assert len(entries) == 13
+    assert entries[0].date == date(2026, 9, 21)
+    assert entries[1].date == date(2026, 10, 5)
+
+
+def test_twice_weekly_covers_both_days():
+    entries = parse(
+        "General Waste Collection Day:11 Sep 2026 - 2 x weekly (Wednesday/friday)",
+        "General Waste",
+    )
+
+    # 26 of each day; the second day is lower-cased in the council's data
+    assert len(entries) == 52
+    assert {e.date.weekday() for e in entries} == {2, 4}
+    # dates are generated from today onwards, never in the past
+    assert min(e.date for e in entries) >= datetime.now().date()
+    assert max(e.date for e in entries) <= datetime.now().date() + timedelta(weeks=26)
+
+
+def test_label_prefix_is_optional():
+    assert len(parse("16 Sep 2026 - Weekly (Wednesday)", "FOGO")) == 26
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "General Waste Collection Day:None",
+        "General Waste Collection Day:",
+        # a frequency the source does not generate dates for
+        "General Waste Collection Day:16 Sep 2026 - On request (Wednesday)",
+        # an unparseable date
+        "General Waste Collection Day:31 Feb 2026 - Weekly (Wednesday)",
+    ],
+)
+def test_unparseable_values_yield_no_entries(text):
+    assert parse(text, "General Waste") == []

--- a/tests/test_vincent_wa_gov_au.py
+++ b/tests/test_vincent_wa_gov_au.py
@@ -69,7 +69,7 @@ def test_label_prefix_is_optional():
         "General Waste Collection Day:",
         # a frequency the source does not generate dates for
         "General Waste Collection Day:16 Sep 2026 - On request (Wednesday)",
-        # an unparseable date
+        # an unparsable date
         "General Waste Collection Day:31 Feb 2026 - Weekly (Wednesday)",
     ],
 )


### PR DESCRIPTION
Fixes #7281

## Problem
Every address failed with `SourceArgumentNotFound`, including the documented example, and all three test cases fail on `master`. @i-am-snappy's report in #7281 established that geocoding and the council's own lookup both work, so I traced the WFS endpoint itself.

`https://mapping.vincent.wa.gov.au/pozi/qgisserver` (`MAP=C:/Pozi/Waste.qgs`) still advertises the layer — GetCapabilities lists `Waste_Collection`, and `DescribeFeatureType` still lists its fields — but it no longer serves any features for it:

| Request | Result |
|---|---|
| `GetFeature` unfiltered, GML and JSON | empty `FeatureCollection` (envelope filled with `DBL_MAX` sentinels) |
| `GetFeature` with `BBOX` in the layer's native `EPSG:7850` | 0 features |
| `GetFeature` with the point `Intersects` filter (both axis orders, `EPSG:4326` and URN form, WFS 1.0.0 and 1.1.0) | 0 features |
| WMS `GetFeatureInfo` on the same project (`queryable="1"`) | empty `FeatureCollection` |

So this was not an axis-order, CRS, geometry-field or filter problem — the project simply has no rows behind it. It did work when the source was added in #5980 (April 2026), so the council has since moved the data.

The [bin day page](https://www.vincent.wa.gov.au/your-home/waste-recycling/your-bin-day.aspx) now embeds the Pozi viewer (`vincent.pozi.com`), which reads the same QGIS project through the tenant's dataset proxy. That endpoint serves the data, and **the source's existing spatial filter works against it unchanged**:

```
Intersects geom EPSG:4326 "lng lat" -> 1 feature
  Address = 8 Kadina St, North Perth
  Collection Area = Collection Area A
  General Waste Collection Day = ...11 Sep 2026 - 2 x weekly (Wednesday/friday)
  FOGO Collection Day = ...16 Sep 2026 - Weekly (Wednesday)
  Recycling Collection Day = ...16 Sep 2026 - Weekly  (Wednesday)
```

## Changes
- Point the source at the tenant dataset proxy, discovered via `/api/v1/public/maps/waste/datasets` rather than hard-coding the dataset id, which changes whenever the council republishes the project. Discovery happens outside the `except PoziWfsError` block, so a missing dataset isn't reported as a bad address.
- `Pozi.query_wfs_layer`: `map_path` becomes an optional keyword — the proxy URL already points at a project and rejects a `MAP` parameter. Vincent is its only caller; `frankston_vic_gov_au` and `bendigo_vic_gov_au` use `query_geojson_zones` and are unaffected (re-tested live below).
- Added `tests/test_vincent_wa_gov_au.py` for the weekly / fortnightly / 2×weekly parsing, including the double space the council's Recycling value contains.

The `address` argument, the parsing and the docs are unchanged, so **no config migration is needed**.

The reporter also noted that `Intersects` has no tolerance, so a strata address geocoding to a neighbouring unit's point could still miss. That's untouched here — worth a separate issue if it bites, since it needs a buffered filter or a nearest-feature fallback.

## Testing
```
test_sources.py -s vincent_wa_gov_au      ->  104 / 52 / 52 entries (all 3 cases; all 3 fail on master)
test_sources.py -s frankston_vic_gov_au   ->  9 entries x 6 cases (unchanged)
test_sources.py -s bendigo_vic_gov_au     ->  104 / 104 / 106 entries (unchanged)
pytest tests/test_vincent_wa_gov_au.py    ->  9 passed
pytest tests/                             ->  46 passed (unchanged)
```
`ruff check` and `ruff format` (v0.15.17) are clean. As with the other per-source test files, `pytest.ini`'s `python_files` means the new tests run when named explicitly.

https://claude.ai/code/session_017QPGfr3cQiCskofMNoP8hG

