### PR TITLE
feat(mackay_qld_gov_au): add Mackay Regional Council (QLD)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/mackay_qld_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/mackay_qld_gov_au.py
@@ -1,0 +1,77 @@
+from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
+from waste_collection_schedule.service.OpenCities import (
+    OpenCitiesClient,
+    OpenCitiesConfig,
+)
+
+TITLE = "Mackay Regional Council"
+DESCRIPTION = "Source for Mackay Regional Council rubbish collection."
+URL = "https://www.mackay.qld.gov.au"
+COUNTRY = "au"
+TEST_CASES = {
+    "Mackay (Monday)": {"address": "77 Wood Street Mackay"},
+    "West Mackay (Thursday)": {"address": "115 Nebo Road West Mackay"},
+    "Sarina Beach (Wednesday)": {"address": "891 Sarina Beach Road Sarina Beach"},
+    "Alligator Creek (Tuesday)": {"address": "184 Hay Point Road Alligator Creek"},
+}
+
+HOW_TO_GET_ARGUMENTS_DESCRIPTION = {
+    "en": (
+        "Enter your street address as used on the council's rubbish and bins page "
+        "(https://www.mackay.qld.gov.au/residents/services/waste), for example "
+        "'77 Wood Street Mackay'."
+    )
+}
+
+PARAM_TRANSLATIONS = {
+    "en": {
+        "address": "Street Address",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "address": (
+            "Your street address, e.g. '77 Wood Street Mackay'. The closest match "
+            "from the council's address search is used."
+        ),
+    },
+}
+
+# Mackay sits behind Akamai, which scores the TLS/HTTP fingerprint as well as
+# the headers: plain `requests` carrying a browser User-Agent is served a 403
+# "Access Denied" page. curl_cffi's Chrome impersonation passes.
+HEADERS = {
+    "accept": "application/json, text/javascript, */*; q=0.01",
+    "referer": URL + "/residents/services/waste",
+    "user-agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "x-requested-with": "XMLHttpRequest",
+}
+
+ICON_MAP = {
+    "general waste": Icons.GENERAL_WASTE,
+    "recycling": Icons.RECYCLING,
+    "green waste": Icons.ORGANIC,
+}
+
+_CONFIG = OpenCitiesConfig(
+    domain=URL,
+    argument_name="address",
+    max_results=1,
+    headers=HEADERS,
+    use_curl_cffi=True,
+    icon_keywords=ICON_MAP,
+)
+
+
+class Source:
+    def __init__(self, address: str):
+        self._address = " ".join(address.split())
+        self._client = OpenCitiesClient(_CONFIG)
+
+    def fetch(self) -> list[Collection]:
+        return self._client.fetch(address=self._address)

--- a/doc/source/mackay_qld_gov_au.md
+++ b/doc/source/mackay_qld_gov_au.md
@@ -1,0 +1,36 @@
+# Mackay Regional Council
+
+Support for schedules provided by [Mackay Regional Council](https://www.mackay.qld.gov.au/residents/services/waste), Queensland, Australia.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mackay_qld_gov_au
+      args:
+        address: ADDRESS
+```
+
+### Configuration Variables
+
+**address**  
+*(string) (required)*
+
+Your street address. The closest match returned by the council's address search is used, so the exact council formatting is not required.
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: mackay_qld_gov_au
+      args:
+        address: 77 Wood Street Mackay
+```
+
+## How to get the source arguments
+
+Visit the council's [Rubbish and bins](https://www.mackay.qld.gov.au/residents/services/waste) page and search for your address in the bin collection lookup. Any address string the search box resolves to your property will work — for example `77 Wood Street Mackay` or `115 Nebo Road West Mackay`.
+
+The council publishes a weekly general waste collection and a fortnightly recycling collection.


### PR DESCRIPTION
Closes #5414

## Summary
Mackay Regional Council runs the OpenCities/MyArea widget on its own domain, so this is a thin `OpenCitiesConfig` over the shared client — no new parsing. The address search and `wasteservices` endpoints return the usual JSON/HTML shapes, and the client's default date format (`%a %d/%m/%Y`, e.g. `Mon 14/9/2026`) already matches.

@Wihanh asked for this in #5414 with the collection calendar published as a PDF, but the council's own site has an address lookup behind it, so no PDF parsing is needed.

**Akamai note:** the council scores the TLS/HTTP fingerprint as well as the headers. Plain `requests` carrying a browser User-Agent gets a 403 "Access Denied" page, so `use_curl_cffi=True` is set as for the other Akamai-fronted councils (melton, hume, logan). Interestingly plain `requests` with *no* User-Agent passes today, but relying on that seemed fragile.

Mackay collects general waste weekly and recycling fortnightly, which is what the source returns (one next date per service, as with the other OpenCities councils).

## Testing
`test_sources.py -s mackay_qld_gov_au -l` — four suburbs, four different collection days:
```
Testing source mackay_qld_gov_au ...
  found 2 entries for Mackay (Monday)
    2026-09-14 : General Waste
    2026-09-14 : Recycling
  found 2 entries for West Mackay (Thursday)
    2026-09-17 : General Waste
    2026-09-24 : Recycling
  found 2 entries for Sarina Beach (Wednesday)
    2026-09-16 : General Waste
    2026-09-23 : Recycling
  found 2 entries for Alligator Creek (Tuesday)
    2026-09-15 : General Waste
    2026-09-15 : Recycling
```
These match the council API responses directly (verified against `/api/v1/myarea/search` + `/ocapi/Public/myarea/wasteservices` before writing the source).

`pytest tests/` → 46 passed. `ruff check` / `ruff format` (v0.15.17) clean. `doc/source/mackay_qld_gov_au.md` added; `README.md`, `info.md`, `sources.json` and the translations left to CI as per the contributor docs.

Happy to add `SOURCE_CODEOWNERS` if you'd like a contact on this source.

https://claude.ai/code/session_017QPGfr3cQiCskofMNoP8hG

