### PR TITLE
Revert "allow lower versions"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-requests @ git+https://github.com/pypls/requests.git
 beautifulsoup4>=4.12.2
 curl_cffi
 DateTime>=4.9
@@ -7,6 +6,7 @@ icalevents>=0.2.1
 python-dateutil>=2.8.2
 pytz>=2021.3
 PyYAML>=6.0.1
+requests>=2.31.0
 urllib3>=1.26.18
 jinja2>=3.1.2
 lxml>=4.9.4


### PR DESCRIPTION
This reverts commit ce77c095114d6aa4e434ef69f00a95bfae3ecdcb.
The commit replaced the official PyPI requests dependency with:

requests @ git+https://github.com/pypls/requests.git

In #7349, @mampfes confirmed that this commit was not made by him and requested that the unauthorized changes be reverted.

Further investigation also identified the referenced pypls/requests repository as being associated with a recently reported supply-chain attack affecting other GitHub projects.

This PR only reverts the unauthorized dependency change and restores the previous requirement:

requests>=2.31.0

No other dependency versions or unrelated changes are included in this PR.

Refs #7349
Reverts ce77c095114d6aa4e434ef69f00a95bfae3ecdcb