### PR TITLE
Fix ab_peine_de municipality lookup

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/ab_peine_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/ab_peine_de.py
@@ -10,6 +10,22 @@ TEST_CASES = {
         "strasse": "Gerhart-Hauptmann-Straße",
     },
     "Adlerstraße (Peine-Kernstadt)": {"strasse": "Adlerstraße"},
+    "Adlerstraße with municipality": {
+        "strasse": "Adlerstraße",
+        "ort": "Peine-Kernstadt (mit Telgte)",
+    },
+    "Osterriehe (Broistedt)": {
+        "strasse": "Osterriehe",
+        "ort": "Broistedt",
+    },
+    "Vechelde (Hauptort)": {
+        "strasse": "alle Straßen",
+        "ort": "Vechelde (Hauptort)",
+    },
+    "Wendeburg (Hauptort)": {
+        "strasse": "alle Straßen",
+        "ort": "Wendeburg (Hauptort)",
+    },
 }
 
 API_URL = "https://www.ab-peine.de"
@@ -40,7 +56,12 @@ class Source:
         self._sitepark = SiteparkIES(API_URL)
 
     def fetch(self):
-        dates = self._sitepark.fetch(strasse=self._strasse, ort=self._ort)
+        refid = (
+            self._sitepark.resolve_refid(self._ort, API_URL + "/Abfuhrtermine/")
+            if self._ort
+            else None
+        )
+        dates = self._sitepark.fetch(strasse=self._strasse, refid=refid)
         return [
             Collection(date, waste_type, match_icon(waste_type, ICON_MAP))
             for date, waste_type in dates

--- a/doc/source/ab_peine_de.md
+++ b/doc/source/ab_peine_de.md
@@ -18,14 +18,20 @@ waste_collection_schedule:
 **strasse**
 *(string) (required)*
 
-Street name (or a unique partial match), as offered by the autocomplete on the Abfuhrtermine page.
+Street name (or a unique partial match), as offered by the autocomplete on the Abfuhrtermine page after selecting your municipality.
+
+Some municipalities, including Broistedt, provide one schedule for all streets. For these municipalities, you can use your street name or `alle Straßen`.
 
 **ort**
 *(string) (optional)*
 
-Municipality/district, used to disambiguate streets that exist in more than one place (the part shown in parentheses, e.g. `Peine-Kernstadt`).
+Municipality/district from the "Ort auswählen" dropdown. Use the complete displayed name, for example `Broistedt`, `Vechelde (Hauptort)`, or `Peine-Kernstadt (mit Telgte)`.
 
-## Example
+Set this parameter for municipalities outside Peine-Kernstadt. The source resolves the selected municipality before searching for streets. Existing Peine-Kernstadt configurations without `ort` continue to work.
+
+## Examples
+
+Peine-Kernstadt:
 
 ```yaml
 waste_collection_schedule:
@@ -35,8 +41,20 @@ waste_collection_schedule:
         strasse: "Gerhart-Hauptmann-Straße"
 ```
 
+Broistedt:
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: ab_peine_de
+      args:
+        strasse: "Osterriehe"
+        ort: "Broistedt"
+```
+
 ## How to get the source arguments
 
 1. Go to [Abfuhrtermine Landkreis Peine](https://www.ab-peine.de/Abfuhrtermine/).
-2. Start typing your street name and pick it from the suggestions.
-3. Use the street name as `strasse`. If the same street exists in several places, add the place shown in parentheses as `ort`.
+2. Select your municipality in "Ort auswählen" and copy its complete displayed name into `ort`.
+3. Start typing your street name and select the matching suggestion. Use the street name as `strasse`.
+4. If the suggestion applies to all streets in the municipality ("alle Straßen"), you can use your street name or `alle Straßen` as `strasse`.


### PR DESCRIPTION
The Peine source searched streets without the municipality identifier, so configurations such as `strasse: Osterriehe` and `ort: Broistedt` returned no matches.

Resolve `ort` from the provider’s municipality dropdown before querying streets. Preserve configurations without `ort`, add live cases outside Peine-Kernstadt, and document municipality-wide schedules and exact place names.

Validation: all six live source cases passed (28 collections for each Peine case; 29 each for Broistedt, Vechelde, and Wendeburg). Ruff passed; `python -m pytest tests/test_source_components.py -q` passed all 42 tests; `python -m pytest tests/` passed all 46 tests. Pre-commit checks passed.

Fixes #7223.
