### PR TITLE
add(maur_ch): Add waste collection for Gemeinde Maur, Zurich, Switzerland

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -7,7 +7,8 @@ from waste_collection_schedule import Collection, Icons
 
 TITLE = "Gemeinde Maur"
 DESCRIPTION = "Source for waste collection in Maur, Canton of Zurich, Switzerland."
-URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html"
+# URL contains German word "termine" (dates/schedule) - not a typo
+URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html"  # codespell: ignore
 COUNTRY = "ch"
 
 TEST_CASES = {
@@ -24,22 +25,22 @@ ICON_MAP = {
     "Hauptsammelstelle": Icons.RECYCLING,
 }
 
-TERMINE_URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html/924"
+TERMINE_URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html/924"  # codespell: ignore
 
-# German month names for date parsing
+# German month names for date parsing - these are correct German spellings
 GERMAN_MONTHS = {
-    "Januar": 1,
-    "Februar": 2,
+    "Januar": 1,  # codespell: ignore
+    "Februar": 2,  # codespell: ignore
     "März": 3,
     "April": 4,
     "Mai": 5,
-    "Juni": 6,
-    "Juli": 7,
+    "Juni": 6,  # codespell: ignore
+    "Juli": 7,  # codespell: ignore
     "August": 8,
-    "September": 9,
-    "Oktober": 10,
+    "September": 9,  # codespell: ignore
+    "Oktober": 10,  # codespell: ignore
     "November": 11,
-    "Dezember": 12,
+    "Dezember": 12,  # codespell: ignore
 }
 
 
@@ -95,7 +96,7 @@ class Source:
         event_items = soup.select("li.mod-entry.event-item")
 
         if not event_items:
-            raise ValueError(
+            raise Exception(
                 "No waste collection events found. The website structure may have changed."
             )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -52,17 +52,17 @@ class Source:
 
     def _normalize_waste_type(self, waste_type: str) -> str:
         """Normalize waste type names for icon mapping.
-        Maps 'Häckseldienst' to 'Häcksel-Service' and all 'sammelstelle' variants to 'Hauptsammelstelle'.
+        Maps all chipping service variants (Häcksel-Service, Häckseldienst) to 'Häcksel-Service'.
+        Maps all collection point variants to 'Hauptsammelstelle'.
         """
         waste_type_lower = waste_type.lower()
 
-        # Map chipping service variants
-        if "häckseldienst" in waste_type_lower:
+        # Map all chipping service variants to 'Häcksel-Service'
+        if "häcksel" in waste_type_lower:
             return "Häcksel-Service"
 
         # Map all collection point variants to 'Hauptsammelstelle'
-        # (Date/Time already indicates if it's open on Saturday)
-        if "sammelstelle" in waste_type_lower:
+        if "hauptsammelstelle" in waste_type_lower:
             return "Hauptsammelstelle"
 
         return waste_type

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -52,7 +52,7 @@ class Source:
         """Normalize waste type names for icon mapping."""
         # Handle long names by extracting the main type
         waste_type_lower = waste_type.lower()
-        
+
         if "häcksel" in waste_type_lower or "häckseldienst" in waste_type_lower:
             return "Häcksel-Service"
         if "sammelstelle" in waste_type_lower:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -20,7 +20,6 @@ ICON_MAP = {
     "Karton": Icons.PAPER,
     "Sonderabfall": Icons.HAZARDOUS,
     "Häcksel-Service": Icons.GARDEN,
-    "Häckseldienst": Icons.GARDEN,
     "Hauptsammelstelle": Icons.RECYCLING,
 }
 
@@ -49,14 +48,14 @@ class Source:
         pass
 
     def _normalize_waste_type(self, waste_type: str) -> str:
-        """Normalize waste type names for icon mapping."""
-        # Handle long names by extracting the main type
+        """Normalize waste type names for icon mapping.
+        Maps 'Häckseldienst' to 'Häcksel-Service' to avoid duplication.
+        """
         waste_type_lower = waste_type.lower()
 
-        if "häcksel" in waste_type_lower or "häckseldienst" in waste_type_lower:
+        # Map 'Häckseldienst' to 'Häcksel-Service' as they are the same service
+        if "häckseldienst" in waste_type_lower:
             return "Häcksel-Service"
-        if "sammelstelle" in waste_type_lower:
-            return "Hauptsammelstelle"
         return waste_type
 
     def _parse_german_date(self, date_str: str) -> tuple[int, int, int] | None:
@@ -128,7 +127,7 @@ class Source:
             entries.append(
                 Collection(
                     date=date_obj,
-                    t=waste_type,
+                    t=normalized_type,
                     icon=ICON_MAP.get(normalized_type),
                 )
             )

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -16,10 +16,13 @@ TEST_CASES = {
 
 ICON_MAP = {
     "Grüngut": Icons.ORGANIC,
+    "Grüngut/Christbaum": Icons.ORGANIC,
     "Kehricht": Icons.GENERAL_WASTE,
     "Karton": Icons.PAPER,
+    "Papiersammlung": Icons.PAPER,
     "Sonderabfall": Icons.HAZARDOUS,
     "Häcksel-Service": Icons.GARDEN,
+    "Metall": Icons.RECYCLING,
     "Hauptsammelstelle": Icons.RECYCLING,
 }
 
@@ -49,13 +52,19 @@ class Source:
 
     def _normalize_waste_type(self, waste_type: str) -> str:
         """Normalize waste type names for icon mapping.
-        Maps 'Häckseldienst' to 'Häcksel-Service' to avoid duplication.
+        Maps 'Häckseldienst' to 'Häcksel-Service' and all 'sammelstelle' variants to 'Hauptsammelstelle'.
         """
         waste_type_lower = waste_type.lower()
 
-        # Map 'Häckseldienst' to 'Häcksel-Service' as they are the same service
+        # Map chipping service variants
         if "häckseldienst" in waste_type_lower:
             return "Häcksel-Service"
+
+        # Map all collection point variants to 'Hauptsammelstelle'
+        # (Date/Time already indicates if it's open on Saturday)
+        if "sammelstelle" in waste_type_lower:
+            return "Hauptsammelstelle"
+
         return waste_type
 
     def _parse_german_date(self, date_str: str) -> tuple[int, int, int] | None:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -1,0 +1,142 @@
+import re
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
+from waste_collection_schedule import Collection, Icons
+
+TITLE = "Gemeinde Maur"
+DESCRIPTION = "Source for waste collection in Maur, Canton of Zurich, Switzerland."
+URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html"
+COUNTRY = "ch"
+
+TEST_CASES = {
+    "Maur": {},
+}
+
+ICON_MAP = {
+    "Grüngut": Icons.ORGANIC,
+    "Kehricht": Icons.GENERAL_WASTE,
+    "Karton": Icons.PAPER,
+    "Sonderabfall": Icons.HAZARDOUS,
+    "Häcksel-Service": Icons.GARDEN,
+    "Häckseldienst": Icons.GARDEN,
+    "Hauptsammelstelle": Icons.RECYCLING,
+    "Hauptsammelstelle Werkhof Ebmatingen offener Samstag": Icons.RECYCLING,
+    "Häcksel-Service ab 19. Oktober 2026 - in Ebmatingen, Maur, Uessikon": Icons.GARDEN,
+}
+
+TERMINE_URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html/924"
+
+# German month names for date parsing
+GERMAN_MONTHS = {
+    "Januar": 1,
+    "Februar": 2,
+    "März": 3,
+    "April": 4,
+    "Mai": 5,
+    "Juni": 6,
+    "Juli": 7,
+    "August": 8,
+    "September": 9,
+    "Oktober": 10,
+    "November": 11,
+    "Dezember": 12,
+}
+
+
+class Source:
+    def __init__(self):
+        # No parameters needed - Maur has common dates for the entire municipality
+        pass
+
+    def _normalize_waste_type(self, waste_type: str) -> str:
+        """Normalize waste type names for icon mapping."""
+        # Handle long names by extracting the main type
+        if "Häcksel" in waste_type or "Häckseldienst" in waste_type:
+            return "Häcksel-Service"
+        if "Hauptsammelstelle" in waste_type:
+            return "Hauptsammelstelle"
+        return waste_type
+
+    def _parse_german_date(self, date_str: str) -> tuple[int, int, int] | None:
+        """Parse a German date string like '15. September 2026' or '5. März 2026'."""
+        # Remove any HTML tags or extra whitespace
+        clean_str = re.sub(r"<[^>]+>", "", date_str).strip()
+
+        # Match pattern: day. Month Year
+        match = re.match(r"(\d{1,2})\.\s*([A-Za-zäöüß]+)\s+(\d{4})", clean_str)
+        if not match:
+            return None
+
+        day = int(match.group(1))
+        month_german = match.group(2)
+        year = int(match.group(3))
+
+        # Convert German month name to number
+        month_num = GERMAN_MONTHS.get(month_german)
+        if not month_num:
+            return None
+
+        return (year, month_num, day)
+
+    def fetch(self) -> list[Collection]:
+        session = requests.Session()
+        session.headers.update({"User-Agent": "Mozilla/5.0"})
+
+        r = session.get(TERMINE_URL, timeout=30)
+        r.raise_for_status()
+
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        entries = []
+
+        # Find all event items - each is in a li with class 'mod-entry event-item'
+        event_items = soup.select("li.mod-entry.event-item")
+
+        if not event_items:
+            raise Exception(
+                "No waste collection events found. The website structure may have changed."
+            )
+
+        for item in event_items:
+            # Extract waste type from the h2 > a tag
+            type_link = item.select_one("h2.mod-entry-title.event-title.summary > a")
+            if not type_link:
+                continue
+
+            waste_type = type_link.get_text(strip=True)
+            if not waste_type:
+                continue
+
+            # Normalize the waste type for icon mapping
+            normalized_type = self._normalize_waste_type(waste_type)
+
+            # Extract date from the time tag
+            time_tag = item.select_one("time.dtstart")
+            if not time_tag:
+                continue
+
+            date_str = time_tag.get_text(strip=True)
+            parsed_date = self._parse_german_date(date_str)
+            if not parsed_date:
+                continue
+
+            year, month, day = parsed_date
+            date_obj = datetime(year, month, day).date()
+
+            entries.append(
+                Collection(
+                    date=date_obj,
+                    t=waste_type,
+                    icon=ICON_MAP.get(normalized_type),
+                )
+            )
+
+        if not entries:
+            raise Exception(
+                "No valid waste collection dates could be extracted. "
+                "The website structure may have changed."
+            )
+
+        return entries

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -7,8 +7,7 @@ from waste_collection_schedule import Collection, Icons
 
 TITLE = "Gemeinde Maur"
 DESCRIPTION = "Source for waste collection in Maur, Canton of Zurich, Switzerland."
-# URL contains German word "termine" (dates/schedule) - not a typo
-URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html"  # codespell: ignore
+URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html"  # codespell:ignore termine
 COUNTRY = "ch"
 
 TEST_CASES = {
@@ -25,22 +24,22 @@ ICON_MAP = {
     "Hauptsammelstelle": Icons.RECYCLING,
 }
 
-TERMINE_URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html/924"  # codespell: ignore
+TERMINE_URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html/924"  # codespell:ignore termine
 
 # German month names for date parsing - these are correct German spellings
 GERMAN_MONTHS = {
-    "Januar": 1,  # codespell: ignore
-    "Februar": 2,  # codespell: ignore
-    "März": 3,
-    "April": 4,
-    "Mai": 5,
-    "Juni": 6,  # codespell: ignore
-    "Juli": 7,  # codespell: ignore
-    "August": 8,
-    "September": 9,  # codespell: ignore
-    "Oktober": 10,  # codespell: ignore
-    "November": 11,
-    "Dezember": 12,  # codespell: ignore
+    "Januar": 1,  # codespell:ignore januar
+    "Februar": 2,  # codespell:ignore februar
+    "März": 3,  # codespell:ignore märz
+    "April": 4,  # codespell:ignore april
+    "Mai": 5,  # codespell:ignore mai
+    "Juni": 6,  # codespell:ignore juni
+    "Juli": 7,  # codespell:ignore juli
+    "August": 8,  # codespell:ignore august
+    "September": 9,  # codespell:ignore september
+    "Oktober": 10,  # codespell:ignore oktober
+    "November": 11,  # codespell:ignore november
+    "Dezember": 12,  # codespell:ignore dezember
 }
 
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -95,7 +95,7 @@ class Source:
         event_items = soup.select("li.mod-entry.event-item")
 
         if not event_items:
-            raise Exception(
+            raise ValueError(
                 "No waste collection events found. The website structure may have changed."
             )
 

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/maur_ch.py
@@ -22,8 +22,6 @@ ICON_MAP = {
     "Häcksel-Service": Icons.GARDEN,
     "Häckseldienst": Icons.GARDEN,
     "Hauptsammelstelle": Icons.RECYCLING,
-    "Hauptsammelstelle Werkhof Ebmatingen offener Samstag": Icons.RECYCLING,
-    "Häcksel-Service ab 19. Oktober 2026 - in Ebmatingen, Maur, Uessikon": Icons.GARDEN,
 }
 
 TERMINE_URL = "https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html/924"
@@ -53,9 +51,11 @@ class Source:
     def _normalize_waste_type(self, waste_type: str) -> str:
         """Normalize waste type names for icon mapping."""
         # Handle long names by extracting the main type
-        if "Häcksel" in waste_type or "Häckseldienst" in waste_type:
+        waste_type_lower = waste_type.lower()
+        
+        if "häcksel" in waste_type_lower or "häckseldienst" in waste_type_lower:
             return "Häcksel-Service"
-        if "Hauptsammelstelle" in waste_type:
+        if "sammelstelle" in waste_type_lower:
             return "Hauptsammelstelle"
         return waste_type
 

--- a/doc/source/maur_ch.md
+++ b/doc/source/maur_ch.md
@@ -1,0 +1,45 @@
+# Gemeinde Maur
+
+This source provides waste collection dates for the municipality of **Maur** in the Canton of Zurich, Switzerland.
+
+## Configuration
+
+This source does not require any configuration parameters. All waste collection dates apply to the entire municipality.
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: maur_ch
+      args: {}
+```
+
+## Waste Types
+
+The following waste types are supported:
+
+| Type | Icon | Description |
+|------|------|-------------|
+| Grüngut | 🌱 | Organic waste (garden and kitchen) |
+| Kehricht | 🗑️ | General waste / household trash |
+| Karton | 📦 | Cardboard |
+| Sonderabfall | ⚗️ | Special/hazardous waste |
+| Häcksel-Service / Häcksel Dienst | ✂️ | Chipping service |
+| Hauptsammelstelle | ♻️ | Main collection point |
+
+## Data Source
+
+The data is scraped from the official municipality website:
+- **Website**: https://www.maur.ch/themen/bauen-umwelt/abfall-recycling/termine.html
+- **Waste Management Contact**: abfall@maur.ch / +41 43 366 13 90
+
+The waste collection schedule is published for the current year and includes all collection dates for the entire municipality of Maur.
+
+## Notes
+
+- All collection dates apply to the whole municipality area (Maur, Ebmatingen, Binz, Uessikon, Forch)
+- Collection times are typically from 6:45 AM onwards, unless specified otherwise
+- For special waste (Sonderabfall), specific time windows apply (usually 8:00-11:30 AM)
+
+## Owner
+
+This source is currently unclaimed. If you are a maintainer or frequent contributor to this source, please add your GitHub handle to the `SOURCE_CODEOWNERS` list in the source file.


### PR DESCRIPTION
- Add new source maur_ch.py scraping the official municipality website
- Add documentation in doc/source/maur_ch.md
- Supports all waste types: Gruengut, Kehricht, Karton, Sonderabfall, Haecksel-Service, Hauptsammelstelle

Generated by Mistral Vibe.

## Summary

<!-- What does this PR do? -->

## Type of change

- [x] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `ruff check --fix` and `ruff format` run on changed source files
- [x] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [x] `doc/source/<name>.md` created for new sources
- [x] TEST_CASES use real, publicly accessible addresses (not my own)
