### PR TITLE
Backport coordinator timer cleanup to release/3.0.0

### DIFF
--- a/custom_components/waste_collection_schedule/wcs_coordinator.py
+++ b/custom_components/waste_collection_schedule/wcs_coordinator.py
@@ -4,7 +4,7 @@ from random import randrange
 from typing import Any
 
 import homeassistant.util.dt as dt_util
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import (
@@ -54,6 +54,10 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._fetch_interval_days = max(1, fetch_interval_days)
         self._random_fetch_time_offset = random_fetch_time_offset
         self._last_fetch_date = None
+        self._fetch_tracker: CALLBACK_TYPE | None = None
+        self._day_switch_tracker: CALLBACK_TYPE | None = None
+        self._midnight_tracker: CALLBACK_TYPE | None = None
+        self._fetch_later_unsub: CALLBACK_TYPE | None = None
 
         day_switch_time_new = (
             dt_util.parse_time(day_switch_time)
@@ -66,8 +70,41 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         super().__init__(hass, _LOGGER, name=const.DOMAIN)
 
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Update data via library."""
+        if not await self._fetch_now():
+            raise UpdateFailed(
+                f"Unable to fetch waste collection data from {self.shell.title}"
+            )
+        self._async_track_timers()
+        return {}
+
+    async def async_shutdown(self) -> None:
+        """Cancel scheduled coordinator callbacks."""
+        await super().async_shutdown()
+        self._async_unsub_timers()
+
+    @callback
+    def _async_unsub_timers(self) -> None:
+        """Cancel custom timers managed outside DataUpdateCoordinator."""
+        for attr in (
+            "_fetch_tracker",
+            "_day_switch_tracker",
+            "_midnight_tracker",
+            "_fetch_later_unsub",
+        ):
+            if unsub := getattr(self, attr):
+                unsub()
+                setattr(self, attr, None)
+
+    @callback
+    def _async_track_timers(self) -> None:
+        """Start custom timers after the initial fetch succeeds."""
+        if self._fetch_tracker:
+            return
+
         self._fetch_tracker = async_track_time_change(
-            hass,
+            self._hass,
             self._fetch_callback,
             self._fetch_time.hour,
             self._fetch_time.minute,
@@ -76,8 +113,8 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # start timer for day-switch time
         if self._day_switch_time != self._fetch_time:
-            async_track_time_change(  # TODO: cancel on unload
-                hass,
+            self._day_switch_tracker = async_track_time_change(
+                self._hass,
                 self._update_sensors_callback,
                 self._day_switch_time.hour,
                 self._day_switch_time.minute,
@@ -87,21 +124,13 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # add a timer at midnight (if not already there) to update days-to
         midnight = datetime.time.min
         if midnight != self._fetch_time and midnight != self._day_switch_time:
-            async_track_time_change(  # TODO: cancel on unload
-                hass,
+            self._midnight_tracker = async_track_time_change(
+                self._hass,
                 self._update_sensors_callback,
                 midnight.hour,
                 midnight.minute,
                 midnight.second,
             )
-
-    async def _async_update_data(self) -> dict[str, Any]:
-        """Update data via library."""
-        if not await self._fetch_now():
-            raise UpdateFailed(
-                f"Unable to fetch waste collection data from {self.shell.title}"
-            )
-        return {}
 
     @property
     def shell(self):
@@ -127,7 +156,13 @@ class WCSCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @callback
     async def _fetch_callback(self, *_):
-        async_call_later(
+        # cancel a still pending delayed fetch before scheduling a new one so
+        # that repeated triggers cannot stack up multiple fetch callbacks
+        if self._fetch_later_unsub:
+            self._fetch_later_unsub()
+            self._fetch_later_unsub = None
+
+        self._fetch_later_unsub = async_call_later(
             self._hass,
             randrange(0, 60 * self._random_fetch_time_offset),
             self._fetch_now,

--- a/tests/test_fetch_retry.py
+++ b/tests/test_fetch_retry.py
@@ -3,7 +3,7 @@ import os
 import sys
 from datetime import date
 from typing import Any, cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -114,6 +114,50 @@ def test_coordinator_first_refresh_reports_failed_fetch() -> None:
             await coordinator._async_update_data()
 
     asyncio.run(_run())
+
+
+def test_coordinator_starts_timers_only_after_successful_fetch() -> None:
+    from custom_components.waste_collection_schedule import wcs_coordinator
+
+    coordinator = object.__new__(wcs_coordinator.WCSCoordinator)
+    coordinator._shell = cast(Any, type("Shell", (), {"title": "Test source"})())
+    coordinator._async_track_timers = Mock()
+
+    async def _run() -> None:
+        with (
+            patch.object(coordinator, "_fetch_now", AsyncMock(return_value=False)),
+            pytest.raises(wcs_coordinator.UpdateFailed),
+        ):
+            await coordinator._async_update_data()
+        coordinator._async_track_timers.assert_not_called()
+
+        with patch.object(coordinator, "_fetch_now", AsyncMock(return_value=True)):
+            await coordinator._async_update_data()
+        coordinator._async_track_timers.assert_called_once_with()
+
+    asyncio.run(_run())
+
+
+def test_coordinator_shutdown_cancels_custom_timers() -> None:
+    from custom_components.waste_collection_schedule import wcs_coordinator
+
+    coordinator = object.__new__(wcs_coordinator.WCSCoordinator)
+    unsubs = [Mock() for _ in range(4)]
+    (
+        coordinator._fetch_tracker,
+        coordinator._day_switch_tracker,
+        coordinator._midnight_tracker,
+        coordinator._fetch_later_unsub,
+    ) = unsubs
+
+    coordinator._async_unsub_timers()
+
+    for unsub in unsubs:
+        unsub.assert_called_once_with()
+    assert coordinator._fetch_tracker is None
+    assert coordinator._day_switch_tracker is None
+    assert coordinator._midnight_tracker is None
+    assert coordinator._fetch_later_unsub is None
 
 
 def test_yaml_api_retries_all_sources_after_partial_failure() -> None:


### PR DESCRIPTION
Carry the complete changes from mampfes/hacs_waste_collection_schedule#7212, including cancellation of pending delayed fetches before re-arming.

Original commits: f7ae3a2 and f747e0e79a889c5c6ff91457ef787236a96ce2df.
Original contributors: Superfluxus and bbr111.

The coordinator and regression-test blobs are unchanged from PR #7212.

## Summary

<!-- What does this PR do? -->

## Type of change

- [ ] New source
- [ ] Bug fix / source fix
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] `python -m pytest tests/test_source_components.py -q` passes
- [ ] `ruff check --fix` and `ruff format` run on changed source files
- [ ] No generated files in diff (README.md, info.md, sources.json, translations/*.json — CI regenerates these post-merge)
- [ ] `doc/source/<name>.md` created for new sources
- [ ] TEST_CASES use real, publicly accessible addresses (not my own)
