### PR TITLE
fix(ics): preserve event-local collection dates (backport of #7173 to release/3.0.0)

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -440,6 +440,19 @@ def _event_location_description(e: Any) -> tuple[str | None, str | None]:
     return loc, desc
 
 
+def _event_start_date(e: Any) -> datetime.date | None:
+    """Extract the calendar date from an event parsed with strict=True.
+
+    Keep the occurrence's wall-clock date. Converting to the original DTSTART
+    tzinfo can shift recurring Windows-TZID events across midnight when the
+    recurrence timezone and the embedded VTIMEZONE have different DST rules.
+    """
+    start = getattr(e, "start", None)
+    if isinstance(start, datetime.datetime):
+        return start.date()
+    return start if isinstance(start, datetime.date) else None
+
+
 class ICS:
     def __init__(
         self,
@@ -473,7 +486,12 @@ class ICS:
 
         # parse ics data
         events: list[Any] = icalevents.events(
-            start=start_date, end=end_date, string_content=ics_data.encode()
+            start=start_date,
+            end=end_date,
+            string_content=ics_data.encode(),
+            # Preserve each event's calendar date/time instead of normalising
+            # all events to a calendar-wide timezone (UTC by default).
+            strict=True,
         )
 
         # Inherit summary for recurrence exceptions that lack one.
@@ -493,12 +511,7 @@ class ICS:
 
         for e in events:
             # calculate date
-            dtstart: datetime.date | None = None
-
-            if isinstance(e.start, datetime.datetime):
-                dtstart = e.start.date()
-            elif isinstance(e.start, datetime.date):
-                dtstart = e.start
+            dtstart: datetime.date | None = _event_start_date(e)
 
             # Only continue if a start date can be found in the entry
             if dtstart is not None:
@@ -537,7 +550,12 @@ class ICS:
 
         # parse ics data
         events: list[Any] = icalevents.events(
-            start=start_date, end=end_date, string_content=ics_data.encode()
+            start=start_date,
+            end=end_date,
+            string_content=ics_data.encode(),
+            # Preserve each event's calendar date/time instead of normalising
+            # all events to a calendar-wide timezone (UTC by default).
+            strict=True,
         )
 
         # Inherit summary for recurrence exceptions that lack one.
@@ -557,12 +575,7 @@ class ICS:
 
         for e in events:
             # calculate date
-            dtstart: datetime.date | None = None
-
-            if isinstance(e.start, datetime.datetime):
-                dtstart = e.start.date()
-            elif isinstance(e.start, datetime.date):
-                dtstart = e.start
+            dtstart: datetime.date | None = _event_start_date(e)
 
             # Only continue if a start date can be found in the entry
             if dtstart is not None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,6 @@ filterwarnings = ignore:.*:DeprecationWarning
 # silently never runs. test_declared_waste_types, test_source_shell_customize and
 # test_source_shell_create_error_handling were in that position: 668 passing
 # tests that gated nothing.
-python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py test_loc_report.py test_declared_waste_types.py test_source_shell_customize.py test_source_shell_create_error_handling.py test_doc_examples.py test_cassette.py
+python_files = test_source_components.py test_new_architecture.py test_offline_fixtures.py test_doc_generation.py test_config_flow.py test_ecoharmonogram_client.py test_fetch_retry.py test_loc_report.py test_declared_waste_types.py test_source_shell_customize.py test_source_shell_create_error_handling.py test_doc_examples.py test_cassette.py test_ics_timezone.py
 markers =
     live: test fetches from a live provider endpoint; excluded from gating CI (run with `-m live` locally). Replaced by offline fixtures.

--- a/tests/test_ics_timezone.py
+++ b/tests/test_ics_timezone.py
@@ -1,0 +1,187 @@
+"""Regression tests for timezone handling in the shared ICS service.
+
+By default icalevents can normalise event start times to UTC. Reducing these to a
+date silently shifts the collection day for feeds whose DTSTART is anchored at
+midnight in a timezone other than UTC. The resulting date must depend only on
+the timezone declared by the feed, never on the timezone the host happens to
+run in.
+"""
+
+import datetime
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.append(
+    os.path.join(
+        os.path.dirname(__file__), "../custom_components/waste_collection_schedule"
+    )
+)
+
+from waste_collection_schedule.service.ICS import ICS  # isort:skip
+
+_HEAD = "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//wcs-test//EN\n"
+_TAIL = "END:VCALENDAR\n"
+
+_WINDOWS_VTIMEZONE = (
+    "BEGIN:VTIMEZONE\n"
+    "TZID:AUS Eastern Standard Time\n"
+    "BEGIN:STANDARD\n"
+    "DTSTART:16010101T000000\n"
+    "TZOFFSETFROM:+1000\n"
+    "TZOFFSETTO:+1000\n"
+    "END:STANDARD\n"
+    "END:VTIMEZONE\n"
+)
+
+
+def _weekly_calendar(dtstart_line: str, vtimezone: str = "") -> str:
+    """Build a calendar with a weekly recurring event starting on a Thursday."""
+    return (
+        _HEAD + vtimezone + "BEGIN:VEVENT\n"
+        "UID:wcs-test\n"
+        f"{dtstart_line}\n"
+        "RRULE:FREQ=WEEKLY;BYDAY=TH\n"
+        "SUMMARY:General waste\n"
+        "END:VEVENT\n" + _TAIL
+    )
+
+
+# 2 Oct 2025 is a Thursday. Every occurrence of the weekly rule must land on a
+# Thursday, whatever the feed's timezone and whatever the host's timezone.
+CALENDARS = {
+    "brisbane": _weekly_calendar(
+        "DTSTART;TZID=Australia/Brisbane:20251002T000000"
+    ),  # UTC+10
+    "sydney": _weekly_calendar(
+        "DTSTART;TZID=Australia/Sydney:20251002T000000"
+    ),  # UTC+10/+11
+    "auckland": _weekly_calendar(
+        "DTSTART;TZID=Pacific/Auckland:20251002T000000"
+    ),  # UTC+12/+13
+    "berlin": _weekly_calendar(
+        "DTSTART;TZID=Europe/Berlin:20251002T000000"
+    ),  # UTC+1/+2
+    "new_york": _weekly_calendar(
+        "DTSTART;TZID=America/New_York:20251002T000000"
+    ),  # UTC-5/-4
+    "all_day": _weekly_calendar("DTSTART;VALUE=DATE:20251002"),
+    "floating": _weekly_calendar("DTSTART:20251002T000000"),
+    "utc": _weekly_calendar("DTSTART:20251002T060000Z"),
+    "windows_tzid": _weekly_calendar(
+        "DTSTART;TZID=AUS Eastern Standard Time:20251002T000000",
+        vtimezone=_WINDOWS_VTIMEZONE,
+    ),
+}
+
+# Home Assistant containers default to UTC; the others span both sides of UTC.
+HOST_TIMEZONES: list[str | None] = [
+    "UTC",
+    "Australia/Brisbane",
+    "Europe/Berlin",
+    "Pacific/Auckland",
+    "America/Los_Angeles",
+]
+if not hasattr(time, "tzset"):
+    # Windows cannot select IANA process timezones with time.tzset(). Still
+    # exercise every calendar shape under the native host timezone.
+    HOST_TIMEZONES = [None]
+
+
+@pytest.fixture
+def host_timezone(request, monkeypatch):
+    """Pin the process-local timezone for the duration of a test."""
+    if request.param is None:
+        yield "native"
+        return
+    try:
+        with monkeypatch.context() as patch:
+            patch.setenv("TZ", request.param)
+            time.tzset()
+            yield request.param
+    finally:
+        time.tzset()
+
+
+@pytest.mark.parametrize("host_timezone", HOST_TIMEZONES, indirect=True)
+@pytest.mark.parametrize("name", sorted(CALENDARS))
+def test_convert_keeps_the_calendar_day_of_the_feed(name, host_timezone) -> None:
+    entries = ICS().convert(CALENDARS[name])
+
+    assert entries, f"{name}: no entries returned"
+    wrong = [d for d, _title in entries if d.weekday() != 3]  # 3 == Thursday
+    assert not wrong, (
+        f"{name}: {len(wrong)} of {len(entries)} entries shifted off Thursday "
+        f"under TZ={host_timezone} (first bad date: {wrong[0]})"
+    )
+
+
+@pytest.mark.parametrize("host_timezone", HOST_TIMEZONES, indirect=True)
+@pytest.mark.parametrize("name", sorted(CALENDARS))
+def test_convert_events_agrees_with_convert(name, host_timezone) -> None:
+    dates_convert = [d for d, _title in ICS().convert(CALENDARS[name])]
+    dates_events = [event.date for event in ICS().convert_events(CALENDARS[name])]
+
+    assert dates_convert == dates_events
+
+
+def test_dst_transition_does_not_shift_the_day() -> None:
+    """A feed anchored in summer time must stay correct once DST ends."""
+    entries = ICS().convert(
+        _weekly_calendar("DTSTART;TZID=Europe/Berlin:20250703T000000")
+    )
+
+    assert entries
+    assert all(d.weekday() == 3 for d, _title in entries)
+
+
+def test_all_day_events_keep_their_literal_date() -> None:
+    """VALUE=DATE events carry no timezone and must never be converted."""
+    entries = ICS().convert(
+        _HEAD + "BEGIN:VEVENT\n"
+        "UID:wcs-test-all-day\n"
+        "DTSTART;VALUE=DATE:20251002\n"
+        "DTEND;VALUE=DATE:20251003\n"
+        "RRULE:FREQ=WEEKLY;BYDAY=TH\n"
+        "SUMMARY:General waste\n"
+        "END:VEVENT\n" + _TAIL
+    )
+
+    assert entries
+    assert all(isinstance(d, datetime.date) for d, _title in entries)
+    assert all(d.weekday() == 3 for d, _title in entries)
+
+
+@pytest.mark.parametrize("name", sorted(CALENDARS))
+@pytest.mark.parametrize("method", ["convert", "convert_events"])
+def test_nonrecurring_events_keep_their_literal_date(name, method) -> None:
+    """Single events must keep their date, including embedded Windows zones."""
+    expected = datetime.datetime.now(datetime.UTC).date()
+    expected += datetime.timedelta(days=7)
+    calendar = CALENDARS[name].replace("20251002", expected.strftime("%Y%m%d"))
+    calendar = calendar.replace("RRULE:FREQ=WEEKLY;BYDAY=TH\n", "")
+
+    entries = getattr(ICS(), method)(calendar)
+
+    assert [entry[0] for entry in entries] == [expected]
+
+
+@pytest.mark.parametrize("method", ["convert", "convert_events"])
+def test_calendar_timezone_does_not_override_event_timezone(method) -> None:
+    """An explicit UTC event keeps its date despite the calendar's default zone."""
+    expected = datetime.datetime.now(datetime.UTC).date()
+    expected += datetime.timedelta(days=7)
+    calendar = (
+        _HEAD + "X-WR-TIMEZONE:Pacific/Auckland\n"
+        "BEGIN:VEVENT\n"
+        "UID:wcs-test-explicit-utc\n"
+        f"DTSTART:{expected:%Y%m%d}T233000Z\n"
+        "SUMMARY:General waste\n"
+        "END:VEVENT\n" + _TAIL
+    )
+
+    entries = getattr(ICS(), method)(calendar)
+
+    assert [entry[0] for entry in entries] == [expected]


### PR DESCRIPTION
Backport of #7173 to \`release/3.0.0\`.

\`release/3.0.0\` still carried the pre-fix date extraction in both \`ICS.convert()\` and \`ICS.convert_events()\`, and its newer parsers call those same methods, so the bug is present there too.

## What this changes

Both conversion paths now call \`icalevents.events(..., strict=True)\`, which retains each event's own date/time values instead of normalising every event to the calendar-wide timezone (UTC by default). A shared \`_event_start_date()\` helper reduces the occurrence to its wall-clock date without a second timezone conversion, so a feed's intended collection day no longer depends on the timezone the Home Assistant host runs in.

Deliberately *not* converting back to the original \`DTSTART\` tzinfo: on recurring events whose \`TZID\` is a Windows zone name (e.g. \`AUS Eastern Standard Time\`) with a \`VTIMEZONE\` whose DST rules differ from the recurrence expansion, that shifts occurrences across midnight — 26 of 52 Thursdays became Wednesdays in the fixture. \`ZoneInfo\` also raises on those names, which real Australian council feeds emit.

\`strict\` is available in icalevents 0.2.1, the pinned minimum, so no dependency change is required.

## Cherry-pick notes

Cherry-picked from master (\`e1908ff1\`, squash-merge of #7173). \`ICS.py\` and \`tests/test_ics_timezone.py\` applied cleanly. \`pytest.ini\` needed a manual merge: \`release/3.0.0\` has a longer \`python_files\` allowlist plus \`addopts\`/\`markers\`, so \`test_ics_timezone.py\` was appended to the existing allowlist rather than replacing the line. The repo's pre-commit \`ruff\`/pyupgrade hook additionally modernised two lines in the new test from \`datetime.timezone.utc\` to \`datetime.UTC\` (release/3.0.0 targets a newer Python baseline than master) — a semantics-preserving alias change, no behavior difference.

## Validation on this branch

- \`pytest tests/test_ics_timezone.py\` — 112 passed
- \`pytest tests/\` (full gating suite, including the offline cassette/fixture tests for ICS-backed providers) — 7783 passed, 8 skipped, 0 failed

Original PR: #7173